### PR TITLE
fix(zh-minimal): preserve ATS text extraction order + strip empty certifications section

### DIFF
--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -1,12 +1,10 @@
 // Shared optional-section stripping for the CV builders (build-cv-html.mjs,
 // build-cv-latex.mjs).
 //
-// Projects and education are the genuinely optional CV sections: a candidate's
-// projects are often already covered under Work Experience, and not every
-// candidate has a degree. The templates wrap both unconditionally, so a payload
-// with no entries renders a bare section header with nothing under it. The
-// builders' buildProjects()/buildEducation() correctly return '' — nothing
-// removes the surrounding wrapper, which is what this module does.
+// Projects, education, and certifications are optional CV sections: projects
+// may already be covered under Work Experience, and not every candidate has a
+// degree or certification. The templates wrap them unconditionally, so an
+// empty payload otherwise renders a bare section header.
 //
 // The section body is delimited by markers rather than parsed, so the boundary
 // pattern carries the whole correctness burden and is easy to get subtly wrong:
@@ -33,6 +31,7 @@ const PATTERNS = {
   html: {
     projects: new RegExp(String.raw`<!--\s+PROJECTS\s+-->[\s\S]*?` + HTML_BOUNDARY),
     education: new RegExp(String.raw`<!--\s+EDUCATION\s+-->[\s\S]*?` + HTML_BOUNDARY),
+    certifications: new RegExp(String.raw`<!--\s+CERTIFICATIONS\s+-->[\s\S]*?` + HTML_BOUNDARY),
   },
   tex: {
     projects: new RegExp(String.raw`%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
@@ -40,7 +39,11 @@ const PATTERNS = {
   },
 };
 
-export const OPTIONAL_SECTIONS = ['projects', 'education'];
+export const OPTIONAL_SECTIONS = ['projects', 'education', 'certifications'];
+const OPTIONAL_SECTIONS_BY_FORMAT = {
+  html: OPTIONAL_SECTIONS,
+  tex: ['projects', 'education'],
+};
 
 export function isEmptySection(payload, section) {
   const entries = payload?.[section];
@@ -54,7 +57,7 @@ export function stripEmptySections(template, payload, format) {
   if (!patterns) throw new Error(`Unknown template format: ${format}`);
 
   let out = template;
-  for (const section of OPTIONAL_SECTIONS) {
+  for (const section of OPTIONAL_SECTIONS_BY_FORMAT[format]) {
     if (isEmptySection(payload, section)) {
       out = out.replace(patterns[section], '');
     }

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -175,10 +175,9 @@ version: 1.0.0
   }
 
   .job-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
+    /* Normal flow preserves company -> period -> role order in ATS extraction.
+       Flex can group several headers before their role and bullet text. */
+    display: block;
     margin-bottom: 4px;
   }
 
@@ -193,6 +192,7 @@ version: 1.0.0
     font-size: 10.5px;
     color: #777;
     white-space: nowrap;
+    margin-left: 10px;
   }
 
   .job-role {
@@ -264,13 +264,11 @@ version: 1.0.0
   }
 
   .edu-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
+    display: block;
   }
 
   .edu-title {
+    display: inline;
     font-weight: 600;
     font-size: 11px;
     color: #333;
@@ -282,9 +280,11 @@ version: 1.0.0
   }
 
   .edu-year {
+    display: inline;
     font-size: 10px;
     color: #777;
     white-space: nowrap;
+    margin-left: 10px;
   }
 
   .edu-desc {
@@ -472,9 +472,12 @@ version: 1.0.0
   body,
   html[lang="zh-CN"] body,
   html[lang="zh"] body {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
-      'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
-      'Noto Sans SC', 'Source Han Sans SC', sans-serif;
+    /* Keep Chinese and Latin text in one font run where possible. Splitting
+       mixed-language lines across Liberation Sans plus a CJK fallback makes
+       Chromium PDFs look correct while text extractors reorder Latin tokens. */
+    font-family: 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei',
+      'Noto Sans CJK SC', 'Noto Sans SC', 'Source Han Sans SC',
+      'Arial Unicode MS', sans-serif;
     color: var(--zhm-text);
     line-break: strict;
     word-break: normal;

--- a/test/zh-minimal-template.test.mjs
+++ b/test/zh-minimal-template.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -10,6 +10,7 @@ import { chromium } from 'playwright';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const TEMPLATE = join(ROOT, 'templates', 'cv-template.zh-minimal.html');
+const HAS_PDFTOTEXT = spawnSync('pdftotext', ['-v'], { stdio: 'ignore' }).status === 0;
 
 test('Chinese Minimal template is discoverable and valid', () => {
   const listed = listTemplates('cv');
@@ -56,7 +57,66 @@ test('Chinese Minimal renders a complete mixed-language payload', () => {
   assert.match(rendered, /<html lang="zh-CN">/);
   assert.match(rendered, /测试候选人/);
   assert.match(rendered, /AI Agent 工作流/);
+  assert.doesNotMatch(rendered, /Certifications/);
   assert.doesNotMatch(rendered, /\{\{[A-Z_]+\}\}/);
+});
+
+test('Chinese Minimal preserves mixed-language and job order in PDF text extraction', {
+  skip: (!existsSync(chromium.executablePath()) || !HAS_PDFTOTEXT)
+    && 'Chromium or pdftotext is not installed',
+}, async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'zh-minimal-extraction-'));
+  const input = join(dir, 'cv.json');
+  const output = join(dir, 'cv.html');
+  const pdf = join(dir, 'cv.pdf');
+  writeFileSync(input, JSON.stringify({
+    lang: 'zh-CN',
+    page_format: 'a4',
+    candidate: { name: '测试候选人', email: 'candidate@example.com', location: '深圳' },
+    sections: {
+      summary: '职业概述', competencies: '核心能力', experience: '工作经历',
+      projects: '项目', education: '教育背景', certifications: '认证', skills: '技能',
+    },
+    summary: '6 年企业数字化经验，服务 ACME、Globex、Initech、Umbrella、Hooli、Vandelay。',
+    competencies: ['项目交付'],
+    experience: [
+      {
+        company: '示例甲公司', role: '产品经理', dates: '2025 至今',
+        bullets: ['交付 AI agent 产品。'],
+      },
+      {
+        company: '示例乙公司', role: '客户经理', dates: '2022 - 2024',
+        bullets: ['主导 CRM 项目。'],
+      },
+    ],
+    projects: [],
+    education: [{ title: '管理学硕士', org: '示例大学', year: '2021' }],
+    certifications: [],
+    skills: [{ category: '工具', items: ['CRM', 'AI agent'] }],
+  }));
+  execFileSync(process.execPath, ['build-cv-html.mjs', input, output, TEMPLATE], { cwd: ROOT });
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(pathToFileURL(output).href);
+    await page.pdf({
+      path: pdf,
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '0.6in', right: '0.6in', bottom: '0.6in', left: '0.6in' },
+    });
+  } finally {
+    await browser.close();
+  }
+
+  const text = execFileSync('pdftotext', [pdf, '-'], { encoding: 'utf8' })
+    .replace(/\s+/g, ' ')
+    .trim();
+  assert.match(text, /6 年.*ACME.*Globex.*Initech.*Umbrella.*Hooli.*Vandelay/);
+  assert.match(text,
+    /示例甲公司 2025 至今.*产品经理.*交付 AI agent 产品.*示例乙公司 2022 - 2024.*客户经理.*主导 CRM 项目/);
+  assert.doesNotMatch(text, /Certifications/);
 });
 
 test('Chinese Minimal keeps long mixed-language contacts inside the A4 page', {

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -1,5 +1,5 @@
 // tests/cv-optional-sections.test.mjs — the optional CV sections (projects,
-// education) must vanish entirely when they have no entries, rather than
+// education, certifications) must vanish entirely when they have no entries, rather than
 // rendering a bare section header with nothing under it.
 //
 // #1879 fixed this for projects; the education half is the same bug (not every
@@ -13,8 +13,12 @@ import { stripEmptySections } from '../cv-sections-core.mjs';
 
 console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
 
-const EMPTY = { projects: [], education: [] };
-const FULL = { projects: [{ name: 'P' }], education: [{ degree: 'D' }] };
+const EMPTY = { projects: [], education: [], certifications: [] };
+const FULL = {
+  projects: [{ name: 'P' }],
+  education: [{ degree: 'D' }],
+  certifications: [{ title: 'C' }],
+};
 
 function check(label, actual, expected) {
   if (actual === expected) pass(label);
@@ -25,21 +29,27 @@ function check(label, actual, expected) {
 // Assert against the shipped templates so a template edit that renames or
 // reorders a marker fails here instead of silently reviving the bare header.
 const TEMPLATES = [
-  { file: 'templates/cv-template.html', format: 'html', after: 'CERTIFICATIONS' },
-  { file: 'templates/resume-template.html', format: 'html', after: 'SKILLS' },
-  { file: 'templates/cv-template.tex', format: 'tex', after: 'Technical Skills' },
+  { file: 'templates/cv-template.html', format: 'html', after: 'SKILLS', hasCertifications: true },
+  { file: 'templates/cv-template.zh-minimal.html', format: 'html', after: 'SKILLS', hasCertifications: true },
+  { file: 'templates/resume-template.html', format: 'html', after: 'SKILLS', hasCertifications: false },
+  { file: 'templates/cv-template.tex', format: 'tex', after: 'Technical Skills', hasCertifications: false },
 ];
 
-for (const { file, format, after } of TEMPLATES) {
+for (const { file, format, after, hasCertifications } of TEMPLATES) {
   const template = readFileSync(join(ROOT, file), 'utf-8');
   const name = file.split('/').pop();
 
   const stripped = stripEmptySections(template, EMPTY, format);
   const projectsMarker = format === 'html' ? '<!-- PROJECTS -->' : 'PROJECTS  %';
   const educationMarker = format === 'html' ? '<!-- EDUCATION -->' : 'Education  %';
+  const certificationsMarker = '<!-- CERTIFICATIONS -->';
 
   check(`${name}: empty payload removes the projects block`, stripped.includes(projectsMarker), false);
   check(`${name}: empty payload removes the education block`, stripped.includes(educationMarker), false);
+  if (hasCertifications) {
+    check(`${name}: empty payload removes the certifications block`,
+      stripped.includes(certificationsMarker), false);
+  }
   check(`${name}: the section after education survives`, stripped.includes(after), true);
   check(`${name}: {{EXPERIENCE}} is untouched`, stripped.includes('{{EXPERIENCE}}'), true);
 


### PR DESCRIPTION
## What does this PR do?

Fixes two ways the Chinese Minimal (`zh-minimal`) CV template produced PDFs that look correct on screen but extract badly in ATS pipelines, plus the certifications half of #1879:

1. **Empty certifications block left a bare header** — #1879 stripped empty projects/education wrappers, but `certifications` was not in `OPTIONAL_SECTIONS`, so a payload without certifications still rendered an empty "Certifications" section in both HTML CV templates.
2. **ATS text extraction scrambled order** — `.job-header`/`.edu-header` used flex with `space-between`, letting extractors group several company/period headers before their role and bullet text; and the font stack led with Liberation Sans, which splits mixed Chinese/Latin lines across two fonts and makes extractors reorder the Latin tokens. Both are invisible in the rendered PDF.

## Related issue

Follow-up to #1879 (certifications is the same bug, one section over).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## How this is tested

- `tests/cv-optional-sections.test.mjs` now covers certifications for `cv-template.html` and `cv-template.zh-minimal.html`.
- New end-to-end test in `test/zh-minimal-template.test.mjs`: renders a mixed-language payload to PDF with Chromium, extracts with `pdftotext`, and asserts brand-name order and company → dates → role order survive (skipped when Chromium/pdftotext are absent, matching the existing pattern).
- `node test-all.mjs` passes locally.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for certifications as an optional CV section.
  * Certifications are automatically omitted when no entries are provided.
* **Bug Fixes**
  * Improved Chinese Minimal template formatting to preserve mixed-language text order in PDF extraction.
  * Updated typography and spacing for better ATS and CJK compatibility.
  * Prevented empty certifications placeholders from appearing in generated documents.
* **Tests**
  * Added coverage for optional certifications handling and PDF text extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->