### PR TITLE
build: add Node.js engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.23.0",
   "description": "AI-powered job search pipeline — works with any AI coding CLI (Claude Code, Codex, OpenCode, Antigravity, Grok, Qwen, Kimi, Copilot)",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "doctor": "node doctor.mjs",
     "or": "node openrouter-runner.mjs",


### PR DESCRIPTION
## Summary

Adds a Node.js engine requirement to the root package.json so npm warns users when running an unsupported Node version before runtime.

## Changes

- Added `"engines": { "node": ">=18" }` to the root package.json.

## Verification

- Verified the Node.js floor by reading `checkNodeVersion()` in `doctor.mjs`.
- Checked `web/package.json` for any differing Node.js requirements.
- `npm install` completed without new warnings.
- `node test-all.mjs` passes.

Fixes #2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Declared Node.js 18 or later as the required runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->