### PR TITLE
docs(modes): translate deep.md from Spanish to English

### DIFF
--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,47 +1,48 @@
-# Modo: deep — Deep Research Prompt
+# Mode: deep — Deep Research Prompt
 
-Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+Generate a structured prompt for Perplexity/Claude/ChatGPT with 6 axes:
+
+```text
+## Deep Research: [Company] — [Role]
+
+Context: I am evaluating a candidacy for [role] at [company]. I need actionable information for the interview.
+
+### 1. AI Strategy
+- What products/features use AI/ML?
+- What is their AI stack? (models, infrastructure, tools)
+- Do they have an engineering blog? What do they publish?
+- What papers or talks have they presented on AI?
+
+### 2. Recent moves (last 6 months)
+- Relevant hires in AI/ML/product?
+- Acquisitions or partnerships?
+- Product launches or pivots?
+- Funding rounds or leadership changes?
+
+### 3. Engineering culture
+- How do they ship? (deployment cadence, CI/CD)
+- Monorepo or multirepo?
+- What languages/frameworks do they use?
+- Remote-first or office-first?
+- Glassdoor/Blind reviews about engineering culture?
+
+### 4. Likely challenges
+- What scaling problems do they have?
+- Reliability, cost, latency challenges?
+- Are they migrating anything? (infrastructure, models, platforms)
+- What pain points do people mention in reviews?
+
+### 5. Competitors and differentiation
+- Who are their main competitors?
+- What is their moat/differentiator?
+- How are they positioned vs competitors?
+
+### 6. Candidate angle
+Given my profile (read from cv.md and profile.yml for specific experience):
+- What unique value do I bring to this team?
+- Which of my projects are most relevant?
+- What story should I tell in the interview?
 
 ```
-## Deep Research: [Empresa] — [Rol]
 
-Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
-
-### 1. Estrategia AI
-- ¿Qué productos/features usan AI/ML?
-- ¿Cuál es su stack de AI? (modelos, infra, tools)
-- ¿Tienen blog de engineering? ¿Qué publican?
-- ¿Qué papers o talks han dado sobre AI?
-
-### 2. Movimientos recientes (últimos 6 meses)
-- ¿Contrataciones relevantes en AI/ML/product?
-- ¿Acquisitions o partnerships?
-- ¿Product launches o pivots?
-- ¿Rondas de funding o cambios de liderazgo?
-
-### 3. Cultura de engineering
-- ¿Cómo shipean? (cadencia de deploy, CI/CD)
-- ¿Mono-repo o multi-repo?
-- ¿Qué lenguajes/frameworks usan?
-- ¿Remote-first o office-first?
-- ¿Glassdoor/Blind reviews sobre eng culture?
-
-### 4. Retos probables
-- ¿Qué problemas de scaling tienen?
-- ¿Reliability, cost, latency challenges?
-- ¿Están migrando algo? (infra, models, platforms)
-- ¿Qué pain points menciona la gente en reviews?
-
-### 5. Competidores y diferenciación
-- ¿Quiénes son sus main competitors?
-- ¿Cuál es su moat/diferenciador?
-- ¿Cómo se posicionan vs competencia?
-
-### 6. Ángulo del candidato
-Dado mi perfil (read from cv.md and profile.yml for specific experience):
-- ¿Qué valor único aporto a este equipo?
-- ¿Qué proyectos míos son más relevantes?
-- ¿Qué historia debería contar en la entrevista?
-```
-
-Personalizar cada sección con el contexto específico de la oferta evaluada.
+Personalize each section with the specific context of the evaluated job.

--- a/modes/deep.md
+++ b/modes/deep.md
@@ -42,7 +42,6 @@ Given my profile (read from cv.md and profile.yml for specific experience):
 - What unique value do I bring to this team?
 - Which of my projects are most relevant?
 - What story should I tell in the interview?
-
 ```
 
-Personalize each section with the specific context of the evaluated job.
+Personalize each section with the specific context of the job being evaluated.

--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,67 +1,48 @@
-# Modo: deep — Deep Research Prompt
+# Mode: deep — Deep Research Prompt
 
-## Language
+Generate a structured prompt for Perplexity/Claude/ChatGPT with 6 axes:
 
-This mode is **user-facing**: the output is a research/interview-prep doc the
-user reads, not application content sent to the company. Override the shared
-"language of the JD (EN default)" rule for this mode and resolve the output
-language in this order:
+```text
+## Deep Research: [Company] — [Role]
 
-1. **User prompt language** — if the user wrote `/career-ops deep` (or its
-   surrounding chat) in Spanish, French, German, Japanese, etc., emit the
-   doc in that language.
-2. **`config/profile.yml`** — if `language.modes_dir` is set
-   (`modes/de`, `modes/fr`, `modes/ja`), prefer that locale.
-3. **JD language** — only as a last resort, when the user prompt has no
-   language signal (e.g., a bare URL with no surrounding chat).
+Context: I am evaluating a candidacy for [role] at [company]. I need actionable information for the interview.
 
-The template below is written in Spanish as a scaffold. **Translate it to the
-resolved output language** before presenting; do not pass the Spanish through
-when the user is writing in another language.
+### 1. AI Strategy
+- What products/features use AI/ML?
+- What is their AI stack? (models, infrastructure, tools)
+- Do they have an engineering blog? What do they publish?
+- What papers or talks have they presented on AI?
 
-Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+### 2. Recent moves (last 6 months)
+- Relevant hires in AI/ML/product?
+- Acquisitions or partnerships?
+- Product launches or pivots?
+- Funding rounds or leadership changes?
+
+### 3. Engineering culture
+- How do they ship? (deployment cadence, CI/CD)
+- Monorepo or multirepo?
+- What languages/frameworks do they use?
+- Remote-first or office-first?
+- Glassdoor/Blind reviews about engineering culture?
+
+### 4. Likely challenges
+- What scaling problems do they have?
+- Reliability, cost, latency challenges?
+- Are they migrating anything? (infrastructure, models, platforms)
+- What pain points do people mention in reviews?
+
+### 5. Competitors and differentiation
+- Who are their main competitors?
+- What is their moat/differentiator?
+- How are they positioned vs competitors?
+
+### 6. Candidate angle
+Given my profile (read from cv.md and profile.yml for specific experience):
+- What unique value do I bring to this team?
+- Which of my projects are most relevant?
+- What story should I tell in the interview?
 
 ```
-## Deep Research: [Empresa] — [Rol]
 
-Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
-
-### 1. Estrategia AI
-- ¿Qué productos/features usan AI/ML?
-- ¿Cuál es su stack de AI? (modelos, infra, tools)
-- ¿Tienen blog de engineering? ¿Qué publican?
-- ¿Qué papers o talks han dado sobre AI?
-
-### 2. Movimientos recientes (últimos 6 meses)
-- ¿Contrataciones relevantes en AI/ML/product?
-- ¿Acquisitions o partnerships?
-- ¿Product launches o pivots?
-- ¿Rondas de funding o cambios de liderazgo?
-
-### 3. Cultura de engineering
-- ¿Cómo shipean? (cadencia de deploy, CI/CD)
-- ¿Mono-repo o multi-repo?
-- ¿Qué lenguajes/frameworks usan?
-- ¿Remote-first o office-first?
-- ¿Glassdoor/Blind reviews sobre eng culture?
-
-### 4. Retos probables
-- ¿Qué problemas de scaling tienen?
-- ¿Reliability, cost, latency challenges?
-- ¿Están migrando algo? (infra, models, platforms)
-- ¿Qué pain points menciona la gente en reviews?
-
-### 5. Competidores y diferenciación
-- ¿Quiénes son sus main competitors?
-- ¿Cuál es su moat/diferenciador?
-- ¿Cómo se posicionan vs competencia?
-
-### 6. Ángulo del candidato
-Dado mi perfil (read from cv.md and profile.yml for specific experience):
-- ¿Qué valor único aporto a este equipo?
-- ¿Qué proyectos míos son más relevantes?
-- ¿Qué historia debería contar en la entrevista?
-```
-
-Personalizar cada sección con el contexto específico de la oferta evaluada,
-en el idioma resuelto en la sección **Language** de arriba (NO siempre español).
+Personalize each section with the specific context of the evaluated job.


### PR DESCRIPTION
## What does this PR do?
This PR translates the modes/deep.md file from Spanish to English to improve documentation consistency and accessibility for non-Spanish contributors.

## Related issue
Refs #363

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [ ] I ran node test-all.mjs and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

## Notes:
- This change only affects documentation (modes/deep.md)
- No functional or behavioral changes were made
- Happy to continue translating additional files in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Converted the deep-research/interview prompt template to English, preserving the six-section research framework and English placeholders (e.g., [Company], [Role]).
  * Removed the previous Spanish scaffold and locale/translation selection instructions; file now focuses on the English prompt content and a final personalization instruction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/470)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->