### PR TITLE
feat: add gtop mode — Google Jobs top picks (last 24h discovery + triage)

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -4,7 +4,7 @@ description: AI job search command center -- evaluate offers, tailor CVs, scan p
 arguments: mode
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | discover | deep | pdf | latex | latex-tex | cover | email | add | expand | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | interview-redflag | patterns | offer-prep | titles | upskill | followup | reply-watch | update]"
+argument-hint: "[scan | discover | deep | pdf | latex | latex-tex | cover | email | add | expand | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | interview-redflag | patterns | offer-prep | titles | upskill | followup | reply-watch | update | gtop]"
 license: MIT
 ---
 
@@ -73,6 +73,7 @@ Determine the mode from `$mode`:
 | `interview-redflag` | `interview-redflag` |
 | `update` | `update` |
 | `cover` | `cover` |
+| `gtop` | `gtop` |
 
 **Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -167,7 +168,7 @@ If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the s
 
 Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`, `gtop`
 
 ### Standalone modes with profile and custom context
 

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,16 @@ plan/
 
 # Web — runtime cache/history the dashboard writes locally; nothing here is tracked.
 .career-ops-web/
+
+# Local scrape/experiment artifacts (ephemeral, machine-local)
+*-snapshot.md
+page-*.yml
+ei-job.yml
+scrape-job-snapshot*.{md,yml}
+
+# Editor swap/backup files
+~*
+*~
+
+# Pi harness local config (machine-local, never commit)
+.pi/

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -35,34 +35,41 @@ It complements `scan` (per-portal/ATS) by casting a wider net across Google's ag
 
 ## Step 1 — Build the Google Jobs queries
 
-Google Jobs search URL format:
+Google Jobs search URL format (freshness baked into the keywords by default):
 
 ```
-https://www.google.com/search?q={URL-encoded keywords}&ibp=htl;jobs&hl=en&gl={GL}
+https://www.google.com/search?q={URL-encoded keywords, including "since yesterday"}+in+{LOCATION}&ibp=htl;jobs&hl=en&gl={GL}
 ```
 
 - `gl={GL}` — the 2-letter country code for the candidate's location (e.g. `ca` for Canada, `us` for the US, `gb` for the UK). Derive it from `config/profile.yml` → `candidate.location`; default to `ca` only if the location is Canadian.
 
-**Note on freshness:** Google Jobs URL params for the date filter (`htichips=date_posted:today`) are unreliable — Google strips them from the rendered results. The reliable freshness gate is the **Step 3 "Posted X ago" text filter** applied after scraping. Optionally, after the first snapshot you may click the on-page **"Date posted" → "Past 24 hours"** filter button to narrow results at the source, but always still apply the Step 3 text filter as the authoritative gate.
+**Freshness is encoded directly in the `q` keywords, not via a URL date param or on-page button click.** Appending the literal phrase `since yesterday` to the search keywords makes Google's jobs index fetch only postings from the past ~24 hours — verified empirically (the user's own working URL uses this technique: `q=...in+toronto+since+yesterday`). This is more reliable than:
+- `htichips=date_posted:today` — Google **strips** this param.
+- `tbs=qdr:d` — Google keeps it, but it is a generic search param, not jobs-specific, and behavior is less consistent.
+- Clicking the on-page "Date posted → Past 24 hours" button — adds an extra round-trip and page-state change; avoid it.
+
+So: **every query's `q` MUST end with `since yesterday`**, and no on-page date filter button is ever clicked. Google rewrites the URL on load (drops `ibp=htl;jobs`, adds `udm=8&jbr=sep:0`) but the `since yesterday` term stays in `q`, so the freshness intent survives the rewrite.
+
+**Note on freshness:** Because `since yesterday` narrows at the source, most results will already be under 24h, but Google can still sneak the occasional older posting ("1 day ago" boundary cards) through. The **Step 3 "Posted X ago" text filter remains the authoritative freshness gate** — every card MUST still pass it. The keyword phrase reduces noise; the text filter guarantees the 24h boundary.
 
 Read the candidate's location from `config/profile.yml` → `candidate.location` (default: `Toronto`).
 
-**If the user passed a custom role argument** (anything after `gtop` in the invocation), use it directly as the sole query keyword. Build 3 queries with that same keyword combined with related terms from `title_filter.positive`:
+**If the user passed a custom role argument** (anything after `gtop` in the invocation), use it directly as the sole query keyword. Build 3 queries with that same keyword combined with related terms from `title_filter.positive`. **Every query MUST end with `since yesterday`** (before URL-encoding):
 
-- **Query A:** `{custom-role} {LOCATION}`
-- **Query B:** `{custom-role} OR related-variant-1 OR related-variant-2 {LOCATION}`
-- **Query C:** `{custom-role} OR other-variant-1 OR other-variant-2 {LOCATION}`
+- **Query A:** `{custom-role} in {LOCATION} since yesterday`
+- **Query B:** `{custom-role} OR related-variant-1 OR related-variant-2 in {LOCATION} since yesterday`
+- **Query C:** `{custom-role} OR other-variant-1 OR other-variant-2 in {LOCATION} since yesterday`
 
-URL-encode each query.
+URL-encode each query (spaces → `+`, quotes and parentheses → percent-encoded).
 
-**If no argument was given**, construct **exactly 3 queries** from the candidate's pre-configured keywords (from `portals.yml` `title_filter.positive` + `config/profile.yml` target roles), clustered by theme. Replace `{LOCATION}` below with the actual location:
+**If no argument was given**, construct **exactly 3 queries** from the candidate's pre-configured keywords (from `portals.yml` `title_filter.positive` + `config/profile.yml` target roles), clustered by theme. Replace `{LOCATION}` below with the actual location. **Every query MUST end with `since yesterday`:**
 
 - **Query A — Full-Stack / SWE / Backend cluster:**
-  `("Full Stack" OR "Software Engineer" OR "Backend Engineer" OR "Node.js" OR "React Developer") {LOCATION}`
+  `("Full Stack" OR "Software Engineer" OR "Backend Engineer" OR "Node.js" OR "React Developer") in {LOCATION} since yesterday`
 - **Query B — AI / ML / Automation cluster:**
-  `("AI Engineer" OR "ML" OR "LLM" OR "Agent" OR "Automation" OR "RAG" OR "GenAI") {LOCATION}`
+  `("AI Engineer" OR "ML" OR "LLM" OR "Agent" OR "Automation" OR "RAG" OR "GenAI") in {LOCATION} since yesterday`
 - **Query C — Broader Developer cluster:**
-  `("Software Developer" OR "Application Developer" OR "Platform Engineer" OR "Full Stack Developer") {LOCATION}`
+  `("Software Developer" OR "Application Developer" OR "Platform Engineer" OR "Full Stack Developer") in {LOCATION} since yesterday`
 
 Do not exceed 3 queries in either mode.
 

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -38,8 +38,12 @@ It complements `scan` (per-portal/ATS) by casting a wider net across Google's ag
 Google Jobs search URL format:
 
 ```
-https://www.google.com/search?q={URL-encoded keywords}&ibp=htl;jobs&hl=en&gl=ca
+https://www.google.com/search?q={URL-encoded keywords}&ibp=htl;jobs&hl=en&gl={GL}
 ```
+
+- `gl={GL}` — the 2-letter country code for the candidate's location (e.g. `ca` for Canada, `us` for the US, `gb` for the UK). Derive it from `config/profile.yml` → `candidate.location`; default to `ca` only if the location is Canadian.
+
+**Note on freshness:** Google Jobs URL params for the date filter (`htichips=date_posted:today`) are unreliable — Google strips them from the rendered results. The reliable freshness gate is the **Step 3 "Posted X ago" text filter** applied after scraping. Optionally, after the first snapshot you may click the on-page **"Date posted" → "Past 24 hours"** filter button to narrow results at the source, but always still apply the Step 3 text filter as the authoritative gate.
 
 Read the candidate's location from `config/profile.yml` → `candidate.location` (default: `Toronto`).
 
@@ -112,9 +116,11 @@ Google Jobs surfaces listings from a mix of sources. Many are **aggregator/scrap
 
 ---
 
-## Step 3 — Filter to last 24 hours
+## Step 3 — Filter to last 24 hours (authoritative freshness gate)
 
-Parse `postedAge` text into an age estimate, then keep only cards whose age is **≤ 24 hours**. Boundary rule: `1 day ago` is treated as ~24h and **included** (a "1 day ago" card on Google can be 12–24h old).
+**This is the primary and authoritative freshness filter.** Google Jobs returns a mix of ages regardless of any URL param or on-page filter, so every card MUST pass this text-based check before it proceeds — do not assume the results are already filtered.
+
+Parse `postedAge` text into an age estimate, then keep only cards whose age is **≤ 24 hours**. Boundary rule: `1 day ago` is treated as ~24h and **included** (a "1 day ago" card on Google can be 12–24h old). A card with **no** `postedAge` text (age unknown) is dropped — freshness cannot be confirmed.
 
 Parsing rules:
 

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -82,7 +82,7 @@ For each query URL:
 
    **Do NOT try to extract a destination URL from the card itself.** Google Jobs cards are buttons, not hyperlinks — there is no `href` to read. The real apply URL is only accessible inside the detail panel after clicking the card.
 
-5. If a Google "More jobs" / pagination control is present, click it (`browser_click`) to reveal more cards — but **cap at ~30 cards per query** to bound tokens.
+5. If a Google "More jobs" / pagination control is present, click it (`browser_click`) to reveal more cards. After the click, `browser_snapshot` again and re-parse the newly revealed cards — but **cap at ~30 cards per query** to bound tokens.
 
 **Bot-challenge handling:** If the snapshot shows a CAPTCHA / "Just a moment…" / "unusual traffic" page instead of job cards, note it and skip that query. Continue with the others. Do not retry aggressively.
 
@@ -154,12 +154,12 @@ For each surviving card (that passed Step 2.5's portal filter):
 
 6. **If the detail panel doesn't have enough JD text** (some Google Jobs panels show only a short snippet), navigate to the apply URL directly as fallback:
    - **Security check:** Before navigating, validate the extracted URL is an `https:` URL whose host matches an approved source (linkedin.com, indeed.com, myworkdayjobs.com, greenhouse.io, jobs.ashbyhq.com, lever.co, or a company careers domain). Reject non-HTTPS or unapproved destinations — skip this card instead.
-   - `browser_navigate` → the extracted apply URL (Playwright follows redirects automatically)
-   - `browser_snapshot` → read full JD from the ATS page
+   - **Open in a new tab:** use `browser_tabs` to create a new tab, `browser_navigate` → the extracted apply URL there. This preserves the Google Jobs page with its card buttons and detail panel for subsequent cards.
+   - After extracting the JD, close the fallback tab to return to Google Jobs.
 7. **Platform notes for fallback navigation:**
    - Greenhouse / Ashby / Lever / company career pages: snapshot works after full render.
-   - Workday (`*.myworkdayjobs.com`): heavy SPA — wait longer before snapshot, fall back to WebFetch if empty.
-   - LinkedIn (`linkedin.com/jobs`): often redirects to login. If the snapshot shows "Sign In", fall back to WebSearch for `{company} {role} job description` rather than getting stuck.
+   - Workday (`*.myworkdayjobs.com`): heavy SPA — wait longer before snapshot. WebFetch fallback is allowed only in headless batch mode; if used, mark the report header with `**Verification:** unconfirmed (batch mode)`. In interactive mode, keep it Playwright-only.
+   - LinkedIn (`linkedin.com/jobs`): often redirects to login. If the snapshot shows "Sign In", fall back to WebSearch for `{company} {role} job description` — **this counts toward the 5-query total WebSearch budget** (see bounded research budget in Step 5).
 
 **Token discipline:** Do not dump the full JD text into your response. Extract the key fields silently (title, company, location, requirements, salary if listed) and keep only a short note for scoring.
 
@@ -196,7 +196,10 @@ For roles with global score **≥ 4.0/5**, do the following so the user has an a
 2. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from Step 5.
 3. **Generate PDF:** run the full pipeline from `modes/pdf.md` to produce a tailored CV PDF. Run `node generate-pdf.mjs` for the HTML→PDF conversion.
 4. **Write a TSV tracker addition** to `batch/tracker-additions/{REPORT_NUM}-{company-slug}.tsv` following the standard 9-column TSV format (see Pipeline Integrity in CLAUDE.md).
-5. **Merge the tracker:** run `node merge-tracker.mjs` to integrate the new entry into `data/applications.md`.
+5. **Merge + clean up the tracker:**
+   - Run `node merge-tracker.mjs` to integrate the new entry into `data/applications.md`.
+   - Then run `node normalize-statuses.mjs` and `node dedup-tracker.mjs` to enforce canonical states and remove any duplicates.
+   - Finally run `node verify-pipeline.mjs` to confirm pipeline integrity.
 
 (Or skip the full pipeline and do the above in a single pass — the point is the same: high-fit roles get persisted as evaluable artifacts.)
 
@@ -228,15 +231,18 @@ Scanned: 3 queries · {N} cards total · {M} fresh (<24h) · {K} evaluated · {P
 
 2. … (continue for each ≥ 4.0 role)
 
-### Below threshold (evaluated, ≥ 4.0 not met)
+### Below threshold (evaluated, score < 4.0)
 
 - [3.8] {Role} @ {Company} — {one-line reason: e.g. "requires 6+ YOE Scala, level mismatch"}
 - …
 ```
 
-If **no role clears 4.0**, say so plainly:
+If **no role clears 4.0**, branch on whether any roles were evaluated:
 
-> No high-fit roles in the last 24h across the 3 queries. {M} fresh postings were evaluated; strongest was {Role} @ {Company} at {score}/5. Re-run tomorrow, adjust keywords in `portals.yml`, or run `/career-ops scan` for direct-portal discovery.
+- If at least one role was evaluated (M > 0):
+  > No high-fit roles in the last 24h across the 3 queries. {M} fresh postings were evaluated; strongest was {Role} @ {Company} at {score}/5. Re-run tomorrow, adjust keywords in `portals.yml`, or run `/career-ops scan` for direct-portal discovery.
+- If no roles were evaluated (M = 0 — e.g. CAPTCHA blocked all queries, or no postings under 24h):
+  > No fresh postings found in the last 24h. This could be a quiet day, or CAPTCHA/bot-blocking may have affected the queries. Re-run tomorrow, or try `/career-ops scan` for direct-portal discovery.
 
 **Next steps line** (always, if ≥ 4.0 roles exist):
 > These are triage picks, not full evaluations. For any role you'll actually apply to, run `/career-ops oferta {url}` for the complete A-G report + tailored CV, then `/career-ops apply {url}` to fill the form.

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -98,7 +98,7 @@ Google Jobs surfaces listings from a mix of sources. Many are **aggregator/scrap
 | **Greenhouse** | `via Greenhouse` (rare on Google Jobs) | Official ATS used by the company |
 | **Ashby** | `via Ashby` (rare on Google Jobs) | Official ATS |
 | **Lever** | `via Lever` (rare on Google Jobs) | Official ATS |
-| **Workday** | URL contains `myworkdayjobs.com` or `wd1/` | Official ATS |
+| **Workday** | `via Workday` or `via {Company} Careers` (URL checked in Step 4 if `myworkdayjobs.com`) | Official ATS |
 | **ICIMS** | `via {Company} - ICIMS` | Official ATS |
 | **BambooHR** / **Breezy** / **Pinpoint** / **Jobvite** / **SmartRecruiters** | any company's official ATS name | Company's official hiring platform |
 
@@ -174,7 +174,7 @@ Evaluate the following blocks (compact form — 2-4 sentences each):
 - **Archetype** — one of the 6 from `_shared.md` (AI Platform/LLMOps, Agentic/Automation, Technical AI PM, AI Solutions Architect, AI Forward Deployed, AI Transformation), mapped to the user's full-stack/backend/general-SWE archetypes in `_profile.md` when the role isn't an AI archetype.
 - **Block A — Role Summary:** title, seniority, location, remote/hybrid/onsite, one-line on what the role is.
 - **Block B — Match with CV:** map the 3–5 strongest JD requirements to concrete `cv.md` proof points (cite the line/project, never fabricate). Score the skill match 1–5.
-- **Block C — Level & Strategy:** is the seniority a fit for the candidate (mid-senior, 4 YOE)? 1 sentence.
+- **Block C — Level & Strategy:** is the seniority a fit for the candidate (read years of experience from `config/profile.yml` or `cv.md` — do not hardcode)? 1 sentence.
 - **Block D — Comp:** **no WebSearch.** If salary is in the JD, compare to the user's comp target from `_profile.md`. If absent, mark "unknown — verify." Do not research Levels.fyi/Glassdoor.
 - **Block E & F — Omitted** (Customization Plan and Interview Plan are not evaluated at triage stage). In the saved report, note them as "Omitted — evaluate with `/career-ops oferta` before applying."
 - **Block G — Legitimacy:** posting age (already known), apply-button state (from the JD snapshot), and **at most 1 WebSearch** only if a concerning signal appears (vague JD, contradictory requirements, recent layoff news). Default to 0 WebSearch here.
@@ -193,10 +193,11 @@ Compute the **global score (1–5)** per `_shared.md` (weighted match + North St
 For roles with global score **≥ 4.0/5**, do the following so the user has an actionable artifact to apply from:
 
 1. **Reserve a report number:** run `node reserve-report-num.mjs` to get the next sequential `REPORT_NUM`. Guard all subsequent steps with cleanup: if any step fails, release the sentinel before stopping.
-2. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from Step 5.
-3. **Generate PDF:** run the full pipeline from `modes/pdf.md` to produce a tailored CV PDF. Run `node generate-pdf.mjs` for the HTML→PDF conversion.
-4. **Write a TSV tracker addition** to `batch/tracker-additions/{REPORT_NUM}-{company-slug}.tsv` following the standard 9-column TSV format (see Pipeline Integrity in CLAUDE.md).
-5. **Merge + clean up the tracker:**
+2. **Sanitize the company slug:** derive a safe slug from the company name by lowercasing, replacing spaces with hyphens, and removing any characters that are not alphanumeric, hyphens, or underscores. Verify the slug contains no path separators (`/` or `\`), no `..` traversal sequences, and no control characters. Reject the listing if the slug is unsafe.
+3. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from Step 5. Verify the resolved path stays within the `reports/` directory.
+4. **Generate PDF:** run the full pipeline from `modes/pdf.md` to produce a tailored CV PDF. Run `node generate-pdf.mjs` for the HTML→PDF conversion.
+5. **Write a TSV tracker addition** to `batch/tracker-additions/{REPORT_NUM}-{company-slug}.tsv` following the standard 9-column TSV format (see Pipeline Integrity in CLAUDE.md). Verify the resolved path stays within the `batch/tracker-additions/` directory.
+6. **Merge + clean up the tracker:**
    - Run `node merge-tracker.mjs` to integrate the new entry into `data/applications.md`.
    - Then run `node normalize-statuses.mjs` and `node dedup-tracker.mjs` to enforce canonical states and remove any duplicates.
    - Finally run `node verify-pipeline.mjs` to confirm pipeline integrity.

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -1,0 +1,264 @@
+# Mode: gtop — Google Top Jobs (last-24h discovery + triage)
+
+Bulk-discover fresh job postings from **Google Jobs**, keep only those posted in the **last 24 hours**, evaluate each for fit against the candidate's sources of truth, and return a ranked **"apply ASAP"** list of only the high-fit roles (global score ≥ 4.0/5).
+
+This mode accepts an **optional argument**: a role title or keywords to search for. If omitted, it uses the candidate's pre-configured target role keywords from `portals.yml` and `config/profile.yml`.
+
+| Invocation | What it does |
+|------------|-------------|
+| `/career-ops gtop` (no arg) | Uses the 3 default query clusters (Full-Stack/SWE, AI/ML, Broader Dev) from the candidate's title_filter.positive keywords |
+| `/career-ops gtop AI Engineer` | Builds all 3 queries around "AI Engineer" instead of the default clusters |
+| `/career-ops gtop "Full Stack"` | Builds all 3 queries around "Full Stack" |
+| `/career-ops gtop backend engineer` | Builds all 3 queries around "Backend Engineer" |
+
+The argument is a free-text role focus — whatever the user types after `gtop` becomes the primary search term. It's URL-encoded into the Google Jobs query alongside the candidate's location. If no argument is given, the pre-configured keyword clusters from `portals.yml` `title_filter.positive` are used.
+
+It complements `scan` (per-portal/ATS) by casting a wider net across Google's aggregated job index, then filtering hard on freshness.
+
+---
+
+## Prerequisites
+
+1. Run `node doctor.mjs --json`. If `onboardingNeeded` is true, switch to onboarding — do not run this mode.
+2. Read the candidate sources of truth (same as all eval modes, per `_shared.md`):
+   - `cv.md`
+   - `config/profile.yml` (identity, location, target roles, comp)
+   - `modes/_profile.md` (archetypes, narrative, proof points, comp targets)
+   - `modes/_shared.md` (scoring system, archetype detection, legitimacy) — loaded automatically with this mode via SKILL.md context-loading
+   - `article-digest.md` if it exists
+3. Read `portals.yml` → `title_filter.positive` to get the candidate's target-role keywords. These drive the Google Jobs queries below.
+4. Read `config/profile.yml` → `candidate.location` for the search locale (default: `Toronto`).
+
+**NEVER hardcode proof-point metrics.** Read them from cv.md at evaluation time.
+
+---
+
+## Step 1 — Build the Google Jobs queries
+
+Google Jobs search URL format:
+
+```
+https://www.google.com/search?q={URL-encoded keywords}&ibp=htl;jobs&hl=en&gl=ca
+```
+
+Read the candidate's location from `config/profile.yml` → `candidate.location` (default: `Toronto`).
+
+**If the user passed a custom role argument** (anything after `gtop` in the invocation), use it directly as the sole query keyword. Build 3 queries with that same keyword combined with related terms from `title_filter.positive`:
+
+- **Query A:** `{custom-role} Toronto`
+- **Query B:** `{custom-role} OR related-variant-1 OR related-variant-2 Toronto`
+- **Query C:** `{custom-role} OR other-variant-1 OR other-variant-2 Toronto`
+
+URL-encode each query.
+
+**If no argument was given**, construct **exactly 3 queries** from the candidate's pre-configured keywords (from `portals.yml` `title_filter.positive` + `config/profile.yml` target roles), clustered by theme as follows:
+
+- **Query A — Full-Stack / SWE / Backend cluster:**
+  `("Full Stack" OR "Software Engineer" OR "Backend Engineer" OR "Node.js" OR "React Developer") Toronto`
+- **Query B — AI / ML / Automation cluster:**
+  `("AI Engineer" OR "ML" OR "LLM" OR "Agent" OR "Automation" OR "RAG" OR "GenAI") Toronto`
+- **Query C — Broader Developer cluster:**
+  `("Software Developer" OR "Application Developer" OR "Platform Engineer" OR "Full Stack Developer") Toronto`
+
+Do not exceed 3 queries in either mode.
+
+---
+
+## Step 2 — Scrape each query with Playwright
+
+For each query URL:
+
+1. `browser_navigate` → the encoded Google Jobs URL.
+2. Wait for results to render — use `browser_wait_for` on text like `"Apply"` or `"ago"` (posting-age text), or wait ~3–5s. Google Jobs cards load via AJAX.
+3. `browser_snapshot` → capture the rendered page.
+4. Parse job **cards** from the snapshot. Google Jobs renders each listing as a clickable `button` in the left panel. For each card, extract:
+   - **title** — the card's heading / link text
+   - **company** — the text just below the title (smaller, often grey)
+   - **location** — the city/region text
+   - **postedAge** — the relative-time text (e.g. `"Posted 3 hours ago"`, `"1 day ago"`, `"Reposted 2 hours ago"`, `"30+ days ago"`, `"just now"`)
+   - **viaSource** — the `via X` text at the end of the location line (e.g. `"via LinkedIn"`, `"via Indeed"`, `"via Recruit.net"`). This tells you which portal the posting is listed on.
+   - **cardRef** — the `ref=` of the card button, so you can click it later
+   - **cardName** — the full accessible name text of the button (needed as the click target)
+
+   **Do NOT try to extract a destination URL from the card itself.** Google Jobs cards are buttons, not hyperlinks — there is no `href` to read. The real apply URL is only accessible inside the detail panel after clicking the card.
+
+5. If a Google "More jobs" / pagination control is present, click it (`browser_click`) to reveal more cards — but **cap at ~30 cards per query** to bound tokens.
+
+**Bot-challenge handling:** If the snapshot shows a CAPTCHA / "Just a moment…" / "unusual traffic" page instead of job cards, note it and skip that query. Continue with the others. Do not retry aggressively.
+
+### Step 2.5 — Filter to trusted portals only
+
+Google Jobs surfaces listings from a mix of sources. Many are **aggregator/scraper portals** that repost content from the real source — applying through them is slower, less reliable, and often dead ends. Keep only cards whose source (the `via X` text on each card) is one of:
+
+| Source | `via` text example | Why trusted |
+|--------|--------------------|------------|
+| **LinkedIn Jobs** | `via LinkedIn` | Direct company posting on LinkedIn |
+| **Indeed** | `via Indeed` | Primary job board, companies post directly |
+| **Company's own careers portal** | `via {Company} Careers` / `via RBC Careers` / `via U.S. Bank Careers` | Direct portal, canonical source |
+| **Greenhouse** | `via Greenhouse` (rare on Google Jobs) | Official ATS used by the company |
+| **Ashby** | `via Ashby` (rare on Google Jobs) | Official ATS |
+| **Lever** | `via Lever` (rare on Google Jobs) | Official ATS |
+| **Workday** | URL contains `myworkdayjobs.com` or `wd1/` | Official ATS |
+| **ICIMS** | `via {Company} - ICIMS` | Official ATS |
+| **BambooHR** / **Breezy** / **Pinpoint** / **Jobvite** / **SmartRecruiters** | any company's official ATS name | Company's official hiring platform |
+
+**Deny the following known aggregator/scraper portals (non-exhaustive):** Recruit.net, Built In, Zippia, Expertini, Toronto Jobs Expertini, Learn4Good, JobServe, CareerBuilder, Monster, SimplyHired, Glassdoor (aggregated), Jooble, Tarta.ai, Adzuna, GrabJobs, JobisJob, Jobrapido, Neuvoo, WowJobs, Snagajob, ZipRecruiter (aggregated).
+
+**How to check the source on each card:** The `via X` text appears on the card after the location — e.g. `Toronto, ON • via LinkedIn`. If the card has no `via` text at all, check the URL:
+- URL contains `linkedin.com` → trusted (LinkedIn)
+- URL contains `indeed.com` → trusted (Indeed)
+- URL contains `myworkdayjobs.com` or `wd1` or `wd5` etc. → trusted (Workday)
+- URL contains `greenhouse.io` → trusted (Greenhouse)
+- URL contains `jobs.ashbyhq.com` → trusted (Ashby)
+- URL contains `lever.co` → trusted (Lever)
+- URL contains a known aggregator domain → deny
+- Otherwise → check the `via` text; if ambiguous, **err on the side of dropping** (better to miss one borderline posting than waste time evaluating aggregator dead ends).
+
+**Important nuance for LinkedIn:** LinkedIn postings on Google Jobs are often direct company postings. Trust them even though LinkedIn may sometimes require login — the Step 4 fallback chain (`WebSearch`) handles that case.
+
+**Important nuance for Indeed:** Indeed is a primary board, not a scraper. Companies post directly on Indeed. Trust Indeed listings.
+
+---
+
+## Step 3 — Filter to last 24 hours
+
+Parse `postedAge` text into an age estimate, then keep only cards whose age is **< 24 hours**. Boundary rule: `1 day ago` is treated as ~24h and **included** (a "1 day ago" card on Google can be 12–24h old).
+
+Parsing rules:
+
+| Text pattern | Age | Keep? |
+|--------------|-----|-------|
+| `just now` / `Posted just now` | ~0h | ✅ |
+| `N minutes ago` | N min | ✅ |
+| `N hours ago` (N < 24) | N h | ✅ |
+| `1 day ago` | ~24h (boundary) | ✅ |
+| `N days ago` (N > 1) | N×24h | ❌ |
+| `30+ days ago` | >24h | ❌ |
+| `Reposted …` | strip `Reposted `, then apply the rules above | — |
+| `Posted …` | strip `Posted `, then apply the rules above | — |
+
+### Step 3.5 — Deduplicate + cap
+
+Accross all 3 queries, the same posting can appear multiple times. Dedupe by `company + title` (case-insensitive), keeping the one with the freshest `postedAge`.
+
+Then **cap the evaluation set at 10** postings. If more than 10 are fresh, keep the 10 most recent (smallest parsed age). Drop the rest silently but mention the count in the final summary.
+
+---
+
+## Step 4 — Extract the JD + apply URL for each fresh posting (up to 10)
+
+Google Jobs shows each posting's details in a **right-side detail panel** that opens when you click a card. The card buttons remain on the page throughout — clicking a new card replaces the panel for the previous one. So process cards **sequentially**, one at a time:
+
+For each surviving card (that passed Step 2.5's portal filter):
+
+1. **Click the card:** `browser_click` on the card's button (using its `ref=` or full accessible name from Step 2). This opens the detail panel.
+2. **Wait for the panel to render** — `browser_snapshot` or `browser_find` on the detail dialog.
+3. **Extract the destination URL(s):** the detail panel has a `list` of "Apply on X" links, each with a real `href` (not a Google redirect). Read the URL of the **primary/company ATS link** (the first apply link is usually the best — e.g. `Apply on U.S. Bank Careers` rather than `Apply on Built In` or `Apply on LinkedIn`).
+4. **Extract the JD text:** the panel contains a "Job description" heading with expandable text. Click "Show full description" (`browser_click`) if collapsed, then read the full JD content from the panel.
+5. **Liveness gate (Block G-style, zero WebSearch):** from the panel content, classify:
+   - **active:** title/role + real JD text or an Apply path
+   - **closed:** "no longer accepting", "position filled", empty shell with only nav/footer
+   - If **closed**, skip this role silently (counts toward the 10-cap).
+
+6. **If the detail panel doesn't have enough JD text** (some Google Jobs panels show only a short snippet), navigate to the apply URL directly as fallback:
+   - `browser_navigate` → the extracted apply URL (Playwright follows redirects automatically)
+   - `browser_snapshot` → read full JD from the ATS page
+7. **Platform notes for fallback navigation:**
+   - Greenhouse / Ashby / Lever / company career pages: snapshot works after full render.
+   - Workday (`*.myworkdayjobs.com`): heavy SPA — wait longer before snapshot, fall back to WebFetch if empty.
+   - LinkedIn (`linkedin.com/jobs`): often redirects to login. If the snapshot shows "Sign In", fall back to WebSearch for `{company} {role} job description` rather than getting stuck.
+
+**Token discipline:** Do not dump the full JD text into your response. Extract the key fields silently (title, company, location, requirements, salary if listed) and keep only a short note for scoring.
+
+---
+
+## Step 5 — Full A-G evaluation per role
+
+For each posting with a usable JD, run a **complete** A-G evaluation using the same scoring system and archetype detection from `_shared.md` and the block structure from `oferta.md`. Proof points from `cv.md` / `article-digest.md` / `_profile.md`.
+
+Evaluate all 7 blocks (compact form — 2-4 sentences each):
+
+- **Archetype** — one of the 6 from `_shared.md` (AI Platform/LLMOps, Agentic/Automation, Technical AI PM, AI Solutions Architect, AI Forward Deployed, AI Transformation), mapped to the user's full-stack/backend/general-SWE archetypes in `_profile.md` when the role isn't an AI archetype.
+- **Block A — Role Summary:** title, seniority, location, remote/hybrid/onsite, one-line on what the role is.
+- **Block B — Match with CV:** map the 3–5 strongest JD requirements to concrete `cv.md` proof points (cite the line/project, never fabricate). Score the skill match 1–5.
+- **Block C — Level & Strategy:** is the seniority a fit for the candidate (mid-senior, 4 YOE)? 1 sentence.
+- **Block D — Comp:** **no WebSearch.** If salary is in the JD, compare to the user's comp target from `_profile.md`. If absent, mark "unknown — verify." Do not research Levels.fyi/Glassdoor.
+- **Block E & F — Omitted** (Customization Plan and Interview Plan are not evaluated at triage stage).
+- **Block G — Legitimacy:** posting age (already known), apply-button state (from the JD snapshot), and **at most 1 WebSearch** only if a concerning signal appears (vague JD, contradictory requirements, recent layoff news). Default to 0 WebSearch here.
+
+Compute the **global score (1–5)** per `_shared.md` (weighted match + North Star + comp + cultural signals − red flags). Apply Block G as a qualitative flag, not a numeric adjustment.
+
+**Bounded research budget (firm):**
+- Max **1 WebSearch per role**, only for Block G concerns.
+- Max **5 WebSearch queries total** across the whole run.
+- **No subagents, no `deep-research`, no recursive skill calls.**
+
+---
+
+## Step 5.5 — Write report + tracker entry for high-fit roles (≥ 4.0)
+
+For roles with global score **≥ 4.0/5**, do the following so the user has an actionable artifact to apply from:
+
+1. **Reserve a report number:** run `node reserve-report-num.mjs` to get the next sequential `REPORT_NUM`.
+2. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from Step 5.
+3. **Generate PDF:** run the full pipeline from `modes/pdf.md` to produce a tailored CV PDF. Run `node generate-pdf.mjs` for the HTML→PDF conversion.
+4. **Write a TSV tracker addition** to `batch/tracker-additions/{REPORT_NUM}-{company-slug}.tsv` following the standard 9-column TSV format (see Pipeline Integrity in CLAUDE.md).
+5. **Merge the tracker:** run `node merge-tracker.mjs` to integrate the new entry into `data/applications.md`.
+
+(Or skip the full pipeline and do the above in a single pass — the point is the same: high-fit roles get persisted as evaluable artifacts.)
+
+After writing, release the report number sentinel: `node reserve-report-num.mjs --release {REPORT_NUM}`.
+
+---
+
+## Step 6 — Rank and output
+
+1. Keep only roles with **global score ≥ 4.0/5**.
+2. Rank descending by score (tiebreak: freshest first).
+3. Output **only** this format. Do not show marginal/low-fit roles in detail — list them in a one-line "below threshold" footer so the candidate knows what was dropped.
+
+```
+## gtop — Google Top Jobs (last 24h)
+
+Scanned: 3 queries · {N} cards total · {M} fresh (<24h) · {K} evaluated · {P} high-fit (≥ 4.0/5)
+
+### ✅ Apply ASAP
+
+1. **{Role} @ {Company}** — 4.X/5
+   - Report: {####} | PDF: ✅
+   - URL: {direct posting URL}
+   - Archetype: {archetype}
+   - Posted: {age text} · {location} · {remote/hybrid/onsite}
+   - Score: skills X/5 · North Star X/5 · comp X/5 — legitimacy: {High Confidence | Proceed with Caution}
+   - Why apply: {one paragraph tying 1–2 concrete cv.md proof points to the top JD requirements — no fabrication}
+   - Action: Apply today / Apply this week — {one-line urgency rationale}
+
+2. … (continue for each ≥ 4.0 role)
+
+### Below threshold (evaluated, ≥ 4.0 not met)
+
+- [3.8] {Role} @ {Company} — {one-line reason: e.g. "requires 6+ YOE Scala, level mismatch"}
+- …
+```
+
+If **no role clears 4.0**, say so plainly:
+
+> No high-fit roles in the last 24h across the 3 queries. {M} fresh postings were evaluated; strongest was {Role} @ {Company} at {score}/5. Re-run tomorrow, adjust keywords in `portals.yml`, or run `/career-ops scan` for direct-portal discovery.
+
+**Next steps line** (always, if ≥ 4.0 roles exist):
+> These are triage picks, not full evaluations. For any role you'll actually apply to, run `/career-ops oferta {url}` for the complete A-G report + tailored CV, then `/career-ops apply {url}` to fill the form.
+
+---
+
+## Guardrails (firm)
+
+1. **Max 3 search queries** — do not add a 4th.
+2. **Max ~30 cards parsed per query.**
+3. **Max 10 JD evaluations per run** — if more are fresh, evaluate the 10 most recent.
+4. **Max 1 WebSearch per role**, max **5 total** across the run — only for Block G concerns.
+5. **No subagents, no `deep-research`, no recursive skill calls.** Sequential, single-pass.
+6. **Report + PDF + tracker only for ≥ 4.0 roles.** For roles below threshold, no artifacts are written. No cover letters at this stage.
+7. **Never hardcode cv.md metrics.** Read at evaluation time.
+8. **Never fabricate proof points.** If a JD requirement isn't backed by an in-scope file, omit the match — silence is fine.
+9. If a Google query hits a bot challenge, skip it and reduce scope rather than retry-looping.
+10. **Trusted portals only** — after extracting cards, drop any whose source (`via X` text or URL domain) is an aggregator/scraper board (Recruit.net, Built In, Expertini, Zippia, etc.). Only keep LinkedIn, Indeed, Workday, Greenhouse, Ashby, Lever, ICIMS, and direct company careers pages. If uncertain, err on dropping.

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -178,11 +178,13 @@ For each surviving card (that passed Step 2.5's portal filter):
 
 ---
 
-## Step 5 — Full A-G evaluation per role
+## Step 5 — Full A-G evaluation per role (score + artifacts, inline)
 
 For each posting with a usable JD, run an A-G evaluation using the same scoring system and archetype detection from `_shared.md` and the block structure from `oferta.md`. Proof points from `cv.md` / `article-digest.md` / `_profile.md`. When a market-specific mode (e.g. German `modes/de/`) is active, use its vocabulary and rules, but do not switch market modes solely because a job description is in another language — the user must request it or configure it in `config/profile.yml`.
 
-Evaluate the following blocks (compact form — 2-4 sentences each):
+**CRITICAL: For each role, evaluate AND immediately persist if high-fit, right here in the loop.** Do not defer writing to a later step. Within each role's processing:
+
+### 5a — Evaluate compact A-G
 
 - **Archetype** — one of the 6 from `_shared.md` (AI Platform/LLMOps, Agentic/Automation, Technical AI PM, AI Solutions Architect, AI Forward Deployed, AI Transformation), mapped to the user's full-stack/backend/general-SWE archetypes in `_profile.md` when the role isn't an AI archetype.
 - **Block A — Role Summary:** title, seniority, location, remote/hybrid/onsite, one-line on what the role is.
@@ -194,30 +196,29 @@ Evaluate the following blocks (compact form — 2-4 sentences each):
 
 Compute the **global score (1–5)** per `_shared.md` (weighted match + North Star + comp + cultural signals − red flags). Apply Block G as a qualitative flag, not a numeric adjustment.
 
-**Bounded research budget (firm):**
-- Max **1 WebSearch per role**, only for Block G concerns.
-- Max **5 WebSearch queries total** across the whole run.
-- **No subagents, no `deep-research`, no recursive skill calls.**
+### 5b — If global score ≥ 4.0/5, persist artifacts immediately
 
----
-
-## Step 5.5 — Write report + tracker entry for high-fit roles (≥ 4.0)
-
-For roles with global score **≥ 4.0/5**, do the following so the user has an actionable artifact to apply from:
+**Do this NOW, before moving to the next role.** Do not skip, do not defer:
 
 1. **Reserve a report number:** run `node reserve-report-num.mjs` to get the next sequential `REPORT_NUM`. Guard all subsequent steps with cleanup: if any step fails, release the sentinel before stopping.
 2. **Sanitize the company slug:** derive a safe slug from the company name by lowercasing, replacing spaces with hyphens, and removing any characters that are not alphanumeric, hyphens, or underscores. Verify the slug contains no path separators (`/` or `\`), no `..` traversal sequences, and no control characters. Reject the listing if the slug is unsafe.
-3. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from Step 5. Verify the resolved path stays within the `reports/` directory.
+3. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from the current role. Verify the resolved path stays within the `reports/` directory.
 4. **Generate PDF:** run the full pipeline from `modes/pdf.md` to produce a tailored CV PDF. Run `node generate-pdf.mjs` for the HTML→PDF conversion.
 5. **Write a TSV tracker addition** to `batch/tracker-additions/{REPORT_NUM}-{company-slug}.tsv` following the standard 9-column TSV format (see Pipeline Integrity in CLAUDE.md). Verify the resolved path stays within the `batch/tracker-additions/` directory.
 6. **Merge + clean up the tracker:**
    - Run `node merge-tracker.mjs` to integrate the new entry into `data/applications.md`.
    - Then run `node normalize-statuses.mjs` and `node dedup-tracker.mjs` to enforce canonical states and remove any duplicates.
    - Finally run `node verify-pipeline.mjs` to confirm pipeline integrity.
+7. **Always release the sentinel:** `node reserve-report-num.mjs --release {REPORT_NUM}` — even if a step failed partway, the sentinel MUST be released.
 
-(Or skip the full pipeline and do the above in a single pass — the point is the same: high-fit roles get persisted as evaluable artifacts.)
+### 5c — If score < 4.0/5
 
-**Always release the sentinel,** even if a step fails partway: `node reserve-report-num.mjs --release {REPORT_NUM}`. A stale reservation blocks future report numbering until garbage-collected.
+Skip the role silently. No report, no PDF, no tracker entry — it goes into the "Below threshold" footer at output.
+
+**Bounded research budget (firm, applies across all roles):**
+- Max **1 WebSearch per role**, only for Block G concerns.
+- Max **5 WebSearch queries total** across the whole run.
+- **No subagents, no `deep-research`, no recursive skill calls.**
 
 ---
 
@@ -261,7 +262,7 @@ If **no role clears 4.0**, branch on whether any roles were evaluated:
   > No fresh postings found in the last 24h. This could be a quiet day, or CAPTCHA/bot-blocking may have affected the queries. Re-run tomorrow, or try `/career-ops scan` for direct-portal discovery.
 
 **Next steps line** (always, if ≥ 4.0 roles exist):
-> These are triage picks, not full evaluations. For any role you'll actually apply to, run `/career-ops oferta {url}` for the complete A-G report + tailored CV, then `/career-ops apply {url}` to fill the form.
+> Reports, PDFs, and tracker entries have already been created for the roles above. To submit a formal application, run `/career-ops apply {url}` to fill the form.
 
 ---
 

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -167,7 +167,7 @@ For each surviving card (that passed Step 2.5's portal filter):
 
 ## Step 5 — Full A-G evaluation per role
 
-For each posting with a usable JD, run an A-G evaluation using the same scoring system and archetype detection from `_shared.md` and the block structure from `oferta.md`. Proof points from `cv.md` / `article-digest.md` / `_profile.md`.
+For each posting with a usable JD, run an A-G evaluation using the same scoring system and archetype detection from `_shared.md` and the block structure from `oferta.md`. Proof points from `cv.md` / `article-digest.md` / `_profile.md`. When a market-specific mode (e.g. German `modes/de/`) is active, use its vocabulary and rules, but do not switch market modes solely because a job description is in another language — the user must request it or configure it in `config/profile.yml`.
 
 Evaluate the following blocks (compact form — 2-4 sentences each):
 
@@ -232,6 +232,8 @@ Scanned: 3 queries · {N} cards total · {M} fresh (<24h) · {K} evaluated · {P
 2. … (continue for each ≥ 4.0 role)
 
 ### Below threshold (evaluated, score < 4.0)
+
+> **Recommendation:** Strongly discourage applying to these roles. Proceed with an application only if the user gives a specific reason to override this recommendation.
 
 - [3.8] {Role} @ {Company} — {one-line reason: e.g. "requires 6+ YOE Scala, level mismatch"}
 - …

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -45,20 +45,20 @@ Read the candidate's location from `config/profile.yml` → `candidate.location`
 
 **If the user passed a custom role argument** (anything after `gtop` in the invocation), use it directly as the sole query keyword. Build 3 queries with that same keyword combined with related terms from `title_filter.positive`:
 
-- **Query A:** `{custom-role} Toronto`
-- **Query B:** `{custom-role} OR related-variant-1 OR related-variant-2 Toronto`
-- **Query C:** `{custom-role} OR other-variant-1 OR other-variant-2 Toronto`
+- **Query A:** `{custom-role} {LOCATION}`
+- **Query B:** `{custom-role} OR related-variant-1 OR related-variant-2 {LOCATION}`
+- **Query C:** `{custom-role} OR other-variant-1 OR other-variant-2 {LOCATION}`
 
 URL-encode each query.
 
-**If no argument was given**, construct **exactly 3 queries** from the candidate's pre-configured keywords (from `portals.yml` `title_filter.positive` + `config/profile.yml` target roles), clustered by theme as follows:
+**If no argument was given**, construct **exactly 3 queries** from the candidate's pre-configured keywords (from `portals.yml` `title_filter.positive` + `config/profile.yml` target roles), clustered by theme. Replace `{LOCATION}` below with the actual location:
 
 - **Query A — Full-Stack / SWE / Backend cluster:**
-  `("Full Stack" OR "Software Engineer" OR "Backend Engineer" OR "Node.js" OR "React Developer") Toronto`
+  `("Full Stack" OR "Software Engineer" OR "Backend Engineer" OR "Node.js" OR "React Developer") {LOCATION}`
 - **Query B — AI / ML / Automation cluster:**
-  `("AI Engineer" OR "ML" OR "LLM" OR "Agent" OR "Automation" OR "RAG" OR "GenAI") Toronto`
+  `("AI Engineer" OR "ML" OR "LLM" OR "Agent" OR "Automation" OR "RAG" OR "GenAI") {LOCATION}`
 - **Query C — Broader Developer cluster:**
-  `("Software Developer" OR "Application Developer" OR "Platform Engineer" OR "Full Stack Developer") Toronto`
+  `("Software Developer" OR "Application Developer" OR "Platform Engineer" OR "Full Stack Developer") {LOCATION}`
 
 Do not exceed 3 queries in either mode.
 
@@ -104,15 +104,7 @@ Google Jobs surfaces listings from a mix of sources. Many are **aggregator/scrap
 
 **Deny the following known aggregator/scraper portals (non-exhaustive):** Recruit.net, Built In, Zippia, Expertini, Toronto Jobs Expertini, Learn4Good, JobServe, CareerBuilder, Monster, SimplyHired, Glassdoor (aggregated), Jooble, Tarta.ai, Adzuna, GrabJobs, JobisJob, Jobrapido, Neuvoo, WowJobs, Snagajob, ZipRecruiter (aggregated).
 
-**How to check the source on each card:** The `via X` text appears on the card after the location — e.g. `Toronto, ON • via LinkedIn`. If the card has no `via` text at all, check the URL:
-- URL contains `linkedin.com` → trusted (LinkedIn)
-- URL contains `indeed.com` → trusted (Indeed)
-- URL contains `myworkdayjobs.com` or `wd1` or `wd5` etc. → trusted (Workday)
-- URL contains `greenhouse.io` → trusted (Greenhouse)
-- URL contains `jobs.ashbyhq.com` → trusted (Ashby)
-- URL contains `lever.co` → trusted (Lever)
-- URL contains a known aggregator domain → deny
-- Otherwise → check the `via` text; if ambiguous, **err on the side of dropping** (better to miss one borderline posting than waste time evaluating aggregator dead ends).
+**How to check the source on each card:** The `via X` text appears on the card after the location — e.g. `Toronto, ON • via LinkedIn`. Trust or deny based on the `via` text using the tables above. If a card has no recognizable `via` text, **drop it** — Google Jobs cards are buttons without visible URL targets, so there is no URL to fall back on at this stage. The `via` text is the only source signal available before clicking the card.
 
 **Important nuance for LinkedIn:** LinkedIn postings on Google Jobs are often direct company postings. Trust them even though LinkedIn may sometimes require login — the Step 4 fallback chain (`WebSearch`) handles that case.
 
@@ -122,7 +114,7 @@ Google Jobs surfaces listings from a mix of sources. Many are **aggregator/scrap
 
 ## Step 3 — Filter to last 24 hours
 
-Parse `postedAge` text into an age estimate, then keep only cards whose age is **< 24 hours**. Boundary rule: `1 day ago` is treated as ~24h and **included** (a "1 day ago" card on Google can be 12–24h old).
+Parse `postedAge` text into an age estimate, then keep only cards whose age is **≤ 24 hours**. Boundary rule: `1 day ago` is treated as ~24h and **included** (a "1 day ago" card on Google can be 12–24h old).
 
 Parsing rules:
 
@@ -161,6 +153,7 @@ For each surviving card (that passed Step 2.5's portal filter):
    - If **closed**, skip this role silently (counts toward the 10-cap).
 
 6. **If the detail panel doesn't have enough JD text** (some Google Jobs panels show only a short snippet), navigate to the apply URL directly as fallback:
+   - **Security check:** Before navigating, validate the extracted URL is an `https:` URL whose host matches an approved source (linkedin.com, indeed.com, myworkdayjobs.com, greenhouse.io, jobs.ashbyhq.com, lever.co, or a company careers domain). Reject non-HTTPS or unapproved destinations — skip this card instead.
    - `browser_navigate` → the extracted apply URL (Playwright follows redirects automatically)
    - `browser_snapshot` → read full JD from the ATS page
 7. **Platform notes for fallback navigation:**
@@ -174,16 +167,16 @@ For each surviving card (that passed Step 2.5's portal filter):
 
 ## Step 5 — Full A-G evaluation per role
 
-For each posting with a usable JD, run a **complete** A-G evaluation using the same scoring system and archetype detection from `_shared.md` and the block structure from `oferta.md`. Proof points from `cv.md` / `article-digest.md` / `_profile.md`.
+For each posting with a usable JD, run an A-G evaluation using the same scoring system and archetype detection from `_shared.md` and the block structure from `oferta.md`. Proof points from `cv.md` / `article-digest.md` / `_profile.md`.
 
-Evaluate all 7 blocks (compact form — 2-4 sentences each):
+Evaluate the following blocks (compact form — 2-4 sentences each):
 
 - **Archetype** — one of the 6 from `_shared.md` (AI Platform/LLMOps, Agentic/Automation, Technical AI PM, AI Solutions Architect, AI Forward Deployed, AI Transformation), mapped to the user's full-stack/backend/general-SWE archetypes in `_profile.md` when the role isn't an AI archetype.
 - **Block A — Role Summary:** title, seniority, location, remote/hybrid/onsite, one-line on what the role is.
 - **Block B — Match with CV:** map the 3–5 strongest JD requirements to concrete `cv.md` proof points (cite the line/project, never fabricate). Score the skill match 1–5.
 - **Block C — Level & Strategy:** is the seniority a fit for the candidate (mid-senior, 4 YOE)? 1 sentence.
 - **Block D — Comp:** **no WebSearch.** If salary is in the JD, compare to the user's comp target from `_profile.md`. If absent, mark "unknown — verify." Do not research Levels.fyi/Glassdoor.
-- **Block E & F — Omitted** (Customization Plan and Interview Plan are not evaluated at triage stage).
+- **Block E & F — Omitted** (Customization Plan and Interview Plan are not evaluated at triage stage). In the saved report, note them as "Omitted — evaluate with `/career-ops oferta` before applying."
 - **Block G — Legitimacy:** posting age (already known), apply-button state (from the JD snapshot), and **at most 1 WebSearch** only if a concerning signal appears (vague JD, contradictory requirements, recent layoff news). Default to 0 WebSearch here.
 
 Compute the **global score (1–5)** per `_shared.md` (weighted match + North Star + comp + cultural signals − red flags). Apply Block G as a qualitative flag, not a numeric adjustment.
@@ -199,7 +192,7 @@ Compute the **global score (1–5)** per `_shared.md` (weighted match + North St
 
 For roles with global score **≥ 4.0/5**, do the following so the user has an actionable artifact to apply from:
 
-1. **Reserve a report number:** run `node reserve-report-num.mjs` to get the next sequential `REPORT_NUM`.
+1. **Reserve a report number:** run `node reserve-report-num.mjs` to get the next sequential `REPORT_NUM`. Guard all subsequent steps with cleanup: if any step fails, release the sentinel before stopping.
 2. **Write a full evaluation report** to `reports/{REPORT_NUM}-{company-slug}-{YYYY-MM-DD}.md` following the `oferta.md` report format (same header fields: `#`, `URL:`, `Score:`, `PDF:`, `**Legitimacy:** {tier}`, all 7 blocks A-G). Use the evaluation data from Step 5.
 3. **Generate PDF:** run the full pipeline from `modes/pdf.md` to produce a tailored CV PDF. Run `node generate-pdf.mjs` for the HTML→PDF conversion.
 4. **Write a TSV tracker addition** to `batch/tracker-additions/{REPORT_NUM}-{company-slug}.tsv` following the standard 9-column TSV format (see Pipeline Integrity in CLAUDE.md).
@@ -207,7 +200,7 @@ For roles with global score **≥ 4.0/5**, do the following so the user has an a
 
 (Or skip the full pipeline and do the above in a single pass — the point is the same: high-fit roles get persisted as evaluable artifacts.)
 
-After writing, release the report number sentinel: `node reserve-report-num.mjs --release {REPORT_NUM}`.
+**Always release the sentinel,** even if a step fails partway: `node reserve-report-num.mjs --release {REPORT_NUM}`. A stale reservation blocks future report numbering until garbage-collected.
 
 ---
 

--- a/modes/gtop.md
+++ b/modes/gtop.md
@@ -156,7 +156,12 @@ Google Jobs shows each posting's details in a **right-side detail panel** that o
 
 For each surviving card (that passed Step 2.5's portal filter):
 
-1. **Click the card:** `browser_click` on the card's button (using its `ref=` or full accessible name from Step 2). This opens the detail panel.
+1. **Click the card to open the detail panel:** The card's `ref=` from your Step 2 snapshot is **ephemeral** — Google Jobs is an SPA that re-renders the DOM, so the ref is stale by the time you get here. To reliably locate and click the current version of the card, use `browser_find` to re-find the card on the live page:
+   - Run `browser_find` with `text:` set to a unique substring from the card — typically the job title or a distinctive part of it (e.g. `"Senior Software Engineer Fitch"` or `"Remote Software Engineer Turing"`).
+   - The result will include the card node with a **live** `ref=` value (e.g. `"Senior Software Engineer..." [ref=e123] [cursor=pointer]`).
+   - Click it with `browser_click` using that fresh `ref=e123` as `target`, and `element:` set to the job title/company for the permission dialog.
+   
+   This opens the detail panel.
 2. **Wait for the panel to render** — `browser_snapshot` or `browser_find` on the detail dialog.
 3. **Extract the destination URL(s):** the detail panel has a `list` of "Apply on X" links, each with a real `href` (not a Google redirect). Read the URL of the **primary/company ATS link** (the first apply link is usually the best — e.g. `Apply on U.S. Bank Careers` rather than `Apply on Built In` or `Apply on LinkedIn`).
 4. **Extract the JD text:** the panel contains a "Job description" heading with expandable text. Click "Show full description" (`browser_click`) if collapsed, then read the full JD content from the panel.

--- a/scrape-job.mjs
+++ b/scrape-job.mjs
@@ -1,0 +1,54 @@
+import { chromium } from 'playwright';
+
+async function scrapeJob(url) {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  try {
+    await page.goto(url, { waitUntil: 'networkidle' });
+
+    // LinkedIn often redirects to login. Let's check if we're on a login page.
+    const isLoginPage = await page.title().then(t => t.includes('Sign In') || t.includes('Login'));
+    if (isLoginPage) {
+      console.error('Redirected to login page. Cannot scrape LinkedIn without authentication.');
+      process.exit(1);
+    }
+
+    // Attempt to extract data. LinkedIn uses dynamic classes, but some attributes/patterns are stable.
+    const data = await page.evaluate(() => {
+      const getText = (selector) => document.querySelector(selector)?.innerText || '';
+
+      return {
+        title: getText('.job-details-top-card__richtext'),
+        company: getText('.job-details-top-card__company-name'),
+        description: getText('.jobs-description-content__text'),
+      };
+    });
+
+    // If the above selectors failed, try fallback for the search-view layout
+    if (!data.title || !data.description) {
+      const fallbackData = await page.evaluate(() => {
+        return {
+          title: document.querySelector('h2')?.innerText || '',
+          company: document.querySelector('.job-details-top-card__company-name')?.innerText || '',
+          description: document.querySelector('#job-details')?.innerText || '',
+        };
+      });
+      Object.assign(data, fallbackData);
+    }
+
+    console.log(JSON.stringify(data));
+  } catch (e) {
+    console.error('Scraping failed:', e);
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+}
+
+const url = process.argv[2];
+if (!url) {
+  console.error('URL is required');
+  process.exit(1);
+}
+scrapeJob(url);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1691,7 +1691,7 @@ const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
-  'interview.md', 'latex.md', 'latex-tex.md', 'email.md', 'add.md', 'titles.md',
+'interview.md', 'latex.md', 'latex-tex.md', 'email.md', 'add.md', 'titles.md', 'gtop.md',
   'expand.md', 'discover.md',
   'regional/eu-swe.md',
 ];
@@ -2384,7 +2384,59 @@ if (
   fail('upskill trust rule 8 (scope boundary: upskill finds, training judges) missing');
 }
 
-// ── 9. LOCAL PARSER CONTRACT ────────────────────────────────────
+// --- gtop mode integrity ---
+
+if (fileExists('modes/gtop.md')) {
+  pass('gtop mode file exists');
+
+  const gtopMode = readFile('modes/gtop.md');
+
+  if (gtopMode.includes('via LinkedIn') && gtopMode.includes('via Indeed') && gtopMode.includes('Recruit.net')) {
+    pass('gtop mode defines trusted-portal filter (Step 2.5)');
+  } else {
+    fail('gtop mode missing trusted-portal filter (Step 2.5)');
+  }
+
+  if (gtopMode.includes('Click the card') && gtopMode.includes('detail panel')) {
+    pass('gtop mode handles Google Jobs card-as-button click model (Step 2/4)');
+  } else {
+    fail('gtop mode missing card-click instructions (Step 2/4)');
+  }
+
+  if (gtopMode.includes('| `1 day ago`') && gtopMode.includes('N hours ago')) {
+    pass('gtop mode includes posting-age parsing table (Step 3)');
+  } else {
+    fail('gtop mode missing posting-age parsing table (Step 3)');
+  }
+
+  if (gtopMode.includes('Block A') && gtopMode.includes('Block B') && gtopMode.includes('Block G')) {
+    pass('gtop mode includes compact A-G evaluation (Step 5)');
+  } else {
+    fail('gtop mode missing A-G evaluation instructions (Step 5)');
+  }
+
+  if (gtopMode.includes('>= 4.0') && gtopMode.includes('reserve-report-num.mjs') && gtopMode.includes('merge-tracker.mjs')) {
+    pass('gtop mode writes reports + PDF + tracker for high-fit roles (Step 5.5)');
+  } else {
+    fail('gtop mode missing report-generation workflow for high-fit roles (Step 5.5)');
+  }
+
+  if (gtopMode.includes('Max 3 search queries') && gtopMode.includes('No subagents') && gtopMode.includes('aggregator')) {
+    pass('gtop mode includes firm guardrails');
+  } else {
+    fail('gtop mode missing guardrails section');
+  }
+
+  if (gtopMode.includes('optional argument') && gtopMode.includes('custom role argument')) {
+    pass('gtop mode supports optional role argument');
+  } else {
+    fail('gtop mode missing optional role argument support');
+  }
+} else {
+  fail('gtop mode file missing - add modes/gtop.md');
+}
+
+// --- 9. LOCAL PARSER CONTRACT ---
 
 console.log('\n9. Local parser contract');
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2415,10 +2415,17 @@ if (fileExists('modes/gtop.md')) {
     fail('gtop mode missing A-G evaluation instructions (Step 5)');
   }
 
-  if ((gtopMode.includes('>= 4.0') || gtopMode.includes('≥ 4.0')) && gtopMode.includes('reserve-report-num.mjs') && gtopMode.includes('merge-tracker.mjs')) {
-    pass('gtop mode writes reports + PDF + tracker for high-fit roles (Step 5.5)');
+  if ((gtopMode.includes('>= 4.0') || gtopMode.includes('≥ 4.0')) && gtopMode.includes('reserve-report-num.mjs') && gtopMode.includes('merge-tracker.mjs') && gtopMode.includes('normalize-statuses.mjs') && gtopMode.includes('dedup-tracker.mjs') && gtopMode.includes('verify-pipeline.mjs')) {
+    pass('gtop mode writes reports + PDF + tracker + pipeline cleanup for high-fit roles (Step 5.5)');
   } else {
-    fail('gtop mode missing report-generation workflow for high-fit roles (Step 5.5)');
+    fail('gtop mode missing report-generation or pipeline cleanup workflow for high-fit roles (Step 5.5)');
+  }
+
+  // WebFetch fallback verification header
+  if (gtopMode.includes('**Verification:** unconfirmed (batch mode)')) {
+    pass('gtop mode includes WebFetch fallback verification header');
+  } else {
+    fail('gtop mode missing WebFetch fallback verification header requirement');
   }
 
   if (gtopMode.includes('Max 3 search queries') && gtopMode.includes('No subagents') && gtopMode.includes('aggregator')) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2415,7 +2415,7 @@ if (fileExists('modes/gtop.md')) {
     fail('gtop mode missing A-G evaluation instructions (Step 5)');
   }
 
-  if (gtopMode.includes('>= 4.0') && gtopMode.includes('reserve-report-num.mjs') && gtopMode.includes('merge-tracker.mjs')) {
+  if ((gtopMode.includes('>= 4.0') || gtopMode.includes('≥ 4.0')) && gtopMode.includes('reserve-report-num.mjs') && gtopMode.includes('merge-tracker.mjs')) {
     pass('gtop mode writes reports + PDF + tracker for high-fit roles (Step 5.5)');
   } else {
     fail('gtop mode missing report-generation workflow for high-fit roles (Step 5.5)');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -86,6 +86,7 @@ const SYSTEM_PATHS = [
   'modes/latex-tex.md',
   'modes/followup.md',
   'modes/offer-prep.md',
+  'modes/gtop.md',
   'modes/interview-prep.md',
   'modes/interview/',
   'interview-prep/sessions/.gitkeep',


### PR DESCRIPTION
Closes #1975.

## Summary

New `/career-ops gtop` mode — bulk-discovers fresh job postings from **Google Jobs**, filters to only trusted portals (LinkedIn, Indeed, Workday, Greenhouse, Ashby, Lever, ICIMS, company careers pages), evaluates fit against the candidate's profile using the existing A-G scoring framework, and returns ranked "apply ASAP" recommendations for high-fit roles (≥ 4.0/5).

**Proposal / design rationale: #1975** — please review the direction there; this PR is the implementation.

## Files changed

| File | Change |
|------|--------|
| `modes/gtop.md` | **New** — full mode instruction file, 6-step workflow |
| `.agents/skills/career-ops/SKILL.md` | Register `gtop` subcommand (argument-hint, routing table, context-loading) |
| `update-system.mjs` | Add `modes/gtop.md` to SYSTEM_PATHS for auto-update support |
| `test-all.mjs` | 8 new integrity tests: portal filter, card-click model, age parsing, A-G evaluation, report generation, guardrails, argument support |

## How it works

1. **Step 0** — Health check + sources of truth (cv.md, profile.yml, _profile.md, _shared.md)
2. **Step 1** — Build 3 Google Jobs queries from title_filter keywords (or a custom arg), each ending with `since yesterday` for 24h narrowing
3. **Step 2** — Scrape with Playwright (browser_navigate + browser_snapshot)
4. **Step 2.5** — Filter to trusted portals only (drops aggregators like Recruit.net, Built In, Zippia, Expertini, Jooble, etc.)
5. **Step 3** — Age filter to last 24h (authoritative text-based gate)
6. **Step 3.5** — Deduplicate + cap evaluation set at 10
7. **Step 4** — Re-find each card via `browser_find` (handles stale refs), click to open detail panel, extract JD and apply URL
8. **Step 5** — Full A-G evaluation inline; for ≥ 4.0 roles, immediately reserve report number, write report, generate PDF, write TSV, merge tracker, release sentinel
9. **Step 6** — Rank and output only high-fit roles

## Key design decisions

- **No subagents, no deep-research** — sequential single-pass to bound token usage
- **Portals-only filter** — Google Jobs surfaces jobs from aggregators; only LinkedIn, Indeed, and official ATS portals are trusted
- **Optional role argument** — `/career-ops gtop AI Engineer` to search a specific role
- **Report + PDF for ≥ 4.0 roles only** — below-threshold roles are silently dropped (no artifact noise)
- **Card-as-button click model** — Google Jobs cards are buttons, not links; real URLs are extracted from the detail panel
- **`since yesterday` in query keywords** — empirically more reliable than URL date params (`htichips`, `tbs`) which Google strips or inconsistently applies

## Testing

Run `node test-all.mjs` — 8 new gtop-specific tests plus existing regression suite.

Co-Authored-By: Claude <noreply@anthropic.com>