### PR TITLE
feat(web): add Kimi Code CLI support

### DIFF
--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -1,11 +1,16 @@
 import { spawn } from "node:child_process";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
-import { parseKimiStreamLine, prepareRunArgs } from "@/lib/cli-run.mjs";
+import {
+  noOutputMessage,
+  parseCodexStreamLine,
+  parseKimiStreamLine,
+  prepareAssistantArgs,
+} from "@/lib/cli-run.mjs";
 
 export const runtime = "nodejs"; // child_process (spawn) requires the Node runtime
 export const dynamic = "force-dynamic";
-export const maxDuration = 120;
+export const maxDuration = 300;
 
 const SYSTEM_PREAMBLE = `You are the career-ops assistant — a proactive, friendly career co-pilot for a person who is actively job-hunting. You live inside their LOCAL career-ops web dashboard (a pipeline of evaluated jobs, A–F reports, their CV, analytics) and run on their own AI CLI.
 
@@ -92,6 +97,7 @@ export async function POST(req: Request) {
   // files directly. Scope its tools so it can advise (read) but not blind-write.
   const isClaude = cliId === "claude";
   const isKimi = cliId === "kimi";
+  const isCodex = cliId === "codex";
   // allowedTools must be COMMA-separated; disallowedTools is the hard guardrail
   // so the advisor can read (and WebFetch) but never blind-writes or shells out.
   const args = isClaude
@@ -109,7 +115,7 @@ export async function POST(req: Request) {
         "--disallowedTools",
         "Bash,Write,Edit,NotebookEdit,Task",
       ]
-    : prepareRunArgs(cliId, spec.args(prompt));
+    : prepareAssistantArgs(cliId, spec.args(prompt));
 
   const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
 
@@ -123,13 +129,16 @@ export async function POST(req: Request) {
     start(controller) {
       let buf = "";
       let emitted = false;
+      let timedOut = false;
+      let stderr = "";
       killer = setTimeout(() => {
+        timedOut = true;
         try {
           child.kill("SIGTERM");
         } catch {
           /* ignore */
         }
-      }, 90_000);
+      }, 240_000);
       const safeClose = () => {
         if (!closed) {
           closed = true;
@@ -157,6 +166,17 @@ export async function POST(req: Request) {
 
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isCodex) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            const text = line ? parseCodexStreamLine(line) : null;
+            if (text) emit(text);
+          }
+          return;
+        }
         if (isKimi) {
           buf += d.toString();
           let nl: number;
@@ -192,7 +212,8 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
-        if (isKimi) return; // normal Kimi thinking/tool progress is written here
+        stderr = (stderr + s).slice(-4_000);
+        if (isKimi || isCodex) return; // normal progress and warnings are written here
         if (/error|not found|denied|fatal/i.test(s)) {
           safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
         }
@@ -201,14 +222,19 @@ export async function POST(req: Request) {
         safeEnqueue(`\n[error launching ${spec.name}: ${e.message}]`);
         safeClose();
       });
-      child.on("close", () => {
+      child.on("close", (code) => {
+        if (isCodex && buf.trim()) {
+          const text = parseCodexStreamLine(buf.trim());
+          if (text) emit(text);
+          buf = "";
+        }
         if (isKimi && buf.trim()) {
           const event = parseKimiStreamLine(buf.trim());
           if (event?.text) emit(event.text);
           buf = "";
         }
         if (!emitted) {
-          safeEnqueue("_(no output — is the CLI authenticated?)_");
+          safeEnqueue(`_(${noOutputMessage({ cliName: spec.name, timedOut, code, stderr })})_`);
         }
         safeClose();
       });

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
+import { parseKimiStreamLine, prepareRunArgs } from "@/lib/cli-run.mjs";
 
 export const runtime = "nodejs"; // child_process (spawn) requires the Node runtime
 export const dynamic = "force-dynamic";
@@ -90,6 +91,7 @@ export async function POST(req: Request) {
   // (remember → /api/memory, setStatus → /api/status), never the CLI editing
   // files directly. Scope its tools so it can advise (read) but not blind-write.
   const isClaude = cliId === "claude";
+  const isKimi = cliId === "kimi";
   // allowedTools must be COMMA-separated; disallowedTools is the hard guardrail
   // so the advisor can read (and WebFetch) but never blind-writes or shells out.
   const args = isClaude
@@ -107,7 +109,7 @@ export async function POST(req: Request) {
         "--disallowedTools",
         "Bash,Write,Edit,NotebookEdit,Task",
       ]
-    : spec.args(prompt);
+    : prepareRunArgs(cliId, spec.args(prompt));
 
   const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
 
@@ -155,6 +157,17 @@ export async function POST(req: Request) {
 
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isKimi) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            const event = line ? parseKimiStreamLine(line) : null;
+            if (event?.text) emit(event.text);
+          }
+          return;
+        }
         if (!isClaude) {
           emit(d.toString());
           return;
@@ -179,6 +192,7 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        if (isKimi) return; // normal Kimi thinking/tool progress is written here
         if (/error|not found|denied|fatal/i.test(s)) {
           safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
         }
@@ -188,6 +202,11 @@ export async function POST(req: Request) {
         safeClose();
       });
       child.on("close", () => {
+        if (isKimi && buf.trim()) {
+          const event = parseKimiStreamLine(buf.trim());
+          if (event?.text) emit(event.text);
+          buf = "";
+        }
         if (!emitted) {
           safeEnqueue("_(no output — is the CLI authenticated?)_");
         }

--- a/web/src/app/api/explore/ai/route.ts
+++ b/web/src/app/api/explore/ai/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { assembleDedupContext } from "@/lib/core/discover";
+import { parseKimiStreamLine, prepareRunArgs } from "@/lib/cli-run.mjs";
 
 // AI search orchestrates modes/discover.md by running the USER'S configured CLI
 // headless (CLI-agnostic, like the assistant). Web hunting is slow → generous
@@ -58,6 +59,7 @@ export async function POST(req: Request) {
   const prompt = `${mode}${OUTPUT_CONTRACT}${memoryLine}${knownBlock}\n\n--- USER INTENT ---\n${query}\n`;
 
   const isClaude = cliId === "claude";
+  const isKimi = cliId === "kimi";
   const args = isClaude
     ? [
         "-p",
@@ -73,7 +75,7 @@ export async function POST(req: Request) {
         "--disallowedTools",
         "Bash,Write,Edit,NotebookEdit,Task", // proposer-not-writer, by construction
       ]
-    : spec.args(prompt);
+    : prepareRunArgs(cliId, spec.args(prompt));
 
   const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
 
@@ -121,6 +123,17 @@ export async function POST(req: Request) {
 
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isKimi) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            const event = line ? parseKimiStreamLine(line) : null;
+            if (event?.text) emit(event.text);
+          }
+          return;
+        }
         if (!isClaude) {
           emit(d.toString());
           return;
@@ -144,6 +157,7 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        if (isKimi) return; // normal Kimi thinking/tool progress is written here
         if (/error|not found|denied|fatal/i.test(s)) {
           safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
         }
@@ -153,6 +167,11 @@ export async function POST(req: Request) {
         safeClose();
       });
       child.on("close", () => {
+        if (isKimi && buf.trim()) {
+          const event = parseKimiStreamLine(buf.trim());
+          if (event?.text) emit(event.text);
+          buf = "";
+        }
         if (!emitted) safeEnqueue("_(no output — is the CLI authenticated?)_");
         safeClose();
       });

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -5,6 +5,7 @@ import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, findReportFile } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf } from "@/lib/pdf-render.mjs";
+import { parseKimiStreamLine, prepareRunArgs, runTimeoutMs } from "@/lib/cli-run.mjs";
 import { acquireTrackerWrite, releaseTrackerWrite } from "@/lib/core/run-registry";
 
 export const runtime = "nodejs";
@@ -151,6 +152,7 @@ export async function POST(req: Request) {
   const prompt = buildPrompt({ kind, input, memory: readMemory(), today, pdfPaths });
 
   const isClaude = cliId === "claude";
+  const isKimi = cliId === "kimi";
   // Tool scope by kind (comma-separated lists; disallowedTools is the hard
   // guardrail). 'evaluate'/'fix-portal' run the REAL mode + persist canonical
   // artifacts → they need Write + Bash (reserve-report-num / merge-tracker /
@@ -172,7 +174,7 @@ export async function POST(req: Request) {
        "--permission-mode", "acceptEdits",
        "--allowedTools", tools.allowed,
        "--disallowedTools", tools.disallowed]
-    : spec.args(prompt);
+    : prepareRunArgs(cliId, spec.args(prompt));
 
   // For write-needing kinds, snapshot reports/ so we can verify the worker
   // actually persisted (non-Claude CLIs lack Write auth and silently no-op).
@@ -227,7 +229,7 @@ export async function POST(req: Request) {
       // generate-pdf.mjs mid-render. 600s agent / ~200s render is ample —
       // a Chromium PDF render normally takes low tens of seconds even with a
       // cold Playwright launch.
-      const killMs = kind === "pdf" ? 600_000 : 285_000;
+      const killMs = runTimeoutMs(kind, cliId);
       killer = setTimeout(() => {
         try { child.kill("SIGTERM"); } catch { /* ignore */ }
       }, killMs);
@@ -244,8 +246,28 @@ export async function POST(req: Request) {
         }
       };
 
+      const emitKimiLine = (line: string) => {
+        const event = parseKimiStreamLine(line);
+        if (!event) return;
+        for (const name of event.tools) send({ type: "tool", name });
+        if (event.text) {
+          emittedText = true;
+          send({ type: "text", text: event.text });
+        }
+      };
+
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isKimi) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            if (line) emitKimiLine(line);
+          }
+          return;
+        }
         if (!isClaude) {
           emittedText = true;
           send({ type: "text", text: d.toString() });
@@ -284,6 +306,9 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        // In print mode Kimi uses stderr for normal thinking/tool progress.
+        // Its structured stdout plus exit code are the reliable error signal.
+        if (isKimi) return;
         // Widened: auth/login/quota failures are the most common real error and
         // the old narrow regex missed them (silent false "success").
         if (/error|denied|fatal|not found|unauthorized|forbidden|auth|login|credential|api[ -]?key|quota|rate limit|not authenticated/i.test(s)) {
@@ -338,6 +363,10 @@ export async function POST(req: Request) {
         // run could still start a brand-new render (and re-touch the tracker)
         // after the stream — and its writeToken guard — is already gone.
         if (closed) return;
+        if (isKimi && buf.trim()) {
+          emitKimiLine(buf.trim());
+          buf = "";
+        }
         const cleanExit = code === 0; // non-zero OR null (killed/signal) = NOT clean
         // Shared by both honesty gates below: a CLI that produced no output at
         // all is the same failure mode whether it was evaluating or tailoring

--- a/web/src/components/assistant-console.tsx
+++ b/web/src/components/assistant-console.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { dispatch, type ActionCtx, type DoneInfo } from "@/app/actions/registry";
 import { scoreNum } from "@/lib/format";
 import { pendingActOpenerStart } from "@/lib/act-envelope.mjs";
+import { CONFIG_CHANGED_EVENT, CONFIG_KEY, readConfiguredCli } from "@/lib/client-config.mjs";
 import { cn } from "@/lib/cn";
 
 // ── message model: messages are PART arrays so a live worker card can render
@@ -28,7 +29,6 @@ type Part =
   | { type: "confirm"; cid: string; summary: string; state: "pending" | "done" | "cancelled" };
 type Msg = { role: "user" | "assistant"; parts: Part[] };
 
-const CONFIG_KEY = "career-ops:config";
 const CHAT_KEY = "career-ops:chat";
 // back-compat shims — the old directives still work, mapped onto the registry
 const NAV_RE = /<<\s*go:\s*(\/[a-z0-9/_-]*)\s*>>/gi;
@@ -163,15 +163,20 @@ export function AssistantConsole() {
   useEffect(() => {
     function read() {
       try {
-        const raw = localStorage.getItem(CONFIG_KEY);
-        setCliId(raw ? JSON.parse(raw).cliId || null : null);
+        setCliId(readConfiguredCli(localStorage.getItem(CONFIG_KEY)));
       } catch {
         setCliId(null);
       }
     }
     read();
     window.addEventListener("storage", read);
-    return () => window.removeEventListener("storage", read);
+    window.addEventListener(CONFIG_CHANGED_EVENT, read);
+    window.addEventListener("focus", read);
+    return () => {
+      window.removeEventListener("storage", read);
+      window.removeEventListener(CONFIG_CHANGED_EVENT, read);
+      window.removeEventListener("focus", read);
+    };
   }, []);
 
   // restore + persist conversation

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { CONFIG_CHANGED_EVENT, CONFIG_KEY, patchClientConfig, readConfiguredCli } from "@/lib/client-config.mjs";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
 
 type Cli = {
@@ -31,8 +32,6 @@ const PROVIDERS = [
   { id: "openrouter", label: "OpenRouter" },
 ] as const;
 
-const STORAGE_KEY = "career-ops:config";
-
 export function ConfigForm() {
   const [mode, setMode] = useState<Mode>("cli");
   const [clis, setClis] = useState<Cli[] | null>(null);
@@ -45,7 +44,7 @@ export function ConfigForm() {
   // Load saved prefs
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(CONFIG_KEY);
       if (raw) {
         const v = JSON.parse(raw);
         // key/manual are not wired yet (nothing reads them) → never restore into
@@ -67,8 +66,19 @@ export function ConfigForm() {
       .then((d) => {
         const list: Cli[] = d.clis ?? [];
         setClis(list);
-        // auto-select first installed if nothing chosen yet
-        setCliId((prev) => prev || list.find((c) => c.installed)?.id || "");
+        const savedCli = readConfiguredCli(localStorage.getItem(CONFIG_KEY));
+        const savedIsInstalled = !!savedCli && list.some((c) => c.installed && c.id === savedCli);
+        const nextCli = savedIsInstalled ? savedCli : list.find((c) => c.installed)?.id || "";
+        setCliId(nextCli);
+        // A visible auto-selection must be real, not cosmetic. Persist it and
+        // notify the persistent assistant mounted outside this page.
+        if (nextCli && nextCli !== savedCli) {
+          localStorage.setItem(
+            CONFIG_KEY,
+            patchClientConfig(localStorage.getItem(CONFIG_KEY), { mode: "cli", cliId: nextCli }),
+          );
+          window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
+        }
       })
       .catch(() => setClis([]));
   }, []);
@@ -77,9 +87,20 @@ export function ConfigForm() {
     // The API key is deliberately NOT persisted: nothing reads it yet (the
     // key/manual panel is unwired) and a secret must never sit in clear-text
     // localStorage. Keys belong in the user's own CLI/provider config.
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode, cliId, provider, logos }));
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ mode, cliId, provider, logos }));
+    window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
+  }
+
+  function selectCli(nextCliId: string) {
+    setCliId(nextCliId);
+    // Selecting an installed CLI should enable the persistent assistant
+    // immediately. The native storage event only fires in OTHER tabs, so emit a
+    // same-tab event as well.
+    const next = patchClientConfig(localStorage.getItem(CONFIG_KEY), { mode: "cli", cliId: nextCliId });
+    localStorage.setItem(CONFIG_KEY, next);
+    window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
   }
 
   const installed = clis?.filter((c) => c.installed) ?? [];
@@ -163,7 +184,7 @@ export function ConfigForm() {
                       <button
                         type="button"
                         disabled={!c.installed}
-                        onClick={() => setCliId(c.id)}
+                        onClick={() => selectCli(c.id)}
                         className={cn(
                           "flex flex-1 items-center gap-2 text-left max-sm:min-h-[44px]",
                           c.installed ? "" : "cursor-default",

--- a/web/src/components/explore/explore-provider.tsx
+++ b/web/src/components/explore/explore-provider.tsx
@@ -379,6 +379,7 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setAiCost({ searches: 0, candidates: 0, fetches: 0 });
     try {
       sessionStorage.removeItem(RESULTS_KEY);
+      localStorage.removeItem(RESULTS_KEY);
     } catch {
       /* ignore */
     }
@@ -492,14 +493,15 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setModeState(m);
   }, []);
 
-  // Rehydrate the last settled result set on mount (per-tab sessionStorage), unless a
-  // search is already running. Done in an effect (not a useState initializer) to avoid
-  // an SSR hydration mismatch.
+  // Rehydrate the last settled result set on mount. Prefer this tab's session
+  // snapshot, then fall back to the durable local snapshot so a tab/browser
+  // restart does not discard an expensive scan or AI search.
   useEffect(() => {
     if (runningRef.current) return;
     let snap: ResultSnapshot | null = null;
     try {
-      snap = JSON.parse(sessionStorage.getItem(RESULTS_KEY) || "null") as ResultSnapshot | null;
+      const raw = sessionStorage.getItem(RESULTS_KEY) || localStorage.getItem(RESULTS_KEY);
+      snap = JSON.parse(raw || "null") as ResultSnapshot | null;
     } catch {
       snap = null;
     }
@@ -524,7 +526,8 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setPhase(RUNNING.has(snap.phase) ? (snap.offers.length ? "results" : "idle") : snap.phase);
   }, []);
 
-  // Persist only SETTLED states (never mid-stream) so a reload restores a complete set.
+  // Persist only SETTLED states (never mid-stream). sessionStorage preserves the
+  // current tab; localStorage is the durable fallback across tab/browser restarts.
   useEffect(() => {
     const SETTLED = new Set<Phase>(["results", "empty-current", "empty-loose", "failed", "degraded", "blocked"]);
     if (!SETTLED.has(phase)) return;
@@ -533,9 +536,11 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
         v: 1, mode, phase, offers, matchCount, companiesScanned, companiesAvailable, capHit, droppedNoDate, sources,
         partial, status, error, added: [...added], aiTrace, aiCost, aiIntent,
       };
-      sessionStorage.setItem(RESULTS_KEY, JSON.stringify(snap));
+      const serialized = JSON.stringify(snap);
+      sessionStorage.setItem(RESULTS_KEY, serialized);
+      localStorage.setItem(RESULTS_KEY, serialized);
     } catch {
-      /* sessionStorage full/unavailable — non-fatal */
+      /* browser storage full/unavailable — non-fatal */
     }
   }, [phase, mode, offers, matchCount, companiesScanned, companiesAvailable, capHit, droppedNoDate, sources, partial, status, error, added, aiTrace, aiCost, aiIntent]);
 

--- a/web/src/lib/cli-run.mjs
+++ b/web/src/lib/cli-run.mjs
@@ -1,0 +1,37 @@
+const DEFAULT_RUN_TIMEOUT_MS = 285_000;
+const LONG_RUN_TIMEOUT_MS = 600_000;
+
+export function prepareRunArgs(cliId, args) {
+  return cliId === "kimi" ? [...args, "--output-format", "stream-json"] : args;
+}
+
+export function runTimeoutMs(kind, cliId) {
+  return kind === "pdf" || (kind === "evaluate" && cliId === "kimi") ? LONG_RUN_TIMEOUT_MS : DEFAULT_RUN_TIMEOUT_MS;
+}
+
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part && typeof part === "object" && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+export function parseKimiStreamLine(line) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!event || event.role !== "assistant") return null;
+
+  const tools = Array.isArray(event.tool_calls)
+    ? event.tool_calls
+        .map((call) => call?.function?.name || call?.name)
+        .filter((name) => typeof name === "string" && name.trim())
+    : [];
+
+  return { text: contentText(event.content), tools };
+}

--- a/web/src/lib/cli-run.mjs
+++ b/web/src/lib/cli-run.mjs
@@ -5,6 +5,14 @@ export function prepareRunArgs(cliId, args) {
   return cliId === "kimi" ? [...args, "--output-format", "stream-json"] : args;
 }
 
+export function prepareAssistantArgs(cliId, args) {
+  if (cliId === "kimi") return prepareRunArgs(cliId, args);
+  if (cliId === "codex" && args[0] === "exec") {
+    return ["exec", "--ephemeral", "--json", ...args.slice(1)];
+  }
+  return args;
+}
+
 export function runTimeoutMs(kind, cliId) {
   return kind === "pdf" || (kind === "evaluate" && cliId === "kimi") ? LONG_RUN_TIMEOUT_MS : DEFAULT_RUN_TIMEOUT_MS;
 }
@@ -34,4 +42,31 @@ export function parseKimiStreamLine(line) {
     : [];
 
   return { text: contentText(event.content), tools };
+}
+
+export function parseCodexStreamLine(line) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (event?.type !== "item.completed" || event.item?.type !== "agent_message") return null;
+  return typeof event.item.text === "string" ? event.item.text : null;
+}
+
+export function noOutputMessage({ cliName, timedOut, code, stderr = "" }) {
+  if (timedOut) {
+    return `${cliName} needed more than 4 minutes for this reply. Try again with a shorter request.`;
+  }
+  if (/quota|rate.?limit|too many requests|insufficient.?credits/i.test(stderr)) {
+    return `${cliName} reported a quota or rate-limit error. Check that provider's usage, then try again.`;
+  }
+  if (/unauthorized|forbidden|not authenticated|login|credential|api.?key/i.test(stderr)) {
+    return `${cliName} is installed but not authenticated. Run it once in a terminal and sign in.`;
+  }
+  if (code !== 0) {
+    return `${cliName} exited with code ${code ?? "unknown"} before returning a reply.`;
+  }
+  return `${cliName} finished without returning a reply.`;
 }

--- a/web/src/lib/client-config.mjs
+++ b/web/src/lib/client-config.mjs
@@ -1,0 +1,21 @@
+export const CONFIG_KEY = "career-ops:config";
+export const CONFIG_CHANGED_EVENT = "career-ops:config-changed";
+
+export function parseClientConfig(raw) {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readConfiguredCli(raw) {
+  const cliId = parseClientConfig(raw).cliId;
+  return typeof cliId === "string" && cliId.trim() ? cliId : null;
+}
+
+export function patchClientConfig(raw, patch) {
+  return JSON.stringify({ ...parseClientConfig(raw), ...patch });
+}

--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -18,19 +18,21 @@ export const KNOWN: CliSpec[] = [
   { id: "claude", name: "Claude Code", bin: "claude", run: "claude -p", url: "https://claude.ai/code", args: (p) => ["-p", p] },
   { id: "codex", name: "Codex", bin: "codex", run: "codex exec", url: "https://github.com/openai/codex", args: (p) => ["exec", p] },
   { id: "gemini", name: "Gemini CLI", bin: "gemini", run: "gemini -p", url: "https://github.com/google-gemini/gemini-cli", args: (p) => ["-p", p] },
+  { id: "kimi", name: "Kimi Code CLI", bin: "kimi", run: "kimi -p", url: "https://www.kimi.com/code/docs/en/", args: (p) => ["-p", p] },
   { id: "opencode", name: "OpenCode", bin: "opencode", run: "opencode run", url: "https://opencode.ai", args: (p) => ["run", p] },
   { id: "copilot", name: "GitHub Copilot CLI", bin: "copilot", run: "copilot -p", url: "https://docs.github.com/en/copilot/github-copilot-in-the-cli", args: (p) => ["-p", p] },
   { id: "qwen", name: "Qwen CLI", bin: "qwen", run: "qwen -p", url: "https://qwen.ai/qwencode", args: (p) => ["-p", p] },
   { id: "antigravity", name: "Antigravity CLI", bin: "agy", run: "agy -p", url: "https://antigravity.google", args: (p) => ["-p", p] },
 ];
 
-function searchDirs(): string[] {
+export function searchDirs(): string[] {
   const home = os.homedir();
   const extra = [
     path.join(home, ".local/bin"),
     path.join(home, ".npm-global/bin"),
     path.join(home, ".bun/bin"),
     path.join(home, ".deno/bin"),
+    path.join(home, ".kimi-code/bin"),
     "/opt/homebrew/bin",
     "/usr/local/bin",
     "/usr/bin",

--- a/web/tests/lib/cli-run.test.mjs
+++ b/web/tests/lib/cli-run.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseKimiStreamLine, prepareRunArgs, runTimeoutMs } from "../../src/lib/cli-run.mjs";
+import {
+  noOutputMessage,
+  parseCodexStreamLine,
+  parseKimiStreamLine,
+  prepareAssistantArgs,
+  prepareRunArgs,
+  runTimeoutMs,
+} from "../../src/lib/cli-run.mjs";
 
 test("adds Kimi's structured JSONL output flag without changing other CLIs", () => {
   const base = ["-p", "hello"];
@@ -16,6 +23,11 @@ test("gives Kimi evaluations enough time while preserving existing limits", () =
   assert.equal(runTimeoutMs("evaluate", "codex"), 285_000);
   assert.equal(runTimeoutMs("research", "kimi"), 285_000);
   assert.equal(runTimeoutMs("pdf", "kimi"), 600_000);
+});
+
+test("uses structured ephemeral output for Codex assistant turns", () => {
+  assert.deepEqual(prepareAssistantArgs("codex", ["exec", "hello"]), ["exec", "--ephemeral", "--json", "hello"]);
+  assert.deepEqual(prepareAssistantArgs("kimi", ["-p", "hello"]), ["-p", "hello", "--output-format", "stream-json"]);
 });
 
 test("parses Kimi assistant text and tool calls", () => {
@@ -36,4 +48,20 @@ test("joins structured text content and ignores tool/meta records", () => {
   assert.equal(parseKimiStreamLine(JSON.stringify({ role: "tool", content: "large tool result" })), null);
   assert.equal(parseKimiStreamLine(JSON.stringify({ role: "meta", type: "session.resume_hint" })), null);
   assert.equal(parseKimiStreamLine("not json"), null);
+});
+
+test("parses only completed Codex agent messages", () => {
+  assert.equal(
+    parseCodexStreamLine(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "hello" } })),
+    "hello",
+  );
+  assert.equal(parseCodexStreamLine(JSON.stringify({ type: "turn.started" })), null);
+  assert.equal(parseCodexStreamLine("not json"), null);
+});
+
+test("explains timeout, quota, authentication and exit failures without raw stderr", () => {
+  assert.match(noOutputMessage({ cliName: "Kimi", timedOut: true, code: null }), /more than 4 minutes/);
+  assert.match(noOutputMessage({ cliName: "Kimi", timedOut: false, code: 1, stderr: "quota exceeded" }), /quota/);
+  assert.match(noOutputMessage({ cliName: "Codex", timedOut: false, code: 1, stderr: "not authenticated" }), /not authenticated/);
+  assert.match(noOutputMessage({ cliName: "Codex", timedOut: false, code: 7 }), /code 7/);
 });

--- a/web/tests/lib/cli-run.test.mjs
+++ b/web/tests/lib/cli-run.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseKimiStreamLine, prepareRunArgs, runTimeoutMs } from "../../src/lib/cli-run.mjs";
+
+test("adds Kimi's structured JSONL output flag without changing other CLIs", () => {
+  const base = ["-p", "hello"];
+
+  assert.deepEqual(prepareRunArgs("kimi", base), ["-p", "hello", "--output-format", "stream-json"]);
+  assert.deepEqual(prepareRunArgs("codex", base), base);
+  assert.deepEqual(base, ["-p", "hello"]);
+});
+
+test("gives Kimi evaluations enough time while preserving existing limits", () => {
+  assert.equal(runTimeoutMs("evaluate", "kimi"), 600_000);
+  assert.equal(runTimeoutMs("evaluate", "codex"), 285_000);
+  assert.equal(runTimeoutMs("research", "kimi"), 285_000);
+  assert.equal(runTimeoutMs("pdf", "kimi"), 600_000);
+});
+
+test("parses Kimi assistant text and tool calls", () => {
+  const event = JSON.stringify({
+    role: "assistant",
+    content: "Checking the posting...",
+    tool_calls: [{ function: { name: "Read", arguments: "{}" } }, { name: "Bash" }],
+  });
+
+  assert.deepEqual(parseKimiStreamLine(event), { text: "Checking the posting...", tools: ["Read", "Bash"] });
+});
+
+test("joins structured text content and ignores tool/meta records", () => {
+  assert.deepEqual(
+    parseKimiStreamLine(JSON.stringify({ role: "assistant", content: [{ type: "text", text: "one" }, { type: "text", text: " two" }] })),
+    { text: "one two", tools: [] },
+  );
+  assert.equal(parseKimiStreamLine(JSON.stringify({ role: "tool", content: "large tool result" })), null);
+  assert.equal(parseKimiStreamLine(JSON.stringify({ role: "meta", type: "session.resume_hint" })), null);
+  assert.equal(parseKimiStreamLine("not json"), null);
+});

--- a/web/tests/lib/client-config.test.mjs
+++ b/web/tests/lib/client-config.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { patchClientConfig, readConfiguredCli } from "../../src/lib/client-config.mjs";
+
+test("reads a configured CLI and rejects malformed or empty values", () => {
+  assert.equal(readConfiguredCli('{"cliId":"kimi"}'), "kimi");
+  assert.equal(readConfiguredCli('{"cliId":""}'), null);
+  assert.equal(readConfiguredCli('{"cliId":42}'), null);
+  assert.equal(readConfiguredCli("not-json"), null);
+});
+
+test("patching a CLI preserves unrelated browser preferences", () => {
+  const next = JSON.parse(patchClientConfig('{"logos":false,"provider":"google"}', { mode: "cli", cliId: "kimi" }));
+
+  assert.deepEqual(next, { logos: false, provider: "google", mode: "cli", cliId: "kimi" });
+});

--- a/web/tests/lib/clis.test.mjs
+++ b/web/tests/lib/clis.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const sourcePath = fileURLToPath(new URL("../../src/lib/clis.ts", import.meta.url));
+const source = fs.readFileSync(sourcePath, "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  fileName: sourcePath,
+}).outputText;
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString("base64")}`;
+const { KNOWN, searchDirs } = await import(moduleUrl);
+
+test("registers Kimi Code CLI for headless prompts", () => {
+  const kimi = KNOWN.find((cli) => cli.id === "kimi");
+
+  assert.ok(kimi);
+  assert.equal(kimi.name, "Kimi Code CLI");
+  assert.equal(kimi.bin, "kimi");
+  assert.equal(kimi.run, "kimi -p");
+  assert.deepEqual(kimi.args("hello"), ["-p", "hello"]);
+});
+
+test("searches the official Kimi Code installation directory", () => {
+  const expected = path.join(os.homedir(), ".kimi-code", "bin");
+
+  assert.ok(searchDirs().includes(expected));
+});


### PR DESCRIPTION
## Summary
- register Kimi Code CLI as a selectable web runtime using its official `kimi -p` prompt mode
- search the official `~/.kimi-code/bin` installation directory in addition to `PATH`
- add unit coverage for the CLI specification and install-directory discovery

## Validation
- Kimi Code CLI `0.29.1` authenticated smoke test - passed
- `/api/clis` detected the native Windows executable as installed
- `cd web && npm test` - 62 passed, 0 failed
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `node test-all.mjs --quick` - 3133 passed, 0 failed (2 expected warnings)

No API keys, OAuth tokens, CV data, or profile data are included in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and launching the Kimi Code CLI.
  * Included Kimi Code’s official documentation link, prompt configuration, and default installation path.
  * Added streaming display of Kimi responses and tool activity.
  * Added support for structured Codex and Kimi assistant responses.
  * Improved CLI configuration synchronization and persistence across the application.
  * Improved result recovery using session and local storage.

* **Bug Fixes**
  * Added clearer timeout, authentication, quota, exit-code, and empty-response diagnostics.
  * Extended processing time for Kimi evaluations and PDF tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- end-to-end Windows: /api/assistant with Kimi returned KIMI_WEB_OK (HTTP 200)