### PR TITLE
fix(update): add sync-pdf-flags.mjs to SYSTEM_PATHS

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -225,6 +225,7 @@ const SYSTEM_PATHS = [
   'batch/README.md',
   'utils/token-tracker.mjs',
   'batch-tailor.mjs',
+  'sync-pdf-flags.mjs',
   'dashboard/',
   'templates/',
   'config/cv-facts.example.json',


### PR DESCRIPTION
## Summary
- `merge-tracker.mjs` imports `sync-pdf-flags.mjs`, but that file was never added to `update-system.mjs`'s `SYSTEM_PATHS` manifest.
- Any client that reaches `sync-pdf-flags.mjs` only via `update-system.mjs apply` (rather than a fresh clone) never gets the file checked out, so `merge-tracker.mjs` crashes with `Cannot find module 'sync-pdf-flags.mjs'` on every run after updating.
- Confirmed with the repo's own `validate-system-paths-coverage.mjs`, which currently fails on `main` with exactly this one orphan file (`node validate-system-paths-coverage.mjs` → `Coverage gap — tracked files not in SYSTEM_PATHS or USER_PATHS: sync-pdf-flags.mjs`).
- One-line fix: add `sync-pdf-flags.mjs` to `SYSTEM_PATHS`. (`tests/sync-pdf-flags.test.mjs` is already covered by the existing blanket `'tests/'` entry, so no separate line needed for it.)

Found while updating a client from v1.10.0 → v1.22.0 — `merge-tracker.mjs` crashed immediately after the update completed successfully.

## Test plan
- [x] `node validate-system-paths-coverage.mjs` now passes (was failing before this change)
- [x] `node updater-migration-tests.mjs` — 300 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Included PDF flag synchronization in automatic system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->