### PR TITLE
feat: guard CV work experience against non-chronological order

### DIFF
--- a/cv-experience-order.mjs
+++ b/cv-experience-order.mjs
@@ -1,0 +1,76 @@
+// cv-experience-order.mjs — reverse-chronological guard for rendered CVs.
+//
+// Split out of generate-pdf.mjs (which already sits near the repo's practical
+// file-size ceiling) following the existing *-core.mjs convention used by
+// liveness-core.mjs and cv-sections-core.mjs.
+
+const MONTHS = new Map([
+  ['jan', 1], ['feb', 2], ['mar', 3], ['apr', 4], ['may', 5], ['jun', 6],
+  ['jul', 7], ['aug', 8], ['sep', 9], ['oct', 10], ['nov', 11], ['dec', 12],
+]);
+const JOB_PERIOD_RE = /<span class="job-period">([\s\S]*?)<\/span>/g;
+
+/**
+ * Parse the START of a rendered job-period string into a sortable integer.
+ *
+ * Only the start date matters: reverse-chronological ordering is defined by
+ * when each role began. Returns null when no year is present, so unparseable
+ * entries are skipped rather than guessed at — the same "don't penalize
+ * missing data" discipline the location and country filters use.
+ *
+ * @param {string} period - e.g. "Jan 2021 - Apr 2022", "2005 - 2008".
+ * @returns {number|null} year * 12 + month, or null when no year is found.
+ */
+export function parseExperienceStart(period) {
+  if (typeof period !== 'string') return null;
+  const text = period.replace(/&[a-z]+;/gi, ' ').trim();
+  const year = text.match(/\b(19|20)\d{2}\b/);
+  if (!year) return null;
+  const before = text.slice(0, year.index);
+  const month = before.match(/\b([a-z]{3})[a-z]*\.?\s*$/i);
+  const monthNum = month ? (MONTHS.get(month[1].toLowerCase()) ?? 1) : 1;
+  return Number(year[0]) * 12 + monthNum;
+}
+
+/**
+ * Enforce reverse-chronological ordering of Work Experience entries.
+ *
+ * Agents tailoring a CV toward a JD are tempted to promote "the most relevant
+ * role" to the top. That is a functional-resume technique and it backfires:
+ * it buries the candidate's most recent senior title, and both ATS parsers and
+ * human recruiters expect newest-first, so deviation reads as concealment.
+ * Tailor via the summary, the competencies block, and bullet selection within
+ * each role instead — never via ordering.
+ *
+ * @param {string} html - Rendered CV HTML.
+ * @param {{ allowNonChronological?: boolean }} [options] - When set, downgrades
+ *   a detected inversion from a thrown error to a console warning, for the rare
+ *   deliberately non-chronological CV.
+ * @returns {void}
+ */
+export function validateCvExperienceOrder(html, { allowNonChronological = false } = {}) {
+  if (typeof html !== 'string') return;
+
+  const entries = [];
+  for (const match of html.matchAll(JOB_PERIOD_RE)) {
+    const raw = match[1].replace(/<[^>]*>/g, '').trim();
+    const start = parseExperienceStart(raw);
+    if (start !== null) entries.push({ raw, start });
+  }
+  if (entries.length < 2) return;
+
+  for (let i = 1; i < entries.length; i++) {
+    if (entries[i].start > entries[i - 1].start) {
+      const order = entries.map(e => e.raw).join(' -> ');
+      const message =
+        `CV work experience is not in reverse-chronological order: "${entries[i].raw}" ` +
+        `appears after "${entries[i - 1].raw}" but starts later. Rendered order: ${order}. ` +
+        `Tailor via the summary, competencies, and bullet selection — not by reordering roles.`;
+      if (allowNonChronological) {
+        console.warn(`⚠️  ${message} (proceeding — --allow-nonchronological set)`);
+        return;
+      }
+      throw new Error(message);
+    }
+  }
+}

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -4,7 +4,7 @@
  * generate-pdf.mjs — HTML → PDF via Playwright
  *
  * Usage:
- *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages]
+ *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--allow-nonchronological] [--max-pages=N] [--strict-pages]
  *
  * --report links the generated PDF to its tracker/report number and records
  * the linkage in data/pdf-index.tsv so downstream tools (e.g. the TUI
@@ -16,6 +16,12 @@
  * tailored (e.g. Projects moved ahead of Education for a technical-heavy
  * role) rather than accidentally scrambled by an agent. Without this flag,
  * any divergence from cv.md's section order still fails generation.
+ *
+ * --allow-nonchronological downgrades the work-experience ordering guard from
+ * a thrown error to a console warning. By default a CV whose experience entries
+ * are not newest-first fails generation: promoting "the most relevant role" to
+ * the top is a functional-resume technique that buries the candidate's most
+ * recent senior title and reads as concealment to ATS parsers and recruiters.
  *
  * --max-pages=N sets the preferred rendered CV length (default: 2 pages).
  * The actual page count is checked after Chromium writes the PDF; overflow
@@ -33,6 +39,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
 import { readStyleTokens, injectThemeStyle } from './theme-style.mjs';
+import { validateCvExperienceOrder } from './cv-experience-order.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PDF_PAGE_MARGIN = '0.6in';
@@ -416,7 +423,7 @@ async function generatePDF() {
   const args = process.argv.slice(2);
 
   // Parse arguments
-  let inputPath, outputPath, format = 'a4', reportNum = '', allowReorder = false;
+  let inputPath, outputPath, format = 'a4', reportNum = '', allowReorder = false, allowNonChronological = false;
   let maxPages = 2, maxPagesInput = '2', strictPages = false;
 
   for (const arg of args) {
@@ -429,6 +436,8 @@ async function generatePDF() {
       maxPages = Number(maxPagesInput);
     } else if (arg === '--allow-reorder') {
       allowReorder = true;
+    } else if (arg === '--allow-nonchronological') {
+      allowNonChronological = true;
     } else if (arg === '--strict-pages') {
       strictPages = true;
     } else if (!inputPath) {
@@ -439,7 +448,7 @@ async function generatePDF() {
   }
 
   if (!inputPath || !outputPath) {
-    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages]');
+    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--allow-nonchronological] [--max-pages=N] [--strict-pages]');
     console.error('');
     console.error('This script only converts an already-built HTML file to PDF.');
     console.error('The input HTML is produced by the pdf mode: the agent fills cv-template.html');
@@ -493,6 +502,7 @@ async function generatePDF() {
     if (err?.code !== 'ENOENT') throw err;
   }
   validateCvSectionOrder(html, cvMarkdown, { allowReorder });
+  validateCvExperienceOrder(html, { allowNonChronological });
 
   // Normalize text for ATS compatibility (issue #1)
   const normalized = normalizeTextForATS(html);

--- a/tests/generate-pdf-experience-order.test.mjs
+++ b/tests/generate-pdf-experience-order.test.mjs
@@ -1,0 +1,101 @@
+// tests/generate-pdf-experience-order.test.mjs
+//
+// Guards the reverse-chronological ordering of Work Experience entries in a
+// rendered CV (companion to the existing section-order guard, #1646).
+//
+// Why this exists: when an agent tailors a CV toward a JD, a tempting move is
+// to promote "the most relevant role" to the top of Work Experience. That is a
+// functional-resume technique and it actively hurts the candidate — it buries
+// the most recent senior title, and ATS parsers plus human recruiters both
+// expect newest-first, so deviation reads as concealment. Tailoring belongs in
+// the summary, the competencies block, and bullet selection within each role.
+
+import { validateCvExperienceOrder } from '../cv-experience-order.mjs';
+import { pass, fail, finish } from './helpers.mjs';
+
+console.log('\n📄 generate-pdf: experience ordering guard');
+
+/** Build a minimal rendered-CV fragment with the given job periods. */
+function html(periods) {
+  const jobs = periods.map(p => `
+  <div class="job">
+    <div class="job-header">
+      <span class="job-company">Example Corp</span>
+      <span class="job-period">${p}</span>
+    </div>
+    <div class="job-role">Engineer</div>
+  </div>`).join('\n');
+  return `<html><body><h2>Work Experience</h2>${jobs}</body></html>`;
+}
+
+function expectThrows(label, fn) {
+  try {
+    fn();
+    fail(`${label} — expected a thrown error, none was raised`);
+  } catch (err) {
+    if (err && /chronolog/i.test(err.message)) pass(`${label} — ${err.message.slice(0, 72)}…`);
+    else fail(`${label} — threw the wrong error: ${err && err.message}`);
+  }
+}
+
+function expectOk(label, fn) {
+  try { fn(); pass(label); }
+  catch (err) { fail(`${label} — unexpected throw: ${err && err.message}`); }
+}
+
+// --- Ordering violations -----------------------------------------------------
+
+expectThrows('rejects an older role promoted above a newer one', () =>
+  validateCvExperienceOrder(html([
+    'Jul 2008 – Nov 2014',
+    'Jan 2021 – Apr 2022',
+    'Jun 2017 – Jan 2021',
+  ])));
+
+expectThrows('rejects a simple two-entry inversion', () =>
+  validateCvExperienceOrder(html(['2015 – 2018', '2019 – 2022'])));
+
+expectThrows('rejects an out-of-order Present role', () =>
+  validateCvExperienceOrder(html(['Jan 2020 – Dec 2021', 'Mar 2024 – Present'])));
+
+// --- Valid orderings ---------------------------------------------------------
+
+expectOk('accepts strict reverse-chronological order', () =>
+  validateCvExperienceOrder(html([
+    'Jan 2025 – Present',
+    'Feb 2023 – May 2026',
+    'Jan 2021 – Apr 2022',
+    'Jun 2017 – Jan 2021',
+    'Jul 2008 – Nov 2014',
+    'Sep 2005 – Jun 2008',
+  ])));
+
+expectOk('accepts year-only periods in descending order', () =>
+  validateCvExperienceOrder(html(['2019 – 2022', '2015 – 2018', '2005 – 2008'])));
+
+expectOk('accepts concurrent roles sharing a start month', () =>
+  validateCvExperienceOrder(html(['Jan 2021 – Present', 'Jan 2021 – Apr 2022'])));
+
+// --- Escape hatch ------------------------------------------------------------
+
+expectOk('downgrades to a warning when allowNonChronological is set', () =>
+  validateCvExperienceOrder(html(['2010 – 2014', '2020 – 2024']), { allowNonChronological: true }));
+
+// --- Don't-penalize-missing-data discipline ---------------------------------
+
+expectOk('no-ops on a single experience entry', () =>
+  validateCvExperienceOrder(html(['Jan 2021 – Apr 2022'])));
+
+expectOk('no-ops when the document has no job entries', () =>
+  validateCvExperienceOrder('<html><body><h2>Skills</h2></body></html>'));
+
+expectOk('no-ops when periods are unparseable', () =>
+  validateCvExperienceOrder(html(['sometime', 'later on'])));
+
+expectOk('ignores unparseable entries but still checks parseable neighbours', () =>
+  validateCvExperienceOrder(html(['Jan 2025 – Present', 'ongoing', 'Jan 2021 – Apr 2022'])));
+
+expectThrows('still catches an inversion around an unparseable entry', () =>
+  validateCvExperienceOrder(html(['Jan 2015 – Dec 2016', 'ongoing', 'Jan 2022 – Present'])));
+
+finish();

--- a/tests/generate-pdf-page-budget.test.mjs
+++ b/tests/generate-pdf-page-budget.test.mjs
@@ -27,6 +27,9 @@ copyFileSync(join(ROOT, 'generate-pdf.mjs'), script);
 // theming, #1837); copy it into the sandbox too or the isolated script fails
 // to load with ERR_MODULE_NOT_FOUND before it can parse any --max-pages arg.
 copyFileSync(join(ROOT, 'theme-style.mjs'), join(sandbox, 'theme-style.mjs'));
+// Same reason for ./cv-experience-order.mjs (reverse-chronological guard): it is a
+// local sibling import of generate-pdf.mjs, so the sandbox needs its own copy.
+copyFileSync(join(ROOT, 'cv-experience-order.mjs'), join(sandbox, 'cv-experience-order.mjs'));
 mkdirSync(playwrightStub, { recursive: true });
 writeFileSync(join(playwrightStub, 'package.json'), JSON.stringify({
   name: 'playwright',


### PR DESCRIPTION
Closes #2342

## What

Adds a reverse-chronological guard for Work Experience entries in rendered CVs, running alongside the existing section-order guard in `generate-pdf.mjs`.

## Why

When tailoring a CV toward a JD, the agent is tempted to promote "the most relevant role" to the top of Work Experience. I hit this in real use — generating a CV for an infrastructure/SRE manager role, a 2008–2014 entry got moved above a 2021–2022 Head of Infrastructure role because it matched the JD better.

It backfires:

- **Amplifies the recency problem it's meant to hide** — the reader's first impression becomes how long ago the relevant work was
- **Buries the most recent senior title** mid-page
- **Reads as concealment** — ATS parsers and recruiters both expect newest-first

Tailoring belongs in the summary, the competencies block, and bullet selection within each role. Never in the ordering.

`generate-pdf.mjs` already guards *section* order against `cv.md` (#1646). Experience ordering had no equivalent, so this reached the PDF silently. Prompt-level instruction is probabilistic; this is a deterministic property of the rendered document, so it belongs at the same enforcement point.

## How

- **`cv-experience-order.mjs`** (new) — `parseExperienceStart()` and `validateCvExperienceOrder()`. Split out rather than inlined because `generate-pdf.mjs` is already near the practical file-size ceiling; follows the existing `*-core.mjs` convention (`liveness-core.mjs`, `cv-sections-core.mjs`).
- **`generate-pdf.mjs`** — invokes the guard next to `validateCvSectionOrder`, adds `--allow-nonchronological` mirroring `--allow-reorder`, updates usage and header docs.
- Only the **start** date is compared — reverse-chronological ordering is defined by when each role began.
- Unparseable or absent dates **no-op**, following the same "don't penalize missing data" discipline as `location_filter` and the country-eligibility filter. A CV with no dates renders exactly as before.

## Tests

`tests/generate-pdf-experience-order.test.mjs` — 12 assertions covering inversions, valid orderings, year-only periods, concurrent roles sharing a start month, the escape hatch, and the missing-data no-ops.

Also updated `tests/generate-pdf-page-budget.test.mjs` to copy the new sibling module into its sandbox — same reason the existing comment gives for `theme-style.mjs`, otherwise the isolated script fails with `ERR_MODULE_NOT_FOUND`.

```
node test-all.mjs
📊 Results: 1211 passed, 0 failed, 0 warnings
```

## Verified end to end

```
# real tailored CV, correctly ordered
✅ PDF generated

# same CV with one entry moved to the top
❌ PDF generation failed: CV work experience is not in reverse-chronological
   order: "Jan 2025 – Present" appears after "Jul 2008 – Nov 2014" but starts
   later. […] Tailor via the summary, competencies, and bullet selection —
   not by reordering roles.

# same scrambled CV with the escape hatch
⚠️  […] (proceeding — --allow-nonchronological set)
✅ PDF generated
```

## Backwards compatibility

No behaviour change for any CV that is already reverse-chronological, has fewer than two dated entries, or has unparseable dates. Existing flags are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure CV Work Experience entries appear in reverse-chronological order.
  * Added a `--allow-nonchronological` option to permit exceptions when needed.

* **Bug Fixes**
  * Improved PDF generation checks to detect incorrectly ordered experience entries.

* **Tests**
  * Added coverage for valid, invalid, incomplete, and exception-enabled experience ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->