### PR TITLE
feat(cli): add --help to followup-cadence

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -9,6 +9,7 @@
  *      node followup-cadence.mjs --summary   (human-readable dashboard)
  *      node followup-cadence.mjs --overdue-only
  *      node followup-cadence.mjs --applied-days 10
+ *      node followup-cadence.mjs --help       (print usage and exit)
  */
 
 import { readFileSync, existsSync } from 'fs';
@@ -31,6 +32,22 @@ const summaryMode = args.includes('--summary');
 const overdueOnly = args.includes('--overdue-only');
 const appliedDaysIdx = args.indexOf('--applied-days');
 const appliedDaysOverride = appliedDaysIdx !== -1 ? parseInt(args[appliedDaysIdx + 1], 10) : null;
+
+const KNOWN_FLAGS = ['--summary', '--overdue-only', '--applied-days', '--help', '-h'];
+const USAGE = `Usage:
+  node followup-cadence.mjs                 # JSON for active applications
+  node followup-cadence.mjs --summary       # human-readable dashboard
+  node followup-cadence.mjs --overdue-only  # show only overdue applications
+  node followup-cadence.mjs --applied-days 10 # override the first follow-up interval
+  node followup-cadence.mjs --help          # print this usage block and exit
+  Supported flags: ${KNOWN_FLAGS.join(', ')}`;
+
+// Keep help side-effect free: resolveCadenceConfig() reads the profile file,
+// so this branch must run before the module-level cadence is loaded.
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(USAGE);
+  process.exit(0);
+}
 
 // --- Cadence config ---
 export const DEFAULT_CADENCE = {

--- a/followup-cadence.test.mjs
+++ b/followup-cadence.test.mjs
@@ -9,6 +9,7 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CADENCE_PROFILE = join(ROOT, 'tests', 'fixtures', 'profile-default-cadence.yml');
@@ -54,6 +55,19 @@ function eq(label, actual, expected) {
     console.log(`    actual:   ${a}`);
   }
 }
+
+const helpOutput = execFileSync(process.execPath, [join(ROOT, 'followup-cadence.mjs'), '--help'], {
+  encoding: 'utf-8',
+});
+eq(
+  '--help prints usage without reading application data',
+  helpOutput.includes('Usage:') &&
+    helpOutput.includes('--summary') &&
+    helpOutput.includes('--overdue-only') &&
+    helpOutput.includes('--applied-days') &&
+    helpOutput.includes('--help'),
+  true,
+);
 
 const APP = '2026-06-30';
 


### PR DESCRIPTION
## Summary

- Add `--help` and `-h` usage output to `followup-cadence.mjs`.
- Handle help before profile and application data resolution so the command is side-effect free.
- Add a regression test that checks the documented flags.

Closes #2477

## Validation

- `node followup-cadence.test.mjs` (22 passed)
- `node followup-cadence.mjs --help`
- `git diff --check`
