### PR TITLE
Connect deep research mode to evaluation pipeline

### DIFF
--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,47 +1,97 @@
-# Modo: deep — Deep Research Prompt
+# Modo: deep — Deep Company Research
 
-Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+Structured company research that feeds directly into evaluations and interview prep.
 
+## Step 0 — Check for existing evaluation
+
+Before researching, check `reports/` for an existing evaluation of this company+role. If found, load the report — deep research should build on what the evaluation already identified (archetype, gaps, proof points), not start from scratch.
+
+## Research Axes (6 areas)
+
+### 1. AI Strategy
+- What products/features use AI/ML?
+- What's their AI stack? (models, infra, tools)
+- Engineering blog — what do they publish?
+- Papers or talks on AI?
+
+### 2. Recent Moves (last 6 months)
+- Relevant hires in AI/ML/product?
+- Acquisitions or partnerships?
+- Product launches or pivots?
+- Funding rounds or leadership changes?
+
+### 3. Engineering Culture
+- How do they ship? (deploy cadence, CI/CD)
+- Mono-repo or multi-repo?
+- Languages/frameworks?
+- Remote-first or office-first?
+- Glassdoor/Blind reviews on eng culture?
+
+### 4. Likely Challenges
+- Scaling problems?
+- Reliability, cost, latency challenges?
+- Migrating anything? (infra, models, platforms)
+- Pain points from reviews?
+
+### 5. Competitors & Differentiation
+- Main competitors?
+- Moat/differentiator?
+- Positioning vs competition?
+
+### 6. Candidate Angle
+Read cv.md and profile.yml:
+- What unique value does the candidate bring to this team?
+- Which projects are most relevant?
+- What story should they tell in the interview?
+
+## Post-Research — Feed Back Into Evaluation
+
+**This is the key step that makes deep research actionable.**
+
+After completing the 6 axes, update the evaluation if one exists:
+
+1. **Score adjustments**: Deep research may reveal information that changes scoring dimensions:
+   - Company reputation (axis 3: culture) → dimension #7
+   - Tech stack modernity (axis 1: AI strategy) → dimension #8
+   - Speed to offer (axis 2: recent moves, hiring pace) → dimension #9
+   - Cultural signals (axis 3: culture) → dimension #10
+   - Growth trajectory (axis 2: funding, launches) → dimension #5
+
+2. **Append a `## Deep Research` section to the existing report** with findings organized by axis. Include date of research so it can be refreshed.
+
+3. **Update Block F (Interview Plan)**: The "likely challenges" (axis 4) directly inform STAR story selection — pick stories that address the company's actual problems, not generic ones.
+
+4. **Update contacto targeting**: The "recent moves" (axis 2) often reveal who to reach out to (new hires, team leads mentioned in blog posts).
+
+If NO evaluation exists yet, save the research to `reports/deep-{company-slug}-{date}.md` so it's available when the user evaluates later. The evaluation mode should check for existing deep research before starting Block D (Comp & Demand).
+
+## Output Format
+
+```markdown
+## Deep Research: [Company] — [Role]
+**Date:** YYYY-MM-DD
+**Linked report:** #NNN (if exists)
+
+### 1. AI Strategy
+(findings)
+
+### 2. Recent Moves
+(findings)
+
+### 3. Engineering Culture
+(findings)
+
+### 4. Likely Challenges
+(findings)
+
+### 5. Competitors & Differentiation
+(findings)
+
+### 6. Candidate Angle
+(findings)
+
+### Score Impact
+| Dimension | Before | After | Why |
+|-----------|--------|-------|-----|
+(only dimensions where research changed the score)
 ```
-## Deep Research: [Empresa] — [Rol]
-
-Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
-
-### 1. Estrategia AI
-- ¿Qué productos/features usan AI/ML?
-- ¿Cuál es su stack de AI? (modelos, infra, tools)
-- ¿Tienen blog de engineering? ¿Qué publican?
-- ¿Qué papers o talks han dado sobre AI?
-
-### 2. Movimientos recientes (últimos 6 meses)
-- ¿Contrataciones relevantes en AI/ML/product?
-- ¿Acquisitions o partnerships?
-- ¿Product launches o pivots?
-- ¿Rondas de funding o cambios de liderazgo?
-
-### 3. Cultura de engineering
-- ¿Cómo shipean? (cadencia de deploy, CI/CD)
-- ¿Mono-repo o multi-repo?
-- ¿Qué lenguajes/frameworks usan?
-- ¿Remote-first o office-first?
-- ¿Glassdoor/Blind reviews sobre eng culture?
-
-### 4. Retos probables
-- ¿Qué problemas de scaling tienen?
-- ¿Reliability, cost, latency challenges?
-- ¿Están migrando algo? (infra, models, platforms)
-- ¿Qué pain points menciona la gente en reviews?
-
-### 5. Competidores y diferenciación
-- ¿Quiénes son sus main competitors?
-- ¿Cuál es su moat/diferenciador?
-- ¿Cómo se posicionan vs competencia?
-
-### 6. Ángulo del candidato
-Dado mi perfil (read from cv.md and profile.yml for specific experience):
-- ¿Qué valor único aporto a este equipo?
-- ¿Qué proyectos míos son más relevantes?
-- ¿Qué historia debería contar en la entrevista?
-```
-
-Personalizar cada sección con el contexto específico de la oferta evaluada.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -46,6 +46,8 @@ Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
 
 ## Bloque D — Comp y Demanda
 
+**First check:** If `reports/deep-{company-slug}-*.md` exists, read it — deep research may already have comp data, funding info, and hiring signals. Use it as a starting point instead of duplicating WebSearch effort.
+
 Usar WebSearch para:
 - Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
 - Reputación de compensación de la empresa


### PR DESCRIPTION
## Summary

- Deep research now appends findings to existing evaluation reports and adjusts scores
- Maps research axes to scoring dimensions (culture → #7, AI strategy → #8, etc.)
- Evaluation mode (Block D) checks for existing deep research before doing WebSearch
- Deep research saved as standalone report when no evaluation exists yet

## Why this matters

Deep research surfaces high-value intelligence — company AI strategy, engineering culture, likely challenges, recent funding/hires. But it ran in complete isolation: the findings never updated the offer score, never informed which STAR stories to prepare, and never fed into the contacto outreach.

Meanwhile, the evaluation mode did its own WebSearch in Block D for company data, potentially duplicating work already done in deep mode. And Block F selected STAR stories generically instead of targeting the company's actual challenges.

### Before
```
/career-ops deep    → standalone research prompt (no output saved)
/career-ops oferta  → evaluation from scratch (ignores deep findings)
```

### After
```
/career-ops deep    → saves to report, adjusts scores, informs STAR selection
/career-ops oferta  → Block D checks for existing deep research first
```

The research axes map directly to scoring dimensions:
- AI Strategy → Tech stack modernity (#8)
- Recent Moves → Growth trajectory (#5), Speed to offer (#9)
- Engineering Culture → Company reputation (#7), Cultural signals (#10)
- Likely Challenges → informs Block F STAR story selection

## Test plan

- [ ] Run `/career-ops deep` for a company with an existing report — verify it appends findings and shows score impact table
- [ ] Run `/career-ops deep` for a company with no report — verify it saves to `reports/deep-{slug}-{date}.md`
- [ ] Run `/career-ops oferta` after deep research — verify Block D reads existing deep findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)