### PR TITLE
fix(cv): ORG/YEAR empty fallbacks never emitted, breaking column alignment

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -901,8 +901,13 @@ async function runSelfTest() {
     console.error(`Self-test failed (cert variant): ${err.message}`);
     process.exit(1);
   }
-  // The partial should emit an empty <span class="cert-org"> for alignment.
-  if (!certHtml.includes('class="cert-org"')) {
+  // The partial should emit an EMPTY <span class="cert-org"></span> for the
+  // org-less row, so the table columns stay aligned. Assert the empty span
+  // specifically: a bare `includes('class="cert-org"')` is satisfied by the
+  // second entry (which has an org), so it passes even when the fallback never
+  // fires -- which is exactly how the ORG_EMPTY/ORG_BLOCK_EMPTY suffix
+  // mismatch shipped unnoticed.
+  if (!certHtml.includes('<span class="cert-org"></span>')) {
     console.error('Self-test failed: cert-org empty-block not emitted for table alignment');
     process.exit(1);
   }

--- a/templates/sections/awards.html
+++ b/templates/sections/awards.html
@@ -4,9 +4,9 @@
   Field placeholders filled per entry:
     TITLE      — award name (e.g. "Gold Medal, International Olympiad in Informatics")
     ORG_BLOCK  — conditional: award-org span with the issuing body when present;
-                 falls back to empty award-org span (ORG_EMPTY) for table-cell alignment
+                 falls back to empty award-org span (ORG_BLOCK_EMPTY) for table-cell alignment
     YEAR_BLOCK — conditional: award-year span with year text when present;
-                 falls back to empty award-year span (YEAR_EMPTY) for alignment
+                 falls back to empty award-year span (YEAR_BLOCK_EMPTY) for alignment
 
   Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
@@ -17,7 +17,7 @@
   {{YEAR_BLOCK}}
 </div>
 <!--ORG_BLOCK--><span class="award-org">{{ORG}}</span><!--/ORG_BLOCK-->
-<!--ORG_EMPTY--><span class="award-org"></span><!--/ORG_EMPTY-->
+<!--ORG_BLOCK_EMPTY--><span class="award-org"></span><!--/ORG_BLOCK_EMPTY-->
 <!--YEAR_BLOCK--><span class="award-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
-<!--YEAR_EMPTY--><span class="award-year"></span><!--/YEAR_EMPTY-->
+<!--YEAR_BLOCK_EMPTY--><span class="award-year"></span><!--/YEAR_BLOCK_EMPTY-->
 <!--/ENTRY-->

--- a/templates/sections/certifications.html
+++ b/templates/sections/certifications.html
@@ -4,9 +4,9 @@
   Field placeholders filled per entry:
     TITLE      — certification name
     ORG_BLOCK  — conditional: cert-org span with org text when present;
-                 falls back to empty cert-org span (ORG_EMPTY) for table-cell alignment
+                 falls back to empty cert-org span (ORG_BLOCK_EMPTY) for table-cell alignment
     YEAR_BLOCK — conditional: cert-year span with year text when present;
-                 falls back to empty cert-year span (YEAR_EMPTY) for alignment
+                 falls back to empty cert-year span (YEAR_BLOCK_EMPTY) for alignment
 
   Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
@@ -17,7 +17,7 @@
   {{YEAR_BLOCK}}
 </div>
 <!--ORG_BLOCK--><span class="cert-org">{{ORG}}</span><!--/ORG_BLOCK-->
-<!--ORG_EMPTY--><span class="cert-org"></span><!--/ORG_EMPTY-->
+<!--ORG_BLOCK_EMPTY--><span class="cert-org"></span><!--/ORG_BLOCK_EMPTY-->
 <!--YEAR_BLOCK--><span class="cert-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
-<!--YEAR_EMPTY--><span class="cert-year"></span><!--/YEAR_EMPTY-->
+<!--YEAR_BLOCK_EMPTY--><span class="cert-year"></span><!--/YEAR_BLOCK_EMPTY-->
 <!--/ENTRY-->

--- a/tests/cv-alignment-fallbacks.test.mjs
+++ b/tests/cv-alignment-fallbacks.test.mjs
@@ -1,0 +1,60 @@
+// tests/cv-alignment-fallbacks.test.mjs -- the certification and award partials
+// declare EMPTY fallbacks so a row missing an org or a year still emits an
+// empty <span>, keeping the table columns aligned.
+//
+// #2486: those fallbacks never fired. parsePartial() derives a block's base
+// name with `name.slice(0, -6)`, stripping the literal "_EMPTY" suffix, so
+// <!--ORG_EMPTY--> resolved to base "ORG" -- an orphan -- while the renderer
+// looks up "ORG_BLOCK". Renaming the markers to ORG_BLOCK_EMPTY /
+// YEAR_BLOCK_EMPTY makes the derived base match.
+//
+// The bug survived a self-test that claimed to cover this case, because the
+// assertion was `includes('class="cert-org"')` and the fixture's *other* row
+// has an org. This test asserts on the empty span itself, and on the span
+// COUNT, so it fails if either row stops rendering.
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, ROOT, NODE, run, lastRunFailure } from './helpers.mjs';
+
+console.log('\nbuild-cv-html.mjs -- absent org/year still emit an aligned empty span');
+
+const SECTIONS = [
+  { key: 'certifications', cls: 'cert' },
+  { key: 'awards', cls: 'award' },
+];
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-align-'));
+const src = join(dir, 'profile.json');
+const out = join(dir, 'cv.html');
+
+// One row missing org+year, one row with both: the mixed case from the issue.
+writeFileSync(src, JSON.stringify({
+  name: 'Alignment Probe',
+  title: 'Engineer',
+  certifications: [{ title: 'No Org Cert' }, { title: 'With Org', org: 'CNCF', year: '2025' }],
+  awards: [{ title: 'No Org Award' }, { title: 'With Org Award', org: 'ACM', year: '2024' }],
+}));
+
+// run() returns the child's stdout on success and null on failure.
+const r = run(NODE, ['build-cv-html.mjs', src, out], { cwd: ROOT });
+if (r === null) {
+  const d = lastRunFailure();
+  fail(`build-cv-html.mjs crashed (status ${d?.status}): ${(d?.stderr || '').trim().slice(0, 200)}`);
+} else {
+  const html = readFileSync(out, 'utf-8');
+  for (const { key, cls } of SECTIONS) {
+    for (const field of ['org', 'year']) {
+      const span = `${cls}-${field}`;
+      const total = (html.match(new RegExp(`class="${span}"`, 'g')) || []).length;
+      const empty = (html.match(new RegExp(`<span class="${span}"></span>`, 'g')) || []).length;
+      if (total === 2 && empty === 1) {
+        pass(`${key}: both rows emit a ${span} span, one of them the empty fallback`);
+      } else {
+        fail(`${key}: expected 2 ${span} spans with 1 empty, got ${total} spans / ${empty} empty`);
+      }
+    }
+  }
+}
+
+rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #2486.

## The mismatch

`parsePartial` (`build-cv-html.mjs:220`) derives a block's base name with `name.slice(0, -6)`, stripping the literal `_EMPTY`. So `<!--ORG_EMPTY-->` resolved to base `ORG`, an orphan, while the renderer resolves `{{ORG_BLOCK}}`. The alignment fallbacks in `certifications.html` and `awards.html` never fired.

Took the rename approach from the issue, applied to both partials, and corrected the header comments that still named the old markers.

## Why it survived a test

The `build-cv-html` self-test already exercised the mixed-rows case, but asserted:

```js
if (!certHtml.includes('class="cert-org"'))
```

The fixture's second entry has an org, so that substring is present whether or not the fallback fires. The check could not fail for the case it covered. It now asserts the empty span itself.

## Measured

One row missing org/year, one row with both:

| span | before | after |
|---|---|---|
| `cert-org` | 1 span, 0 empty | 2 spans, 1 empty |
| `cert-year` | 1 span, 0 empty | 2 spans, 1 empty |
| `award-org` | 1 span, 0 empty | 2 spans, 1 empty |
| `award-year` | 1 span, 0 empty | 2 spans, 1 empty |

## Test

`tests/cv-alignment-fallbacks.test.mjs` drives the real builder with the mixed-rows profile and asserts on the span **count** as well as the empty span, so it fails if either row stops rendering. Verified red before the fix (4 failures) and green after.

`node test-all.mjs --quick`: **2977 passed, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved awards and certifications rendering when organization or year details are missing.
  - Empty fields now display consistently without incorrect placeholder text or visible artifacts.
  - Ensured organization and year information remains correctly aligned across entries with mixed or incomplete details.

- **Tests**
  - Added coverage for awards and certifications containing missing organization and year values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->