### PR TITLE
fix(update-system): force-add explicitly named system files in addPaths

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -579,7 +579,20 @@ function revertPaths(paths) {
 
 function addPaths(paths) {
   if (paths.length === 0) return;
-  git('add', '--', ...paths);
+  // `git add` refuses explicitly named paths that match a .gitignore rule —
+  // even when `git checkout FETCH_HEAD --` already staged them. A clone whose
+  // .gitignore predates the negations for a newly shipped file (e.g. the #1242
+  // interview-prep/sessions scaffold arriving in a repo that still ignores all
+  // of interview-prep/*) would abort the whole update commit, so explicitly
+  // named files are force-added: every file entry here is updater-owned and
+  // meant to be tracked. Directory entries (trailing '/', the manifest
+  // convention) must stay un-forced — plain `git add dir/` silently skips
+  // ignored content, while `-f` would drag user files matched by the PII
+  // safety net (*passport*), .env.local or node_modules into the commit.
+  const fileEntries = paths.filter((p) => !p.endsWith('/'));
+  const dirEntries = paths.filter((p) => p.endsWith('/'));
+  if (fileEntries.length > 0) git('add', '-f', '--', ...fileEntries);
+  if (dirEntries.length > 0) git('add', '--', ...dirEntries);
 }
 
 function dashboardGoSourcesChanged() {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -160,6 +160,21 @@ const twoPassManifestChecks = [
     name: 'apply captures uncommitted work via git stash create before branching (#915)',
     pattern: /git\('stash',\s*'create'\)/,
   },
+  {
+    // `git add` refuses explicitly named paths that match a .gitignore rule,
+    // even when `git checkout FETCH_HEAD --` already staged them. A clone whose
+    // .gitignore predates the negations for a newly shipped file (e.g. the
+    // #1242 interview-prep/sessions scaffold) aborts the whole update commit.
+    name: 'addPaths force-adds explicitly named file entries so a stale user .gitignore cannot abort the update commit',
+    pattern: /git\('add',\s*'-f',\s*'--',\s*\.\.\.fileEntries\)/,
+  },
+  {
+    // Directory pathspecs must stay un-forced: plain `git add dir/` silently
+    // skips ignored content, while `-f` would drag user files matched by the
+    // PII safety net (*passport*), .env.local or node_modules into the commit.
+    name: 'addPaths never force-adds directory entries — ignored user content must stay skipped',
+    pattern: /git\('add',\s*'--',\s*\.\.\.dirEntries\)/,
+  },
 ];
 
 for (const check of twoPassManifestChecks) {


### PR DESCRIPTION
## Bug

`git add` refuses explicitly named paths that match a `.gitignore` rule — even when `git checkout FETCH_HEAD --` already staged them. A clone whose `.gitignore` predates the negations for a newly shipped file (e.g. the #1242 `interview-prep/sessions` scaffold arriving in a repo that still ignores all of `interview-prep/*`) aborted the whole update commit with `Update commit failed (files may be staged but not committed)`.

## Fix

Split `addPaths()`:

- **Explicitly named file entries** are updater-owned and meant to be tracked → `git add -f`.
- **Directory entries** (trailing-slash manifest convention) stay un-forced → plain `git add dir/` keeps silently skipping ignored user content (the `*passport*` PII safety net, `.env.local`, `node_modules`) instead of dragging it into the update commit.

Reproduced with a 1.12.0 → 1.20.0 apply; verified `add -f` + the scoped commit succeed against a stale `.gitignore`, and that directory pathspecs still skip ignored files.

Note this is distinct from the `.update-dismissed` unmatched-pathspec abort fixed in #1996: `-f` only bypasses the ignore check, so both fixes are needed. The two touch adjacent code and merge cleanly in either order.

## Tests

Regression checks added to `updater-migration-tests.mjs` following its existing source-check pattern. `node test-all.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update staging so explicitly included files are applied reliably, even when affected by ignore rules.
  * Prevented ignored user content within directories from being unintentionally included in updates.
  * Added safeguards covering both file and directory update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->