### PR TITLE
fix(update-system): skip staging the dismiss marker when git never tracked it

### DIFF
--- a/tests/updater-is-tracked.test.mjs
+++ b/tests/updater-is-tracked.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * updater-is-tracked.test.mjs — BEHAVIORAL tests for isTracked().
+ *
+ * apply() deletes the .update-dismissed marker and then stages it so the
+ * deletion lands in the update commit. The marker is gitignored by default, so
+ * on a stock checkout it is not in the index — and staging a path git has never
+ * heard of is a fatal "pathspec did not match any files" that takes the whole
+ * batch down, leaving the update uncommitted. Reproduces with no local
+ * customization: dismiss an update, then apply one.
+ *
+ * isTracked() is what separates the cases, so each of its outcomes needs its
+ * own oracle:
+ *
+ *   - false (not tracked) is the common path. The upgrade-tests.mjs PR gate
+ *     covers it end to end by seeding a marker into the fixture install.
+ *   - true (force-tracked) is rare and the PR gate CANNOT reach it. Without the
+ *     assertion below, a hardcoded `return false` would pass CI while silently
+ *     dropping the deletion for a user who had force-added the marker.
+ *   - a throwing probe must PROPAGATE, not report "untracked". `ls-files` exits
+ *     0 with empty output when nothing matches, so a throw is an abnormal git
+ *     failure and answering "untracked" for a tracked marker would drop its
+ *     deletion while the update still printed success.
+ *
+ * Drives the real export against a throwaway repo through the gitIn seam,
+ * following updater-rollback-behavior.test.mjs, so the property is verified
+ * rather than the source merely pattern-matched.
+ */
+
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import { gitIn, isTracked } from '../update-system.mjs';
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-istracked-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  // Isolate the fixture from the contributor's global git config. A global
+  // core.excludesFile is the one that matters here — these assertions turn on
+  // ignore resolution, so a stray global rule silently changes the result (the
+  // failure mode reported in #2269). Signing and hooks would break the commits.
+  //
+  // Point at an empty file/dir rather than /dev/null: git on Windows maps that
+  // to `nul` and dies with "fatal: cannot use nul as an exclude file".
+  const emptyExcludes = join(dir, '.git', 'co-empty-excludes');
+  const emptyHooks = join(dir, '.git', 'co-empty-hooks');
+  writeFileSync(emptyExcludes, '');
+  mkdirSync(emptyHooks, { recursive: true });
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.excludesFile', emptyExcludes);
+  g('config', 'core.hooksPath', emptyHooks);
+  return { dir, g, ctx: { git: g } };
+}
+
+console.log('\n🧪 Testing isTracked (ignored-but-tracked vs never-tracked)...');
+
+{
+  const { dir, g, ctx } = makeRepo();
+  writeFileSync(join(dir, 'seed.txt'), 'x');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+  writeFileSync(join(dir, '.gitignore'), '.update-dismissed\nkept.txt\n');
+  g('add', '.gitignore');
+  g('commit', '-qm', 'ignores');
+
+  // Ignored AND tracked (force-added at some point) — its deletion has to be
+  // staged, or an otherwise successful update leaves the worktree dirty.
+  writeFileSync(join(dir, 'kept.txt'), 'k');
+  g('add', '-f', 'kept.txt');
+  g('commit', '-qm', 'track an ignored file');
+
+  // Ignored and never tracked — the .update-dismissed shape.
+  writeFileSync(join(dir, '.update-dismissed'), new Date(0).toISOString());
+
+  if (isTracked('kept.txt', ctx)) {
+    pass('isTracked: true for an ignored-but-tracked path');
+  } else {
+    fail('isTracked said false for a tracked path — apply() would skip a deletion it must stage');
+  }
+
+  if (!isTracked('.update-dismissed', ctx)) {
+    pass('isTracked: false for an ignored, never-tracked path');
+  } else {
+    fail('isTracked said true for a never-tracked path — apply() would stage an unmatched pathspec');
+  }
+
+  // A failing probe must not be reported as "untracked". `ls-files` returns
+  // successfully with empty output when nothing matches, so a throw means git
+  // itself failed (a timeout, an unreadable index, git failing to launch) —
+  // and answering false there would drop a tracked marker's deletion while
+  // apply() still printed success.
+  let propagated = false;
+  try {
+    isTracked('.update-dismissed', { git: () => { throw new Error('git probe failed'); } });
+  } catch {
+    propagated = true;
+  }
+  if (propagated) {
+    pass('isTracked: an abnormal git failure propagates instead of reporting untracked');
+  } else {
+    fail('isTracked swallowed a git failure — a tracked deletion would be silently dropped');
+  }
+
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -771,6 +771,39 @@ export function removeAdditionsNotInHead(pathspec, protectedPaths = new Set(), c
   }
 }
 
+/**
+ * Is a repo-relative path present in the index?
+ *
+ * Used to tell "tracked" (a deletion that must be staged to be committed) apart
+ * from "never tracked" (a deleted one is an unmatched pathspec, which no flag
+ * fixes). Reads the index, so a worktree deletion does not change the answer
+ * and callers are free to probe on either side of an unlink. Callers that are
+ * about to delete should probe first anyway: this can throw, and probing first
+ * keeps the file on disk so a retry sees the same state.
+ *
+ * Deliberately does NOT catch. `ls-files` exits 0 with empty output when
+ * nothing matches, so "untracked" is a successful return, never an exception —
+ * which means a throw here is an abnormal git failure (a timeout, an unreadable
+ * index, git failing to launch), not an answer. Swallowing it would report
+ * "untracked" for a path that IS tracked and silently drop a deletion that has
+ * to be staged, leaving the worktree dirty after an update that printed
+ * success. Let the caller's error handling see it instead.
+ *
+ * Expects a literal single-file path: it reports whether `ls-files` matched
+ * anything, not whether it matched this exact entry. A directory pathspec would
+ * report true for any tracked file beneath it, and a wrong-case path reports
+ * false even on a case-insensitive filesystem, since `ls-files` does not fold.
+ *
+ * @param {string} path - Repo-relative path.
+ * @param {{git?: Function}} [ctx] - Test seam; defaults to the ROOT-bound runner.
+ * @returns {boolean}
+ * @throws if the git probe itself fails.
+ */
+export function isTracked(path, ctx = {}) {
+  const runGit = ctx.git || git;
+  return runGit('ls-files', '--', path).trim().length > 0;
+}
+
 function addPaths(paths) {
   if (paths.length === 0) return;
   git('add', '--', ...paths);
@@ -1176,8 +1209,22 @@ async function apply() {
     const pathsToStage = [...updated];
     const dismissFile = join(ROOT, '.update-dismissed');
     if (existsSync(dismissFile)) {
+      // Only stage the marker when git actually tracks it. It is gitignored by
+      // default, so on a stock checkout it is not in the index — and `git add`
+      // on a deleted, never-tracked path is a fatal "pathspec did not match any
+      // files" that takes the whole batch down with it. Staging it
+      // unconditionally meant dismissing an update and then applying one broke
+      // the commit, with no local customization involved.
+      //
+      // Probe BEFORE unlinking. isTracked reads the index, which a worktree
+      // deletion does not touch, so the answer is identical either way — but
+      // the probe can throw on an abnormal git failure, and doing it first
+      // leaves the marker on disk when it does. A retry then re-enters this
+      // block and re-probes, instead of finding the marker already gone and
+      // skipping a deletion it still owed the commit.
+      const dismissMarkerTracked = isTracked('.update-dismissed');
       unlinkSync(dismissFile);
-      pathsToStage.push('.update-dismissed');
+      if (dismissMarkerTracked) pathsToStage.push('.update-dismissed');
     }
 
     try {

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -13,7 +13,8 @@
  * VERSION (apply has no version gate; equal-VERSION content drift is normal).
  *
  * Usage:
- *   node upgrade-tests.mjs --pr-gate    # newest old tag -> HEAD, one leg
+ *   node upgrade-tests.mjs --pr-gate    # newest old tag -> HEAD, one leg per
+ *                                       # dismiss-marker state (untracked/tracked)
  *   node upgrade-tests.mjs --canary     # planted user-file clobber must go RED
  */
 import { execFileSync } from 'child_process';
@@ -84,7 +85,7 @@ function isAncestor(cwd, tag, sha) {
   try { git(cwd, 'merge-base', '--is-ancestor', tag, sha); return true; } catch { return false; }
 }
 
-export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null }) {
+export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null, dismissMarker = 'untracked' }) {
   const work = realpathSync(mkdtempSync(join(tmpdir(), 'upgrade-leg-')));
   const failures = [];
   const ok = (cond, msg) => { console.log(`  ${cond ? 'PASS' : 'FAIL'} [${label}] ${msg}`); if (!cond) failures.push(msg); };
@@ -112,12 +113,34 @@ export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null 
     const { manifest } = seedFixture(install, { state });
 
     // Dismiss an update before applying one — the shape a user reaches by
-    // running `update-system.mjs dismiss` and then `apply`. The marker is
-    // gitignored and never tracked, so staging it after apply() deletes it is a
-    // fatal unmatched pathspec and the update never commits. Costs nothing when
-    // the marker is filtered out; without that guard both the `apply exits 0`
-    // and the oracle-blob assertions below go RED.
-    writeFileSync(join(install, '.update-dismissed'), new Date(0).toISOString());
+    // running `update-system.mjs dismiss` and then `apply`. Both marker states
+    // have to be exercised, because apply() branches on trackedness and each
+    // branch fails differently:
+    //
+    //   'untracked' (every stock install) — the marker is gitignored, so
+    //     staging it after apply() deletes it is a fatal unmatched pathspec and
+    //     the update never commits. Without the guard, `apply exits 0` and the
+    //     oracle-blob assertion below both go RED.
+    //   'tracked' (legacy repos that committed it before it was gitignored) —
+    //     the deletion MUST be staged, or the update commits without it and
+    //     leaves an unstaged deletion behind. Nothing else in the suite covers
+    //     this: dropping the push is invisible to the untracked leg, since that
+    //     leg skips the push anyway.
+    if (dismissMarker) {
+      writeFileSync(join(install, '.update-dismissed'), new Date(0).toISOString());
+      if (dismissMarker === 'tracked') {
+        git(install, 'add', '-f', '--', '.update-dismissed');
+        // Identity must be supplied inline, the way canary() does. Signing is
+        // additionally disabled here, so a contributor's global commit.gpgsign
+        // cannot break the fixture.
+        // The isolated GIT_CONFIG_GLOBAL below is handed to apply() only, and
+        // the upgrade CI job configures no author identity — so relying on
+        // ambient config passes on a developer box and aborts the leg with
+        // "Author identity unknown" on a clean runner, before apply() ever runs.
+        git(install, '-c', 'user.name=upgrade-tests', '-c', 'user.email=upgrade-tests@career-ops.test',
+          '-c', 'commit.gpgsign=false', 'commit', '-qm', 'legacy: track the dismiss marker');
+      }
+    }
 
     // New-path delta for the #1998-class assertion: concrete files in the
     // target's SYSTEM_PATHS that don't exist at the old tag but do at target.
@@ -139,6 +162,19 @@ export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null 
     let installOracle = null;
     try { installOracle = git(install, 'rev-parse', `HEAD:${oracle}`); } catch { /* leave null */ }
     ok(installOracle === oracleBlob, `upgrade executed: ${oracle} blob matches target (non-vacuity oracle)`);
+    if (dismissMarker === 'tracked') {
+      // The marker was committed before the upgrade, so apply() had to stage its
+      // deletion for the update commit to carry it. Two independent oracles,
+      // because dropping that push shows up in two places: the deletion is
+      // missing from the commit, AND it is left behind as an unstaged worktree
+      // deletion (the file is gone from disk but still in the index).
+      let stillInHead = true;
+      try { git(install, 'cat-file', '-e', 'HEAD:.update-dismissed'); } catch { stillInHead = false; }
+      ok(!stillInHead, 'tracked dismiss marker: its deletion reached the update commit');
+
+      const dirty = git(install, 'status', '--porcelain', '--', '.update-dismissed');
+      ok(dirty === '', `tracked dismiss marker: no deletion left behind (git status: ${dirty || 'clean'})`);
+    }
     for (const [f, hash] of Object.entries(manifest)) {
       const p = join(install, f);
       ok(existsSync(p) && sha256(p) === hash, `user file byte-identical: ${f}`);
@@ -208,7 +244,15 @@ function prGate() {
   const newestOld = newestAncestorTag(targetSha);
   if (!newestOld) { console.error('No release tag is an ancestor of HEAD — fetch tags first (CI: fetch-depth: 0)'); process.exit(1); }
   console.log(`PR gate: ${newestOld} -> ${targetSha.slice(0, 8)}`);
-  const { failures } = runLeg({ oldTag: newestOld, targetSha });
+  // Two legs, one per dismiss-marker state. apply() branches on trackedness and
+  // each branch has its own failure mode, so a single leg leaves the other one
+  // ungated — dropping the tracked-marker push is invisible to the untracked
+  // leg, which skips that push anyway.
+  const failures = [];
+  for (const dismissMarker of ['untracked', 'tracked']) {
+    const leg = runLeg({ oldTag: newestOld, targetSha, label: `${newestOld} dismiss=${dismissMarker}`, dismissMarker });
+    failures.push(...leg.failures);
+  }
   console.log(failures.length ? `RED: ${failures.length} failure(s)` : 'GREEN');
   process.exit(failures.length ? 1 : 0);
 }

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -111,6 +111,14 @@ export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null 
     const state = fixtureStateFor(oldTag);
     const { manifest } = seedFixture(install, { state });
 
+    // Dismiss an update before applying one — the shape a user reaches by
+    // running `update-system.mjs dismiss` and then `apply`. The marker is
+    // gitignored and never tracked, so staging it after apply() deletes it is a
+    // fatal unmatched pathspec and the update never commits. Costs nothing when
+    // the marker is filtered out; without that guard both the `apply exits 0`
+    // and the oracle-blob assertions below go RED.
+    writeFileSync(join(install, '.update-dismissed'), new Date(0).toISOString());
+
     // New-path delta for the #1998-class assertion: concrete files in the
     // target's SYSTEM_PATHS that don't exist at the old tag but do at target.
     const newConcrete = targetSystemPaths.filter((p) => !p.endsWith('/'))


### PR DESCRIPTION
## What does this PR do?

Stops `apply()` from staging the `.update-dismissed` marker when git has never tracked it. Today that add is a fatal unmatched pathspec, so the update finishes on disk and the commit never runs — on a stock checkout, with no local customization.

This is cause 2 of #2531, split out at @santifer's [invitation](https://github.com/santifer/career-ops/pull/2531#issuecomment-5217091270). Cause 1 (the `-f` change) stays in #2531 and is being rebuilt; his blocker there is correct and I've confirmed it.

### Prior art — #1996

**@calebwhite-io got here first.** [#1996](https://github.com/santifer/career-ops/pull/1996) diagnosed this same bug and proposed the same `ls-files` guard on 2026-07-17. The diagnosis in its commit message is correct and independently arrived at, and it also gets the probe/unlink ordering right — it reads the index *before* deleting the marker, which is the detail that makes a probe failure retry-safe. I'm not claiming either.

I'm opening this rather than waiting because #1996 hasn't been updated by its author since 2026-07-17, has drifted into conflict since, and had no reply to the rebase request on 2026-07-27. If @calebwhite-io returns and rebases, I'd rather close this one — say the word and it's done.

Two things here differ, and both are behaviour changes rather than restatements:

| | #1996 | here |
|---|---|---|
| probe failure | `catch` → treated as untracked | propagates |
| gate | source-pattern regex in `updater-migration-tests.mjs` | real `apply()` run via the `upgrade-tests.mjs` PR gate |

## Related issue

No issue — bug fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## Detail

### Repro

```console
$ node update-system.mjs dismiss
$ node update-system.mjs apply
```

`dismiss()` writes `.update-dismissed`; `apply()` deletes it and then stages it. The marker is in the shipped `.gitignore` and was never added, so git gets a pathspec matching nothing:

```console
$ git add -- real.txt .update-dismissed        # marker deleted, never tracked
fatal: pathspec '.update-dismissed' did not match any files
$ git diff --cached --name-only                # this add staged nothing
$ git add -- real.txt                          # same batch minus the marker
$ git diff --cached --name-only
real.txt
```

git validates pathspecs before staging anything, so the marker takes its whole batch down with it. `-f` is no rescue — a deleted, never-tracked path is unmatched regardless of flags — which is why this needs a guard rather than a flag.

### How it got here

Four stages. Worth being precise, because the bug is older than the error message it produces.

**Before `9b17fa8a`** — staging was `git add .`, the commit was unscoped, and the marker was deleted *after* the commit:

```js
git('add .');
git(`commit -m "chore: auto-update system files to v${remote}"`);
// 7. Clean up dismiss flag if it exists
if (existsSync(dismissFile)) unlinkSync(dismissFile);
```

A never-tracked marker was simply invisible to `git add .`.

**`9b17fa8a` — "scope update-system file changes (#119)"** replaced `git add .` with `addPaths(pathsToStage)`, moved the deletion to *before* the commit, and pushed the marker onto the list. That is where the bug starts. But the handler around it was a bare swallow:

```js
addPaths(pathsToStage);
git('commit', '-m', `chore: auto-update system files to v${remote}`);
} catch {
  // Nothing to commit (already up to date)
}
```

so `apply()` printed **`Update complete`** while the commit had never run.

**`deef6365` — "#915 bug 2" (#1099)** scoped the commit to an explicit pathspec list. The swallow stayed exactly as it was, so the bug stayed silent.

**`2ad34539` — "surface commit failures instead of silently swallowing them" (#1855)** replaced that bare `catch` with real commit-failure detection. It moves the marker block out of the broad `try` to just above it, but leaves the unconditional staging decision exactly as it was — so the already-present failure simply stopped being invisible and became the exit 1 you get today.

That ordering is the reason this looks like a recent regression and isn't one.

### The fix

Stage the marker only when git actually tracks it:

```js
if (existsSync(dismissFile)) {
  const dismissMarkerTracked = isTracked('.update-dismissed');
  unlinkSync(dismissFile);
  if (dismissMarkerTracked) pathsToStage.push('.update-dismissed');
}
```

The probe runs *before* `unlinkSync`. `ls-files` reads the index, which a worktree deletion doesn't touch, so the answer is identical either way — but the probe can throw, and probing first leaves the marker on disk when it does. A retry then re-enters the block and re-probes, rather than finding the marker already gone and skipping a deletion it still owed the commit.

`isTracked` deliberately does not catch. `ls-files` exits 0 with empty output when nothing matches, so "untracked" is a successful return and a throw can only mean git itself failed — a timeout, an unreadable index, git failing to launch. Catching that and returning `false` would answer "untracked" for a marker that *is* tracked, drop its deletion, and still print success. Letting it propagate puts it in front of `apply()`'s existing error handling instead.

I considered simply never pushing the marker, which is smaller. It regresses the rare case: someone who force-added `.update-dismissed` would get its deletion left dirty after an otherwise successful update. The guard changes only the row that is broken:

| marker state | today | with the guard |
|---|---|---|
| never tracked (every stock install) | fatal; commit never runs | marker omitted; commit succeeds |
| force-tracked (rare) | deletion staged and committed | **unchanged** |

`addPaths` is deliberately untouched — that's #2531's territory.

### What gates what

**`upgrade-tests.mjs` is the regression gate.** `runLeg()` already clones an old tag, points it at a bare mirror standing in for GitHub, and runs a real `node update-system.mjs apply`. Seeding a dismiss marker into the fixture install makes it drive the dismiss-then-apply shape end to end.

`apply()` branches on trackedness and each branch fails differently, so `--pr-gate` now runs one leg per marker state:

- **`untracked`** (every stock install) — needs no new assertion. Two existing ones catch it: `apply exits 0`, since the updater CLI catches git's 128 and exits 1; and the non-vacuity oracle, which reads `git rev-parse HEAD:<oracle>` from the **committed** tree, so a stranded commit leaves it at the old blob.
- **`tracked`** (legacy repos that committed the marker before it was gitignored) — the deletion must reach the commit, and dropping it shows up in two independent places. One assertion reads `HEAD:.update-dismissed`; the other checks `git status` for that path, because unlinking a *tracked* file leaves a pending deletion (` D .update-dismissed`) rather than a clean tree.

Both mutation-checked as commits rather than worktree edits, since `prGate()` starts with `git rev-parse HEAD` and can't see uncommitted target-updater changes. Reverting the guard turns the untracked leg RED on both its assertions; replacing the tracked-branch push with `if (false)` turns the tracked leg RED on both of its own.

The tracked leg's fixture commit supplies `user.name`/`user.email` inline, the way `canary()` does — the isolated `GIT_CONFIG_GLOBAL` is handed to `apply()` only, and the upgrade job configures no author identity, so ambient config would pass locally and abort on a clean runner.

That second leg exists because of [a review catch from CodeRabbit](https://github.com/santifer/career-ops/pull/2591#discussion_r3737364834) — before it, dropping the tracked-marker push passed the entire suite *and* the PR gate, since the untracked leg skips that push anyway.

**`tests/updater-is-tracked.test.mjs` covers the helper itself** — that `isTracked()` returns true for an ignored-but-tracked path, false for a never-tracked one, and propagates an abnormal git failure rather than reporting "untracked."

```
🧪 Testing isTracked (ignored-but-tracked vs never-tracked)...
  ✅ isTracked: true for an ignored-but-tracked path
  ✅ isTracked: false for an ignored, never-tracked path
  ✅ isTracked: an abnormal git failure propagates instead of reporting untracked
```

Each was mutation-checked separately. The two Boolean mutations keep the `runGit(...)` call and replace only the returned value, so the propagation oracle still sees a throwing runner and each mutation flips exactly one assertion: forcing `true` fails only the never-tracked one, forcing `false` fails only the tracked one. Restoring `catch { return false }` fails only the propagation one. (A bare literal `return true;` that dropped the `runGit` call would fail two, since it can no longer throw.)

Full suite: `3057 passed, 0 failed, 2 warnings`. `--pr-gate` and `--canary` both GREEN.

### One correction to #2531

#2531's description says this fatal means "**nothing** is staged". That's true of its console demo, which starts from a clean index, and false in production. Step 3 runs `git checkout FETCH_HEAD -- <path>` for every system path, and checkout of a tree-ish into a pathspec writes the index as well as the worktree — the updater's own rollback comment records this. So the system updates are already staged by the time the add fails.

What's actually lost is the **commit**, plus the pruned deletions and materialized entrypoints that only `addPaths` would have staged. Same symptom for the user; different mechanism. Stating it correctly here so the wrong version doesn't propagate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update dismissal handling for ignored files, including markers that have never been tracked.
  * Removed tracked dismissal markers cleanly during upgrades without leaving the working tree in a dirty state.
  * Git status-check failures are now reported instead of being misinterpreted as untracked files.
  * Improved reliability of dismiss-then-apply upgrade flows.

* **Tests**
  * Added coverage for tracked, ignored, untracked, and Git-error scenarios across upgrade paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->