### PR TITLE
feat(batch): add safe agent selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ modes/_profile.md
 
 # Generated
 .resolved-prompt-*
+batch/.resolved-codex-*
 node_modules/
 bun.lock
 # Report-number reservation sentinels (ephemeral, created by reserve-report-num.mjs)

--- a/batch/README.md
+++ b/batch/README.md
@@ -24,6 +24,12 @@ Process multiple job offers in parallel via headless workers. Each worker runs t
    ./batch/batch-runner.sh
    ```
 
+   To use Codex instead of Claude Code:
+
+   ```bash
+   CAREER_OPS_AGENT=codex ./batch/batch-runner.sh
+   ```
+
 4. **Results** are automatically merged into `data/applications.md`, processed offers are reconciled out of the `data/pipeline.md` inbox, and integrity is verified with `verify-pipeline.mjs` at the end of the run.
 
 ## Options
@@ -33,10 +39,23 @@ Process multiple job offers in parallel via headless workers. Each worker runs t
 | `--parallel N` | `1` | Number of concurrent headless workers |
 | `--dry-run` | off | Preview pending offers without processing |
 | `--retry-failed` | off | Only retry offers marked as `failed` in state |
-| `--resume-paused` | off | Resume offers paused after a Claude session/rate limit |
+| `--resume-paused` | off | Resume offers paused after a worker session/rate limit |
 | `--start-from N` | `0` | Skip offers with ID below N |
 | `--max-retries N` | `2` | Max retry attempts per offer before giving up |
 | `--rate-limit-sleep N` | `300` | Seconds to wait before retrying a transient rate-limited worker; use `0` to pause the batch immediately |
+| `--agent NAME` | `CAREER_OPS_AGENT`, otherwise `claude` | Worker CLI: `claude` or `codex` |
+| `--model NAME` | unset | Model passed to the selected CLI |
+
+## Codex Safety
+
+Claude keeps the existing batch default, including `--dangerously-skip-permissions`
+and `--strict-mcp-config`, to avoid breaking current headless users. Codex does
+not pass its dangerous bypass flag unless explicitly requested with
+`CAREER_OPS_UNSAFE_AGENT_EXEC=1` or `true`:
+
+```bash
+CAREER_OPS_AGENT=codex CAREER_OPS_UNSAFE_AGENT_EXEC=1 ./batch/batch-runner.sh
+```
 
 ## Directory Layout
 
@@ -79,7 +98,7 @@ Batch mode reads offers from `batch-input.tsv`, but the `data/pipeline.md` inbox
 
 `batch-state.tsv` tracks the status of every offer (`pending`, `processing`, `completed`, `failed`, `skipped`, `rate_limited`, `paused_rate_limit`). If the batch is interrupted, re-running `batch-runner.sh` picks up where it left off -- completed offers are skipped automatically. `rate_limited` is a non-completed state used while the runner waits before retrying, so interrupted rate-limited jobs are eligible on the next normal run.
 
-`paused_rate_limit` is different: it means a worker hit a Claude session/usage limit, so the runner stopped scheduling new offers and preserved the retry count. Resume those rows explicitly after the limit resets:
+`paused_rate_limit` is different: it means a worker hit a session/usage limit, so the runner stopped scheduling new offers and preserved the retry count. Resume those rows explicitly after the limit resets:
 
 ```bash
 ./batch/batch-runner.sh --resume-paused

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# career-ops batch runner — standalone orchestrator for claude -p workers
-# Reads batch-input.tsv, delegates each offer to a claude -p worker,
+# career-ops batch runner — standalone orchestrator for AI CLI workers
+# Reads batch-input.tsv, delegates each offer to a headless worker,
 # tracks state in batch-state.tsv for resumability.
 #
-# NOTE: This script is Claude Code-specific. It uses claude -p with
-# --dangerously-skip-permissions and --append-system-prompt-file flags
-# that are not available in other CLIs. Multi-CLI support is out of scope
-# for now — contributions welcome.
+# Built-in adapters:
+#   - claude: existing claude -p flow, including --dangerously-skip-permissions
+#   - codex: codex exec with a combined stdin prompt
+# Codex dangerous bypass is opt-in via CAREER_OPS_UNSAFE_AGENT_EXEC=1 or true.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -35,16 +35,24 @@ RESUME_PAUSED=false
 START_FROM=0
 MAX_RETRIES=2
 MIN_SCORE=0
-MODEL=""  # empty = let claude -p use the Claude Max default
+AGENT="${CAREER_OPS_AGENT:-claude}"
+MODEL=""  # empty = let the selected CLI use its default model
 RATE_LIMIT_SLEEP=300
 BATCH_PAUSED=false
 STATUS_ONLY=false
 WATCH_MODE=false
+UNSAFE_AGENT_EXEC="${CAREER_OPS_UNSAFE_AGENT_EXEC:-false}"
+AGENT_BIN=""
+AGENT_COMMAND_BUILDER=""
+AGENT_RATE_LIMIT_PATTERN=""
+
+# name<TAB>binary<TAB>command-builder<TAB>rate-limit-pattern
+AGENT_ADAPTERS=$'claude\tclaude\tbuild_claude_worker_command\t(rate[ _-]?limit(ed)?|too many requests|429|quota exceeded|try again later|temporarily unavailable|throttl(e|ed|ing)|temporarily at capacity|currently at capacity|model (is )?(at capacity|overloaded)|server (is )?(at capacity|overloaded)|error: (service unavailable|requests? exceeded)|status: 503|503 service unavailable)\ncodex\tcodex\tbuild_codex_worker_command\t(rate[ _-]?limit(ed)?|too many requests|429|quota exceeded|try again later|temporarily unavailable|throttl(e|ed|ing)|temporarily at capacity|currently at capacity|model (is )?(at capacity|overloaded)|server (is )?(at capacity|overloaded)|error: (service unavailable|requests? exceeded)|status: 503|503 service unavailable)'
 
 usage() {
   cat <<'USAGE'
-career-ops batch runner — process job offers in batch via claude -p workers
-Uses your default Claude model (Claude Max subscription).
+career-ops batch runner — process job offers in batch via headless workers
+Uses Claude Code by default. Set CAREER_OPS_AGENT=codex for Codex CLI.
 
 Usage: batch-runner.sh [OPTIONS]
 
@@ -52,15 +60,14 @@ Options:
   --parallel N         Number of parallel workers (default: 1)
   --dry-run            Show what would be processed, don't execute
   --retry-failed       Only retry offers marked as "failed" in state
-  --resume-paused      Resume offers paused by a Claude session/rate limit
+  --resume-paused      Resume offers paused by a worker session/rate limit
   --start-from N       Start from offer ID N (skip earlier IDs)
   --max-retries N      Max retry attempts per offer (default: 2)
   --min-score N        Skip PDF/tracker for offers scoring below N (default: 0 = off)
   --rate-limit-sleep N Seconds to wait before retrying a rate-limited worker
                        (default: 300)
-  --model NAME         Claude model passed to `claude -p --model` (default:
-                       unset = Claude Max default). Use a cheaper model for
-                       large batches, e.g. `--model claude-sonnet-4-6`.
+  --agent NAME         Worker CLI: claude or codex (default: CAREER_OPS_AGENT or claude)
+  --model NAME         Model passed to the selected CLI (default: CLI default)
   --status             Show batch progress and a per-job table, then exit
   --watch              Live-refresh progress until the run completes
   -h, --help           Show this help
@@ -84,6 +91,9 @@ Examples:
 
   # Process 2 at a time starting from ID 10
   ./batch-runner.sh --parallel 2 --start-from 10
+
+  # Use Codex CLI workers without enabling the dangerous bypass flag
+  CAREER_OPS_AGENT=codex ./batch-runner.sh
 USAGE
 }
 
@@ -100,6 +110,11 @@ while [[ $# -gt 0 ]]; do
     --rate-limit-sleep)
       [[ $# -ge 2 ]] || { echo "ERROR: --rate-limit-sleep requires an argument"; exit 1; }
       RATE_LIMIT_SLEEP="$2"
+      shift 2
+      ;;
+    --agent)
+      [[ $# -ge 2 && "$2" != -* ]] || { echo "ERROR: --agent requires claude or codex"; exit 1; }
+      AGENT="$2"
       shift 2
       ;;
     --model) MODEL="$2"; shift 2 ;;
@@ -141,6 +156,25 @@ release_lock() {
 
 trap release_lock EXIT
 
+resolve_agent_adapter() {
+  AGENT_BIN=""
+  AGENT_COMMAND_BUILDER=""
+  AGENT_RATE_LIMIT_PATTERN=""
+
+  local name binary builder rate_limit_pattern
+  while IFS=$'\t' read -r name binary builder rate_limit_pattern; do
+    if [[ "$name" == "$AGENT" ]]; then
+      AGENT_BIN="$binary"
+      AGENT_COMMAND_BUILDER="$builder"
+      AGENT_RATE_LIMIT_PATTERN="$rate_limit_pattern"
+      return 0
+    fi
+  done <<< "$AGENT_ADAPTERS"
+
+  echo "ERROR: unsupported agent '$AGENT' (expected: claude or codex)."
+  return 1
+}
+
 # Validate prerequisites
 check_prerequisites() {
   if [[ ! -f "$INPUT_FILE" ]]; then
@@ -153,8 +187,10 @@ check_prerequisites() {
     exit 1
   fi
 
-  if ! command -v claude &>/dev/null; then
-    echo "ERROR: 'claude' CLI not found in PATH."
+  resolve_agent_adapter || exit 1
+
+  if ! command -v "$AGENT_BIN" &>/dev/null; then
+    echo "ERROR: '$AGENT_BIN' CLI not found in PATH."
     exit 1
   fi
 
@@ -325,7 +361,7 @@ update_state() {
 
 is_rate_limit_log() {
   local log_file="$1"
-  grep -Eiq '(rate limit|rate_limit|too many requests|429|quota exceeded|try again later|temporarily unavailable)' "$log_file"
+  grep -Eiq "$AGENT_RATE_LIMIT_PATTERN" "$log_file"
 }
 
 is_session_limit_log() {
@@ -342,6 +378,59 @@ mark_paused_rate_limit() {
   update_state "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
   printf '%s\t%s\t%s\n' "$id" "$report_num" "$error_msg" > "$PAUSE_FILE"
   BATCH_PAUSED=true
+}
+
+build_claude_worker_command() {
+  local resolved_prompt="$1" prompt="$2" _id="$3"
+
+  # Preserve the existing Claude batch default for headless users.
+  # --strict-mcp-config prevents parallel workers from inheriting shared MCP
+  # servers and fighting over a single browser connection.
+  worker_command=("$AGENT_BIN" -p --dangerously-skip-permissions --strict-mcp-config)
+  if [[ -n "$MODEL" ]]; then
+    worker_command+=(--model "$MODEL")
+  fi
+  worker_command+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
+}
+
+build_codex_worker_command() {
+  local resolved_prompt="$1" prompt="$2" id="$3"
+
+  worker_stdin_file="$BATCH_DIR/.resolved-codex-${id}.md"
+  {
+    printf '%s\n\n' 'Career-ops batch worker instructions:'
+    cat "$resolved_prompt"
+    printf '\n\nTask:\n%s\n' "$prompt"
+  } > "$worker_stdin_file"
+
+  worker_command=("$AGENT_BIN" exec -C "$PROJECT_DIR")
+  if [[ "$UNSAFE_AGENT_EXEC" == "1" || "$UNSAFE_AGENT_EXEC" == "true" ]]; then
+    worker_command+=(--dangerously-bypass-approvals-and-sandbox)
+  else
+    worker_command+=(--full-auto)
+  fi
+  if [[ -n "$MODEL" ]]; then
+    worker_command+=(--model "$MODEL")
+  fi
+  worker_command+=(-)
+}
+
+run_worker() {
+  local resolved_prompt="$1" prompt="$2" log_file="$3" id="$4"
+  local -a worker_command=()
+  local worker_stdin_file=""
+  local worker_exit=0
+
+  "$AGENT_COMMAND_BUILDER" "$resolved_prompt" "$prompt" "$id"
+
+  if [[ -n "$worker_stdin_file" ]]; then
+    "${worker_command[@]}" < "$worker_stdin_file" > "$log_file" 2>&1 || worker_exit=$?
+    rm -f "$worker_stdin_file"
+  else
+    "${worker_command[@]}" > "$log_file" 2>&1 || worker_exit=$?
+  fi
+
+  return "$worker_exit"
 }
 
 reserve_report_num_unlocked() {
@@ -419,24 +508,11 @@ process_offer() {
     fi
   done
 
-  # Launch claude -p worker.
-  # Model defaults to the Claude Max subscription default unless --model was
-  # passed. Building the command in an array keeps quoting safe regardless.
-  # --strict-mcp-config (with no --mcp-config) starts workers with no MCP
-  # servers: they only evaluate offers and need none. Without it each parallel
-  # worker inherits the parent session's MCP (e.g. Playwright) and they deadlock
-  # fighting over the single shared browser when --parallel > 1 (issue #506).
-  local -a claude_args=(-p --dangerously-skip-permissions --strict-mcp-config)
-  if [[ -n "$MODEL" ]]; then
-    claude_args+=(--model "$MODEL")
-  fi
-  claude_args+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
-
   local exit_code=0
   local terminal_failure_recorded=false
   while true; do
     exit_code=0
-    claude "${claude_args[@]}" > "$log_file" 2>&1 || exit_code=$?
+    run_worker "$resolved_prompt" "$prompt" "$log_file" "$id" || exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then
       break

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -361,7 +361,7 @@ update_state() {
 
 is_rate_limit_log() {
   local log_file="$1"
-  grep -Eiq "$AGENT_RATE_LIMIT_PATTERN" "$log_file"
+  tail -40 "$log_file" 2>/dev/null | grep -Eiq "$AGENT_RATE_LIMIT_PATTERN"
 }
 
 is_session_limit_log() {

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -41,13 +41,13 @@ RATE_LIMIT_SLEEP=300
 BATCH_PAUSED=false
 STATUS_ONLY=false
 WATCH_MODE=false
-UNSAFE_AGENT_EXEC="${CAREER_OPS_UNSAFE_AGENT_EXEC:-false}"
 AGENT_BIN=""
 AGENT_COMMAND_BUILDER=""
 AGENT_RATE_LIMIT_PATTERN=""
+AGENT_UNSAFE_ENV_VAR=""
 
-# name<TAB>binary<TAB>command-builder<TAB>rate-limit-pattern
-AGENT_ADAPTERS=$'claude\tclaude\tbuild_claude_worker_command\t(rate[ _-]?limit(ed)?|too many requests|429|quota exceeded|try again later|temporarily unavailable|throttl(e|ed|ing)|temporarily at capacity|currently at capacity|model (is )?(at capacity|overloaded)|server (is )?(at capacity|overloaded)|error: (service unavailable|requests? exceeded)|status: 503|503 service unavailable)\ncodex\tcodex\tbuild_codex_worker_command\t(rate[ _-]?limit(ed)?|too many requests|429|quota exceeded|try again later|temporarily unavailable|throttl(e|ed|ing)|temporarily at capacity|currently at capacity|model (is )?(at capacity|overloaded)|server (is )?(at capacity|overloaded)|error: (service unavailable|requests? exceeded)|status: 503|503 service unavailable)'
+# name<TAB>binary<TAB>command-builder<TAB>rate-limit-pattern<TAB>unsafe-opt-in-env
+AGENT_ADAPTERS=$'claude\tclaude\tbuild_claude_worker_command\t(rate[ _-]?limit(ed)?|too many requests|429|quota exceeded|try again later|temporarily unavailable|throttl(e|ed|ing)|temporarily at capacity|currently at capacity|model (is )?(at capacity|overloaded)|server (is )?(at capacity|overloaded)|error: (service unavailable|requests? exceeded)|status: 503|503 service unavailable)\t-\ncodex\tcodex\tbuild_codex_worker_command\t(rate[ _-]?limit(ed)?|too many requests|429|quota exceeded|try again later|temporarily unavailable|throttl(e|ed|ing)|temporarily at capacity|currently at capacity|model (is )?(at capacity|overloaded)|server (is )?(at capacity|overloaded)|error: (service unavailable|requests? exceeded)|status: 503|503 service unavailable)\tCAREER_OPS_UNSAFE_AGENT_EXEC'
 
 usage() {
   cat <<'USAGE'
@@ -160,13 +160,15 @@ resolve_agent_adapter() {
   AGENT_BIN=""
   AGENT_COMMAND_BUILDER=""
   AGENT_RATE_LIMIT_PATTERN=""
+  AGENT_UNSAFE_ENV_VAR=""
 
-  local name binary builder rate_limit_pattern
-  while IFS=$'\t' read -r name binary builder rate_limit_pattern; do
+  local name binary builder rate_limit_pattern unsafe_env_var
+  while IFS=$'\t' read -r name binary builder rate_limit_pattern unsafe_env_var; do
     if [[ "$name" == "$AGENT" ]]; then
       AGENT_BIN="$binary"
       AGENT_COMMAND_BUILDER="$builder"
       AGENT_RATE_LIMIT_PATTERN="$rate_limit_pattern"
+      [[ "$unsafe_env_var" != "-" ]] && AGENT_UNSAFE_ENV_VAR="$unsafe_env_var"
       return 0
     fi
   done <<< "$AGENT_ADAPTERS"
@@ -369,6 +371,12 @@ is_session_limit_log() {
   grep -Eiq '(session limit|resets [0-9:]+[ap]m|usage limit|limit[[:space:]]+reached)' "$log_file"
 }
 
+agent_unsafe_exec_enabled() {
+  [[ -n "$AGENT_UNSAFE_ENV_VAR" ]] || return 1
+  local unsafe_value="${!AGENT_UNSAFE_ENV_VAR:-false}"
+  [[ "$unsafe_value" == "1" || "$unsafe_value" == "true" ]]
+}
+
 mark_paused_rate_limit() {
   local id="$1" url="$2" started_at="$3" report_num="$4" retries="$5" log_file="$6"
   local completed_at
@@ -404,10 +412,10 @@ build_codex_worker_command() {
   } > "$worker_stdin_file"
 
   worker_command=("$AGENT_BIN" exec -C "$PROJECT_DIR")
-  if [[ "$UNSAFE_AGENT_EXEC" == "1" || "$UNSAFE_AGENT_EXEC" == "true" ]]; then
+  if agent_unsafe_exec_enabled; then
     worker_command+=(--dangerously-bypass-approvals-and-sandbox)
   else
-    worker_command+=(--full-auto)
+    worker_command+=(--sandbox workspace-write)
   fi
   if [[ -n "$MODEL" ]]; then
     worker_command+=(--model "$MODEL")

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -71,7 +71,7 @@ node verify-pipeline.mjs     # Check pipeline integrity
 Claude headless flags, including MCP isolation, for compatibility. Set
 `CAREER_OPS_AGENT=codex` or pass `--agent codex` to run Codex CLI workers.
 Codex omits its dangerous bypass flag unless `CAREER_OPS_UNSAFE_AGENT_EXEC=1`
-is set explicitly.
+or `true` is set explicitly.
 
 ## Build Dashboard (Optional)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -65,6 +65,14 @@ node cv-sync-check.mjs      # Check configuration
 node verify-pipeline.mjs     # Check pipeline integrity
 ```
 
+## Batch Runtime
+
+`batch/batch-runner.sh` uses Claude Code by default and keeps the existing
+Claude headless flags, including MCP isolation, for compatibility. Set
+`CAREER_OPS_AGENT=codex` or pass `--agent codex` to run Codex CLI workers.
+Codex omits its dangerous bypass flag unless `CAREER_OPS_UNSAFE_AGENT_EXEC=1`
+is set explicitly.
+
 ## Build Dashboard (Optional)
 
 ```bash

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3083,6 +3083,82 @@ try {
 
 // ── 15. BATCH RUNNER MCP ISOLATION (#506) ───────────────────────
 
+// Batch Codex adapter
+
+console.log('\n14. Batch Codex adapter');
+
+try {
+  const tmp = mkdtempSync(join(tmpdir(), 'co-batch-codex-'));
+  const batchDir = join(tmp, 'batch');
+  const fakeBin = join(tmp, 'bin');
+  mkdirSync(batchDir, { recursive: true });
+  mkdirSync(join(tmp, 'reports'), { recursive: true });
+  mkdirSync(join(tmp, 'data'), { recursive: true });
+  mkdirSync(join(tmp, 'config'), { recursive: true });
+  mkdirSync(join(tmp, 'modes'), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+
+  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8'));
+  execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
+  writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
+  writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
+  writeFileSync(join(tmp, 'config', 'profile.yml'), 'target_roles:\n  - Staff Engineer\n');
+  writeFileSync(join(tmp, 'modes', '_profile.md'), '# User profile fixture\n');
+  writeFileSync(join(batchDir, 'batch-prompt.md'), 'URL={{URL}}\nJD={{JD_FILE}}\nREPORT={{REPORT_NUM}}\n');
+  writeFileSync(join(batchDir, 'batch-input.tsv'), [
+    'id\turl\tsource\tnotes',
+    '1\thttps://example.com/one?x=1&y=2\tfixture\t-',
+  ].join('\n') + '\n');
+  writeFileSync(join(fakeBin, 'codex'), [
+    '#!/usr/bin/env bash',
+    'printf "%s\\n" "$@" > "$CAPTURE_DIR/codex-args.txt"',
+    'cat > "$CAPTURE_DIR/codex-stdin.md"',
+    'printf \'{"score":4.6}\\n\'',
+    'exit 0',
+  ].join('\n') + '\n');
+  execFileSync('chmod', ['+x', join(fakeBin, 'codex')]);
+
+  const env = { ...process.env, PATH: `${fakeBin}:${process.env.PATH}`, CAPTURE_DIR: tmp };
+  const out = run('bash', [join(batchDir, 'batch-runner.sh'), '--agent', 'codex', '--parallel', '1'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const args = readFileSync(join(tmp, 'codex-args.txt'), 'utf-8');
+  const stdin = readFileSync(join(tmp, 'codex-stdin.md'), 'utf-8');
+  const state = readFileSync(join(batchDir, 'batch-state.tsv'), 'utf-8');
+  const leftovers = readdirSync(batchDir).filter(name => name.startsWith('.resolved-codex-'));
+
+  if (state.includes('\tcompleted\t') && out.includes('Completed')) {
+    pass('Codex adapter can complete a batch offer');
+  } else {
+    fail(`Codex adapter did not complete fixture offer: ${JSON.stringify({ out: out.slice(-240), state })}`);
+  }
+  const argLines = args.trim().split('\n');
+  if (argLines[0] === 'exec' && argLines.includes('-C') && argLines.includes('--full-auto') && argLines.at(-1) === '-' &&
+      !args.includes('--dangerously-bypass-approvals-and-sandbox')) {
+    pass('Codex adapter uses safe default exec arguments');
+  } else {
+    fail(`Codex adapter args wrong: ${JSON.stringify(args)}`);
+  }
+  if (stdin.includes('Runtime personalization: modes/_profile.md') &&
+      stdin.includes('Runtime personalization: config/profile.yml') &&
+      stdin.includes('Task:')) {
+    pass('Codex adapter stdin includes resolved prompt, profile context, and task');
+  } else {
+    fail('Codex adapter stdin is missing prompt/profile/task context');
+  }
+  if (leftovers.length === 0 && readFile('.gitignore').includes('batch/.resolved-codex-*')) {
+    pass('Codex adapter cleans and ignores temporary resolved prompt files');
+  } else {
+    fail(`Codex resolved prompt cleanup/ignore failed: leftovers=${leftovers.join(',')}`);
+  }
+
+  rmSync(tmp, { recursive: true, force: true });
+} catch (e) {
+  fail(`Batch Codex adapter test crashed: ${e.message}`);
+}
+
 console.log('\n15. Batch runner MCP isolation');
 
 try {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -527,6 +527,34 @@ if (profileInjectionIndex !== -1 && runWorkerIndex !== -1 && profileInjectionInd
   fail('Batch worker prompts can lose user profile context');
 }
 
+const adapterTableMatch = batchRunnerSource.match(/AGENT_ADAPTERS=\$'([^']+)'/s);
+const adapterRateLimitPatterns = adapterTableMatch
+  ? adapterTableMatch[1]
+    .split('\\n')
+    .map(row => row.split('\\t')[3])
+    .filter(Boolean)
+    .map(pattern => new RegExp(pattern, 'i'))
+  : [];
+const rateLimitSamples = [
+  '429 Too Many Requests',
+  'Error: request was throttled by the service',
+  'Codex is temporarily at capacity, try again later',
+  'model overloaded, please retry',
+  'service unavailable',
+  'monthly requests exceeded',
+];
+const nonRateLimitSamples = [
+  'Candidate has capacity to start immediately',
+  'Application completed successfully',
+];
+if (adapterRateLimitPatterns.length >= 2 &&
+    adapterRateLimitPatterns.every(pattern => rateLimitSamples.every(sample => pattern.test(sample))) &&
+    adapterRateLimitPatterns.every(pattern => nonRateLimitSamples.every(sample => !pattern.test(sample)))) {
+  pass('Batch rate-limit detection covers Codex/Claude transient capacity logs');
+} else {
+  fail('Batch rate-limit detection misses expected agent capacity logs or is too broad');
+}
+
 // ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
 console.log('\n6. Personal data leak check');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -82,7 +82,30 @@ function run(cmd, args = [], opts = {}) {
   }
 }
 
-const BASH_AVAILABLE = run('bash', ['-lc', 'printf ok'], { stdio: ['ignore', 'pipe', 'pipe'] }) === 'ok';
+function resolveBashCommand() {
+  const candidates = ['bash'];
+  if (process.platform === 'win32') {
+    candidates.push(
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+    );
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const out = execFileSync(candidate, ['-lc', 'printf ok'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30000,
+      }).trim();
+      if (out === 'ok') return candidate;
+    } catch {}
+  }
+  return null;
+}
+
+const BASH_CMD = resolveBashCommand();
+const BASH_AVAILABLE = BASH_CMD !== null;
 
 function requireBashTest(name) {
   if (BASH_AVAILABLE) return true;
@@ -98,7 +121,7 @@ function makeExecutable(path) {
   }
   if (process.platform === 'win32' && BASH_AVAILABLE) {
     try {
-      execFileSync('bash', ['-lc', `chmod +x ${JSON.stringify(toBashPath(path))}`]);
+      execFileSync(BASH_CMD, ['-lc', `chmod +x ${JSON.stringify(toBashPath(path))}`]);
     } catch {}
   }
 }
@@ -527,7 +550,9 @@ if (/worker_command=\(\s*"\$AGENT_BIN"\s+-p\s+--dangerously-skip-permissions\s+-
   fail('Batch runner changed Claude headless defaults or lost strict MCP isolation');
 }
 
-if (/if \[\[ "\$UNSAFE_AGENT_EXEC" == "1" \|\| "\$UNSAFE_AGENT_EXEC" == "true" \]\][\s\S]{0,180}worker_command\+=\(--dangerously-bypass-approvals-and-sandbox\)/.test(batchRunnerSource)) {
+if (/AGENT_ADAPTERS=\$'[^']*codex\\tcodex\\tbuild_codex_worker_command[^']*\\tCAREER_OPS_UNSAFE_AGENT_EXEC/.test(batchRunnerSource) &&
+    /agent_unsafe_exec_enabled\(\)[\s\S]*\$\{!AGENT_UNSAFE_ENV_VAR:-false\}[\s\S]*unsafe_value" == "1"[\s\S]*unsafe_value" == "true"/.test(batchRunnerSource) &&
+    /if agent_unsafe_exec_enabled; then[\s\S]{0,120}worker_command\+=\(--dangerously-bypass-approvals-and-sandbox\)/.test(batchRunnerSource)) {
   pass('Batch runner gates Codex dangerous bypass behind explicit opt-in');
 } else {
   fail('Batch runner does not gate Codex dangerous bypass correctly');
@@ -3060,7 +3085,7 @@ try {
   makeExecutable(join(fakeBin, 'claude'));
 
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}` };
-  const out = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--max-retries', '3', '--rate-limit-sleep', '0'], {
+  const out = run(BASH_CMD, [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--max-retries', '3', '--rate-limit-sleep', '0'], {
     cwd: tmp,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -3079,7 +3104,7 @@ try {
     '1\thttps://example.com/one\tpaused_rate_limit\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t001\t-\tsession-limit; paused\t0',
     '2\thttps://example.com/two\tfailed\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t002\t-\tworker-crash\t1',
   ].join('\n') + '\n');
-  const dry = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--resume-paused', '--dry-run'], {
+  const dry = run(BASH_CMD, [toBashPath(join(batchDir, 'batch-runner.sh')), '--resume-paused', '--dry-run'], {
     cwd: tmp,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -3135,7 +3160,7 @@ try {
   makeExecutable(join(fakeBin, 'codex'));
 
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, CAPTURE_DIR: tmp };
-  const out = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--agent', 'codex', '--parallel', '1'], {
+  const out = run(BASH_CMD, [toBashPath(join(batchDir, 'batch-runner.sh')), '--agent', 'codex', '--parallel', '1'], {
     cwd: tmp,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -3151,7 +3176,8 @@ try {
     fail(`Codex adapter did not complete fixture offer: ${JSON.stringify({ out: out.slice(-240), state })}`);
   }
   const argLines = args.trim().split('\n');
-  if (argLines[0] === 'exec' && argLines.includes('-C') && argLines.includes('--full-auto') && argLines.at(-1) === '-' &&
+  if (argLines[0] === 'exec' && argLines.includes('-C') &&
+      args.includes('--sandbox\nworkspace-write') && argLines.at(-1) === '-' &&
       !args.includes('--dangerously-bypass-approvals-and-sandbox')) {
     pass('Codex adapter uses safe default exec arguments');
   } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12,7 +12,7 @@
  */
 
 import { execSync, execFileSync, spawn } from 'child_process';
-import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'fs';
+import { chmodSync, readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'fs';
 import { join, dirname, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -79,6 +79,27 @@ function run(cmd, args = [], opts = {}) {
     return execSync(cmd, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
   } catch (e) {
     return null;
+  }
+}
+
+const BASH_AVAILABLE = run('bash', ['-lc', 'printf ok'], { stdio: ['ignore', 'pipe', 'pipe'] }) === 'ok';
+
+function requireBashTest(name) {
+  if (BASH_AVAILABLE) return true;
+  warn(`${name} skipped because bash is unavailable in this environment`);
+  return false;
+}
+
+function makeExecutable(path) {
+  try {
+    chmodSync(path, 0o755);
+  } catch {
+    // Windows ignores POSIX execute bits; Unix CI still gets executable fixtures.
+  }
+  if (process.platform === 'win32' && BASH_AVAILABLE) {
+    try {
+      execFileSync('bash', ['-lc', `chmod +x ${JSON.stringify(toBashPath(path))}`]);
+    } catch {}
   }
 }
 
@@ -500,7 +521,7 @@ if (/AGENT="\$\{CAREER_OPS_AGENT:-claude\}"/.test(batchRunnerSource) &&
   fail('Batch runner missing CAREER_OPS_AGENT/agent adapter table support');
 }
 
-if (batchRunnerSource.includes('worker_command=("$AGENT_BIN" -p --dangerously-skip-permissions --strict-mcp-config)')) {
+if (/worker_command=\(\s*"\$AGENT_BIN"\s+-p\s+--dangerously-skip-permissions\s+--strict-mcp-config\s*\)/.test(batchRunnerSource)) {
   pass('Batch runner preserves existing Claude headless defaults and strict MCP isolation');
 } else {
   fail('Batch runner changed Claude headless defaults or lost strict MCP isolation');
@@ -3011,6 +3032,7 @@ try {
 console.log('\n13. Batch rate-limit pause');
 
 try {
+  if (requireBashTest('Batch rate-limit pause')) {
   const tmp = mkdtempSync(join(tmpdir(), 'co-batch-rate-'));
   const batchDir = join(tmp, 'batch');
   const fakeBin = join(tmp, 'bin');
@@ -3020,11 +3042,7 @@ try {
   mkdirSync(fakeBin, { recursive: true });
 
   writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n'));
-  if (process.platform === 'win32') {
-    try { execFileSync('bash', ['-c', 'chmod +x batch/batch-runner.sh'], { cwd: tmp }); } catch {}
-  } else {
-    execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
-  }
+  makeExecutable(join(batchDir, 'batch-runner.sh'));
   writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
   writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
   writeFileSync(join(batchDir, 'batch-prompt.md'), 'URL={{URL}}\nJD={{JD_FILE}}\nREPORT={{REPORT_NUM}}\n');
@@ -3039,11 +3057,7 @@ try {
     'echo "You\\x27ve hit your session limit · resets 12:30pm (Asia/Taipei)"',
     'exit 1',
   ].join('\n') + '\n');
-  if (process.platform === 'win32') {
-    try { execFileSync('bash', ['-c', 'chmod +x bin/claude'], { cwd: tmp }); } catch {}
-  } else {
-    execFileSync('chmod', ['+x', join(fakeBin, 'claude')]);
-  }
+  makeExecutable(join(fakeBin, 'claude'));
 
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}` };
   const out = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--max-retries', '3', '--rate-limit-sleep', '0'], {
@@ -3076,7 +3090,8 @@ try {
     fail(`--resume-paused selection wrong: ${dry}`);
   }
 
-  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+  rmSync(tmp, { recursive: true, force: true });
+  }
 } catch (e) {
   fail(`Batch rate-limit pause test crashed: ${e.message}`);
 }
@@ -3088,6 +3103,7 @@ try {
 console.log('\n14. Batch Codex adapter');
 
 try {
+  if (requireBashTest('Batch Codex adapter')) {
   const tmp = mkdtempSync(join(tmpdir(), 'co-batch-codex-'));
   const batchDir = join(tmp, 'batch');
   const fakeBin = join(tmp, 'bin');
@@ -3098,8 +3114,8 @@ try {
   mkdirSync(join(tmp, 'modes'), { recursive: true });
   mkdirSync(fakeBin, { recursive: true });
 
-  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8'));
-  execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
+  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n'));
+  makeExecutable(join(batchDir, 'batch-runner.sh'));
   writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
   writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
   writeFileSync(join(tmp, 'config', 'profile.yml'), 'target_roles:\n  - Staff Engineer\n');
@@ -3116,10 +3132,10 @@ try {
     'printf \'{"score":4.6}\\n\'',
     'exit 0',
   ].join('\n') + '\n');
-  execFileSync('chmod', ['+x', join(fakeBin, 'codex')]);
+  makeExecutable(join(fakeBin, 'codex'));
 
-  const env = { ...process.env, PATH: `${fakeBin}:${process.env.PATH}`, CAPTURE_DIR: tmp };
-  const out = run('bash', [join(batchDir, 'batch-runner.sh'), '--agent', 'codex', '--parallel', '1'], {
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, CAPTURE_DIR: tmp };
+  const out = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--agent', 'codex', '--parallel', '1'], {
     cwd: tmp,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -3155,6 +3171,7 @@ try {
   }
 
   rmSync(tmp, { recursive: true, force: true });
+  }
 } catch (e) {
   fail(`Batch Codex adapter test crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -491,6 +491,42 @@ if (/local total=0 completed=0 skipped=0 failed=0 pending=0/.test(batchRunnerSou
   fail('Batch summary can misreport skipped offers as pending');
 }
 
+// Check batch runner agent-adapter invariants.
+if (/AGENT="\$\{CAREER_OPS_AGENT:-claude\}"/.test(batchRunnerSource) &&
+    /--agent\)/.test(batchRunnerSource) &&
+    /AGENT_ADAPTERS=\$'[^']*claude\\tclaude\\tbuild_claude_worker_command[^']*codex\\tcodex\\tbuild_codex_worker_command/s.test(batchRunnerSource)) {
+  pass('Batch runner selects workers through an extensible agent adapter table');
+} else {
+  fail('Batch runner missing CAREER_OPS_AGENT/agent adapter table support');
+}
+
+if (batchRunnerSource.includes('worker_command=("$AGENT_BIN" -p --dangerously-skip-permissions --strict-mcp-config)')) {
+  pass('Batch runner preserves existing Claude headless defaults and strict MCP isolation');
+} else {
+  fail('Batch runner changed Claude headless defaults or lost strict MCP isolation');
+}
+
+if (/if \[\[ "\$UNSAFE_AGENT_EXEC" == "1" \|\| "\$UNSAFE_AGENT_EXEC" == "true" \]\][\s\S]{0,180}worker_command\+=\(--dangerously-bypass-approvals-and-sandbox\)/.test(batchRunnerSource)) {
+  pass('Batch runner gates Codex dangerous bypass behind explicit opt-in');
+} else {
+  fail('Batch runner does not gate Codex dangerous bypass correctly');
+}
+
+const retryLoopMatch = batchRunnerSource.match(/while true; do[\s\S]*?run_worker "\$resolved_prompt" "\$prompt" "\$log_file" "\$id"[\s\S]*?is_rate_limit_log "\$log_file"[\s\S]*?continue[\s\S]*?done/);
+if (retryLoopMatch) {
+  pass('Batch rate-limit retry wraps the selected worker agent');
+} else {
+  fail('Batch rate-limit retry does not wrap the selected worker agent');
+}
+
+const profileInjectionIndex = batchRunnerSource.indexOf('## Runtime personalization: %s');
+const runWorkerIndex = batchRunnerSource.indexOf('run_worker "$resolved_prompt" "$prompt" "$log_file" "$id"');
+if (profileInjectionIndex !== -1 && runWorkerIndex !== -1 && profileInjectionIndex < runWorkerIndex) {
+  pass('Batch worker prompts keep user profile context before agent dispatch');
+} else {
+  fail('Batch worker prompts can lose user profile context');
+}
+
 // ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
 console.log('\n6. Personal data leak check');
@@ -3022,10 +3058,10 @@ try {
   // Workers must be spawned with --strict-mcp-config so they don't inherit the
   // parent session's MCP servers (e.g. Playwright) and deadlock fighting over a
   // single browser when --parallel > 1 (issue #506).
-  const claudeArgsLine = batchRunner
+  const claudeWorkerLine = batchRunner
     .split('\n')
-    .find(l => l.includes('claude_args=('));
-  if (claudeArgsLine && claudeArgsLine.includes('--strict-mcp-config')) {
+    .find(l => l.includes('worker_command=') && l.includes('-p'));
+  if (claudeWorkerLine && claudeWorkerLine.includes('--strict-mcp-config')) {
     pass('batch workers spawn with --strict-mcp-config (no inherited MCP)');
   } else {
     fail('batch-runner.sh worker spawn missing --strict-mcp-config (issue #506 regression)');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -540,14 +540,18 @@ const rateLimitSamples = [
   'Error: request was throttled by the service',
   'Codex is temporarily at capacity, try again later',
   'model overloaded, please retry',
-  'service unavailable',
-  'monthly requests exceeded',
+  'Error: service unavailable',
+  'Error: requests exceeded',
+  '503 Service Unavailable',
 ];
 const nonRateLimitSamples = [
   'Candidate has capacity to start immediately',
+  'Runbook includes service unavailable incident examples',
+  'Monthly requests exceeded the hiring team forecast',
   'Application completed successfully',
 ];
 if (adapterRateLimitPatterns.length >= 2 &&
+    batchRunnerSource.includes('tail -40 "$log_file"') &&
     adapterRateLimitPatterns.every(pattern => rateLimitSamples.every(sample => pattern.test(sample))) &&
     adapterRateLimitPatterns.every(pattern => nonRateLimitSamples.every(sample => !pattern.test(sample)))) {
   pass('Batch rate-limit detection covers Codex/Claude transient capacity logs');


### PR DESCRIPTION
## Context

This updates the batch runner for multi-agent dispatch while preserving the existing Claude default requested in review. It is rebased on current `main`, so the rate-limit retry loop wraps both Claude and Codex workers.

## Changes

- Add `--agent NAME` and `CAREER_OPS_AGENT` support with `claude` as the default.
- Preserve the existing Claude `claude -p --dangerously-skip-permissions --strict-mcp-config` path for current headless users.
- Add a Codex worker path using `codex exec -C $PROJECT_DIR` with stdin prompt input.
- Keep Codex safe by default with `--sandbox workspace-write`; only pass `--dangerously-bypass-approvals-and-sandbox` when `CAREER_OPS_UNSAFE_AGENT_EXEC=1` or `true` is set.
- Dispatch from an adapter table that carries the binary, command builder, rate-limit pattern, and unsafe opt-in env quirk.
- Keep user-profile context injection before agent dispatch, and keep retry/session-limit handling around the selected worker.
- Update docs and `test-all.mjs` coverage, including Windows Git Bash fallback for the batch fixtures.

The min-score fallthrough fix was split into #873 as requested.

## How to test

```bash
bash -n batch/batch-runner.sh
node test-all.mjs
cd dashboard && go test ./...
```

Verified locally on Windows. `test-all.mjs` reports the existing expected warning from `cv-sync-check.mjs` when no local user CV data is present.

## Risks / rollback

Moderate: this touches batch worker dispatch. The existing Claude default is intentionally unchanged; Codex support is opt-in via `--agent codex` or `CAREER_OPS_AGENT=codex`. Rollback is a straight revert.