### PR TITLE
fix(scan): guard salary/content filter summary lines behind config checks

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1695,8 +1695,12 @@ async function main() {
   if (config.max_posting_age_days != null || totalFilteredPostingAge > 0) {
     console.log(`Filtered by age:       ${totalFilteredPostingAge} removed`);
   }
-  console.log(`Filtered by salary:   ${totalFilteredSalary} removed`);
-  console.log(`Filtered by content:  ${totalFilteredContent} removed`);
+  if (config.salary_filter || totalFilteredSalary > 0) {
+    console.log(`Filtered by salary:    ${totalFilteredSalary} removed`);
+  }
+  if (config.content_filter || totalFilteredContent > 0) {
+    console.log(`Filtered by content:   ${totalFilteredContent} removed`);
+  }
   if (Object.keys(windows).length > 0 || totalFilteredCooldown > 0) {
     console.log(`Filtered by cooldown:  ${totalFilteredCooldown} removed`);
   }


### PR DESCRIPTION
## Problem

`scan.mjs` unconditionally prints `Filtered by salary` and `Filtered by content` summary lines at the end of every scan, regardless of whether the user has configured either filter in `portals.yml`. This is inconsistent with every other filter in the same summary block (tier, age, cooldown), all of which are only printed if configured.

Additionally, the salary and content lines had misaligned spacing compared to the rest of the summary block.

## Fix

- Added guard conditions `if (config.salary_filter || totalFilteredSalary > 0)` and `if (config.content_filter || totalFilteredContent > 0)`, matching the existing pattern used by tier, age, and cooldown filters.
- Fixed column alignment by adding the missing padding spaces.

## Testing

- When neither `salary_filter` nor `content_filter` is configured, the lines no longer appear in the summary.
- When either filter is configured and removes entries, the line appears with correct count.
- When either filter is configured but removes 0 entries (e.g., all jobs pass), the line still appears — consistent with age/cooldown behavior.

Closes #1924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * End-of-run summaries now show salary and content filtering statistics only when those filters are configured or have affected results.
  * Removed irrelevant zero-value filter messages from summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->