### PR TITLE
fix(web): use next/link for decision-card report link

### DIFF
--- a/web/src/components/home/decision-card.tsx
+++ b/web/src/components/home/decision-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { Check, X, FileText, Loader2 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CompanyLogo } from "@/components/company-logo";
@@ -54,12 +55,12 @@ export function DecisionCard({ app }: { app: Application }) {
       <div className="flex items-center gap-2">
         {/* Primary is the report (PDF + Apply live there). Marking Applied from
             Today skipped that path and wrote a status with no application. */}
-        <a
+        <Link
           href={`/pipeline/${app.n}`}
           className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-brand-soft px-2.5 py-1.5 text-xs font-medium text-brand-text transition hover:bg-brand/15 max-sm:min-h-[44px]"
         >
           <FileText className="size-3.5" /> Review
-        </a>
+        </Link>
         <button
           type="button"
           disabled={!!busy}


### PR DESCRIPTION
## Summary
- reduce the PR to the still-live improvement requested in review
- replace the decision-card internal report route anchor with Next.js Link after the current decision-card rewrite

## Validation
- rebased onto current main
- CI rerun pending on GitHub