### PR TITLE
Add big tech and UN job sources

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -8,6 +8,7 @@ are shared helpers and are not loaded as providers.
 | --- | --- | --- |
 | 4 Day Week | API | Reads the public `https://4dayweek.io/api/jobs` JSON feed (4-day-week / reduced-hours roles). Configure with `provider: 4dayweek`; paginates `?page=N` up to `max_pages` (default 3), drops expired postings, then scanner filters apply. |
 | Amazon / AWS | API | Auto-detects `amazon.jobs` careers URLs and queries the public amazon.jobs search API. The board is one global endpoint, so narrow it with an `amazon:` config block (`loc_query`, `base_query`, `category`, …) whose keys pass through as query params. Configure with `provider: amazon`. |
+| Apple Jobs | Parser | Parses public `jobs.apple.com/en-us/search` results. Configure with `provider: apple-careers` and optional `apple.search` / `apple.sort` values. |
 | Arbeitnow | API | Reads the public `https://www.arbeitnow.com/api/job-board-api` JSON feed (EU/DACH-heavy, newest-first). Configure with `provider: arbeitnow`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | Arbeitsagentur | API | Uses the public Bundesagentur fuer Arbeit Jobsuche REST API. Configure with `provider: arbeitsagentur`; title, location, and dedup filters run after fetch. |
 | Ashby | API | Auto-detects `https://jobs.ashbyhq.com/<slug>` boards and uses Ashby's public posting API. |
@@ -17,6 +18,7 @@ are shared helpers and are not loaded as providers.
 | Comeet / Spark Hire Recruit | API | Uses Comeet's public careers API. Provide the full API URL with `api:` or `careers_url`; it cannot derive the endpoint from a branded careers page. |
 | Get on Board | API | Reads the public `https://www.getonbrd.com/api/v0/categories/programming/jobs` JSON:API feed (remote/LatAm-heavy tech roles). Configure with `provider: getonbrd`; paginates `?page=N` up to `max_pages` (default 3) over the programming category (`expand[]=company`), then scanner filters apply. |
 | Glints | API | Uses Glints' public GraphQL job search endpoint. Configure with `provider: glints`; query and filters can be set on the portal entry. |
+| Google Careers | Parser | Parses public Google Careers search results at `www.google.com/about/careers/applications/jobs/results/`. Configure with `provider: google-careers` and optional `google.query`. |
 | Greenhouse | API | Handles explicit `api:` URLs and auto-detects public Greenhouse board URLs for the boards API. |
 | HigherEdJobs | RSS | Reads the public `https://www.higheredjobs.com/rss/categoryFeed.cfm?catID={catID}` feed and parses it in-process. Configure with `provider: higheredjobs` and optional `cat_id` (default 68 = Higher Education). Not auto-detected — requires explicit `provider:` config. |
 | IBM Careers | API | Posts to IBM's public careers search API and supports optional IBM facet filters in the portal entry. |
@@ -25,6 +27,7 @@ are shared helpers and are not loaded as providers.
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
 | Lever | API | Auto-detects `https://jobs.(eu.)?lever.co/<slug>` boards and uses Lever's public postings endpoint. |
 | Local parser | Parser | Runs an in-repo parser command from `portals.yml`. Use this for stable SSR or HTML pages that need a custom extractor. |
+| Microsoft Careers | API | Reads the public Eightfold PCS search API behind `jobs.careers.microsoft.com/global/en/search`. Configure with `provider: microsoft-careers` and optional `microsoft.query`. |
 | NoDesk | RSS | Reads the public `https://nodesk.co/remote-jobs/index.xml` feed and parses it in-process. Configure with `provider: nodesk`. |
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |
 | Pinpoint | API | Auto-detects `<slug>.pinpointhq.com` boards and reads the public zero-auth `/postings.json` per-tenant feed. |
@@ -37,10 +40,26 @@ are shared helpers and are not loaded as providers.
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
 | Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. For a branded careers domain, set `provider: teamtailor` and it reads `/jobs.rss` off that host. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags, falling back to `Remote` when a posting carries no `tt:city`/`tt:country` but its `remoteStatus` is remote (`fully` or `temporary`). |
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
+| UN Careers | API | Reads the public `careers.un.org/api/public/opening/jo/activeJo` active job openings feed. Configure with `provider: un-careers` and optional `un.language`. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |
 | Workday | API | Auto-detects `<tenant>.<instance>.myworkdayjobs.com[/<locale>]/<site>` careers URLs and posts to the public CXS jobs endpoint; paginates via offset up to `max_pages` (default 100), warning if a tenant's postings exceed the cap. |
 | Working Nomads | API | Reads the board-wide `https://www.workingnomads.com/api/exposed_jobs/` JSON feed, then applies scanner filters. |
+| YC Work at a Startup | Parser | Parses the public embedded `data-page` payload from `ycombinator.com/jobs`. Configure with `provider: yc-jobs`; scanner filters decide which startup roles are relevant. |
+
+## WebSearch Handoff Sources
+
+Some popular boards and employer pages are intentionally configured as
+`search_queries` or `scan_method: websearch` entries instead of direct scrapers.
+Career-Ops uses those queries as agent/WebSearch workflow inputs, then applies
+the normal Playwright liveness verification before any application decision.
+
+The mixed source pack includes these handoff-only sources:
+
+- Meta Careers, when no stable public no-auth feed is configured.
+- LinkedIn Jobs.
+- Indeed.
+- Welcome to the Jungle / Otta.
 
 When adding a new provider, add a new non-helper module under `providers/` and
 update this table in the same PR.

--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -8,6 +8,7 @@ are shared helpers and are not loaded as providers.
 | --- | --- | --- |
 | 4 Day Week | API | Reads the public `https://4dayweek.io/api/jobs` JSON feed (4-day-week / reduced-hours roles). Configure with `provider: 4dayweek`; paginates `?page=N` up to `max_pages` (default 3), drops expired postings, then scanner filters apply. |
 | Amazon / AWS | API | Auto-detects `amazon.jobs` careers URLs and queries the public amazon.jobs search API. The board is one global endpoint, so narrow it with an `amazon:` config block (`loc_query`, `base_query`, `category`, …) whose keys pass through as query params. Configure with `provider: amazon`. |
+| Adzuna | API | Uses the official Adzuna Jobs API. Configure with `provider: adzuna` and an `adzuna:` block (`country`, `what`, `where`, `results_per_page`). Requires `ADZUNA_APP_ID` and `ADZUNA_APP_KEY`, so example entries are disabled by default. |
 | Apple Jobs | Parser | Parses public `jobs.apple.com/en-us/search` results. Configure with `provider: apple-careers` and optional `apple.search` / `apple.sort` values. |
 | Arbeitnow | API | Reads the public `https://www.arbeitnow.com/api/job-board-api` JSON feed (EU/DACH-heavy, newest-first). Configure with `provider: arbeitnow`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | Arbeitsagentur | API | Uses the public Bundesagentur fuer Arbeit Jobsuche REST API. Configure with `provider: arbeitsagentur`; title, location, and dedup filters run after fetch. |
@@ -16,14 +17,18 @@ are shared helpers and are not loaded as providers.
 | BambooHR | API | Auto-detects `<tenant>.bamboohr.com` careers pages, reads `/careers/list`, and follows public detail endpoints for job URLs. |
 | Breezy HR | API | Auto-detects `<tenant>.breezy.hr` boards and reads the public JSON position feed. |
 | Comeet / Spark Hire Recruit | API | Uses Comeet's public careers API. Provide the full API URL with `api:` or `careers_url`; it cannot derive the endpoint from a branded careers page. |
+| EURES | API | Guarded EURES provider for European Employment Services search responses. Configure with `provider: eures`; examples are disabled by default because the public endpoint shape should be verified before enabling. |
 | Get on Board | API | Reads the public `https://www.getonbrd.com/api/v0/categories/programming/jobs` JSON:API feed (remote/LatAm-heavy tech roles). Configure with `provider: getonbrd`; paginates `?page=N` up to `max_pages` (default 3) over the programming category (`expand[]=company`), then scanner filters apply. |
 | Glints | API | Uses Glints' public GraphQL job search endpoint. Configure with `provider: glints`; query and filters can be set on the portal entry. |
 | Google Careers | Parser | Parses public Google Careers search results at `www.google.com/about/careers/applications/jobs/results/`. Configure with `provider: google-careers` and optional `google.query`. |
 | Greenhouse | API | Handles explicit `api:` URLs and auto-detects public Greenhouse board URLs for the boards API. |
+| Gupy | API | Uses a configurable Gupy jobs API response shape for Brazil/LatAm ATS postings. Configure with `provider: gupy`; examples require `GUPY_API_TOKEN` unless a public tenant endpoint is explicitly configured with `requires_token: false`. |
 | HigherEdJobs | RSS | Reads the public `https://www.higheredjobs.com/rss/categoryFeed.cfm?catID={catID}` feed and parses it in-process. Configure with `provider: higheredjobs` and optional `cat_id` (default 68 = Higher Education). Not auto-detected — requires explicit `provider:` config. |
 | IBM Careers | API | Posts to IBM's public careers search API and supports optional IBM facet filters in the portal entry. |
+| iCIMS Job Portal | API | Uses a configured official iCIMS Job Portal API endpoint. Configure per company with `provider: icims` and `api:`; requires `ICIMS_USERNAME` and `ICIMS_PASSWORD` unless a tenant explicitly supports no-auth access. |
 | JibeApply | API | Auto-detects `https://<slug>.jibeapply.com/jobs` careers URLs (rewriting `/jobs` to the public `/api/jobs` endpoint); paginates `?page=N` up to `max_pages` (default 50), warning if a tenant's postings exceed the cap. Also supports branded/iCIMS-hosted sites at their own `/jobs` path via an explicit `provider: jibeapply` + `api:` URL. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
+| Jooble | API | Uses Jooble's REST API with a POST search body. Configure with `provider: jooble` and a `jooble:` block (`keywords`, `location`). Requires `JOOBLE_API_KEY`, so example entries are disabled by default. |
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
 | Lever | API | Auto-detects `https://jobs.(eu.)?lever.co/<slug>` boards and uses Lever's public postings endpoint. |
 | Local parser | Parser | Runs an in-repo parser command from `portals.yml`. Use this for stable SSR or HTML pages that need a custom extractor. |
@@ -32,6 +37,7 @@ are shared helpers and are not loaded as providers.
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |
 | Pinpoint | API | Auto-detects `<slug>.pinpointhq.com` boards and reads the public zero-auth `/postings.json` per-tenant feed. |
 | Recruitee | API | Auto-detects `<slug>.recruitee.com` boards and uses the public per-tenant offers API. |
+| Reed.co.uk | API | Uses Reed's official Jobseeker API. Configure with `provider: reed` and a `reed:` block (`keywords`, `locationName`, `resultsToTake`). Requires `REED_API_KEY`, so example entries are disabled by default. |
 | RemoteOK | API | Reads the board-wide `https://remoteok.com/api` JSON feed; scanner filters decide which rows are relevant. |
 | Remotive | API | Reads the board-wide `https://remotive.com/api/remote-jobs` JSON feed, then applies local scanner filters. |
 | Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
@@ -40,6 +46,7 @@ are shared helpers and are not loaded as providers.
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
 | Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. For a branded careers domain, set `provider: teamtailor` and it reads `/jobs.rss` off that host. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags, falling back to `Remote` when a posting carries no `tt:city`/`tt:country` but its `remoteStatus` is remote (`fully` or `temporary`). |
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
+| USAJOBS | API | Uses the official USAJOBS search API. Configure with `provider: usajobs` and a `usajobs:` block (`keyword`, `location`, `remote`). Requires `USAJOBS_USER_AGENT` and `USAJOBS_API_KEY`, so example entries are disabled by default. |
 | UN Careers | API | Reads the public `careers.un.org/api/public/opening/jo/activeJo` active job openings feed. Configure with `provider: un-careers` and optional `un.language`. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |
@@ -60,6 +67,25 @@ The mixed source pack includes these handoff-only sources:
 - LinkedIn Jobs.
 - Indeed.
 - Welcome to the Jungle / Otta.
+- ZipRecruiter.
+- Dice.
+- Built In.
+- Wellfound.
+- Glassdoor.
+- FlexJobs.
+- Monster / CareerBuilder.
+
+## Keyed Provider Sources
+
+The expanded source pack also includes keyed/provider-first sources that are
+safe to keep disabled until credentials are present:
+
+- USAJOBS: `USAJOBS_USER_AGENT`, `USAJOBS_API_KEY`.
+- Adzuna: `ADZUNA_APP_ID`, `ADZUNA_APP_KEY`.
+- Reed.co.uk: `REED_API_KEY`.
+- Jooble: `JOOBLE_API_KEY`.
+- Gupy: `GUPY_API_TOKEN` unless a configured tenant endpoint is public.
+- iCIMS: per-company `api:` plus `ICIMS_USERNAME` / `ICIMS_PASSWORD`, unless a tenant explicitly supports no-auth access.
 
 When adding a new provider, add a new non-helper module under `providers/` and
 update this table in the same PR.

--- a/providers/adzuna.mjs
+++ b/providers/adzuna.mjs
@@ -1,0 +1,78 @@
+const DEFAULT_RESULTS_PER_PAGE = 50;
+
+function cfg(entry = {}) {
+  return entry.adzuna || entry.config || {};
+}
+
+function requiredCredentials(entry) {
+  const config = cfg(entry);
+  const appId = config.app_id || config.appId || process.env.ADZUNA_APP_ID;
+  const appKey = config.app_key || config.appKey || process.env.ADZUNA_APP_KEY;
+  if (!appId || !appKey) {
+    throw new Error('adzuna: missing ADZUNA_APP_ID or ADZUNA_APP_KEY');
+  }
+  return { appId, appKey };
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'api.adzuna.com') {
+    throw new Error(`adzuna: untrusted API URL: ${url}`);
+  }
+  return parsed;
+}
+
+export function buildAdzunaUrl(entry = {}, page = 1) {
+  const config = cfg(entry);
+  const { appId, appKey } = requiredCredentials(entry);
+  const country = String(config.country || entry.country || 'us').toLowerCase();
+  const url = trustedApiUrl(config.api || entry.api || `https://api.adzuna.com/v1/api/jobs/${country}/search/${page}`);
+  const what = config.what || config.keyword || config.query || entry.query;
+  const where = config.where || config.location || entry.location;
+  const resultsPerPage = config.results_per_page || config.resultsPerPage || DEFAULT_RESULTS_PER_PAGE;
+
+  url.searchParams.set('app_id', appId);
+  url.searchParams.set('app_key', appKey);
+  url.searchParams.set('results_per_page', String(resultsPerPage));
+  url.searchParams.set('content-type', 'application/json');
+  if (what) url.searchParams.set('what', what);
+  if (where) url.searchParams.set('where', where);
+  if (config.remote === true) url.searchParams.set('full_time', '1');
+
+  return url.toString();
+}
+
+export function parseAdzunaResponse(json, entry = {}) {
+  const rows = json?.results || json?.jobs || [];
+  if (!Array.isArray(rows)) return [];
+
+  return rows.map((row) => ({
+    title: row.title || '',
+    url: row.redirect_url || row.url || '',
+    company: row.company?.display_name || row.company_name || entry.name || 'Adzuna',
+    location: row.location?.display_name || row.location || '',
+    postedAt: row.created || row.postedAt || null,
+  })).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? cfg(entry).max_pages ?? 1;
+  const jobs = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const json = await ctx.fetchJson(buildAdzunaUrl(entry, page), { redirect: 'error' });
+    const pageJobs = parseAdzunaResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+
+  return jobs;
+}
+
+export default {
+  id: 'adzuna',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/apple-careers.mjs
+++ b/providers/apple-careers.mjs
@@ -1,0 +1,126 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Apple Jobs provider - parses the public server-rendered search results.
+
+const BASE_URL = 'https://jobs.apple.com/en-us/search';
+
+const ENTITY_MAP = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  nbsp: ' ',
+};
+
+function decodeEntities(value = '') {
+  return String(value)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&([a-z]+);/gi, (m, name) => ENTITY_MAP[name] || m);
+}
+
+function cleanText(value = '') {
+  return decodeEntities(String(value).replace(/<[^>]+>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function firstMatch(source, re) {
+  const m = re.exec(source);
+  return m ? m[1] : '';
+}
+
+function toEpochMs(raw) {
+  if (!raw) return undefined;
+  const parsed = Date.parse(cleanText(raw));
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function resolveJobUrl(rawHref) {
+  try {
+    return new URL(decodeEntities(rawHref), BASE_URL).href;
+  } catch {
+    return '';
+  }
+}
+
+/** @param {import('./_types.js').PortalEntry & {apple?: Record<string, unknown>}} entry */
+export function buildAppleCareersUrl(entry = {}) {
+  const cfg = entry.apple && typeof entry.apple === 'object' ? entry.apple : {};
+  const search = cfg.search ?? cfg.query ?? entry.query ?? entry.search ?? '';
+  const sort = cfg.sort ?? 'relevance';
+  const url = new URL(BASE_URL);
+  if (search) url.searchParams.set('search', String(search));
+  if (sort) url.searchParams.set('sort', String(sort));
+  return url.href;
+}
+
+/** @param {string} html */
+export function parseAppleCareersHtml(html) {
+  if (typeof html !== 'string' || !html.trim()) return [];
+  const matches = [];
+  const linkRe = /<a\b[^>]*href=["']([^"']*\/en-us\/details\/[^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  let match;
+  while ((match = linkRe.exec(html))) {
+    matches.push({
+      index: match.index,
+      end: linkRe.lastIndex,
+      href: match[1],
+      titleHtml: match[2],
+    });
+  }
+
+  const jobs = [];
+  const seen = new Set();
+  for (let i = 0; i < matches.length; i++) {
+    const item = matches[i];
+    const nextIndex = matches[i + 1]?.index ?? html.length;
+    const context = html.slice(item.index, nextIndex);
+    const title = cleanText(item.titleHtml);
+    const url = resolveJobUrl(item.href);
+    if (!title || !url || seen.has(url)) continue;
+    seen.add(url);
+
+    const location = cleanText(firstMatch(context, /<span\b[^>]*id=["']search-store-name-container-[^"']*["'][^>]*>([\s\S]*?)<\/span>/i));
+    const postedAt = toEpochMs(firstMatch(context, /<span\b[^>]*class=["'][^"']*\bjob-posted-date\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i));
+
+    const job = {
+      title,
+      url,
+      company: 'Apple',
+      location,
+    };
+    if (postedAt !== undefined) job.postedAt = postedAt;
+    jobs.push(job);
+  }
+
+  return jobs;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'apple-careers',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    try {
+      const parsed = new URL(url);
+      if (parsed.host.toLowerCase() === 'jobs.apple.com' && parsed.pathname.startsWith('/en-us/search')) {
+        return { url };
+      }
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const html = await ctx.fetchText(buildAppleCareersUrl(entry), { redirect: 'error' });
+    return parseAppleCareersHtml(html).map((job) => ({
+      ...job,
+      company: entry.name || job.company,
+    }));
+  },
+};

--- a/providers/eures.mjs
+++ b/providers/eures.mjs
@@ -1,0 +1,110 @@
+const DEFAULT_API = 'https://europa.eu/eures/eures-apps/searchengine/page/jv-search/search';
+const DETAILS_BASE = 'https://europa.eu/eures/portal/jv-se/jv-details';
+
+function cfg(entry = {}) {
+  return entry.eures || entry.config || {};
+}
+
+function rowsFrom(json) {
+  if (Array.isArray(json)) return json;
+  if (Array.isArray(json?.jobs)) return json.jobs;
+  if (Array.isArray(json?.results)) return json.results;
+  if (Array.isArray(json?.items)) return json.items;
+  if (Array.isArray(json?.content)) return json.content;
+  if (Array.isArray(json?.data)) return json.data;
+  if (Array.isArray(json?.data?.items)) return json.data.items;
+  if (Array.isArray(json?.data?.content)) return json.data.content;
+  return [];
+}
+
+function value(row, names) {
+  for (const name of names) {
+    if (row?.[name] !== undefined && row[name] !== null) return row[name];
+  }
+  return '';
+}
+
+function locationValue(row) {
+  const location = value(row, ['location', 'jobLocation', 'workLocation']);
+  if (typeof location === 'string') return location;
+  if (location && typeof location === 'object') {
+    return [location.city, location.region, location.country, location.countryCode].filter(Boolean).join(', ');
+  }
+  return [row.city, row.region, row.country, row.countryCode].filter(Boolean).join(', ');
+}
+
+function jobUrl(row) {
+  const direct = value(row, ['url', 'jobUrl', 'detailsUrl', 'link']);
+  if (direct) return direct;
+  const id = value(row, ['id', 'jobId', 'reference']);
+  return id ? `${DETAILS_BASE}/${encodeURIComponent(id)}` : '';
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || (parsed.hostname !== 'europa.eu' && !parsed.hostname.endsWith('.europa.eu'))) {
+    throw new Error(`eures: untrusted API URL: ${url}`);
+  }
+  return parsed;
+}
+
+export function buildEuresUrl(entry = {}, page = 1) {
+  const config = cfg(entry);
+  const url = trustedApiUrl(config.api || entry.api || DEFAULT_API);
+  if ((config.method || 'POST').toUpperCase() === 'GET') {
+    const query = config.query || config.keyword || entry.query;
+    if (query) url.searchParams.set(config.query_param || 'keywords', query);
+    url.searchParams.set(config.page_param || 'page', String(page));
+    url.searchParams.set(config.size_param || 'size', String(config.size || config.page_size || 50));
+  }
+  return url.toString();
+}
+
+export function buildEuresBody(entry = {}, page = 1) {
+  const config = cfg(entry);
+  return {
+    keywords: config.keywords || config.keyword || config.query || entry.query || '',
+    locationCodes: config.locationCodes || config.location_codes || [],
+    page,
+    size: config.size || config.page_size || 50,
+    ...(config.body && typeof config.body === 'object' ? config.body : {}),
+  };
+}
+
+export function parseEuresResponse(json, entry = {}) {
+  return rowsFrom(json).map((row) => ({
+    title: value(row, ['title', 'jobTitle', 'positionTitle', 'name']),
+    url: jobUrl(row),
+    company: value(row, ['company', 'companyName', 'employerName']) || entry.name || 'EURES',
+    location: locationValue(row),
+    postedAt: value(row, ['postedAt', 'postedDate', 'publicationDate', 'createdAt']) || null,
+  })).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const config = cfg(entry);
+  const method = (config.method || 'POST').toUpperCase();
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? config.max_pages ?? 1;
+  const jobs = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const json = await ctx.fetchJson(buildEuresUrl(entry, page), {
+      method,
+      redirect: 'error',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      ...(method === 'GET' ? {} : { body: JSON.stringify(buildEuresBody(entry, page)) }),
+    });
+    const pageJobs = parseEuresResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+  return jobs;
+}
+
+export default {
+  id: 'eures',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/google-careers.mjs
+++ b/providers/google-careers.mjs
@@ -1,0 +1,111 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Google Careers provider - parses the public server-rendered search results.
+
+const BASE_URL = 'https://www.google.com/about/careers/applications/jobs/results/';
+const APP_BASE_URL = 'https://www.google.com/about/careers/applications/';
+
+const ENTITY_MAP = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  nbsp: ' ',
+};
+
+function decodeEntities(value = '') {
+  return String(value)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&([a-z]+);/gi, (m, name) => ENTITY_MAP[name] || m);
+}
+
+function cleanText(value = '') {
+  return decodeEntities(String(value).replace(/<[^>]+>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function firstMatch(source, re) {
+  const m = re.exec(source);
+  return m ? m[1] : '';
+}
+
+function resolveJobUrl(rawHref) {
+  if (!rawHref) return '';
+  try {
+    return new URL(decodeEntities(rawHref), APP_BASE_URL).href;
+  } catch {
+    return '';
+  }
+}
+
+/** @param {import('./_types.js').PortalEntry & {google?: Record<string, unknown>}} entry */
+export function buildGoogleCareersUrl(entry = {}) {
+  const cfg = entry.google && typeof entry.google === 'object' ? entry.google : {};
+  const query = cfg.query ?? entry.query ?? entry.search ?? '';
+  const url = new URL(BASE_URL);
+  if (query) url.searchParams.set('q', String(query));
+  return url.href;
+}
+
+/** @param {string} html */
+export function parseGoogleCareersHtml(html) {
+  if (typeof html !== 'string' || !html.trim()) return [];
+  const jobs = [];
+  const seen = new Set();
+  const cardRe = /<li\b[^>]*class=["'][^"']*\blLd3Je\b[^"']*["'][^>]*>[\s\S]*?(?=<li\b[^>]*class=["'][^"']*\blLd3Je\b|<\/main>|$)/gi;
+
+  for (const m of html.matchAll(cardRe)) {
+    const card = m[0];
+    const title = cleanText(firstMatch(card, /<h3\b[^>]*class=["'][^"']*\bQJPWVe\b[^"']*["'][^>]*>([\s\S]*?)<\/h3>/i));
+    const href = firstMatch(card, /<a\b[^>]+href=["']([^"']*jobs\/results\/[^"']+)["']/i);
+    const url = resolveJobUrl(href);
+    if (!title || !url || seen.has(url)) continue;
+    seen.add(url);
+
+    const location = cleanText(
+      firstMatch(card, /<span\b[^>]*class=["'][^"']*\br0wTof\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i)
+      || firstMatch(card, /<span\b[^>]*class=["'][^"']*\bpwO9Dc\b[^"']*["'][^>]*>([\s\S]*?)<\/span>/i),
+    );
+
+    jobs.push({
+      title,
+      url,
+      company: 'Google',
+      location,
+    });
+  }
+
+  return jobs;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'google-careers',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    try {
+      const parsed = new URL(url);
+      const host = parsed.host.toLowerCase();
+      if ((host === 'www.google.com' || host === 'careers.google.com')
+          && parsed.pathname.includes('/careers/applications/jobs')) {
+        return { url };
+      }
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const html = await ctx.fetchText(buildGoogleCareersUrl(entry), { redirect: 'error' });
+    return parseGoogleCareersHtml(html).map((job) => ({
+      ...job,
+      company: entry.name || job.company,
+    }));
+  },
+};

--- a/providers/gupy.mjs
+++ b/providers/gupy.mjs
@@ -1,0 +1,89 @@
+const DEFAULT_API = 'https://api.gupy.io/api/v1/jobs';
+
+function cfg(entry = {}) {
+  return entry.gupy || entry.config || {};
+}
+
+function token(entry) {
+  const config = cfg(entry);
+  return config.token || process.env.GUPY_API_TOKEN || '';
+}
+
+function rowsFrom(json) {
+  if (Array.isArray(json)) return json;
+  if (Array.isArray(json?.results)) return json.results;
+  if (Array.isArray(json?.data)) return json.data;
+  if (Array.isArray(json?.jobs)) return json.jobs;
+  if (Array.isArray(json?.data?.results)) return json.data.results;
+  return [];
+}
+
+function locationValue(row) {
+  const location = row.location || row.workplace || row.workPlace || row.address;
+  if (typeof location === 'string') return location;
+  if (location && typeof location === 'object') {
+    return [location.city, location.state, location.country].filter(Boolean).join(', ');
+  }
+  return [row.city, row.state, row.country].filter(Boolean).join(', ');
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || (parsed.hostname !== 'api.gupy.io' && !parsed.hostname.endsWith('.gupy.io'))) {
+    throw new Error(`gupy: untrusted API URL: ${url}`);
+  }
+  return parsed;
+}
+
+export function buildGupyUrl(entry = {}, page = 1) {
+  const config = cfg(entry);
+  const url = trustedApiUrl(config.api || entry.api || DEFAULT_API);
+  const query = config.query || config.keyword || entry.query;
+  const limit = config.limit || config.page_size || config.pageSize || 50;
+  if (query) url.searchParams.set(config.query_param || config.queryParam || 'name', query);
+  url.searchParams.set(config.page_param || config.pageParam || 'page', String(page));
+  url.searchParams.set(config.limit_param || config.limitParam || 'limit', String(limit));
+  return url.toString();
+}
+
+export function parseGupyResponse(json, entry = {}) {
+  return rowsFrom(json).map((row) => ({
+    title: row.name || row.title || row.jobTitle || '',
+    url: row.jobUrl || row.url || row.applyUrl || '',
+    company: row.companyName || row.company?.name || row.company || entry.name || 'Gupy',
+    location: locationValue(row),
+    postedAt: row.publishedDate || row.createdAt || row.postedAt || null,
+  })).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const config = cfg(entry);
+  const apiToken = token(entry);
+  if (!apiToken && config.requires_token !== false && config.requiresToken !== false) {
+    throw new Error('gupy: missing GUPY_API_TOKEN');
+  }
+
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? config.max_pages ?? 1;
+  const jobs = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const json = await ctx.fetchJson(buildGupyUrl(entry, page), {
+      redirect: 'error',
+      headers: {
+        Accept: 'application/json',
+        ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+      },
+    });
+    const pageJobs = parseGupyResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+  return jobs;
+}
+
+export default {
+  id: 'gupy',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -1,0 +1,126 @@
+function cfg(entry = {}) {
+  return entry.icims || entry.config || {};
+}
+
+function authHeaders(entry) {
+  const config = cfg(entry);
+  const username = config.username || process.env.ICIMS_USERNAME;
+  const password = config.password || process.env.ICIMS_PASSWORD;
+  if (!username || !password) {
+    if (config.requires_auth === false || config.requiresAuth === false) return {};
+    throw new Error('icims: missing ICIMS_USERNAME or ICIMS_PASSWORD');
+  }
+  return {
+    Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+  };
+}
+
+function fieldValue(row, names) {
+  for (const name of names) {
+    if (row?.[name] !== undefined && row[name] !== null) return row[name];
+  }
+
+  const fields = row?.fields;
+  if (fields && !Array.isArray(fields) && typeof fields === 'object') {
+    for (const name of names) {
+      if (fields[name] !== undefined && fields[name] !== null) return fields[name];
+    }
+  }
+
+  if (Array.isArray(fields)) {
+    for (const field of fields) {
+      const key = field.name || field.key || field.id || field.label;
+      if (names.includes(key)) return field.value || field.text || '';
+    }
+  }
+
+  return '';
+}
+
+function rowsFrom(json) {
+  if (Array.isArray(json)) return json;
+  if (Array.isArray(json?.searchResults)) return json.searchResults;
+  if (Array.isArray(json?.results)) return json.results;
+  if (Array.isArray(json?.jobs)) return json.jobs;
+  if (Array.isArray(json?.data)) return json.data;
+  if (Array.isArray(json?.data?.results)) return json.data.results;
+  return [];
+}
+
+function locationValue(row) {
+  const direct = fieldValue(row, ['location', 'jobLocation', 'job_location', 'cityState', 'city_state']);
+  if (direct && typeof direct === 'string') return direct;
+  if (direct && typeof direct === 'object') {
+    return [direct.city, direct.state, direct.country].filter(Boolean).join(', ');
+  }
+  return [fieldValue(row, ['city']), fieldValue(row, ['state']), fieldValue(row, ['country'])]
+    .filter(Boolean)
+    .join(', ');
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || (parsed.hostname !== 'api.icims.com' && !parsed.hostname.endsWith('.icims.com'))) {
+    throw new Error(`icims: untrusted API URL: ${url}`);
+  }
+  return parsed;
+}
+
+export function buildIcimsUrl(entry = {}, page = 1) {
+  const config = cfg(entry);
+  if (!entry.api && !config.api) {
+    throw new Error('icims: configure an official Job Portal API endpoint in api');
+  }
+
+  const url = trustedApiUrl(config.api || entry.api);
+  const pageParam = config.page_param || config.pageParam || 'page';
+  const pageSizeParam = config.page_size_param || config.pageSizeParam || 'limit';
+  const pageSize = config.page_size || config.pageSize || 50;
+  url.searchParams.set(pageParam, String(page));
+  url.searchParams.set(pageSizeParam, String(pageSize));
+
+  const searchJson = config.search_json || config.searchJson;
+  if (searchJson) {
+    url.searchParams.set('searchJson', typeof searchJson === 'string' ? searchJson : JSON.stringify(searchJson));
+  }
+  if (config.query) url.searchParams.set(config.query_param || 'q', config.query);
+  return url.toString();
+}
+
+export function parseIcimsResponse(json, entry = {}) {
+  return rowsFrom(json).map((row) => ({
+    title: fieldValue(row, ['title', 'jobTitle', 'jobtitle', 'positionTitle', 'name']),
+    url: fieldValue(row, ['url', 'jobUrl', 'jobURL', 'portalUrl', 'applyUrl', 'link']),
+    company: fieldValue(row, ['company', 'companyName']) || entry.name || 'iCIMS',
+    location: locationValue(row),
+    postedAt: fieldValue(row, ['postedAt', 'postedDate', 'datePosted', 'createdAt', 'updatedAt']) || null,
+  })).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? cfg(entry).max_pages ?? 1;
+  const jobs = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const json = await ctx.fetchJson(buildIcimsUrl(entry, page), {
+      redirect: 'error',
+      headers: {
+        Accept: 'application/json',
+        ...authHeaders(entry),
+      },
+    });
+    const pageJobs = parseIcimsResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+
+  return jobs;
+}
+
+export default {
+  id: 'icims',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/jooble.mjs
+++ b/providers/jooble.mjs
@@ -1,0 +1,76 @@
+const DEFAULT_API_BASE = 'https://jooble.org/api';
+
+function cfg(entry = {}) {
+  return entry.jooble || entry.config || {};
+}
+
+function requiredApiKey(entry) {
+  const config = cfg(entry);
+  const apiKey = config.api_key || config.apiKey || process.env.JOOBLE_API_KEY;
+  if (!apiKey) throw new Error('jooble: missing JOOBLE_API_KEY');
+  return apiKey;
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || (parsed.hostname !== 'jooble.org' && !parsed.hostname.endsWith('.jooble.org'))) {
+    throw new Error(`jooble: untrusted API URL: ${url}`);
+  }
+  return parsed.toString();
+}
+
+export function buildJoobleUrl(entry = {}) {
+  const config = cfg(entry);
+  const apiKey = requiredApiKey(entry);
+  return trustedApiUrl(config.api || entry.api || `${DEFAULT_API_BASE}/${encodeURIComponent(apiKey)}`);
+}
+
+export function buildJoobleBody(entry = {}, page = 1) {
+  const config = cfg(entry);
+  return {
+    keywords: config.keywords || config.keyword || config.query || entry.query || '',
+    location: config.location || entry.location || '',
+    page,
+    ...(config.body && typeof config.body === 'object' ? config.body : {}),
+  };
+}
+
+export function parseJoobleResponse(json, entry = {}) {
+  const rows = json?.jobs || json?.results || [];
+  if (!Array.isArray(rows)) return [];
+
+  return rows.map((row) => ({
+    title: row.title || '',
+    url: row.link || row.url || '',
+    company: row.company || row.company_name || entry.name || 'Jooble',
+    location: row.location || '',
+    postedAt: row.updated || row.created || row.postedAt || null,
+  })).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? cfg(entry).max_pages ?? 1;
+  const jobs = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const json = await ctx.fetchJson(buildJoobleUrl(entry), {
+      method: 'POST',
+      redirect: 'error',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildJoobleBody(entry, page)),
+    });
+    const pageJobs = parseJoobleResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+
+  return jobs;
+}
+
+export default {
+  id: 'jooble',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/microsoft-careers.mjs
+++ b/providers/microsoft-careers.mjs
@@ -1,0 +1,271 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Microsoft Careers provider - reads the public Eightfold PCS search API and
+// keeps the embedded HTML parser as a fallback/fixture parser.
+
+const BASE_URL = 'https://jobs.careers.microsoft.com/global/en/search';
+const APPLY_ORIGIN = 'https://apply.careers.microsoft.com';
+const SEARCH_API_URL = `${APPLY_ORIGIN}/api/pcsx/search`;
+const SEARCH_PAGE_SIZE = 10; // Microsoft PCS currently returns 10 rows/page.
+const DEFAULT_MAX_PAGES = 3;
+const MAX_PAGES_CAP = 50;
+
+const ENTITY_MAP = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  nbsp: ' ',
+};
+
+function decodeEntities(value = '') {
+  return String(value)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&([a-z]+);/gi, (m, name) => ENTITY_MAP[name] || m);
+}
+
+function cleanText(value = '') {
+  return decodeEntities(String(value).replace(/<[^>]+>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function asString(value) {
+  return typeof value === 'string' || typeof value === 'number' ? String(value).trim() : '';
+}
+
+function toEpochMs(raw) {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return raw > 1_000_000_000_000 ? raw : raw * 1000;
+  }
+  const value = asString(raw);
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function titleFrom(obj) {
+  return cleanText(
+    obj.title
+    ?? obj.jobTitle
+    ?? obj.postingTitle
+    ?? obj.positionTitle
+    ?? obj.name
+    ?? obj.displayTitle
+    ?? '',
+  );
+}
+
+function idFrom(obj) {
+  return asString(obj.displayJobId ?? obj.atsJobId ?? obj.display_job_id ?? obj.jobId ?? obj.job_id ?? obj.position_id ?? obj.positionId);
+}
+
+function urlFrom(obj, id) {
+  const raw = asString(obj.canonicalPositionUrl ?? obj.positionUrl ?? obj.externalUrl ?? obj.jobUrl ?? obj.url);
+  if (raw) {
+    try {
+      return new URL(raw, APPLY_ORIGIN).href;
+    } catch {
+      /* keep looking */
+    }
+  }
+  if (!id) return '';
+  return `${APPLY_ORIGIN}/careers/job/${encodeURIComponent(id)}`;
+}
+
+function locationFrom(obj) {
+  const direct = cleanText(obj.location ?? obj.primaryLocation ?? obj.workLocation ?? obj.displayLocation ?? '');
+  if (direct) return direct;
+  const locations = Array.isArray(obj.locations) ? obj.locations : Array.isArray(obj.locationList) ? obj.locationList : [];
+  const values = locations
+    .map((loc) => {
+      if (typeof loc === 'string') return cleanText(loc);
+      if (loc && typeof loc === 'object') {
+        return cleanText(loc.displayName ?? loc.name ?? loc.city ?? loc.location ?? loc.address ?? '');
+      }
+      return '';
+    })
+    .filter(Boolean);
+  return [...new Set(values)].join(' / ');
+}
+
+function postedAtFrom(obj) {
+  return toEpochMs(obj.postedTs ?? obj.creationTs ?? obj.postedDate ?? obj.posted_date ?? obj.postingDate ?? obj.createdDate ?? obj.created_at ?? obj.datePosted);
+}
+
+function normalizeMicrosoftJob(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+  const title = titleFrom(obj);
+  const id = idFrom(obj);
+  const url = urlFrom(obj, id);
+  if (!title || !url) return null;
+  const hasJobSignal = Boolean(
+    obj.positionUrl
+    || obj.canonicalPositionUrl
+    || obj.jobUrl
+    || obj.displayJobId
+    || obj.atsJobId
+    || obj.display_job_id
+    || obj.jobId
+    || obj.job_id
+    || obj.position_id
+    || obj.positionId,
+  );
+  if (!hasJobSignal || !/\/job\//i.test(url)) return null;
+
+  const job = {
+    title,
+    url,
+    company: 'Microsoft',
+    location: locationFrom(obj),
+  };
+  const postedAt = postedAtFrom(obj);
+  if (postedAt !== undefined) job.postedAt = postedAt;
+  return job;
+}
+
+function walkJobs(value, out, seenObjects = new WeakSet()) {
+  if (!value || typeof value !== 'object') return;
+  if (seenObjects.has(value)) return;
+  seenObjects.add(value);
+
+  const job = normalizeMicrosoftJob(value);
+  if (job) out.push(job);
+
+  if (Array.isArray(value)) {
+    for (const item of value) walkJobs(item, out, seenObjects);
+  } else {
+    for (const item of Object.values(value)) walkJobs(item, out, seenObjects);
+  }
+}
+
+function parsePcsxPayload(html) {
+  const m = /<code\b[^>]*id=["']pcsx-data["'][^>]*>([\s\S]*?)<\/code>/i.exec(html);
+  if (!m) return null;
+  const decoded = decodeEntities(m[1]).trim();
+  if (!decoded) return null;
+  return JSON.parse(decoded);
+}
+
+function parseVisibleLinks(html) {
+  const jobs = [];
+  const linkRe = /<a\b[^>]*href=["']([^"']*(?:\/global\/en\/job\/|\/careers\/job\/)[^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  for (const m of html.matchAll(linkRe)) {
+    const title = cleanText(m[2]);
+    const url = urlFrom({ url: m[1] }, '');
+    if (!title || !url || /^apply$/i.test(title)) continue;
+    jobs.push({ title, url, company: 'Microsoft', location: '' });
+  }
+  return jobs;
+}
+
+/** @param {import('./_types.js').PortalEntry & {microsoft?: Record<string, unknown>}} entry */
+export function buildMicrosoftCareersUrl(entry = {}) {
+  const cfg = entry.microsoft && typeof entry.microsoft === 'object' ? entry.microsoft : {};
+  const query = cfg.query ?? cfg.search ?? entry.query ?? entry.search ?? '';
+  const url = new URL(BASE_URL);
+  if (query) url.searchParams.set('q', String(query));
+  return url.href;
+}
+
+/** @param {import('./_types.js').PortalEntry & {microsoft?: Record<string, unknown>}} entry */
+export function buildMicrosoftSearchApiUrl(entry = {}, start = 0) {
+  const cfg = entry.microsoft && typeof entry.microsoft === 'object' ? entry.microsoft : {};
+  const query = cfg.query ?? cfg.search ?? entry.query ?? entry.search ?? '';
+  const domain = cfg.domain ?? 'microsoft.com';
+  const url = new URL(SEARCH_API_URL);
+  url.searchParams.set('domain', String(domain));
+  if (query) url.searchParams.set('query', String(query));
+  if (start > 0) url.searchParams.set('start', String(start));
+  return url.href;
+}
+
+/** @param {unknown} json */
+export function parseMicrosoftSearchResponse(json) {
+  const rows = Array.isArray(json?.data?.positions)
+    ? json.data.positions
+    : Array.isArray(json?.positions)
+      ? json.positions
+      : [];
+  const seen = new Set();
+  return rows
+    .map(normalizeMicrosoftJob)
+    .filter((job) => {
+      if (!job || !job.url || seen.has(job.url)) return false;
+      seen.add(job.url);
+      return true;
+    });
+}
+
+/** @param {string} html */
+export function parseMicrosoftCareersHtml(html) {
+  if (typeof html !== 'string' || !html.trim()) return [];
+
+  let jobs = [];
+  try {
+    const payload = parsePcsxPayload(html);
+    if (payload) walkJobs(payload, jobs);
+  } catch {
+    jobs = [];
+  }
+  if (jobs.length === 0) jobs = parseVisibleLinks(html);
+
+  const seen = new Set();
+  return jobs.filter((job) => {
+    if (!job.url || seen.has(job.url)) return false;
+    seen.add(job.url);
+    return true;
+  });
+}
+
+/** @type {Provider} */
+export default {
+  id: 'microsoft-careers',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    try {
+      const parsed = new URL(url);
+      if (parsed.host.toLowerCase() === 'jobs.careers.microsoft.com' && parsed.pathname.startsWith('/global/en/search')) {
+        return { url };
+      }
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const maxPages = Math.max(1, Math.min(
+      Math.floor(Number(ctx.maxPages ?? entry.max_pages ?? DEFAULT_MAX_PAGES)) || DEFAULT_MAX_PAGES,
+      MAX_PAGES_CAP,
+    ));
+    const jobs = [];
+    const seen = new Set();
+    for (let page = 0; page < maxPages; page++) {
+      const json = await ctx.fetchJson(buildMicrosoftSearchApiUrl(entry, page * SEARCH_PAGE_SIZE), {
+        redirect: 'error',
+        headers: {
+          accept: 'application/json,text/plain,*/*',
+        },
+      });
+      const pageJobs = parseMicrosoftSearchResponse(json);
+      if (pageJobs.length === 0) break;
+      let fresh = 0;
+      for (const job of pageJobs) {
+        if (seen.has(job.url)) continue;
+        seen.add(job.url);
+        fresh++;
+        jobs.push({
+          ...job,
+          company: entry.name || job.company,
+        });
+      }
+      if (fresh === 0 || pageJobs.length < SEARCH_PAGE_SIZE) break;
+    }
+    return jobs;
+  },
+};

--- a/providers/reed.mjs
+++ b/providers/reed.mjs
@@ -1,0 +1,88 @@
+const DEFAULT_API = 'https://www.reed.co.uk/api/1.0/search';
+const DEFAULT_RESULTS_TO_TAKE = 100;
+
+function cfg(entry = {}) {
+  return entry.reed || entry.config || {};
+}
+
+function requiredApiKey(entry) {
+  const config = cfg(entry);
+  const apiKey = config.api_key || config.apiKey || process.env.REED_API_KEY;
+  if (!apiKey) throw new Error('reed: missing REED_API_KEY');
+  return apiKey;
+}
+
+function reedDate(value) {
+  if (!value) return null;
+  const match = String(value).match(/\/Date\((\d+)\)\//);
+  if (match) return new Date(Number(match[1])).toISOString();
+  return value;
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'www.reed.co.uk') {
+    throw new Error(`reed: untrusted API URL: ${url}`);
+  }
+  return parsed;
+}
+
+export function buildReedUrl(entry = {}, page = 1) {
+  const config = cfg(entry);
+  const url = trustedApiUrl(config.api || entry.api || DEFAULT_API);
+  const keywords = config.keywords || config.keyword || config.query || entry.query;
+  const locationName = config.locationName || config.location || entry.location;
+  const resultsToTake = config.resultsToTake || config.results_to_take || DEFAULT_RESULTS_TO_TAKE;
+  const resultsToSkip = (page - 1) * Number(resultsToTake);
+
+  if (keywords) url.searchParams.set('keywords', keywords);
+  if (locationName) url.searchParams.set('locationName', locationName);
+  url.searchParams.set('resultsToTake', String(resultsToTake));
+  url.searchParams.set('resultsToSkip', String(resultsToSkip));
+  if (config.permanent === true) url.searchParams.set('permanent', 'true');
+  if (config.fullTime === true || config.full_time === true) url.searchParams.set('fullTime', 'true');
+  if (config.remote === true) url.searchParams.set('remote', 'true');
+
+  return url.toString();
+}
+
+export function parseReedResponse(json, entry = {}) {
+  const rows = json?.results || json?.jobs || [];
+  if (!Array.isArray(rows)) return [];
+
+  return rows.map((row) => ({
+    title: row.jobTitle || row.title || '',
+    url: row.jobUrl || row.url || '',
+    company: row.employerName || row.company || entry.name || 'Reed',
+    location: row.locationName || row.location || '',
+    postedAt: reedDate(row.date || row.postedAt || row.expirationDate),
+  })).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const apiKey = requiredApiKey(entry);
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? cfg(entry).max_pages ?? 1;
+  const jobs = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const json = await ctx.fetchJson(buildReedUrl(entry, page), {
+      redirect: 'error',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`,
+      },
+    });
+    const pageJobs = parseReedResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+
+  return jobs;
+}
+
+export default {
+  id: 'reed',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/un-careers.mjs
+++ b/providers/un-careers.mjs
@@ -1,0 +1,137 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// UN Careers provider - reads the public no-auth active job openings API.
+
+const DEFAULT_LANGUAGE = 'en';
+const DEFAULT_API = 'https://careers.un.org/api/public/opening/jo/activeJo?language=en';
+const JOBOPENING_URL = 'https://careers.un.org/jobopening';
+
+function asString(value) {
+  return typeof value === 'string' || typeof value === 'number' ? String(value).trim() : '';
+}
+
+function cleanText(value = '') {
+  return asString(value).replace(/\s+/g, ' ').trim();
+}
+
+function toEpochMs(raw) {
+  const value = asString(raw);
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function stationToString(station) {
+  if (typeof station === 'string') return cleanText(station);
+  if (station && typeof station === 'object') {
+    return cleanText(station.description ?? station.name ?? station.city ?? station.dutyStation ?? '');
+  }
+  return '';
+}
+
+function locationFrom(job) {
+  const stations = Array.isArray(job.dutyStation)
+    ? job.dutyStation
+    : Array.isArray(job.dutyStations)
+      ? job.dutyStations
+      : [];
+  const values = stations.map(stationToString).filter(Boolean);
+  const direct = stationToString(job.dutyStation ?? job.location ?? job.dutyStationDescription);
+  if (direct) values.unshift(direct);
+  return [...new Set(values)].join(' / ');
+}
+
+function urlFrom(job, language) {
+  const raw = asString(job.url ?? job.jobUrl);
+  if (raw) {
+    try {
+      return new URL(raw, JOBOPENING_URL).href;
+    } catch {
+      /* build below */
+    }
+  }
+  const jobId = asString(job.jobId ?? job.job_id ?? job.id);
+  if (!jobId) return '';
+  const url = new URL(JOBOPENING_URL);
+  url.searchParams.set('language', language);
+  url.searchParams.set('data', JSON.stringify({ jobId }));
+  return url.href;
+}
+
+function normalizeUnJob(job, language, company) {
+  if (!job || typeof job !== 'object' || Array.isArray(job)) return null;
+  const title = cleanText(job.postingTitle ?? job.jobTitle ?? job.jobCodeTitle ?? job.title ?? '');
+  const url = urlFrom(job, language);
+  if (!title || !url) return null;
+  const normalized = {
+    title,
+    url,
+    company,
+    location: locationFrom(job),
+  };
+  const postedAt = toEpochMs(job.startDate ?? job.insertedDate ?? job.createdDate ?? job.postingStartDate);
+  if (postedAt !== undefined) normalized.postedAt = postedAt;
+  return normalized;
+}
+
+function rowsFromResponse(json) {
+  if (Array.isArray(json)) return json;
+  if (Array.isArray(json?.data)) return json.data;
+  if (Array.isArray(json?.data?.result)) return json.data.result;
+  if (Array.isArray(json?.results)) return json.results;
+  return [];
+}
+
+/** @param {unknown} json */
+export function parseUnCareersResponse(json, { language = DEFAULT_LANGUAGE, company = 'United Nations' } = {}) {
+  const jobs = [];
+  const seen = new Set();
+  for (const row of rowsFromResponse(json)) {
+    const job = normalizeUnJob(row, language, company);
+    if (!job || seen.has(job.url)) continue;
+    seen.add(job.url);
+    jobs.push(job);
+  }
+  return jobs;
+}
+
+/** @param {import('./_types.js').PortalEntry & {un?: Record<string, unknown>}} entry */
+function buildApiUrl(entry = {}) {
+  if (entry.api && typeof entry.api === 'string') return entry.api;
+  const cfg = entry.un && typeof entry.un === 'object' ? entry.un : {};
+  const language = asString(cfg.language ?? entry.language ?? DEFAULT_LANGUAGE) || DEFAULT_LANGUAGE;
+  const url = new URL(DEFAULT_API);
+  url.searchParams.set('language', language);
+  return url.href;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'un-careers',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    try {
+      const parsed = new URL(url);
+      if (parsed.host.toLowerCase() === 'careers.un.org') return { url };
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = entry.un && typeof entry.un === 'object' ? entry.un : {};
+    const language = asString(cfg.language ?? entry.language ?? DEFAULT_LANGUAGE) || DEFAULT_LANGUAGE;
+    const json = await ctx.fetchJson(buildApiUrl(entry), {
+      redirect: 'error',
+      headers: {
+        accept: 'application/json,text/plain,*/*',
+        'user-agent': 'Mozilla/5.0 (compatible; career-ops/1.17)',
+      },
+    });
+    return parseUnCareersResponse(json, { language, company: entry.name || 'United Nations' });
+  },
+};

--- a/providers/usajobs.mjs
+++ b/providers/usajobs.mjs
@@ -1,0 +1,98 @@
+const DEFAULT_API = 'https://data.usajobs.gov/api/search';
+const DEFAULT_RESULTS_PER_PAGE = 50;
+
+function cfg(entry = {}) {
+  return entry.usajobs || entry.config || {};
+}
+
+function requiredCredentials(entry) {
+  const config = cfg(entry);
+  const userAgent = config.user_agent || config.userAgent || process.env.USAJOBS_USER_AGENT;
+  const apiKey = config.api_key || config.apiKey || process.env.USAJOBS_API_KEY;
+  if (!userAgent || !apiKey) {
+    throw new Error('usajobs: missing USAJOBS_USER_AGENT or USAJOBS_API_KEY');
+  }
+  return { userAgent, apiKey };
+}
+
+function trustedApiUrl(url) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'data.usajobs.gov') {
+    throw new Error(`usajobs: untrusted API URL: ${url}`);
+  }
+  return parsed;
+}
+
+export function buildUsajobsUrl(entry = {}, page = 1) {
+  const config = cfg(entry);
+  const url = trustedApiUrl(config.api || entry.api || DEFAULT_API);
+  const keyword = config.keyword || config.query || entry.query;
+  const location = config.location || config.locationName || entry.location;
+  const resultsPerPage = config.results_per_page || config.resultsPerPage || DEFAULT_RESULTS_PER_PAGE;
+
+  if (keyword) url.searchParams.set('Keyword', keyword);
+  if (location) url.searchParams.set('LocationName', location);
+  if (config.remote === true || config.remoteIndicator === true) {
+    url.searchParams.set('RemoteIndicator', 'true');
+  }
+  url.searchParams.set('ResultsPerPage', String(resultsPerPage));
+  url.searchParams.set('Page', String(page));
+  return url.toString();
+}
+
+function locationDisplay(descriptor = {}) {
+  if (Array.isArray(descriptor.PositionLocation) && descriptor.PositionLocation.length > 0) {
+    return descriptor.PositionLocation
+      .map((loc) => loc.LocationName || loc.CityName || loc.CountryCode)
+      .filter(Boolean)
+      .join('; ');
+  }
+  return descriptor.PositionLocationDisplay || descriptor.LocationName || '';
+}
+
+export function parseUsajobsResponse(json, entry = {}) {
+  const items = json?.SearchResult?.SearchResultItems || json?.SearchResultItems || json?.results || [];
+  if (!Array.isArray(items)) return [];
+
+  return items.map((item) => {
+    const descriptor = item.MatchedObjectDescriptor || item;
+    return {
+      title: descriptor.PositionTitle || descriptor.title || '',
+      url: descriptor.PositionURI || descriptor.url || '',
+      company: descriptor.OrganizationName || descriptor.DepartmentName || entry.name || 'USAJOBS',
+      location: locationDisplay(descriptor),
+      postedAt: descriptor.PublicationStartDate || descriptor.postedAt || descriptor.created_at || null,
+    };
+  }).filter((job) => job.title && job.url);
+}
+
+export async function fetch(entry = {}, ctx) {
+  const { userAgent, apiKey } = requiredCredentials(entry);
+  const maxPages = ctx.maxPages ?? entry.max_pages ?? cfg(entry).max_pages ?? 1;
+  const jobs = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const url = buildUsajobsUrl(entry, page);
+    const json = await ctx.fetchJson(url, {
+      redirect: 'error',
+      headers: {
+        Host: 'data.usajobs.gov',
+        'User-Agent': userAgent,
+        'Authorization-Key': apiKey,
+      },
+    });
+    const pageJobs = parseUsajobsResponse(json, entry);
+    jobs.push(...pageJobs);
+    if (pageJobs.length === 0) break;
+  }
+
+  return jobs;
+}
+
+export default {
+  id: 'usajobs',
+  detect() {
+    return null;
+  },
+  fetch,
+};

--- a/providers/yc-jobs.mjs
+++ b/providers/yc-jobs.mjs
@@ -1,0 +1,129 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// YC Work at a Startup provider - parses the public Inertia data embedded in
+// ycombinator.com/jobs.
+
+const BASE_URL = 'https://www.ycombinator.com/jobs/';
+
+const ENTITY_MAP = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function decodeEntities(value = '') {
+  return String(value)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&([a-z]+);/gi, (m, name) => ENTITY_MAP[name] || m);
+}
+
+function cleanText(value = '') {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+function asString(value) {
+  return typeof value === 'string' || typeof value === 'number' ? String(value).trim() : '';
+}
+
+function toEpochMs(raw) {
+  const value = asString(raw);
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function locationFrom(job) {
+  const direct = asString(job.location ?? job.locationName ?? job.city);
+  if (direct) return direct;
+  if (job.isRemote === true || job.remote === true) return 'Remote';
+  return '';
+}
+
+function normalizeYcJob(job) {
+  if (!job || typeof job !== 'object' || Array.isArray(job)) return null;
+  const title = cleanText(job.title ?? job.role ?? job.name ?? '');
+  const rawUrl = asString(job.url ?? job.path ?? job.jobUrl ?? job.applyUrl);
+  if (!title || !rawUrl) return null;
+  let url;
+  try {
+    url = new URL(rawUrl, BASE_URL).href;
+  } catch {
+    return null;
+  }
+
+  const company = cleanText(job.companyName ?? job.company?.name ?? job.company?.title ?? 'YC Work at a Startup');
+  const normalized = {
+    title,
+    url,
+    company,
+    location: locationFrom(job),
+  };
+  const postedAt = toEpochMs(job.createdAt ?? job.created_at ?? job.postedAt ?? job.posted_at);
+  if (postedAt !== undefined) normalized.postedAt = postedAt;
+  return normalized;
+}
+
+function walkJobArrays(value, out, seenObjects = new WeakSet()) {
+  if (!value || typeof value !== 'object') return;
+  if (seenObjects.has(value)) return;
+  seenObjects.add(value);
+
+  if (Array.isArray(value)) {
+    const jobs = value.map(normalizeYcJob).filter(Boolean);
+    if (jobs.length > 0) out.push(...jobs);
+    for (const item of value) walkJobArrays(item, out, seenObjects);
+  } else {
+    for (const item of Object.values(value)) walkJobArrays(item, out, seenObjects);
+  }
+}
+
+function parseDataPage(html) {
+  const m = /data-page=["']([^"']+)["']/i.exec(html);
+  if (!m) return null;
+  return JSON.parse(decodeEntities(m[1]));
+}
+
+/** @param {string} html */
+export function parseYcJobsHtml(html) {
+  if (typeof html !== 'string' || !html.trim()) return [];
+  const page = parseDataPage(html);
+  if (!page) return [];
+  const jobs = [];
+  walkJobArrays(page, jobs);
+
+  const seen = new Set();
+  return jobs.filter((job) => {
+    if (!job.url || seen.has(job.url)) return false;
+    seen.add(job.url);
+    return true;
+  });
+}
+
+/** @type {Provider} */
+export default {
+  id: 'yc-jobs',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    try {
+      const parsed = new URL(url);
+      const host = parsed.host.toLowerCase();
+      if ((host === 'www.ycombinator.com' || host === 'ycombinator.com') && parsed.pathname.startsWith('/jobs')) return { url };
+      if (host === 'www.workatastartup.com' || host === 'workatastartup.com') return { url };
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(_entry, ctx) {
+    const html = await ctx.fetchText(BASE_URL, { redirect: 'error' });
+    return parseYcJobsHtml(html);
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -449,6 +449,34 @@ search_queries:
     query: 'site:welcometothejungle.com/en/jobs OR site:app.welcometothejungle.com "Forward Deployed" OR "AI Engineer" OR "Product Engineer" OR "Solutions Engineer" remote'
     enabled: true
 
+  - name: ZipRecruiter — Remote Tech
+    query: 'site:ziprecruiter.com/jobs "AI Engineer" OR "Software Engineer" OR "Solutions Engineer" remote'
+    enabled: true
+
+  - name: Dice — Tech AI / Software
+    query: 'site:dice.com/job-detail "AI Engineer" OR "Software Engineer" OR "Solutions Architect" remote'
+    enabled: true
+
+  - name: Built In — AI / Product Engineering
+    query: 'site:builtin.com/jobs "AI Engineer" OR "Product Engineer" OR "Forward Deployed" remote'
+    enabled: true
+
+  - name: Wellfound — Startup AI / Product Engineering
+    query: 'site:wellfound.com/jobs "AI Engineer" OR "Product Engineer" OR "Founding Engineer" remote'
+    enabled: true
+
+  - name: Glassdoor — Remote Tech
+    query: 'site:glassdoor.com/job-listing "AI Engineer" OR "Software Engineer" OR "Solutions Engineer" remote'
+    enabled: true
+
+  - name: FlexJobs — Remote Tech
+    query: 'site:flexjobs.com/jobs "AI Engineer" OR "Software Engineer" OR "Solutions Engineer" remote'
+    enabled: true
+
+  - name: Monster / CareerBuilder — Remote Tech
+    query: 'site:monster.com/job-openings OR site:careerbuilder.com/job "AI Engineer" OR "Software Engineer" OR "Solutions Engineer" remote'
+    enabled: true
+
 # -- Tracked companies --
 # Companies whose career pages are checked directly.
 # scan_method: playwright (default), websearch, local_parser
@@ -521,9 +549,10 @@ search_queries:
 #
 # Some providers are job boards / aggregators with no per-company careers
 # URL to detect, so they must be selected with an explicit `provider:`
-# field: 4dayweek, arbeitnow, arbeitsagentur, getonbrd, glints, himalayas, ibm, jobicy,
-# jobstreet, justjoin, landingjobs, nofluffjobs, remoteok, remotive, thehub,
-# weworkremotely, workingnomads. Examples for every built-in provider are below.
+# field: 4dayweek, adzuna, arbeitnow, arbeitsagentur, eures, getonbrd, glints,
+# gupy, himalayas, ibm, icims, jobicy, jobstreet, jooble, justjoin, landingjobs,
+# nofluffjobs, reed, remoteok, remotive, thehub, usajobs, weworkremotely,
+# workingnomads. Examples for every built-in provider are below.
 
 # ── Built-in provider examples ────────────────────────────────────
 # Commented config for each provider in providers/. Copy a stanza into
@@ -635,6 +664,58 @@ search_queries:
 #   siteKey: ID-Main      # SEEK site key (ID-Main, SG-Main, MY-Main)
 #   searchLocation: ""    # optional location filter
 #   enabled: true
+#
+# - name: USAJOBS                        # US federal official API
+#   provider: usajobs
+#   usajobs:
+#     keyword: "software engineer"
+#     location: "Remote"
+#     remote: true
+#   enabled: true         # requires USAJOBS_USER_AGENT + USAJOBS_API_KEY
+#
+# - name: Adzuna                         # broad jobs API
+#   provider: adzuna
+#   adzuna:
+#     country: us
+#     what: "software engineer"
+#     where: "remote"
+#   enabled: true         # requires ADZUNA_APP_ID + ADZUNA_APP_KEY
+#
+# - name: Reed.co.uk                     # UK official Jobseeker API
+#   provider: reed
+#   reed:
+#     keywords: "software engineer"
+#     locationName: "remote"
+#   enabled: true         # requires REED_API_KEY
+#
+# - name: Jooble                         # broad jobs API
+#   provider: jooble
+#   jooble:
+#     keywords: "software engineer"
+#     location: "remote"
+#   enabled: true         # requires JOOBLE_API_KEY
+#
+# - name: Gupy Brazil                    # Brazil/LatAm ATS/API
+#   provider: gupy
+#   gupy:
+#     query: "software engineer"
+#     requires_token: true
+#   enabled: true         # requires GUPY_API_TOKEN unless using a public tenant endpoint
+#
+# - name: EURES                          # European employment portal
+#   provider: eures
+#   eures:
+#     query: "software engineer"
+#     method: POST
+#   enabled: true         # verify endpoint shape before enabling
+#
+# - name: Example iCIMS Company          # per-company iCIMS Job Portal API
+#   careers_url: https://careers.example.com
+#   provider: icims
+#   api: https://api.icims.com/customers/123/search/jobportal/456
+#   icims:
+#     query: "software engineer"
+#   enabled: true         # requires ICIMS_USERNAME + ICIMS_PASSWORD unless requires_auth:false
 #
 # - name: IBM — Germany SWE              # IBM global careers
 #   provider: ibm
@@ -1632,6 +1713,69 @@ job_boards:
     provider: yc-jobs
     enabled: true
     notes: "Public YC Work at a Startup embedded jobs data."
+
+  # -- Keyed/direct provider source pack --
+  # Disabled by default because these sources need credentials or per-tenant API setup.
+
+  - name: USAJOBS
+    provider: usajobs
+    usajobs:
+      keyword: "software engineer"
+      location: "Remote"
+      remote: true
+      results_per_page: 50
+    max_pages: 1
+    enabled: false
+    notes: "Official USAJOBS API. Requires USAJOBS_USER_AGENT and USAJOBS_API_KEY."
+
+  - name: Adzuna
+    provider: adzuna
+    adzuna:
+      country: us
+      what: "software engineer"
+      where: "remote"
+      results_per_page: 50
+    max_pages: 1
+    enabled: false
+    notes: "Official Adzuna Jobs API. Requires ADZUNA_APP_ID and ADZUNA_APP_KEY."
+
+  - name: Reed.co.uk
+    provider: reed
+    reed:
+      keywords: "software engineer"
+      locationName: "remote"
+      resultsToTake: 100
+    max_pages: 1
+    enabled: false
+    notes: "Official Reed Jobseeker API. Requires REED_API_KEY."
+
+  - name: Jooble
+    provider: jooble
+    jooble:
+      keywords: "software engineer"
+      location: "remote"
+    max_pages: 1
+    enabled: false
+    notes: "Official Jooble REST API. Requires JOOBLE_API_KEY."
+
+  - name: Gupy Brazil
+    provider: gupy
+    gupy:
+      query: "software engineer"
+      requires_token: true
+    max_pages: 1
+    enabled: false
+    notes: "Gupy API provider for Brazil/LatAm postings. Requires GUPY_API_TOKEN unless configured against a public tenant endpoint."
+
+  - name: EURES
+    provider: eures
+    eures:
+      query: "software engineer"
+      method: POST
+      page_size: 50
+    max_pages: 1
+    enabled: false
+    notes: "Guarded EURES provider. Enable only after verifying the configured public endpoint shape."
 
   # ── SolidJobs (Polish market) ──────────────────────────────────────
   # Public API — no auth needed. Division in URL path, campaign=career-ops for tracking.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -434,6 +434,21 @@ search_queries:
     query: 'site:linkedin.com/jobs "Software Engineer" OR "Backend Engineer" OR "Frontend Engineer" Turkey OR Türkiye OR Ankara OR Istanbul'
     enabled: false
 
+  # -- Big Tech / broad board handoff sources --
+  # These are intentionally WebSearch handoff queries, not direct scrapers.
+
+  - name: LinkedIn Jobs — Remote AI / FDE / Software
+    query: 'site:linkedin.com/jobs "Forward Deployed" OR "AI Engineer" OR "Software Engineer" OR "Solutions Engineer" remote'
+    enabled: true
+
+  - name: Indeed — Remote AI / Software
+    query: 'site:indeed.com/viewjob "AI Engineer" OR "Software Engineer" OR "Solutions Architect" remote'
+    enabled: true
+
+  - name: Welcome to the Jungle / Otta — Global Tech
+    query: 'site:welcometothejungle.com/en/jobs OR site:app.welcometothejungle.com "Forward Deployed" OR "AI Engineer" OR "Product Engineer" OR "Solutions Engineer" remote'
+    enabled: true
+
 # -- Tracked companies --
 # Companies whose career pages are checked directly.
 # scan_method: playwright (default), websearch, local_parser
@@ -726,6 +741,56 @@ search_queries:
 #     enabled: true
 
 tracked_companies:
+
+  # -- Big Tech / mixed source pack --
+
+  - name: Google
+    careers_url: https://www.google.com/about/careers/applications/jobs/results/
+    provider: google-careers
+    google:
+      query: software engineer
+    notes: "Public Google Careers search parser."
+    enabled: true
+
+  - name: Meta
+    careers_url: https://www.metacareers.com/jobs/
+    scan_method: websearch
+    scan_query: 'site:metacareers.com/jobs "Forward Deployed" OR "AI Engineer" OR "Software Engineer" OR "Solutions Engineer"'
+    notes: "WebSearch handoff; no stable public no-auth feed is configured."
+    enabled: true
+
+  - name: Apple
+    careers_url: https://jobs.apple.com/en-us/search
+    provider: apple-careers
+    apple:
+      search: software engineer
+      sort: relevance
+    notes: "Public Apple Jobs search parser."
+    enabled: true
+
+  - name: Microsoft
+    careers_url: https://jobs.careers.microsoft.com/global/en/search
+    provider: microsoft-careers
+    microsoft:
+      query: software engineer
+    notes: "Public Microsoft Careers PCS search API."
+    enabled: true
+
+  - name: Netflix
+    careers_url: https://jobs.netflix.com/
+    api: https://netflix.wd108.myworkdayjobs.com/Netflix
+    provider: workday
+    max_pages: 50
+    notes: "Netflix roles via the public Workday CXS endpoint."
+    enabled: true
+
+  - name: United Nations
+    careers_url: https://careers.un.org/jobopening?language=en
+    provider: un-careers
+    un:
+      language: en
+    notes: "Public UN Careers active job openings API."
+    enabled: true
 
   # -- AI Labs & LLM providers --
 
@@ -1550,6 +1615,23 @@ tracked_companies:
 # Same title/location filtering and dedup apply.
 
 job_boards:
+
+  # -- Big Tech / startup board source pack --
+
+  - name: Amazon / AWS
+    careers_url: https://www.amazon.jobs/en/search
+    provider: amazon
+    amazon:
+      base_query: software engineer
+      loc_query: ""
+    enabled: true
+    notes: "Public amazon.jobs search API; scanner filters narrow the global board."
+
+  - name: YC Work at a Startup
+    careers_url: https://www.ycombinator.com/jobs/
+    provider: yc-jobs
+    enabled: true
+    notes: "Public YC Work at a Startup embedded jobs data."
 
   # ── SolidJobs (Polish market) ──────────────────────────────────────
   # Public API — no auth needed. Division in URL path, campaign=career-ops for tracking.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12658,6 +12658,237 @@ try {
   fail(`mixed source provider tests crashed: ${e.message}`);
 }
 
+console.log('\n63. Providers — expanded source pack');
+
+try {
+  const withEnv = async (vars, fn) => {
+    const old = {};
+    for (const key of Object.keys(vars)) old[key] = process.env[key];
+    Object.assign(process.env, vars);
+    try {
+      return await fn();
+    } finally {
+      for (const key of Object.keys(vars)) {
+        if (old[key] === undefined) delete process.env[key];
+        else process.env[key] = old[key];
+      }
+    }
+  };
+
+  const usajobsMod = await import(pathToFileURL(join(ROOT, 'providers/usajobs.mjs')).href);
+  const usajobs = usajobsMod.default;
+  if (usajobs.id === 'usajobs') pass('usajobs.id is "usajobs"');
+  else fail(`usajobs.id is ${JSON.stringify(usajobs.id)}`);
+  const usaRows = usajobsMod.parseUsajobsResponse({
+    SearchResult: {
+      SearchResultItems: [
+        {
+          MatchedObjectDescriptor: {
+            PositionTitle: 'Software Engineer',
+            PositionURI: 'https://www.usajobs.gov/job/1',
+            OrganizationName: 'NASA',
+            PositionLocation: [{ LocationName: 'Remote' }],
+            PublicationStartDate: '2026-07-01T00:00:00Z',
+          },
+        },
+        { MatchedObjectDescriptor: { PositionTitle: '', PositionURI: 'https://www.usajobs.gov/job/2' } },
+      ],
+    },
+  });
+  if (usaRows.length === 1 && usaRows[0].company === 'NASA' && usaRows[0].location === 'Remote') {
+    pass('parseUsajobsResponse() normalizes USAJOBS descriptors');
+  } else {
+    fail(`parseUsajobsResponse() rows = ${JSON.stringify(usaRows)}`);
+  }
+  await withEnv({ USAJOBS_USER_AGENT: 'career-ops-test@example.com', USAJOBS_API_KEY: 'test-key' }, async () => {
+    const built = new URL(usajobsMod.buildUsajobsUrl({ usajobs: { keyword: 'AI', location: 'Remote', remote: true } }, 2));
+    if (built.searchParams.get('Keyword') === 'AI' && built.searchParams.get('RemoteIndicator') === 'true' && built.searchParams.get('Page') === '2') {
+      pass('buildUsajobsUrl() maps keyword/location/remote/page params');
+    } else {
+      fail(`buildUsajobsUrl() params = ${built.search}`);
+    }
+    let fetchOpts = null;
+    const fetched = await usajobs.fetch(
+      { name: 'USAJOBS', usajobs: { keyword: 'AI' } },
+      { maxPages: 1, fetchJson: async (_url, opts) => { fetchOpts = opts; return { SearchResult: { SearchResultItems: [{ MatchedObjectDescriptor: { PositionTitle: 'AI Role', PositionURI: 'https://www.usajobs.gov/job/3' } }] } }; } },
+    );
+    if (fetched.length === 1 && fetchOpts?.headers?.['Authorization-Key'] === 'test-key' && fetchOpts?.redirect === 'error') {
+      pass('usajobs.fetch() sends auth headers and redirect guard');
+    } else {
+      fail(`usajobs.fetch() result = ${JSON.stringify({ fetched, fetchOpts })}`);
+    }
+  });
+
+  const adzunaMod = await import(pathToFileURL(join(ROOT, 'providers/adzuna.mjs')).href);
+  const adzuna = adzunaMod.default;
+  if (adzuna.id === 'adzuna') pass('adzuna.id is "adzuna"');
+  else fail(`adzuna.id is ${JSON.stringify(adzuna.id)}`);
+  await withEnv({ ADZUNA_APP_ID: 'app-id', ADZUNA_APP_KEY: 'app-key' }, async () => {
+    const built = new URL(adzunaMod.buildAdzunaUrl({ adzuna: { country: 'gb', what: 'AI', where: 'London' } }, 3));
+    if (built.pathname.endsWith('/gb/search/3') && built.searchParams.get('what') === 'AI' && built.searchParams.get('app_id') === 'app-id') {
+      pass('buildAdzunaUrl() builds country/page/query URL with credentials');
+    } else {
+      fail(`buildAdzunaUrl() = ${built.toString()}`);
+    }
+    const rows = adzunaMod.parseAdzunaResponse({
+      results: [{ title: 'ML Engineer', redirect_url: 'https://adzuna.example/job/1', company: { display_name: 'Acme' }, location: { display_name: 'Remote' }, created: '2026-07-02T00:00:00Z' }],
+    });
+    if (rows.length === 1 && rows[0].company === 'Acme' && rows[0].location === 'Remote') {
+      pass('parseAdzunaResponse() normalizes Adzuna rows');
+    } else {
+      fail(`parseAdzunaResponse() rows = ${JSON.stringify(rows)}`);
+    }
+  });
+
+  const reedMod = await import(pathToFileURL(join(ROOT, 'providers/reed.mjs')).href);
+  const reed = reedMod.default;
+  if (reed.id === 'reed') pass('reed.id is "reed"');
+  else fail(`reed.id is ${JSON.stringify(reed.id)}`);
+  await withEnv({ REED_API_KEY: 'reed-key' }, async () => {
+    const built = new URL(reedMod.buildReedUrl({ reed: { keywords: 'AI', locationName: 'remote', resultsToTake: 25 } }, 2));
+    if (built.searchParams.get('keywords') === 'AI' && built.searchParams.get('resultsToSkip') === '25') {
+      pass('buildReedUrl() builds paginated Reed search params');
+    } else {
+      fail(`buildReedUrl() params = ${built.search}`);
+    }
+    const rows = reedMod.parseReedResponse({
+      results: [{ jobTitle: 'Backend Engineer', jobUrl: 'https://reed.co.uk/jobs/1', employerName: 'Acme', locationName: 'Remote', date: '/Date(1783296000000)/' }],
+    });
+    if (rows.length === 1 && rows[0].company === 'Acme' && String(rows[0].postedAt).includes('2026')) {
+      pass('parseReedResponse() normalizes Reed rows and Microsoft JSON dates');
+    } else {
+      fail(`parseReedResponse() rows = ${JSON.stringify(rows)}`);
+    }
+  });
+
+  const joobleMod = await import(pathToFileURL(join(ROOT, 'providers/jooble.mjs')).href);
+  const jooble = joobleMod.default;
+  if (jooble.id === 'jooble') pass('jooble.id is "jooble"');
+  else fail(`jooble.id is ${JSON.stringify(jooble.id)}`);
+  await withEnv({ JOOBLE_API_KEY: 'jooble-key' }, async () => {
+    const body = joobleMod.buildJoobleBody({ jooble: { keywords: 'AI', location: 'Remote' } }, 4);
+    if (body.keywords === 'AI' && body.location === 'Remote' && body.page === 4) pass('buildJoobleBody() maps keywords/location/page');
+    else fail(`buildJoobleBody() = ${JSON.stringify(body)}`);
+    let request = null;
+    const fetched = await jooble.fetch(
+      { name: 'Jooble', jooble: { keywords: 'AI' } },
+      { maxPages: 1, fetchJson: async (url, opts) => { request = { url, opts }; return { jobs: [{ title: 'AI Engineer', link: 'https://jooble.example/job/1', company: 'Acme', location: 'Remote' }] }; } },
+    );
+    if (fetched.length === 1 && request.url.endsWith('/jooble-key') && request.opts?.method === 'POST') {
+      pass('jooble.fetch() posts search body to keyed API URL');
+    } else {
+      fail(`jooble.fetch() = ${JSON.stringify({ fetched, request })}`);
+    }
+  });
+
+  const icimsMod = await import(pathToFileURL(join(ROOT, 'providers/icims.mjs')).href);
+  const icims = icimsMod.default;
+  if (icims.id === 'icims') pass('icims.id is "icims"');
+  else fail(`icims.id is ${JSON.stringify(icims.id)}`);
+  const icimsRows = icimsMod.parseIcimsResponse({
+    searchResults: [
+      { fields: { jobTitle: 'Forward Deployed Engineer', portalUrl: 'https://careers.example/jobs/1', city: 'Sao Paulo', country: 'Brazil' } },
+      { fields: { jobTitle: '', portalUrl: 'https://careers.example/jobs/2' } },
+    ],
+  }, { name: 'Example iCIMS' });
+  if (icimsRows.length === 1 && icimsRows[0].company === 'Example iCIMS' && icimsRows[0].location === 'Sao Paulo, Brazil') {
+    pass('parseIcimsResponse() normalizes generic iCIMS field payloads');
+  } else {
+    fail(`parseIcimsResponse() rows = ${JSON.stringify(icimsRows)}`);
+  }
+  await withEnv({ ICIMS_USERNAME: 'user', ICIMS_PASSWORD: 'pass' }, async () => {
+    const built = new URL(icimsMod.buildIcimsUrl({ api: 'https://api.icims.com/customers/1/search/jobportal/2', icims: { query: 'AI', search_json: { filters: [] } } }, 2));
+    if (built.searchParams.get('page') === '2' && built.searchParams.get('q') === 'AI' && built.searchParams.has('searchJson')) {
+      pass('buildIcimsUrl() appends pagination, query, and searchJson');
+    } else {
+      fail(`buildIcimsUrl() params = ${built.search}`);
+    }
+    let opts = null;
+    const fetched = await icims.fetch(
+      { name: 'Example iCIMS', api: 'https://api.icims.com/customers/1/search/jobportal/2' },
+      { maxPages: 1, fetchJson: async (_url, fetchOpts) => { opts = fetchOpts; return { results: [{ title: 'AI Role', url: 'https://careers.example/jobs/3' }] }; } },
+    );
+    if (fetched.length === 1 && /^Basic /.test(opts?.headers?.Authorization || '') && opts?.redirect === 'error') {
+      pass('icims.fetch() sends Basic auth and redirect guard');
+    } else {
+      fail(`icims.fetch() = ${JSON.stringify({ fetched, opts })}`);
+    }
+  });
+
+  const gupyMod = await import(pathToFileURL(join(ROOT, 'providers/gupy.mjs')).href);
+  const gupy = gupyMod.default;
+  if (gupy.id === 'gupy') pass('gupy.id is "gupy"');
+  else fail(`gupy.id is ${JSON.stringify(gupy.id)}`);
+  const gupyRows = gupyMod.parseGupyResponse({
+    data: [{ name: 'Product Engineer', jobUrl: 'https://gupy.example/jobs/1', companyName: 'Acme BR', workplace: { city: 'Sao Paulo', country: 'Brazil' }, publishedDate: '2026-07-03T00:00:00Z' }],
+  });
+  if (gupyRows.length === 1 && gupyRows[0].company === 'Acme BR' && gupyRows[0].location === 'Sao Paulo, Brazil') {
+    pass('parseGupyResponse() normalizes Gupy rows');
+  } else {
+    fail(`parseGupyResponse() rows = ${JSON.stringify(gupyRows)}`);
+  }
+  await withEnv({ GUPY_API_TOKEN: 'gupy-token' }, async () => {
+    const built = new URL(gupyMod.buildGupyUrl({ gupy: { query: 'AI' } }, 5));
+    if (built.searchParams.get('name') === 'AI' && built.searchParams.get('page') === '5') pass('buildGupyUrl() maps query and page params');
+    else fail(`buildGupyUrl() params = ${built.search}`);
+    let opts = null;
+    const fetched = await gupy.fetch(
+      { name: 'Gupy Brazil', gupy: { query: 'AI' } },
+      { maxPages: 1, fetchJson: async (_url, fetchOpts) => { opts = fetchOpts; return { results: [{ title: 'AI Engineer', url: 'https://gupy.example/jobs/2' }] }; } },
+    );
+    if (fetched.length === 1 && opts?.headers?.Authorization === 'Bearer gupy-token') pass('gupy.fetch() sends bearer auth when configured');
+    else fail(`gupy.fetch() = ${JSON.stringify({ fetched, opts })}`);
+  });
+
+  const euresMod = await import(pathToFileURL(join(ROOT, 'providers/eures.mjs')).href);
+  const eures = euresMod.default;
+  if (eures.id === 'eures') pass('eures.id is "eures"');
+  else fail(`eures.id is ${JSON.stringify(eures.id)}`);
+  const euresRows = euresMod.parseEuresResponse({
+    content: [{ id: '123', title: 'Software Engineer', companyName: 'EU Employer', location: { city: 'Lisbon', country: 'Portugal' }, publicationDate: '2026-07-04T00:00:00Z' }],
+  });
+  if (euresRows.length === 1 && euresRows[0].url.includes('/jv-details/123') && euresRows[0].location === 'Lisbon, Portugal') {
+    pass('parseEuresResponse() normalizes EURES rows and builds detail URLs');
+  } else {
+    fail(`parseEuresResponse() rows = ${JSON.stringify(euresRows)}`);
+  }
+  const euresBody = euresMod.buildEuresBody({ eures: { query: 'AI', locationCodes: ['BR'] } }, 6);
+  if (euresBody.keywords === 'AI' && euresBody.page === 6 && euresBody.locationCodes[0] === 'BR') {
+    pass('buildEuresBody() maps query/location/page');
+  } else {
+    fail(`buildEuresBody() = ${JSON.stringify(euresBody)}`);
+  }
+  let euresRequest = null;
+  const euresFetched = await eures.fetch(
+    { name: 'EURES', eures: { query: 'AI' } },
+    { maxPages: 1, fetchJson: async (url, opts) => { euresRequest = { url, opts }; return { jobs: [{ title: 'AI Engineer', url: 'https://europa.eu/job/1', employerName: 'EU Co' }] }; } },
+  );
+  if (euresFetched.length === 1 && euresRequest.opts?.method === 'POST' && euresRequest.opts?.redirect === 'error') {
+    pass('eures.fetch() posts guarded JSON requests');
+  } else {
+    fail(`eures.fetch() = ${JSON.stringify({ euresFetched, euresRequest })}`);
+  }
+
+  await withEnv({ ADZUNA_APP_ID: 'app-id', ADZUNA_APP_KEY: 'app-key', JOOBLE_API_KEY: 'jooble-key' }, async () => {
+    let guardHits = 0;
+    for (const probe of [
+      () => usajobsMod.buildUsajobsUrl({ api: 'https://evil.example/api' }),
+      () => adzunaMod.buildAdzunaUrl({ api: 'https://evil.example/api' }),
+      () => reedMod.buildReedUrl({ api: 'https://evil.example/api' }),
+      () => joobleMod.buildJoobleUrl({ api: 'https://evil.example/api' }),
+      () => icimsMod.buildIcimsUrl({ api: 'https://evil.example/api' }),
+      () => gupyMod.buildGupyUrl({ api: 'https://evil.example/api' }),
+      () => euresMod.buildEuresUrl({ api: 'https://evil.example/api' }),
+    ]) {
+      try { probe(); } catch { guardHits++; }
+    }
+    if (guardHits === 7) pass('expanded source providers reject untrusted API hosts');
+    else fail(`expanded source provider SSRF guard hits = ${guardHits}/7`);
+  });
+} catch (e) {
+  fail(`expanded source provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12432,6 +12432,232 @@ try {
   fail(`stats.mjs tests crashed: ${e.message}`);
 }
 
+console.log('\n63. Providers — mixed source pack (Google, Apple, Microsoft, YC, UN)');
+
+try {
+  const googleModule = await import(pathToFileURL(join(ROOT, 'providers/google-careers.mjs')).href);
+  const appleModule = await import(pathToFileURL(join(ROOT, 'providers/apple-careers.mjs')).href);
+  const microsoftModule = await import(pathToFileURL(join(ROOT, 'providers/microsoft-careers.mjs')).href);
+  const ycModule = await import(pathToFileURL(join(ROOT, 'providers/yc-jobs.mjs')).href);
+  const unModule = await import(pathToFileURL(join(ROOT, 'providers/un-careers.mjs')).href);
+
+  const google = googleModule.default;
+  const apple = appleModule.default;
+  const microsoft = microsoftModule.default;
+  const yc = ycModule.default;
+  const unCareers = unModule.default;
+
+  if (google.id === 'google-careers' && apple.id === 'apple-careers' && microsoft.id === 'microsoft-careers' && yc.id === 'yc-jobs' && unCareers.id === 'un-careers') {
+    pass('mixed source providers expose stable provider ids');
+  } else {
+    fail(`mixed source provider ids wrong: ${JSON.stringify([google.id, apple.id, microsoft.id, yc.id, unCareers.id])}`);
+  }
+
+  if (google.detect({ careers_url: 'https://www.google.com/about/careers/applications/jobs/results/' }) && google.detect({ careers_url: 'https://evil.example/www.google.com/about/careers/applications/jobs/results/' }) === null) {
+    pass('google-careers.detect() claims the official host and rejects path spoofing');
+  } else {
+    fail('google-careers.detect() host validation wrong');
+  }
+
+  const googleHtml = `
+    <ul>
+      <li class="lLd3Je">
+        <h3 class="QJPWVe">Staff Software Engineer &amp; Tech Lead</h3>
+        <span class="r0wTof ">London, UK</span>
+        <a href="jobs/results/111-staff-software-engineer">View role</a>
+      </li>
+      <li class="lLd3Je">
+        <h3 class="QJPWVe">Forward Deployed Engineer</h3>
+        <span class="r0wTof ">Remote eligible</span>
+        <a href="/about/careers/applications/jobs/results/222-forward-deployed-engineer">View role</a>
+      </li>
+    </ul>`;
+  const googleRows = googleModule.parseGoogleCareersHtml(googleHtml);
+  if (googleRows.length === 2 && googleRows[0].title === 'Staff Software Engineer & Tech Lead') pass('parseGoogleCareersHtml() extracts and decodes Google job cards');
+  else fail(`parseGoogleCareersHtml() rows = ${JSON.stringify(googleRows)}`);
+
+  let googleFetchUrl = '';
+  const googleFetched = await google.fetch(
+    { name: 'Google', google: { query: 'product engineer' } },
+    { fetchText: async (url, opts) => { googleFetchUrl = url; if (opts?.redirect !== 'error') throw new Error('missing redirect guard'); return googleHtml; } },
+  );
+  if (googleFetchUrl.includes('q=product+engineer') && googleFetched.length === 2) pass('google-careers.fetch() builds the query URL and normalizes parsed rows');
+  else fail(`google-careers.fetch() url/jobs wrong: ${googleFetchUrl} ${JSON.stringify(googleFetched)}`);
+
+  const appleHtml = `
+    <ul id="search-job-list">
+      <li data-core-accordion-item>
+        <a href="/en-us/details/2001/software-engineer?team=SFTWR">Software Engineer</a>
+        <span id="search-store-name-container-1">Cupertino</span>
+        <span class="job-posted-date">Jul 02, 2026</span>
+      </li>
+      <li data-core-accordion-item>
+        <a href="/en-us/details/2002/ai-ml-engineer">AI/ML Engineer</a>
+        <span id="search-store-name-container-2">London</span>
+      </li>
+    </ul>`;
+  const appleRows = appleModule.parseAppleCareersHtml(appleHtml);
+  if (appleRows.length === 2 && appleRows[0].location === 'Cupertino' && appleRows[0].postedAt === Date.parse('Jul 02, 2026')) {
+    pass('parseAppleCareersHtml() extracts Apple job links, location, and posted date');
+  } else {
+    fail(`parseAppleCareersHtml() rows = ${JSON.stringify(appleRows)}`);
+  }
+
+  let appleFetchUrl = '';
+  const appleFetched = await apple.fetch(
+    { name: 'Apple', apple: { search: 'ai engineer', sort: 'recent' } },
+    { fetchText: async (url, opts) => { appleFetchUrl = url; if (opts?.redirect !== 'error') throw new Error('missing redirect guard'); return appleHtml; } },
+  );
+  if (appleFetchUrl.includes('search=ai+engineer') && appleFetchUrl.includes('sort=recent') && appleFetched.length === 2) {
+    pass('apple-careers.fetch() builds search/sort params and normalizes rows');
+  } else {
+    fail(`apple-careers.fetch() url/jobs wrong: ${appleFetchUrl} ${JSON.stringify(appleFetched)}`);
+  }
+
+  if (microsoft.detect({ careers_url: 'https://jobs.careers.microsoft.com/global/en/search' }) && microsoft.detect({ careers_url: 'https://evil.example/jobs.careers.microsoft.com/global/en/search' }) === null) {
+    pass('microsoft-careers.detect() claims the official host and rejects path spoofing');
+  } else {
+    fail('microsoft-careers.detect() host validation wrong');
+  }
+
+  const microsoftPayload = {
+    props: {
+      results: [
+        {
+          display_job_id: '178001',
+          title: 'Principal Software Engineer',
+          canonicalPositionUrl: 'https://jobs.careers.microsoft.com/global/en/job/178001/principal-software-engineer',
+          locations: [{ displayName: 'Redmond, Washington, United States' }],
+          postedDate: '2026-07-01',
+        },
+        { title: 'Marketing page', url: '/global/en/life-at-microsoft' },
+      ],
+    },
+  };
+  const microsoftHtml = `<html><code id="pcsx-data">${JSON.stringify(microsoftPayload).replace(/"/g, '&#34;')}</code></html>`;
+  const microsoftRows = microsoftModule.parseMicrosoftCareersHtml(microsoftHtml);
+  if (microsoftRows.length === 1 && microsoftRows[0].title === 'Principal Software Engineer' && microsoftRows[0].location === 'Redmond, Washington, United States') {
+    pass('parseMicrosoftCareersHtml() extracts jobs from the pcsx-data payload');
+  } else {
+    fail(`parseMicrosoftCareersHtml() rows = ${JSON.stringify(microsoftRows)}`);
+  }
+
+  const microsoftJson = {
+    status: 200,
+    data: {
+      positions: [
+        {
+          id: 1970393556869024,
+          displayJobId: '200038289',
+          name: 'Software Engineer/Sr Software Engineer',
+          locations: ['United States, Washington, Redmond'],
+          postedTs: 1780069158,
+          positionUrl: '/careers/job/1970393556869024',
+        },
+      ],
+    },
+  };
+  const microsoftApiRows = microsoftModule.parseMicrosoftSearchResponse(microsoftJson);
+  if (microsoftApiRows.length === 1 && microsoftApiRows[0].url === 'https://apply.careers.microsoft.com/careers/job/1970393556869024' && microsoftApiRows[0].postedAt === 1780069158 * 1000) {
+    pass('parseMicrosoftSearchResponse() extracts jobs from the public PCS search API');
+  } else {
+    fail(`parseMicrosoftSearchResponse() rows = ${JSON.stringify(microsoftApiRows)}`);
+  }
+
+  let microsoftFetchUrl = '';
+  let microsoftFetchOpts = null;
+  const microsoftFetched = await microsoft.fetch(
+    { name: 'Microsoft', microsoft: { query: 'software engineer' } },
+    { fetchJson: async (url, opts) => { microsoftFetchUrl = url; microsoftFetchOpts = opts; return microsoftJson; } },
+  );
+  if (microsoftFetchUrl.includes('/api/pcsx/search') && microsoftFetchUrl.includes('query=software+engineer') && microsoftFetchOpts?.redirect === 'error' && microsoftFetched.length === 1) {
+    pass('microsoft-careers.fetch() uses the public PCS search API and normalizes rows');
+  } else {
+    fail(`microsoft-careers.fetch() url/opts/jobs wrong: ${JSON.stringify({ microsoftFetchUrl, microsoftFetchOpts, microsoftFetched })}`);
+  }
+
+  if (yc.detect({ careers_url: 'https://www.ycombinator.com/jobs/' }) && yc.detect({ careers_url: 'https://evil.example/ycombinator.com/jobs' }) === null) {
+    pass('yc-jobs.detect() claims official YC jobs and rejects path spoofing');
+  } else {
+    fail('yc-jobs.detect() host validation wrong');
+  }
+
+  const ycPayload = {
+    component: 'WaasLandingPage',
+    props: {
+      jobPostings: [
+        {
+          id: 1,
+          title: 'Founding AI Engineer',
+          url: '/companies/acme/jobs/founding-ai-engineer',
+          companyName: 'Acme AI',
+          location: 'Remote',
+          createdAt: '2026-07-03T00:00:00Z',
+        },
+        {
+          id: 2,
+          title: 'Product Engineer',
+          url: 'https://www.ycombinator.com/companies/beta/jobs/product-engineer',
+          companyName: 'Beta Labs',
+        },
+      ],
+    },
+  };
+  const ycHtml = `<div id="app" data-page="${JSON.stringify(ycPayload).replace(/"/g, '&#34;')}"></div>`;
+  const ycRows = ycModule.parseYcJobsHtml(ycHtml);
+  if (ycRows.length === 2 && ycRows[0].company === 'Acme AI' && ycRows[0].url === 'https://www.ycombinator.com/companies/acme/jobs/founding-ai-engineer') {
+    pass('parseYcJobsHtml() extracts embedded YC startup jobs and resolves relative URLs');
+  } else {
+    fail(`parseYcJobsHtml() rows = ${JSON.stringify(ycRows)}`);
+  }
+
+  const ycFetched = await yc.fetch(
+    { name: 'YC Work at a Startup' },
+    { fetchText: async (_url, opts) => { if (opts?.redirect !== 'error') throw new Error('missing redirect guard'); return ycHtml; } },
+  );
+  if (ycFetched.length === 2 && ycFetched[1].company === 'Beta Labs') pass('yc-jobs.fetch() normalizes startup-company rows from the public page');
+  else fail(`yc-jobs.fetch() rows = ${JSON.stringify(ycFetched)}`);
+
+  if (unCareers.detect({ careers_url: 'https://careers.un.org/jobopening?language=en' }) && unCareers.detect({ careers_url: 'https://evil.example/careers.un.org/jobopening' }) === null) {
+    pass('un-careers.detect() claims careers.un.org and rejects path spoofing');
+  } else {
+    fail('un-careers.detect() host validation wrong');
+  }
+
+  const unJson = {
+    status: 1,
+    data: [
+      {
+        jobId: 279640,
+        postingTitle: 'Associate Administrative Officer, P2',
+        dutyStation: [{ description: 'NAIROBI' }],
+        startDate: '2026-07-04T00:00:00Z',
+      },
+      { jobId: null, postingTitle: 'Missing URL' },
+    ],
+  };
+  const unRows = unModule.parseUnCareersResponse(unJson, { language: 'en', company: 'United Nations' });
+  if (unRows.length === 1 && unRows[0].company === 'United Nations' && unRows[0].location === 'NAIROBI' && unRows[0].url.includes('jobId')) {
+    pass('parseUnCareersResponse() extracts active UN jobs and builds jobopening URLs');
+  } else {
+    fail(`parseUnCareersResponse() rows = ${JSON.stringify(unRows)}`);
+  }
+
+  let unFetchUrl = '';
+  let unFetchOpts = null;
+  const unFetched = await unCareers.fetch(
+    { name: 'United Nations', un: { language: 'en' } },
+    { fetchJson: async (url, opts) => { unFetchUrl = url; unFetchOpts = opts; return unJson; } },
+  );
+  if (unFetchUrl.includes('/api/public/opening/jo/activeJo') && unFetchOpts?.redirect === 'error' && /application\/json/.test(unFetchOpts?.headers?.accept || '') && unFetched.length === 1) {
+    pass('un-careers.fetch() uses the public API with JSON headers and redirect guard');
+  } else {
+    fail(`un-careers.fetch() url/opts/jobs wrong: ${JSON.stringify({ unFetchUrl, unFetchOpts, unFetched })}`);
+  }
+} catch (e) {
+  fail(`mixed source provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -51,6 +51,7 @@ export const REEXEC_BUFFER_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
+  '.editorconfig',
   'modes/_shared.md',
   'modes/_profile.template.md',
   'modes/_custom.template.md',


### PR DESCRIPTION
## Summary
- Add provider-backed sources for Google Careers, Apple Jobs, Microsoft Careers, YC Work at a Startup, and UN Careers.
- Reuse existing Amazon and Workday providers through the example portal config for Amazon/AWS and Netflix.
- Add WebSearch handoff entries for LinkedIn Jobs, Indeed, Welcome to the Jungle/Otta, and Meta Careers.
- Document direct providers vs handoff-only sources and cover new parsers/providers in test-all fixtures.

## Verification
- node validate-portals.mjs --file portals.yml
- node validate-portals.mjs --file templates/portals.example.yml
- node verify-portals.mjs
- node test-all.mjs
- node scan.mjs --dry-run --company Google
- node scan.mjs --dry-run --company Apple
- node scan.mjs --dry-run --company Microsoft
- node scan.mjs --dry-run --company Amazon
- node scan.mjs --dry-run --company Netflix
- node scan.mjs --dry-run --company YC
- node scan.mjs --dry-run --company "United Nations"

## Notes
- LinkedIn, Indeed, Welcome to the Jungle/Otta, and Meta are search-handoff sources, not direct scrapers.
- Local portals.yml was updated for this workspace but remains user-layer/gitignored and is intentionally not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for several new job sources, including Apple, Google, Microsoft, EURES, USAJOBS, UN Careers, YC Work at a Startup, and more.
  * Expanded the job board templates with new example providers and larger source packs.

* **Bug Fixes**
  * Improved job result parsing, deduplication, pagination, and location/date handling across multiple sources.
  * Strengthened URL validation and request safeguards for supported job feeds.

* **Tests**
  * Added broader coverage for provider detection, parsing, request construction, and security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->