### PR TITLE
fix(update-system): stage .update-dismissed deletion only when tracked

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -955,8 +955,22 @@ async function apply() {
     const pathsToStage = [...updated];
     const dismissFile = join(ROOT, '.update-dismissed');
     if (existsSync(dismissFile)) {
+      // .update-dismissed is gitignored, so it is normally untracked and its
+      // deletion needs no git action. Staging it anyway would put a pathspec
+      // that matches nothing into `git add`/`git commit` — git exits 128
+      // ("pathspec did not match any files"), which blocks staging of every
+      // other path in the same command and aborts the update commit. Only
+      // stage the deletion when the file is genuinely tracked (legacy repos
+      // that committed it before it was gitignored).
+      let dismissTracked = false;
+      try {
+        dismissTracked = git('ls-files', '--', '.update-dismissed') !== '';
+      } catch {
+        // If git can't tell us, treat as untracked — worst case the tracked
+        // deletion lands in a later commit instead of aborting this one.
+      }
       unlinkSync(dismissFile);
-      pathsToStage.push('.update-dismissed');
+      if (dismissTracked) pathsToStage.push('.update-dismissed');
     }
 
     try {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -160,6 +160,10 @@ const twoPassManifestChecks = [
     name: 'apply captures uncommitted work via git stash create before branching (#915)',
     pattern: /git\('stash',\s*'create'\)/,
   },
+  {
+    name: 'apply stages the .update-dismissed deletion only when git ls-files says it is tracked',
+    pattern: /git\('ls-files',\s*'--',\s*'\.update-dismissed'\)/,
+  },
 ];
 
 for (const check of twoPassManifestChecks) {
@@ -178,6 +182,19 @@ if (staticRelativeImport.test(source)) {
   fail('update-system.mjs is self-loading — no static relative imports (#1706)');
 } else {
   pass('update-system.mjs is self-loading — no static relative imports (#1706)');
+}
+
+// .update-dismissed is gitignored, so it is normally untracked. Deleting it and
+// then passing it to `git add -- <paths...>` / `git commit -- <paths...>` makes
+// the pathspec match nothing → git exits 128 ("pathspec did not match any
+// files"), which blocks staging of EVERY path in that command and aborts the
+// convenience commit. apply() must never push it into pathsToStage
+// unconditionally after unlinking it.
+const unconditionalDismissStage = /unlinkSync\(dismissFile\);\s*pathsToStage\.push\('\.update-dismissed'\)/;
+if (unconditionalDismissStage.test(source)) {
+  fail('apply must not unconditionally stage .update-dismissed after unlinking it (gitignored → unmatched pathspec aborts the commit)');
+} else {
+  pass('apply must not unconditionally stage .update-dismissed after unlinking it (gitignored → unmatched pathspec aborts the commit)');
 }
 
 for (const userPath of ['cv.md', 'config/profile.yml', 'modes/_profile.md', 'portals.yml', 'data/', 'reports/']) {


### PR DESCRIPTION
## Bug

In `apply()` step 7 ("Commit the update"), if `.update-dismissed` exists it is `unlinkSync`'d and then unconditionally pushed into `pathsToStage`. But `.update-dismissed` is gitignored, so it is normally **untracked** — after deletion the pathspec matches nothing in the worktree or index, and:

```
git add -- <updated paths...> .update-dismissed
```

exits 128 with `fatal: pathspec '.update-dismissed' did not match any files`. Git validates every pathspec in one invocation before acting, so the one dead pathspec blocks staging of **all** system paths in the command and the update aborts with `Update commit failed (files may be staged but not committed)` — even though the update itself succeeded.

Reproduced with git 2.53: in a scratch repo, `git add -- somefile .update-dismissed` with the dismiss file deleted+untracked exits 128 and leaves `somefile` unstaged.

## Fix

Deleting an untracked file needs no git action. `apply()` now checks `git ls-files -- .update-dismissed` and only pushes the path into `pathsToStage` when the file is genuinely tracked (legacy clones that committed it before it was gitignored). In that legacy case the staged deletion works as before (verified: `git add` stages `D .update-dismissed`, exit 0).

Note this is distinct from the `addPaths` force-add bug (see #1997): `git add -f` only bypasses the ignore check — a deleted+untracked path still matches no pathspec, so `-f` cannot fix this one.

## Tests

Two regression checks added to `updater-migration-tests.mjs` following its existing source-check pattern (both fail on the pre-fix source):

- positive: `apply` guards the `.update-dismissed` stage on `git ls-files` tracked-ness
- negative (same style as the #1706 check): the unconditional `unlinkSync(dismissFile); pathsToStage.push('.update-dismissed')` shape must not reappear

`node test-all.mjs`: 1795 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update handling when removing a dismissal marker, preventing update commits from failing in certain repository states.
  * Ensured updates continue successfully whether the dismissal marker is tracked or untracked.
* **Tests**
  * Added safety checks covering dismissal-marker cleanup and update commit staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->