### PR TITLE
fix(web): launch npm CLIs on Windows

### DIFF
--- a/web/src/app/api/apply/prefill/route.ts
+++ b/web/src/app/api/apply/prefill/route.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { getSession } from "@/lib/apply/session";
 
@@ -157,7 +157,8 @@ Output ONLY a compact JSON object mapping each field id → {"value": "...", "ne
 
       const result = await new Promise<{ buf: string; code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
         // stdin = /dev/null so the CLI doesn't wait 3s for piped input.
-        const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+        const launch = prepareCliLaunch(binPath, args);
+        const child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
         let buf = "";
         let firstByteAt = 0;
         const hb = setInterval(() => {

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
 
 export const runtime = "nodejs"; // child_process (spawn) requires the Node runtime
@@ -109,7 +109,8 @@ export async function POST(req: Request) {
       ]
     : spec.args(prompt);
 
-  const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+  const launch = prepareCliLaunch(binPath, args);
+  const child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
 
   const encoder = new TextEncoder();
   // `closed` + kill timer in the OUTER scope so cancel() can flip `closed` before
@@ -120,6 +121,7 @@ export async function POST(req: Request) {
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       let buf = "";
+      let stderrBuf = "";
       let emitted = false;
       killer = setTimeout(() => {
         try {
@@ -179,8 +181,9 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        stderrBuf += s;
         if (/error|not found|denied|fatal/i.test(s)) {
-          safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
+          emit(`\n[${spec.name}] ${s.trim()}\n`);
         }
       });
       child.on("error", (e) => {
@@ -189,7 +192,8 @@ export async function POST(req: Request) {
       });
       child.on("close", () => {
         if (!emitted) {
-          safeEnqueue("_(no output — is the CLI authenticated?)_");
+          const detail = stderrBuf.trim();
+          safeEnqueue(detail ? `[${spec.name}] ${detail}` : "_(no output — is the CLI authenticated?)_");
         }
         safeClose();
       });

--- a/web/src/app/api/cv/ingest/route.ts
+++ b/web/src/app/api/cv/ingest/route.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot } from "@/lib/career-ops";
 
 // Parse a CV (pasted text or an uploaded PDF) into clean cv.md markdown by running
@@ -119,7 +119,8 @@ export async function POST(req: Request) {
 
   let child;
   try {
-    child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+    const launch = prepareCliLaunch(binPath, args);
+    child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
   } catch (e) {
     if (tempFile) cleanupTemp(tempFile); // never leak the CV temp if spawn throws sync
     return Response.json({ error: e instanceof Error ? e.message : "failed to start the CLI" }, { status: 500 });

--- a/web/src/app/api/explore/ai/route.ts
+++ b/web/src/app/api/explore/ai/route.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { assembleDedupContext } from "@/lib/core/discover";
 
@@ -75,7 +75,8 @@ export async function POST(req: Request) {
       ]
     : spec.args(prompt);
 
-  const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+  const launch = prepareCliLaunch(binPath, args);
+  const child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
 
   const encoder = new TextEncoder();
   // `closed` + kill timer in the OUTER scope so cancel() can flip `closed` before

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, findReportFile } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf } from "@/lib/pdf-render.mjs";
@@ -190,7 +190,8 @@ export async function POST(req: Request) {
   // (tracker.mjs delete doesn't yet share a lock with merge-tracker — see run-registry).
   const writeToken = kind === "evaluate" || kind === "pdf" ? acquireTrackerWrite() : null;
 
-  const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+  const launch = prepareCliLaunch(binPath, args);
+  const child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
   const enc = new TextEncoder();
 
   // `closed` + kill timer in the OUTER scope so cancel() (client disconnect) can

--- a/web/src/lib/apply/agent-interpret.ts
+++ b/web/src/lib/apply/agent-interpret.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import type { Frame } from "playwright-core";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot } from "@/lib/career-ops";
 import type { ApplyField } from "./extract";
 
@@ -82,7 +82,8 @@ Return ONLY a JSON array, no prose, no code fence:
 function runPlanner(binPath: string, isClaude: boolean, argsFor: (p: string) => string[], prompt: string): Promise<string> {
   const args = isClaude ? ["-p", prompt, "--permission-mode", "acceptEdits", "--strict-mcp-config", "--allowedTools", "Read", "--disallowedTools", "Bash,Write,Edit,NotebookEdit,Task,WebFetch,WebSearch"] : argsFor(prompt);
   return new Promise((resolve) => {
-    const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+    const launch = prepareCliLaunch(binPath, args);
+    const child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
     let buf = "";
     child.stdout.on("data", (d: Buffer) => (buf += d.toString()));
     child.stderr.on("data", () => {});

--- a/web/src/lib/apply/drive.ts
+++ b/web/src/lib/apply/drive.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import type { Page, Frame } from "playwright-core";
-import { resolveCli } from "@/lib/clis";
+import { prepareCliLaunch, resolveCli } from "@/lib/clis";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { dropNewTabs } from "./diagnose";
 import type { DriveStep } from "./issue";
@@ -59,7 +59,8 @@ function plannerTurn(binPath: string, prompt: string, resumeId: string | null): 
   const base = resumeId ? ["-p", "--resume", resumeId, prompt] : ["-p", prompt];
   const args = [...base, "--output-format", "json", "--strict-mcp-config", "--disallowedTools", "Bash,Read,Write,Edit,NotebookEdit,Task,WebFetch,WebSearch,Glob,Grep"];
   return new Promise((resolve) => {
-    const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+    const launch = prepareCliLaunch(binPath, args);
+    const child = spawn(launch.command, launch.args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
     let buf = "";
     child.stdout.on("data", (d: Buffer) => (buf += d.toString()));
     child.stderr.on("data", () => {});

--- a/web/src/lib/cli-launch.mjs
+++ b/web/src/lib/cli-launch.mjs
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Prepare a CLI process without routing user-controlled prompts through a shell.
+ *
+ * npm installs an extensionless POSIX shim plus `.cmd` and `.ps1` wrappers on
+ * Windows. `findBin()` can discover the extensionless shim, but CreateProcess
+ * cannot execute it (`ENOENT`); `.cmd` also requires a shell (`EINVAL`). npm's
+ * generated PowerShell wrapper names the real JS/native entrypoint immediately
+ * before `$args`. Resolve that trusted local target and spawn it directly, so
+ * prompts keep their argument boundaries without `shell: true` or PowerShell's
+ * lossy `-File` argument conversion.
+ *
+ * @param {string} binPath
+ * @param {string[]} args
+ * @param {string} [platform]
+ * @returns {{ command: string, args: string[] }}
+ */
+export function prepareCliLaunch(binPath, args, platform = process.platform) {
+  if (platform !== "win32") return { command: binPath, args };
+
+  const ext = path.extname(binPath).toLowerCase();
+  if (ext && ![".cmd", ".bat", ".ps1"].includes(ext)) return { command: binPath, args };
+
+  const shimBase = ext ? binPath.slice(0, -ext.length) : binPath;
+  const ps1Shim = `${shimBase}.ps1`;
+  if (!fs.existsSync(ps1Shim)) return { command: binPath, args };
+
+  let wrapper = "";
+  try {
+    wrapper = fs.readFileSync(ps1Shim, "utf8");
+  } catch {
+    return { command: binPath, args };
+  }
+
+  const targetMatches = wrapper.matchAll(/["']\$basedir[\\/]([^"']+)["']\s+\$args/g);
+  for (const match of targetMatches) {
+    const target = path.resolve(path.dirname(ps1Shim), match[1].replace(/[\\/]/g, path.sep));
+    if (!fs.existsSync(target)) continue;
+    const targetExt = path.extname(target).toLowerCase();
+    if ([".js", ".cjs", ".mjs"].includes(targetExt)) {
+      return { command: process.execPath, args: [target, ...args] };
+    }
+    if ([".exe", ".com"].includes(targetExt)) {
+      return { command: target, args };
+    }
+  }
+
+  return { command: binPath, args };
+}

--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -82,6 +82,8 @@ export function findBin(bin: string, dirs = searchDirs()): string | null {
   return null;
 }
 
+export { prepareCliLaunch } from "./cli-launch.mjs";
+
 export function detectClis() {
   const dirs = searchDirs();
   return KNOWN.map((c) => {

--- a/web/tests/lib/clis.test.mjs
+++ b/web/tests/lib/clis.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { prepareCliLaunch } from "../../src/lib/cli-launch.mjs";
+
+test("prepareCliLaunch leaves POSIX commands unchanged", () => {
+  const args = ["-p", "hello"];
+  assert.deepEqual(prepareCliLaunch("/usr/local/bin/gemini", args, "linux"), {
+    command: "/usr/local/bin/gemini",
+    args,
+  });
+});
+
+test("prepareCliLaunch leaves native Windows executables unchanged", () => {
+  const args = ["exec", "hello"];
+  assert.deepEqual(prepareCliLaunch("C:\\tools\\codex.exe", args, "win32"), {
+    command: "C:\\tools\\codex.exe",
+    args,
+  });
+});
+
+test("prepareCliLaunch resolves an npm Windows shim to its real Node entrypoint", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "career-ops-cli-"));
+  try {
+    const bare = path.join(dir, "gemini");
+    const ps1 = `${bare}.ps1`;
+    const entry = path.join(dir, "node_modules", "example", "cli.js");
+    fs.mkdirSync(path.dirname(entry), { recursive: true });
+    fs.writeFileSync(entry, "// test entry\n", "utf8");
+    fs.writeFileSync(ps1, '& "node$exe" "$basedir/node_modules/example/cli.js" $args\n', "utf8");
+    const prompt = 'review this & echo "not a shell command"';
+    const launch = prepareCliLaunch(bare, ["-p", prompt], "win32");
+
+    assert.equal(launch.command, process.execPath);
+    assert.deepEqual(launch.args, [entry, "-p", prompt]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("prepareCliLaunch handles a discovered .cmd shim when an adjacent .ps1 exists", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "career-ops-cli-"));
+  try {
+    const cmd = path.join(dir, "gemini.cmd");
+    const ps1 = path.join(dir, "gemini.ps1");
+    const entry = path.join(dir, "node_modules", "example", "cli.cjs");
+    fs.mkdirSync(path.dirname(entry), { recursive: true });
+    fs.writeFileSync(entry, "// test entry\n", "utf8");
+    fs.writeFileSync(ps1, '& "node$exe" "$basedir/node_modules/example/cli.cjs" $args\n', "utf8");
+    const launch = prepareCliLaunch(cmd, ["--help"], "win32");
+    assert.equal(launch.command, process.execPath);
+    assert.deepEqual(launch.args, [entry, "--help"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("prepareCliLaunch resolves an npm shim that targets a native executable", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "career-ops-cli-"));
+  try {
+    const bare = path.join(dir, "opencode");
+    const ps1 = `${bare}.ps1`;
+    const entry = path.join(dir, "node_modules", "example", "opencode.exe");
+    fs.mkdirSync(path.dirname(entry), { recursive: true });
+    fs.writeFileSync(entry, "", "utf8");
+    fs.writeFileSync(ps1, '& "$basedir/node_modules/example/opencode.exe" $args\n', "utf8");
+    const launch = prepareCliLaunch(bare, ["run", "hello"], "win32");
+    assert.deepEqual(launch, { command: entry, args: ["run", "hello"] });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("prepareCliLaunch preserves the original command when no PowerShell shim exists", () => {
+  const missing = path.join(os.tmpdir(), `career-ops-missing-${Date.now()}`, "gemini");
+  assert.deepEqual(prepareCliLaunch(missing, ["-p", "hello"], "win32"), {
+    command: missing,
+    args: ["-p", "hello"],
+  });
+});


### PR DESCRIPTION
## Summary
- resolve npm-generated Windows shims to their real JavaScript or native entrypoint
- launch web CLI workers without shell interpolation and with stdin closed
- surface stderr when the assistant CLI exits without stdout
- add cross-platform and npm-shim unit coverage

## Problem
On Windows, `findBin()` could select an extensionless npm shim and `spawn()` returned `ENOENT`. Directly launching the `.cmd` shim returned `EINVAL`, while routing prompts through PowerShell could alter multiline or quoted arguments. Resolving the trusted npm wrapper to its actual entrypoint avoids those failures without enabling `shell: true`.

## Validation
- `cd web && npm test` - 66 passed, 0 failed
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `node test-all.mjs --quick` - 3133 passed, 0 failed (2 expected warnings)
- end-to-end on Windows: `/api/assistant` with Gemini CLI returned `GEMINI_WEB_OK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line tool launching on Windows, including npm-installed tools and PowerShell wrappers.
  * Preserved arguments containing spaces and special characters.
  * Improved assistant error reporting when no output is produced.
  * Added safe fallback behavior when launch wrappers are missing or unreadable.

* **Tests**
  * Added coverage for Windows, POSIX, native executable, wrapper, argument-handling, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->