### PR TITLE
ci: nightly + release-tag upgrade qualification matrix (3 OS, 5 versions, rollback)

### DIFF
--- a/.github/workflows/upgrade-matrix.yml
+++ b/.github/workflows/upgrade-matrix.yml
@@ -7,6 +7,10 @@ on:
     tags: ['career-ops-v*']
   workflow_dispatch:
 
+# The harness only ever reads the repo and writes to throwaway temp mirrors.
+permissions:
+  contents: read
+
 jobs:
   qualify:
     strategy:
@@ -18,15 +22,16 @@ jobs:
       - name: Force LF checkout on Windows
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v6
+          fetch-depth: 0            # harness needs release tags
+          persist-credentials: false # the harness only ever touches a local mirror
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          go-version: '1.26'   # old updaters rebuild the dashboard during apply
       - run: npm install --ignore-scripts
       - name: Full upgrade qualification (last 5 releases, own shims, rollback)
         run: node upgrade-tests.mjs --all-versions

--- a/.github/workflows/upgrade-matrix.yml
+++ b/.github/workflows/upgrade-matrix.yml
@@ -26,12 +26,17 @@ jobs:
         with:
           fetch-depth: 0            # harness needs release tags
           persist-credentials: false # the harness only ever touches a local mirror
+      # No dependency caches: the qualification legs install for OLD release
+      # tags too, and a cache keyed on the checked-out commit's lockfile must
+      # not bleed into what an old tag's install would really see.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          package-manager-cache: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'   # old updaters rebuild the dashboard during apply
+          cache: false
       - run: npm install --ignore-scripts
       - name: Full upgrade qualification (last 5 releases, own shims, rollback)
         run: node upgrade-tests.mjs --all-versions

--- a/.github/workflows/upgrade-matrix.yml
+++ b/.github/workflows/upgrade-matrix.yml
@@ -1,0 +1,32 @@
+name: Upgrade matrix
+
+on:
+  schedule:
+    - cron: '17 3 * * *'   # nightly; offset to avoid top-of-hour congestion
+  push:
+    tags: ['career-ops-v*']
+  workflow_dispatch:
+
+jobs:
+  qualify:
+    strategy:
+      fail-fast: false     # a platform-specific failure is the point
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Force LF checkout on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+      - run: npm install --ignore-scripts
+      - name: Full upgrade qualification (last 5 releases, own shims, rollback)
+        run: node upgrade-tests.mjs --all-versions

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -289,7 +289,11 @@ function rollbackLeg(oldTag, targetSha) {
   try {
     const mirror = buildMirror(work, targetSha);
     const { cfg, install, manifest } = setupLeg(work, mirror, oldTag);
-    const versionBefore = readFileSync(join(install, 'VERSION'), 'utf-8');
+    // An unreadable VERSION is a leg failure to report, not an exception to
+    // escape on — a throw here would abort the remaining legs of the sweep.
+    const readVersion = () => { try { return readFileSync(join(install, 'VERSION'), 'utf-8'); } catch { return null; } };
+    const versionBefore = readVersion();
+    ok(versionBefore !== null, 'VERSION readable before apply');
     const env = { ...process.env, GIT_CONFIG_GLOBAL: cfg };
     let phase = 'apply', exitCode = 0, output = '';
     try {
@@ -298,7 +302,10 @@ function rollbackLeg(oldTag, targetSha) {
       output = execFileSync(process.execPath, ['update-system.mjs', 'rollback'], { cwd: install, encoding: 'utf-8', timeout: 120000, env });
     } catch (e) { exitCode = e.status ?? 1; output = `${e.stdout ?? ''}${e.stderr ?? ''}`; }
     ok(exitCode === 0, `${phase} exits 0 (got ${exitCode})`);
-    ok(readFileSync(join(install, 'VERSION'), 'utf-8') === versionBefore, 'VERSION restored');
+    // versionBefore !== null is part of the assertion: null === null must
+    // not pass "restored" when VERSION was never readable to begin with.
+    const versionAfter = readVersion();
+    ok(versionBefore !== null && versionAfter === versionBefore, 'VERSION restored');
     for (const [f, hash] of Object.entries(manifest)) {
       const p = join(install, f);
       ok(existsSync(p) && sha256(p) === hash, `user file intact after rollback: ${f}`);

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -275,8 +275,20 @@ function allVersions() {
   if (!tags.length) { console.error('No ancestor release tags found — fetch tags first (CI: fetch-depth: 0)'); process.exit(1); }
   console.log(`Release qualification: ${tags.join(', ')} -> ${targetSha.slice(0, 8)}`);
   const results = [];
-  for (const tag of tags) results.push(runLeg({ oldTag: tag, targetSha }));
-  results.push(rollbackLeg(tags[0], targetSha));
+  // A leg that THROWS (git failure, SYSTEM_PATHS not found, fixture error) must
+  // not abort the sweep — convert it to a reported failed result so every
+  // remaining tag and the rollback leg still run and appear in the summary
+  // (matches the in-leg discipline: report through ok(), never throw out).
+  const guard = (label, fn) => {
+    try { return fn(); }
+    catch (e) {
+      const msg = `leg threw: ${String((e && e.message) || e).split('\n')[0]}`;
+      console.log(`  FAIL [${label}] ${msg}`);
+      return { label, failures: [msg] };
+    }
+  };
+  for (const tag of tags) results.push(guard(tag, () => runLeg({ oldTag: tag, targetSha })));
+  results.push(guard(`rollback:${tags[0]}`, () => rollbackLeg(tags[0], targetSha)));
   const red = results.filter((r) => r.failures.length);
   for (const r of results) console.log(`${r.failures.length ? 'RED ' : 'GREEN'} ${r.label}`);
   process.exit(red.length ? 1 : 0);

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -13,8 +13,9 @@
  * VERSION (apply has no version gate; equal-VERSION content drift is normal).
  *
  * Usage:
- *   node upgrade-tests.mjs --pr-gate    # newest old tag -> HEAD, one leg
- *   node upgrade-tests.mjs --canary     # planted user-file clobber must go RED
+ *   node upgrade-tests.mjs --pr-gate       # newest old tag -> HEAD, one leg
+ *   node upgrade-tests.mjs --canary        # planted user-file clobber must go RED
+ *   node upgrade-tests.mjs --all-versions  # release qualification: last 5 tags, own shims, rollback
  */
 import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
@@ -94,6 +95,19 @@ function isAncestor(cwd, tag, sha) {
   try { git(cwd, 'merge-base', '--is-ancestor', tag, sha); return true; } catch { return false; }
 }
 
+/** Shared per-leg scaffolding: redirect config, old-tag install, seeded fixture.
+ *  The caller owns the temp workdir and the already-built mirror — the canary
+ *  path mutates the mirror between buildMirror and this call. */
+function setupLeg(work, mirror, oldTag) {
+  const cfg = writeGitConfig(work, mirror);
+  const install = join(work, 'install');
+  git(ROOT, 'clone', '--quiet', '--branch', oldTag, ROOT, install);
+  git(install, 'remote', 'set-url', 'origin', CANONICAL);
+  const state = fixtureStateFor(oldTag);
+  const { manifest } = seedFixture(install, { state });
+  return { cfg, install, manifest, state };
+}
+
 export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null }) {
   const work = realpathSync(mkdtempSync(join(tmpdir(), 'upgrade-leg-')));
   const failures = [];
@@ -101,7 +115,7 @@ export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null 
   try {
     const mirror = buildMirror(work, targetSha);
     if (mutateMirror) targetSha = mutateMirror(mirror, work);
-    const cfg = writeGitConfig(work, mirror);
+    const { cfg, install, manifest, state } = setupLeg(work, mirror, oldTag);
 
     // The target's SYSTEM_PATHS — the set apply manages. Drives both the oracle
     // selection (a changed file apply actually rewrites) and the #1998-class
@@ -122,12 +136,6 @@ export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null 
       return { failures: [], skipped: true };
     }
     const oracleBlob = git(mirror, 'rev-parse', `${targetSha}:${oracle}`);
-
-    const install = join(work, 'install');
-    git(ROOT, 'clone', '--quiet', '--branch', oldTag, ROOT, install);
-    git(install, 'remote', 'set-url', 'origin', CANONICAL);
-    const state = fixtureStateFor(oldTag);
-    const { manifest } = seedFixture(install, { state });
 
     // New-path delta for the #1998-class assertion: concrete files in the
     // target's SYSTEM_PATHS that don't exist at the old tag but do at target.
@@ -258,9 +266,57 @@ function canary() {
   process.exit(1);
 }
 
+/** Layer 2: every supported old tag's own shim, end-to-end, plus a rollback leg.
+ *  Each leg is already the maximal jump (old -> HEAD in one hop) — the common
+ *  real-world upgrade shape. Deliberately not a PR gate (see #2007). */
+function allVersions() {
+  const targetSha = git(ROOT, 'rev-parse', 'HEAD');
+  const tags = releaseTags().filter((t) => isAncestor(ROOT, t, targetSha)).slice(-5);
+  if (!tags.length) { console.error('No ancestor release tags found — fetch tags first (CI: fetch-depth: 0)'); process.exit(1); }
+  console.log(`Release qualification: ${tags.join(', ')} -> ${targetSha.slice(0, 8)}`);
+  const results = [];
+  for (const tag of tags) results.push(runLeg({ oldTag: tag, targetSha }));
+  results.push(rollbackLeg(tags[0], targetSha));
+  const red = results.filter((r) => r.failures.length);
+  for (const r of results) console.log(`${r.failures.length ? 'RED ' : 'GREEN'} ${r.label}`);
+  process.exit(red.length ? 1 : 0);
+}
+
+function rollbackLeg(oldTag, targetSha) {
+  const work = realpathSync(mkdtempSync(join(tmpdir(), 'upgrade-rollback-')));
+  const failures = [];
+  const ok = (cond, msg) => { console.log(`  ${cond ? 'PASS' : 'FAIL'} [rollback:${oldTag}] ${msg}`); if (!cond) failures.push(msg); };
+  try {
+    const mirror = buildMirror(work, targetSha);
+    const { cfg, install, manifest } = setupLeg(work, mirror, oldTag);
+    const versionBefore = readFileSync(join(install, 'VERSION'), 'utf-8');
+    const env = { ...process.env, GIT_CONFIG_GLOBAL: cfg };
+    let phase = 'apply', exitCode = 0, output = '';
+    try {
+      output = execFileSync(process.execPath, ['update-system.mjs', 'apply'], { cwd: install, encoding: 'utf-8', timeout: 300000, env });
+      phase = 'rollback';
+      output = execFileSync(process.execPath, ['update-system.mjs', 'rollback'], { cwd: install, encoding: 'utf-8', timeout: 120000, env });
+    } catch (e) { exitCode = e.status ?? 1; output = `${e.stdout ?? ''}${e.stderr ?? ''}`; }
+    ok(exitCode === 0, `${phase} exits 0 (got ${exitCode})`);
+    ok(readFileSync(join(install, 'VERSION'), 'utf-8') === versionBefore, 'VERSION restored');
+    for (const [f, hash] of Object.entries(manifest)) {
+      const p = join(install, f);
+      ok(existsSync(p) && sha256(p) === hash, `user file intact after rollback: ${f}`);
+    }
+    if (failures.length && output) {
+      console.log(`  --- ${phase} output tail [rollback:${oldTag}] ---`);
+      console.log(output.split('\n').slice(-15).join('\n'));
+    }
+    return { label: `rollback:${oldTag}`, failures };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const mode = process.argv[2];
   if (mode === '--pr-gate') prGate();
   else if (mode === '--canary') canary();
-  else { console.error('Usage: node upgrade-tests.mjs --pr-gate | --canary'); process.exit(1); }
+  else if (mode === '--all-versions') allVersions();
+  else { console.error('Usage: node upgrade-tests.mjs --pr-gate | --canary | --all-versions'); process.exit(1); }
 }


### PR DESCRIPTION
Layer 2 of #2007, the release-cadence matrix I said I'd file once #2358 landed.

## What it adds

A new workflow, `upgrade-matrix.yml`, running nightly (03:17), on `career-ops-v*` tag pushes, and on dispatch, across ubuntu, macos and windows with `fail-fast: false`, since a platform-specific failure is exactly what it exists to surface. Each run takes the last 5 release tags that are ancestors of HEAD and upgrades each one to the current commit through that release's own frozen updater shim, plus a rollback leg on the oldest tag asserting user files come through byte-identical. This is deliberately not a PR gate: a quirk in a frozen old shim should never block unrelated PRs. The `upgrade-gate` check from #2358 stays the only required one.

In `upgrade-tests.mjs`: the per-leg scaffolding the gate, matrix and rollback legs all share (redirect config, old-tag install, seeded fixture) moves into a `setupLeg()` helper, and `--all-versions` drives the tag loop. The canary path still mutates the mirror between `buildMirror` and setup, which is why the caller keeps ownership of both.

Rebase note: #2358 merged with review fixes (the guarded `SYSTEM_PATHS` extraction and the oracle restricted to system files). This branch is rebased on top and keeps those semantics unchanged; `setupLeg()` is structure only, no behavior change to the gate leg.

## Local runs

- `--pr-gate` GREEN (v1.25.0 to HEAD, 23 assertions)
- `--canary` GREEN (planted user-file clobber detected)
- `--all-versions` GREEN: v1.21.0 through v1.25.0 each through their own shim, plus rollback on v1.21.0
- `test-all.mjs`: 3137 passed, 0 failed

## The three questions from #2007, still open

Restating them here since this PR is where two of them become concrete:

1. Non-vacuity oracle: this stays with the changed-blob compare from #2358. If you'd rather have a planted version sentinel the updater must rewrite, it slots into `pickOracle` without touching the legs.
2. Support window: `--all-versions` takes `.slice(-5)` of ancestor tags. If you want a policy instead of a number (last N minors, or 12 months), that one line is the knob.
3. Nightly failure routing: right now a red nightly is just a failed run and a badge. Auto-filing an issue is a small follow-up if you'd rather be paged that way; I left it out to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Added automated upgrade qualification across Ubuntu, macOS, and Windows.
  * Added support for testing upgrades across the five newest versions.
  * Added rollback verification, including version restoration and preservation of user files.
  * Documented the option to run upgrade tests across all supported versions.

* **Chores**
  * Added nightly, version-tag, and manual test runs for upgrade validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->