### PR TITLE
docs(agents): require employer-side confirmation for aggregator listings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,6 +333,19 @@ Two separate axes:
 
 **Exception for batch workers (headless mode):** Playwright is unavailable in headless pipe mode. Use WebFetch as fallback and mark the report header `**Verification:** unconfirmed (batch mode)`; the user can verify manually later.
 
+### Aggregator Listings -- Confirm at the Employer
+
+Job aggregators keep stale, filled, and ghost listings live long after the employer closed the req. A closed role's aggregator page still renders a title, a description, and an Apply button, so `check-liveness.mjs` reads it as `active` — the aggregator page itself proves nothing. **A listing sourced from an aggregator is UNCONFIRMED by default: it is not a real opening until the employer says so.** This covers Wellfound / LinkedIn / Instahyre / Cutshort / Internshala / Naukri and similar, however the listing arrived — pasted, scanned, or found via WebSearch.
+
+**Before an aggregator listing is evaluated, applied to, or presented to the user as live:**
+
+1. Identify the employer, then locate the same role on the **employer's own careers page / ATS** (Greenhouse, Lever, Ashby, Workday, or the company's `/careers`). Same Playwright discipline as above.
+2. **Found at the employer → the employer URL is canonical.** Use it as the report `**URL:**` and apply direct, never through the aggregator.
+3. **Not found at the employer → treat as stale.** Do not apply and do not present it as live. Mark it in `data/scan-history.tsv` or on the tracker row — never silently delete the record, since that is what stops it being re-added as new on the next scan.
+4. **Employer unidentifiable** (some aggregator and agency posts hide the company) → that is a **Block G posting-legitimacy signal**, not a research gap. Report it and stop. NEVER infer, guess, or invent the employer.
+
+This is a confirmation step, not a replacement for `check-liveness.mjs` — run the liveness checker against the **employer** URL once you have it. The headless-batch exception above still applies.
+
 ---
 
 ## CI/CD, Community and Governance


### PR DESCRIPTION
## Problem

`check-liveness.mjs` answers *"does this URL still render a job?"* — but for an aggregator, that question has the wrong answer built in. A filled or expired role on Wellfound still serves a title, a full description, and an Apply button, so `classifyLiveness` returns `active` and the listing flows through evaluation as a genuine opening.

The liveness checker isn't wrong; it just can't see this failure mode. Nothing upstream currently distinguishes "the employer is hiring" from "an aggregator still has a page up."

## Evidence

I hit this while scanning for product roles. Nine Wellfound listings, each checked against the employer's own careers page or ATS:

| Outcome | Count | Signal |
|---|---|---|
| Confirmed stale | 5 | 2 returned HTTP **410 Gone**; one mirror read *"Position Closed"*; one employer's careers page listed 7 open roles, none matching; one company is down to a single employee and publicly "rebuilding" |
| Confirmed live at employer | 1 | Present on the employer's own careers index — applied direct instead |
| Unverifiable | 3 | Real, operating companies with no discoverable employer-side job board |

So **5 of 9 were dead**, and every one of them would have passed a liveness check on the aggregator page. One company's careers link pointed straight back to the aggregator, making "verification" circular.

## Change

One new `###` subsection inside the existing **Offer Verification -- MANDATORY** section. Documentation only — no code changes.

It establishes that aggregator-sourced listings are unconfirmed by default, and specifies four outcomes:

1. **Found at the employer** → the employer URL becomes canonical; apply direct, not through the aggregator.
2. **Not found** → mark stale in `data/scan-history.tsv` or on the tracker row, never delete — the record is what prevents re-adding it as new on the next scan.
3. **Employer unidentifiable** → routes to the existing **Block G** posting-legitimacy path rather than guesswork.
4. Explicitly a confirmation step *before* `check-liveness.mjs`, not a replacement — run the liveness checker against the employer URL once you have it.

It reuses the section's existing Playwright mandate and keeps the headless-batch exception intact, rather than restating either.

## Notes for review

- Placed inside the existing verification section deliberately, rather than as a standalone section — it's the same discipline, and `AGENTS.md` warns that reinforcement-without-enforcement decays.
- Routes the unidentifiable-employer case into **Block G** instead of inventing a new flag type.
- Geography-neutral: names Wellfound / LinkedIn / Instahyre / Cutshort / Internshala / Naukri as examples, but the rule is source-agnostic.
- Happy to follow up with an issue first if this is better discussed before merging, or to extend it into a `verify-employer.mjs` helper if a scripted check would be more useful than an agent-level rule.

One practical caveat worth flagging for anyone implementing the scripted version: both Wellfound and Keka serve identical fallback pages to non-browser clients. During this run, every Keka job URL returned a byte-identical "job not available" page — including a control fetch against an unrelated tenant. These checks need a real browser, not WebFetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Aggregated job listings are now verified against the employer’s careers page or applicant tracking system before being evaluated, applied to, or presented as live.
  - Verified employer listings are treated as canonical sources.
  - Unverified or outdated listings are clearly recorded as such.
  - Unidentified employers are flagged as potential posting-legitimacy signals without unsupported conclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->