### PR TITLE
feat(tracker): add canonical status updater

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -10,6 +10,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run verify` | `verify-pipeline.mjs` | Check pipeline data integrity |
 | `npm run normalize` | `normalize-statuses.mjs` | Fix non-canonical statuses |
 | `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
+| `npm run set-status` | `set-status.mjs` | Safely update one tracker row's canonical status |
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
 | `npm run pdf` | `generate-pdf.mjs` | Convert HTML to ATS-optimized PDF |
 | `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
@@ -79,6 +80,21 @@ npm run dedup -- --dry-run  # preview without writing
 Creates a `.bak` backup before writing.
 
 **Exit codes:** `0` always.
+
+---
+
+## set-status
+
+Updates one `applications.md` row's status through a canonical write path. The command resolves a row by report number, tracker number, or company/role fragment, refuses ambiguous matches, validates the target state against `templates/states.yml`, and appends an optional note without replacing existing context.
+
+```bash
+npm run set-status -- 371 Rejected --note "Rejected after R1; feedback captured"
+npm run set-status -- "Acme" Applied --dry-run
+```
+
+Creates a `.bak` backup and writes atomically. Use `--dry-run` to preview without writing.
+
+**Exit codes:** `0` update applied or no change needed, `1` invalid status, no match, ambiguous match, or missing tracker.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "verify": "node verify-pipeline.mjs",
     "normalize": "node normalize-statuses.mjs",
     "dedup": "node dedup-tracker.mjs",
+    "set-status": "node set-status.mjs",
     "merge": "node merge-tracker.mjs",
     "reconcile": "node reconcile-pipeline.mjs",
     "pdf": "node generate-pdf.mjs",

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -319,6 +319,12 @@ function main() {
   try {
     const text = readFileSync(TRACKER_PATH, 'utf-8');
     const result = updateTrackerStatus(text, args.query, args.status, args.note);
+
+    if (!args.dryRun && result.changed) {
+      copyFileSync(TRACKER_PATH, `${TRACKER_PATH}.bak`);
+      atomicWriteFile(TRACKER_PATH, result.lines.join('\n'));
+    }
+
     if (args.json) {
       console.log(JSON.stringify({
         changed: result.changed,
@@ -339,14 +345,11 @@ function main() {
       console.log(`Status: ${result.oldStatus || '-'} -> ${result.status}`);
       if (args.note) console.log(`Note: ${result.notes}`);
       if (!result.changed) console.log('No changes needed.');
-    }
-
-    if (!args.dryRun && result.changed) {
-      copyFileSync(TRACKER_PATH, `${TRACKER_PATH}.bak`);
-      atomicWriteFile(TRACKER_PATH, result.lines.join('\n'));
-      if (!args.json) console.log(`Written to ${TRACKER_PATH} (backup: ${TRACKER_PATH}.bak)`);
-    } else if (args.dryRun && !args.json) {
-      console.log('(dry-run - no changes written)');
+      if (!args.dryRun && result.changed) {
+        console.log(`Written to ${TRACKER_PATH} (backup: ${TRACKER_PATH}.bak)`);
+      } else if (args.dryRun) {
+        console.log('(dry-run - no changes written)');
+      }
     }
   } catch (err) {
     console.error(`Error: ${err.message}`);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+/**
+ * set-status.mjs - canonical status updater for data/applications.md (#1428).
+ *
+ * Usage:
+ *   node set-status.mjs <report#|tracker#|company> <CanonicalState> [--note "..."] [--dry-run]
+ *
+ * The tracker is the source of truth, so this script updates the markdown table
+ * directly while preserving its current column layout. It refuses ambiguous
+ * matches, validates statuses against templates/states.yml, and writes
+ * atomically after creating an applications.md.bak backup.
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { basename, dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
+import { roleFuzzyMatch } from './role-matcher.mjs';
+import { rebuildRow } from './tracker-utils.mjs';
+import { parseTrackerRow, resolveColumns } from './tracker-parse.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const TRACKER_PATH = process.env.CAREER_OPS_TRACKER
+  ? process.env.CAREER_OPS_TRACKER
+  : existsSync(join(ROOT, 'data/applications.md'))
+    ? join(ROOT, 'data/applications.md')
+    : join(ROOT, 'applications.md');
+const STATES_PATH = existsSync(join(ROOT, 'templates/states.yml'))
+  ? join(ROOT, 'templates/states.yml')
+  : join(ROOT, 'states.yml');
+
+/**
+ * Normalize a report/tracker number so "007" and "7" compare equal.
+ *
+ * @param {string|number|null|undefined} value - Raw numeric identifier.
+ * @returns {string} Normalized numeric string.
+ */
+function normNum(value) {
+  return String(value ?? '').trim().replace(/^0+(?=\d)/, '');
+}
+
+/**
+ * Normalize free text for loose company and role matching.
+ *
+ * @param {string} value - Raw company, role, or query text.
+ * @returns {string} Lowercase alphanumeric text with collapsed spaces.
+ */
+function normalizeText(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract the report number from a markdown report link cell.
+ *
+ * @param {string} reportCell - Raw Report column cell.
+ * @returns {string|null} Normalized report number, or null.
+ */
+function extractReportNum(reportCell) {
+  const match = String(reportCell ?? '').match(/\[(\d+)\]/);
+  return match ? normNum(match[1]) : null;
+}
+
+/**
+ * Sanitize a note before placing it in a markdown table cell.
+ *
+ * Existing tracker parsers split rows on raw pipe characters, so notes must not
+ * introduce newlines or pipes that would shift later columns.
+ *
+ * @param {string} note - Raw note from CLI args.
+ * @returns {string} Single-line table-safe note.
+ */
+function sanitizeNote(note) {
+  return String(note ?? '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\|/g, '/')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Load canonical status labels from templates/states.yml.
+ *
+ * The command accepts canonical labels and IDs case-insensitively, but always
+ * writes the canonical label. Legacy aliases are deliberately not accepted so
+ * this remains a canonical write path.
+ *
+ * @param {string} statesPath - Path to templates/states.yml.
+ * @returns {Map<string,string>} Lowercase label/id -> canonical label.
+ */
+export function loadCanonicalStatuses(statesPath = STATES_PATH) {
+  if (!existsSync(statesPath)) {
+    throw new Error(`${statesPath} not found - cannot validate statuses.`);
+  }
+  const doc = yaml.load(readFileSync(statesPath, 'utf-8'));
+  const map = new Map();
+  for (const state of doc?.states || []) {
+    if (!state?.label) continue;
+    map.set(String(state.label).toLowerCase(), state.label);
+    if (state.id) map.set(String(state.id).toLowerCase(), state.label);
+  }
+  return map;
+}
+
+/**
+ * Parse applications.md into rows with line indexes attached.
+ *
+ * @param {string} text - Full tracker markdown.
+ * @returns {{lines:string[], colmap:object, rows:Array<object>}}
+ */
+export function parseTracker(text) {
+  const lines = String(text ?? '').split('\n');
+  const colmap = resolveColumns(lines);
+  const rows = [];
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const row = parseTrackerRow(lines[lineIndex], colmap);
+    if (!row) continue;
+    rows.push({
+      ...row,
+      reportNum: extractReportNum(row.report),
+      lineIndex,
+    });
+  }
+  return { lines, colmap, rows };
+}
+
+/**
+ * Find tracker rows matching a report number, tracker number, company, or role.
+ *
+ * @param {Array<object>} rows - Parsed tracker rows.
+ * @param {string} query - User query.
+ * @returns {Array<object>} Matching rows.
+ */
+export function findRows(rows, query) {
+  const raw = String(query ?? '').trim();
+  if (!raw) return [];
+
+  if (/^\d+$/.test(raw)) {
+    const wanted = normNum(raw);
+    return rows.filter((row) =>
+      normNum(row.num) === wanted || row.reportNum === wanted);
+  }
+
+  const normalizedQuery = normalizeText(raw);
+  return rows.filter((row) => {
+    const company = normalizeText(row.company);
+    const role = normalizeText(row.role);
+    return company.includes(normalizedQuery) ||
+      role.includes(normalizedQuery) ||
+      roleFuzzyMatch(row.company, raw) ||
+      roleFuzzyMatch(row.role, raw);
+  });
+}
+
+/**
+ * Append a note without losing existing tracker context.
+ *
+ * @param {string} existing - Current Notes cell.
+ * @param {string} note - Sanitized note to append.
+ * @returns {string} Updated notes cell.
+ */
+export function appendNote(existing, note) {
+  if (!note) return existing;
+  const current = String(existing ?? '').trim();
+  if (!current || current === '\u2014' || current === '-') return note;
+  if (current.includes(note)) return current;
+  const separator = /[.!?)]$/.test(current) ? ' ' : '. ';
+  return `${current}${separator}${note}`;
+}
+
+/**
+ * Replace the matched row's status and optional note.
+ *
+ * @param {string} text - Current tracker markdown.
+ * @param {string} query - Report/tracker number or company fragment.
+ * @param {string} status - Canonical status label/id.
+ * @param {string} [note=''] - Optional note.
+ * @param {Map<string,string>} [statusMap] - From loadCanonicalStatuses().
+ * @returns {{changed:boolean, lines:string[], row:object, status:string, oldStatus:string, oldNotes:string, notes:string}}
+ */
+export function updateTrackerStatus(text, query, status, note = '', statusMap = loadCanonicalStatuses()) {
+  const canonicalStatus = statusMap.get(String(status ?? '').trim().toLowerCase());
+  if (!canonicalStatus) {
+    const allowed = [...new Set(statusMap.values())].join(', ');
+    throw new Error(`Invalid status "${status}". Use one of: ${allowed}`);
+  }
+
+  const parsed = parseTracker(text);
+  const matches = findRows(parsed.rows, query);
+  if (matches.length === 0) {
+    throw new Error(`No tracker row matches "${query}".`);
+  }
+  if (matches.length > 1) {
+    const summary = matches
+      .map((row) => `#${row.num}${row.reportNum ? ` / report ${row.reportNum}` : ''}: ${row.company} - ${row.role}`)
+      .join('\n');
+    throw new Error(`Ambiguous query "${query}" matched ${matches.length} rows:\n${summary}`);
+  }
+
+  const row = matches[0];
+  const parts = parsed.lines[row.lineIndex].split('|').map((cell) => cell.trim());
+  const oldStatus = parts[parsed.colmap.status] ?? '';
+  const oldNotes = parsed.colmap.notes != null ? (parts[parsed.colmap.notes] ?? '') : '';
+  const cleanNote = sanitizeNote(note);
+  const notes = parsed.colmap.notes != null ? appendNote(oldNotes, cleanNote) : oldNotes;
+
+  parts[parsed.colmap.status] = canonicalStatus;
+  if (cleanNote && parsed.colmap.notes == null) {
+    throw new Error('Tracker has no Notes column, so --note cannot be applied.');
+  }
+  if (parsed.colmap.notes != null) parts[parsed.colmap.notes] = notes;
+
+  const newLine = rebuildRow(parts);
+  const changed = newLine !== parsed.lines[row.lineIndex];
+  parsed.lines[row.lineIndex] = newLine;
+  return { changed, lines: parsed.lines, row, status: canonicalStatus, oldStatus, oldNotes, notes };
+}
+
+/**
+ * Atomically write a text file, cleaning up a temp file on failure.
+ *
+ * @param {string} filePath - Target path.
+ * @param {string} content - New file contents.
+ * @returns {void}
+ */
+function atomicWriteFile(filePath, content) {
+  const tmpPath = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    rmSync(tmpPath, { force: true });
+    throw err;
+  }
+}
+
+/**
+ * Parse command-line args.
+ *
+ * @param {string[]} argv - process.argv.slice(2)
+ * @returns {{help:boolean,dryRun:boolean,json:boolean,query:string,status:string,note:string}}
+ */
+function parseArgs(argv) {
+  const args = [...argv];
+  const parsed = { help: false, dryRun: false, json: false, query: '', status: '', note: '' };
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--note') {
+      if (i + 1 >= args.length) throw new Error('--note requires a value.');
+      parsed.note = args[++i];
+    } else if (arg.startsWith('--note=')) {
+      parsed.note = arg.slice('--note='.length);
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+  parsed.query = positional[0] ?? '';
+  parsed.status = positional.slice(1).join(' ').trim();
+  return parsed;
+}
+
+function printUsage() {
+  console.log(`Usage: node set-status.mjs <report#|tracker#|company> <CanonicalState> [--note "..."] [--dry-run] [--json]
+
+Examples:
+  node set-status.mjs 371 Rejected --note "Rejected after R1; feedback captured"
+  node set-status.mjs "Acme" Applied --dry-run
+
+Statuses come from templates/states.yml and are written as canonical labels.`);
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  if (!args.query || !args.status) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!existsSync(TRACKER_PATH)) {
+    console.error(`Error: ${TRACKER_PATH} not found - nothing to update.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const text = readFileSync(TRACKER_PATH, 'utf-8');
+    const result = updateTrackerStatus(text, args.query, args.status, args.note);
+    if (args.json) {
+      console.log(JSON.stringify({
+        changed: result.changed,
+        trackerPath: resolve(TRACKER_PATH),
+        row: {
+          num: result.row.num,
+          reportNum: result.row.reportNum,
+          company: result.row.company,
+          role: result.row.role,
+        },
+        oldStatus: result.oldStatus,
+        status: result.status,
+        notes: result.notes,
+        dryRun: args.dryRun,
+      }, null, 2));
+    } else {
+      console.log(`#${result.row.num}: ${result.row.company} - ${result.row.role}`);
+      console.log(`Status: ${result.oldStatus || '-'} -> ${result.status}`);
+      if (args.note) console.log(`Note: ${result.notes}`);
+      if (!result.changed) console.log('No changes needed.');
+    }
+
+    if (!args.dryRun && result.changed) {
+      copyFileSync(TRACKER_PATH, `${TRACKER_PATH}.bak`);
+      atomicWriteFile(TRACKER_PATH, result.lines.join('\n'));
+      if (!args.json) console.log(`Written to ${TRACKER_PATH} (backup: ${TRACKER_PATH}.bak)`);
+    } else if (args.dryRun && !args.json) {
+      console.log('(dry-run - no changes written)');
+    }
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main();
+}

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -183,6 +183,7 @@ const scripts = [
   // tests inside their active career-ops workspace.
   { name: 'normalize-statuses.mjs --dry-run', expectExit: 0 },
   { name: 'dedup-tracker.mjs --dry-run', expectExit: 0 },
+  { name: 'set-status.mjs --help', expectExit: 0 },
   { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
@@ -4292,6 +4293,104 @@ try {
   }
 } catch (e) {
   fail(`find.mjs unit test crashed: ${e.message}`);
+}
+
+// #1428: agents were hand-editing applications.md to move rows through
+// Applied/Rejected/etc., which is fragile once trackers grow and columns drift.
+// set-status.mjs is the canonical write path: header-aware, status-validated,
+// ambiguity-safe, and note-preserving.
+console.log('\n🧪 Testing set-status.mjs canonical tracker updates...');
+try {
+  const statusTmp = mkdtempSync(join(tmpdir(), 'career-ops-set-status-'));
+  try {
+    mkdirSync(join(statusTmp, 'data'));
+    const tracker = join(statusTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|----------|-------|--------|-----|--------|-------|\n' +
+      '| 7 | 2026-06-01 | Acme Labs | Platform Product Manager | London | 4.2/5 | Evaluated | ❌ | [142](reports/142-acme-labs-2026-06-01.md) | Warm lead |\n' +
+      '| 8 | 2026-06-02 | Fabrikam | Data Product Manager | Remote | 3.6/5 | Evaluated | ❌ | [143](reports/143-fabrikam-2026-06-02.md) | — |\n');
+
+    const okRun = run(NODE, ['set-status.mjs', '142', 'Applied', '--note', 'Applied | via ATS'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker },
+    });
+    if (okRun === null) {
+      fail('set-status.mjs crashed on a valid report-number update');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+      const acme = out.split('\n').find(l => l.includes('| 7 |'));
+      if (acme && acme.includes('| London | 4.2/5 | Applied |') &&
+          acme.includes('Warm lead. Applied / via ATS') &&
+          existsSync(`${tracker}.bak`)) {
+        pass('set-status.mjs updates by report#, preserves inserted columns, appends notes, and writes a backup');
+      } else {
+        fail(`set-status.mjs wrote the wrong row/content: "${acme}"`);
+      }
+    }
+
+    const dryRun = run(NODE, ['set-status.mjs', 'fabrikam', 'Rejected', '--dry-run', '--json'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker },
+    });
+    const afterDryRun = readFileSync(tracker, 'utf-8');
+    if (dryRun !== null && JSON.parse(dryRun).dryRun === true && afterDryRun.includes('| 8 | 2026-06-02 | Fabrikam | Data Product Manager | Remote | 3.6/5 | Evaluated |')) {
+      pass('set-status.mjs supports dry-run JSON output without modifying applications.md');
+    } else {
+      fail('set-status.mjs dry-run changed the tracker or emitted invalid JSON');
+    }
+
+    let invalidRejected = false;
+    try {
+      execFileSync(NODE, ['set-status.mjs', '143', 'Sent'], {
+        cwd: ROOT,
+        env: { ...process.env, CAREER_OPS_TRACKER: tracker },
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch {
+      invalidRejected = true;
+    }
+    if (invalidRejected && readFileSync(tracker, 'utf-8').includes('| 8 | 2026-06-02 | Fabrikam | Data Product Manager | Remote | 3.6/5 | Evaluated |')) {
+      pass('set-status.mjs rejects non-canonical statuses and leaves the tracker untouched');
+    } else {
+      fail('set-status.mjs accepted a non-canonical status or mutated the tracker after rejection');
+    }
+  } finally {
+    rmSync(statusTmp, { recursive: true, force: true });
+  }
+
+  const ambiguousTmp = mkdtempSync(join(tmpdir(), 'career-ops-set-status-ambiguous-'));
+  try {
+    mkdirSync(join(ambiguousTmp, 'data'));
+    const tracker = join(ambiguousTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 7 | 2026-06-01 | Acme Labs | Platform Product Manager | 4.2/5 | Evaluated | ❌ | [12](reports/012-acme-labs-2026-06-01.md) | — |\n' +
+      '| 12 | 2026-06-02 | Globex | Data Product Manager | 3.6/5 | Evaluated | ❌ | [13](reports/013-globex-2026-06-02.md) | — |\n');
+    const before = readFileSync(tracker, 'utf-8');
+    let ambiguousRejected = false;
+    try {
+      execFileSync(NODE, ['set-status.mjs', '12', 'Applied'], {
+        cwd: ROOT,
+        env: { ...process.env, CAREER_OPS_TRACKER: tracker },
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch {
+      ambiguousRejected = true;
+    }
+    if (ambiguousRejected && readFileSync(tracker, 'utf-8') === before) {
+      pass('set-status.mjs refuses ambiguous report#/tracker# collisions without writing');
+    } else {
+      fail('set-status.mjs did not fail closed on an ambiguous numeric query');
+    }
+  } finally {
+    rmSync(ambiguousTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`set-status.mjs regression tests crashed: ${e.message}`);
 }
 
 // dedup-tracker reads AND writes by column; with a Location column its status

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -22,6 +22,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
 const QUICK = process.argv.includes('--quick');
 const NODE = process.execPath;
+const CHILD_TIMEOUT_MS = 30000;
 
 let passed = 0;
 let failed = 0;
@@ -75,9 +76,9 @@ function warn(msg) { console.log(`  ⚠️  ${msg}`); warnings++; }
 function run(cmd, args = [], opts = {}) {
   try {
     if (Array.isArray(args) && args.length > 0) {
-      return execFileSync(cmd, args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
+      return execFileSync(cmd, args, { cwd: ROOT, encoding: 'utf-8', timeout: CHILD_TIMEOUT_MS, ...opts }).trim();
     }
-    return execSync(cmd, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
+    return execSync(cmd, { cwd: ROOT, encoding: 'utf-8', timeout: CHILD_TIMEOUT_MS, ...opts }).trim();
   } catch (e) {
     return null;
   }
@@ -183,7 +184,6 @@ const scripts = [
   // tests inside their active career-ops workspace.
   { name: 'normalize-statuses.mjs --dry-run', expectExit: 0 },
   { name: 'dedup-tracker.mjs --dry-run', expectExit: 0 },
-  { name: 'set-status.mjs --help', expectExit: 0 },
   { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
@@ -213,6 +213,34 @@ for (const { name, allowFail } of scripts) {
   } else {
     fail(`${name} crashed`);
   }
+}
+
+const missingStatusTmp = mkdtempSync(join(tmpdir(), 'career-ops-set-status-missing-'));
+try {
+  const missingTracker = join(missingStatusTmp, 'data', 'applications.md');
+  let rejected = false;
+  let stderr = '';
+  try {
+    execFileSync(NODE, ['set-status.mjs', '1', 'Applied'], {
+      cwd: ROOT,
+      env: { ...process.env, CAREER_OPS_TRACKER: missingTracker },
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: CHILD_TIMEOUT_MS,
+    });
+  } catch (err) {
+    rejected = true;
+    stderr = String(err.stderr || '');
+  }
+  if (rejected &&
+      stderr.includes('not found - nothing to update.') &&
+      !stderr.includes('\n    at ')) {
+    pass('set-status.mjs reports missing applications.md cleanly');
+  } else {
+    fail(`set-status.mjs missing-tracker path was not graceful: ${stderr.trim() || 'no stderr'}`);
+  }
+} finally {
+  rmSync(missingStatusTmp, { recursive: true, force: true });
 }
 
 // ── 3. LIVENESS CLASSIFICATION ──────────────────────────────────
@@ -4346,6 +4374,7 @@ try {
         env: { ...process.env, CAREER_OPS_TRACKER: tracker },
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: CHILD_TIMEOUT_MS,
       });
     } catch {
       invalidRejected = true;
@@ -4377,6 +4406,7 @@ try {
         env: { ...process.env, CAREER_OPS_TRACKER: tracker },
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: CHILD_TIMEOUT_MS,
       });
     } catch {
       ambiguousRejected = true;

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -117,6 +117,7 @@ const SYSTEM_PATHS = [
   'verify-pipeline.mjs',
   'reconcile-pipeline.mjs',
   'dedup-tracker.mjs',
+  'set-status.mjs',
   'add-entry.mjs',
   'role-matcher.mjs',
   'tracker-utils.mjs',


### PR DESCRIPTION
## What does this PR do?

Adds `set-status.mjs`, a canonical CLI write path for updating one `applications.md` row's status and optional note without hand-editing the tracker table.

The script resolves a row by tracker number, report number, or company/role fragment; refuses ambiguous matches; validates target statuses against `templates/states.yml`; preserves custom tracker columns; appends optional notes safely; creates a `.bak`; and writes atomically.

## Related issue

Fixes #1428

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Verification

- `node validate-system-paths-coverage.mjs`
- `node test-all.mjs` -> `1240 passed, 0 failed, 0 warnings` in the working checkout
- Fresh clone verification against upstream main + this patch:
  - `npm install` -> `0 vulnerabilities`
  - `node validate-system-paths-coverage.mjs`
  - `node test-all.mjs` -> `1239 passed, 0 failed, 1 warning`

Fresh clone warning was the expected no-user-data `cv-sync-check.mjs` warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `set-status` command to update a single tracker entry’s canonical status and optionally append a note.
  * Includes preview (`--dry-run`), JSON diff output (`--json`), and safe atomic updates with backup creation.

* **Documentation**
  * Updated the Scripts Reference to include `npm run set-status`, including behavior, validation rules, exit codes, and edge-case handling.

* **Tests**
  * Added regression coverage for missing tracker files, correct row updates (including preserving other columns), dry-run non-mutation, invalid status rejection, and ambiguity handling.

* **Chores**
  * Registered the new command for system-layer processing/validation and rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->