### PR TITLE
test(jd-skill-gap): assert CRLF classification parity

### DIFF
--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -626,6 +626,13 @@ Benefits and Perks (US Only)
   const crlfSkills = extractJdSkills(lineEndingJd.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n'));
   eq('CRLF JD extracts the same skills as the LF JD', crlfSkills, lfSkills);
   eq('CRLF JD extracts a non-zero number of skills', crlfSkills.length > 0, true);
+  const lfClassification = classifySkillGaps(lfSkills, fakeCv);
+  const crlfClassification = classifySkillGaps(crlfSkills, fakeCv);
+  eq(
+    'CRLF JD produces the same classification as the LF JD',
+    JSON.stringify(crlfClassification),
+    JSON.stringify(lfClassification)
+  );
 
   // Regression (#1896): the reported bug. A CV alias and a JD's canonical name
   // must not read as a gap. Before the shared skill-extract canonicalization,

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -79,7 +79,7 @@ const NON_REQUIREMENT_HEADER_RE = new RegExp(
   'im'
 );
 
-const BULLET_LINE_RE = /^\s*[-*•]\s*(.+)$/;
+const BULLET_LINE_RE = /^\s*[-*•]\s*(.+)\r?$/;
 
 // A conservative skill-token extractor: pulls comma/slash/and-separated
 // technical-looking tokens out of a requirement bullet, rather than treating
@@ -386,6 +386,12 @@ Deployed services onto Kubernetes clusters and wrote FastAPI endpoints for inter
   eq('extracts Python from requirements bullet', jdSkills.includes('Python'), true);
   eq('extracts Kubernetes from a separate bullet', jdSkills.includes('Kubernetes'), true);
   eq('does not extract stopword "Strong"', jdSkills.includes('Strong'), false);
+
+  // Regression (#2540): CRLF-terminated JDs must extract the same skills as
+  // LF-terminated JDs. `\r` is a line terminator, so the old pattern never
+  // matched a bullet that still carried a trailing carriage return.
+  const crlfSkills = extractJdSkills(fakeJd.replace(/\n/g, '\r\n'));
+  eq('CRLF JD extracts the same skill list as LF', JSON.stringify(crlfSkills), JSON.stringify(jdSkills));
 
   const result = classifySkillGaps(['Python', 'PostgreSQL', 'Kubernetes', 'FastAPI', 'Rust'], fakeCv);
   eq('Python classified as existing (named skill)', result.existing.includes('Python'), true);

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -392,6 +392,13 @@ Deployed services onto Kubernetes clusters and wrote FastAPI endpoints for inter
   // matched a bullet that still carried a trailing carriage return.
   const crlfSkills = extractJdSkills(fakeJd.replace(/\n/g, '\r\n'));
   eq('CRLF JD extracts the same skill list as LF', JSON.stringify(crlfSkills), JSON.stringify(jdSkills));
+  const lfClassification = classifySkillGaps(jdSkills, fakeCv);
+  const crlfClassification = classifySkillGaps(crlfSkills, fakeCv);
+  eq(
+    'CRLF JD produces the same classification as LF',
+    JSON.stringify(crlfClassification),
+    JSON.stringify(lfClassification)
+  );
 
   const result = classifySkillGaps(['Python', 'PostgreSQL', 'Kubernetes', 'FastAPI', 'Rust'], fakeCv);
   eq('Python classified as existing (named skill)', result.existing.includes('Python'), true);


### PR DESCRIPTION
## Summary

- Adds regression coverage that compares the full skill-gap classification from CRLF and LF versions of the same JD.
- Protects the fix from #2540 at the output level, beyond extraction-count parity.

## Rebase note

#2541 is now in main, so the duplicate parser implementation disappeared during the rebase. This PR intentionally keeps only the additional classification-parity assertion.

## Verification

- node jd-skill-gap.mjs --self-test — 67 passed, 0 failed
- npx -y node@24 test-all.mjs — 6558 passed, 0 failed, 11 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation to ensure skill-gap classifications remain consistent for files with Unix-style (LF) and Windows-style (CRLF) line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->