### PR TITLE
docs(_shared): clarify Playwright parallel rule is per-session, not per-agent-count

### DIFF
--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -195,7 +195,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 |------|-----|
 | WebSearch | Comp research, trends, company culture, LinkedIn contacts, fallback for JDs |
 | WebFetch | Fallback for extracting JDs from static pages |
-| Playwright | Verify offers (browser_navigate + browser_snapshot). **NEVER 2+ agents with Playwright in parallel.** |
+| Playwright | Verify offers (browser_navigate + browser_snapshot). **NEVER let 2+ agents drive the same Playwright/MCP browser session concurrently.** This is a per-session rule, not a per-agent-count one: agents each holding their own isolated browser session are fine in parallel; agents sharing one interactive MCP browser session are not — they race for control and can silently read or act on each other's page state. |
 | Read | cv.md, _profile.md, article-digest.md, cv-template.html |
 | Write | Temporary HTML for PDF, applications.md, reports .md |
 | Edit | Update tracker |
@@ -207,6 +207,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 A mode may tell you to run work in a background subagent (e.g. `scan`, or parallel `pipeline` URLs) to spare the main agent's context. Any subagent you spawn for career-ops is a **single-pass worker**:
 
 - It MUST NOT spawn further subagents, and MUST NOT invoke other skills — especially open-ended or recursive research skills (e.g. a `deep-research` skill). Those fan out into nested agents and can burn tens of millions of tokens on one run.
+- If the work involves Playwright (e.g. parallel `pipeline` workers each verifying a posting), the Playwright rule above still applies in full: parallel subagents must never share one interactive Playwright/MCP browser session. Each worker needs its own isolated session, or the Playwright-touching step must run sequentially.
 - Company, role, and compensation research is ALWAYS done **inline**, with the small explicit set of WebSearch/WebFetch queries the mode names (e.g. `oferta` Blocks C/D) — never delegated to a recursive research harness.
 - One `/career-ops <JD>` evaluates one role; it must never explode into a self-replicating swarm of agents. If you are about to delegate research or nest agents, stop and do it inline, bounded.
 


### PR DESCRIPTION
## Summary
- `modes/_shared.md`'s Playwright rule ("NEVER 2+ agents with Playwright in parallel") reads as a raw agent-count limit and doesn't state the actual constraint — concurrent access to one *shared* browser/MCP session. Spells that out explicitly, and adds the same clarification inline in the Subagent delegation section, since parallel `pipeline` workers are named right there as an example.
- Most market-mode translations (`de`, `es`, `fr`, `hi`, `id`, `it`, `ko`, `nl`, `pl`, `pt`, `tr`, `da`) already independently phrase this as "they share the same browser instance" — this brings the English canonical source in line with what those translations already say, rather than the other way around.
- `ja`/`ru`/`ua`/`ar` still carry the old, terser phrasing (`ja` is actually an untranslated copy of the old English string) — left untouched here since translating them accurately is out of scope for this fix. Flagging in case a translation-fluent contributor wants to pick those up.

Fixes #2545.

## Test plan
- [x] `node test-all.mjs` — 2975 passed, 0 failed, 2 pre-existing/expected warnings (no user data in a fresh checkout, no Go compiler present) unrelated to this change
- [x] Docs-only change to `modes/_shared.md`; no other files reference the old string in the English canonical mode set

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Playwright tasks may run in parallel when each worker uses an isolated browser session.
  * Reinforced that shared interactive browser sessions must not be accessed concurrently.
  * Applied the same session-isolation requirement to delegated Playwright work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->