### PR TITLE
Integrate contacto mode with evaluation reports

### DIFF
--- a/modes/apply.md
+++ b/modes/apply.md
@@ -97,7 +97,7 @@ Notas:
 Si el candidato confirma que envió la aplicación:
 1. Actualizar estado en `applications.md` de "Evaluada" a "Aplicado"
 2. Actualizar Section G del report con las respuestas finales
-3. Sugerir siguiente paso: `/career-ops contacto` para LinkedIn outreach
+3. Sugerir siguiente paso: `/career-ops contacto` para LinkedIn outreach — contacto will automatically load this evaluation report and use the top proof points from Block B to craft targeted messages
 
 ## Scroll handling
 

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -1,26 +1,70 @@
 # Modo: contacto — LinkedIn Power Move
 
-1. **Identificar targets** via WebSearch:
-   - Hiring manager del equipo
-   - Recruiter asignado
-   - 2-3 peers del equipo (gente con rol similar)
+## Step 0 — Load evaluation context
 
-2. **Seleccionar target primario**: la persona que más se beneficiaría de que el candidato estuviera allí
+**Before generating any message, check for an existing evaluation report.**
 
-3. **Generar mensaje** con framework de 3 frases:
-   - **Frase 1 (Gancho)**: Algo específico sobre su empresa o reto actual con IA (NO genérico)
-   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato relevante para ESE rol (ej: "I built an AI agent handling 90% of customer service at my company before selling it")
-   - **Frase 3 (Propuesta)**: Charla rápida, sin presión ("Would love to chat about [tema específico] for 15 min")
+1. Identify the company + role (from user input, current conversation, or most recent evaluation)
+2. Search `reports/` for a matching report (Grep case-insensitive by company name)
+3. If a report exists, read it and extract:
+   - **Archetype** detected (Step 0 of evaluation)
+   - **Top 3 proof points** from Block B (the JD requirements where CV match was strongest)
+   - **Score** and key gaps from Block B
+   - **STAR stories** from Block F that are most relevant
+   - **Case study** recommended in Block F
+4. Also read `data/applications.md` to check current status of this application
+5. If NO report exists, inform the user and offer to run an evaluation first — or proceed with cv.md only
 
-4. **Versiones**:
-   - EN (default)
-   - ES (si empresa española)
+This context is what makes the outreach message specific instead of generic.
 
-5. **Targets alternativos** con justificación de por qué son buenos second choices
+## Step 1 — Identify targets
 
-**Reglas del mensaje:**
-- Máximo 300 caracteres (LinkedIn connection request limit)
+Use WebSearch to find:
+- Hiring manager of the team
+- Recruiter assigned to the role
+- 2-3 peers on the team (people in a similar role)
+
+## Step 2 — Select primary target
+
+Choose the person who would most benefit from the candidate joining. Typically:
+- For IC roles: the hiring manager or tech lead
+- For leadership roles: a peer or the person the role reports to
+- Avoid cold-messaging the recruiter first unless no other option — a warm intro from a team member is stronger
+
+## Step 3 — Generate message
+
+**The message must draw from the evaluation report, not generic claims.**
+
+Framework (3 sentences, max 300 characters for LinkedIn connection request):
+
+- **Sentence 1 (Hook)**: Something specific about their company or current challenge with AI — NOT generic. If the report's Block A identified the domain and function, reference it.
+- **Sentence 2 (Proof)**: The single strongest proof point from Block B's top matches. Use the exact framing that scored highest against the JD. If article-digest.md has a quantified metric for this proof point, use it.
+- **Sentence 3 (Proposal)**: Quick chat, no pressure — "Would love to chat about [specific topic from the JD] for 15 min"
+
+**Archetype-adapted framing** (from the report):
+- If FDE → emphasize fast delivery, client-facing results
+- If SA → emphasize system design, integration wins
+- If PM → emphasize product discovery, stakeholder outcomes
+- If LLMOps → emphasize production metrics, evals, observability
+- If Agentic → emphasize orchestration, reliability, HITL
+- If Transformation → emphasize adoption, change management, org impact
+
+## Step 4 — Versions
+
+Generate:
+- EN (default)
+- ES (if the company or target is Spanish-speaking)
+- **Follow-up variant**: A longer version (2-3 sentences) for LinkedIn InMail or email, where the 300-char limit doesn't apply. This version can include a second proof point and a link to the relevant case study from Block F.
+
+## Step 5 — Alternative targets
+
+List 2-3 backup contacts with justification for why they're good second choices.
+
+## Message rules
+
+- Max 300 characters for connection request version
 - NO corporate-speak
 - NO "I'm passionate about..."
-- Algo que haga que quieran responder
-- NUNCA compartir teléfono
+- Something that makes them want to respond
+- NEVER share phone number
+- **Every claim must trace back to cv.md or article-digest.md** — no invented metrics


### PR DESCRIPTION
## Summary

- Rewrites `contacto.md` to read existing evaluation reports before generating LinkedIn messages
- Adds archetype-adapted framing so the outreach pitch matches how the offer was scored
- Adds a follow-up variant for InMail/email (no 300-char limit) that includes a second proof point and case study link
- Updates `apply.md` handoff to explain that contacto will use the report context

## Why this matters

The evaluation pipeline does significant work in Block B (mapping JD requirements to CV proof points) and Block F (selecting STAR stories and case studies). But when the user runs `contacto` after evaluating or applying, none of that context is used — it does a cold WebSearch and generates a generic 3-sentence message.

For competitive roles, the LinkedIn message is often the only thing that gets a hiring manager's attention. A message that references the *exact* proof point that scored highest against *their specific JD* is materially more compelling than a generic pitch. The evaluation already did the hard work of identifying which proof points matter most — contacto should use them.

### Before
```
contacto → WebSearch for targets → generic message from cv.md
```

### After
```
contacto → read report → extract top proof points from Block B
         → adapt framing to detected archetype
         → WebSearch for targets → targeted message using evaluation intelligence
```

## Test plan

- [ ] Run `/career-ops contacto` for a company with an existing report in `reports/` — verify it reads the report and references Block B proof points
- [ ] Run `/career-ops contacto` for a company with NO report — verify it informs the user and offers to evaluate first
- [ ] After running `/career-ops apply` and confirming submission — verify the suggested next step mentions contacto will use the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)