### PR TITLE
feat(latam): fix ElEmpleo encoding, update Magneto URL, harden location filters & add Computrabajo

### DIFF
--- a/providers/computrabajo.mjs
+++ b/providers/computrabajo.mjs
@@ -1,0 +1,162 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+const MAX_PAGES = 3; // Limitado para evitar baneos (usuario solicitó límite estricto)
+const DEFAULT_MAX_JOBS = 15; // 10-15 resultados según lo solicitado
+
+import { decodeEntities } from './_html-entities.mjs';
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim());
+}
+
+/** Keep user overrides bounded so a typo cannot turn one board into a ban-prone crawl. */
+function boundedPositiveInt(value, fallback, cap) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, cap) : fallback;
+}
+
+function companyFromCard(html, fallback) {
+  const company = html.match(/class=\x22[^\x22]*(?:fc_base|company|empresa)[^\x22]*\x22[^>]*>([\s\S]*?)<\/(?:a|p|span|div)>/i);
+  return company ? clean(company[1]) : fallback;
+}
+
+function titleFromCard(html, anchorHtml = '') {
+  const heading = html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i);
+  const titleClass = html.match(/class=\x22[^\x22]*tc-it[^\x22]*\x22[^>]*>([^<]+)/i);
+  return clean(heading ? heading[1] : titleClass ? titleClass[1] : anchorHtml);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'computrabajo',
+
+  detect(entry) {
+    if (entry.provider === 'computrabajo') return { url: entry.api || entry.careers_url };
+    const raw = entry.api || entry.careers_url || '';
+    if (raw.includes('computrabajo.com')) return { url: raw };
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const listUrl = entry.api || entry.careers_url;
+    if (!listUrl) throw new Error(`computrabajo: no URL provided for ${entry.name}`);
+
+    const origin = new URL(listUrl).origin;
+    const maxPages = boundedPositiveInt(entry.max_pages, MAX_PAGES, MAX_PAGES);
+    const maxJobs = boundedPositiveInt(entry.max_jobs, DEFAULT_MAX_JOBS, DEFAULT_MAX_JOBS);
+    const jobs = [];
+    const seen = new Set();
+    
+    // Tiempos de espera aleatorios (random delays de 2 a 5 segundos) solicitados
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const randomDelay = () => wait(2000 + Math.random() * 3000);
+
+    for (let page = 1; page <= maxPages; page++) {
+      if (page > 1) await randomDelay();
+      
+      const pageUrl = new URL(listUrl);
+      pageUrl.searchParams.set('p', String(page));
+      
+      let html;
+      try {
+        html = await ctx.fetchText(pageUrl.href, {
+          timeoutMs: 20_000,
+          headers: {
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+            'Accept-Language': 'es-CO,es;q=0.9,en-US;q=0.8,en;q=0.7',
+            'Cache-Control': 'no-cache',
+            'Pragma': 'no-cache'
+          }
+        });
+      } catch (err) {
+        if (page === 1) throw err;
+        break; // Stop paginating on error
+      }
+
+      // Evitamos bloqueos de IP
+      if (/cloudflare|captcha|access denied/i.test(html)) {
+         console.warn(`[computrabajo] Bloqueo anti-bot detectado en página ${page}. Abortando listado.`);
+         break;
+      }
+
+      // Buscar tarjetas de ofertas
+      // Las vacantes suelen estar en anclas dentro de la lista de artículos
+      const anchors = html.matchAll(/<a[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi);
+      let fresh = 0;
+
+      for (const match of anchors) {
+        const href = match[1];
+        const inner = match[2];
+        const cardStart = typeof match.index === 'number' ? html.lastIndexOf('<article', match.index) : -1;
+        const cardEnd = typeof match.index === 'number' ? html.indexOf('</article>', match.index) : -1;
+        const cardHtml = cardStart >= 0 && cardEnd > cardStart ? html.slice(cardStart, cardEnd + 10) : inner;
+
+        // Filtramos para asegurar que es una vacante (Computrabajo usa /ofertas-de-trabajo/ o /trabajo-de-)
+        if (!href.includes('/ofertas-de-trabajo/') && !href.includes('/trabajo-de-')) continue;
+        
+        // Excluir enlaces a evaluaciones de empresa
+        if (href.includes('/evaluaciones/')) continue;
+        
+        let url;
+        try {
+          url = new URL(href, origin).href;
+        } catch {
+          continue;
+        }
+
+        // Deduplicar: las urls de computrabajo a veces tienen parámetros ?busqueda=
+        const urlId = url.split('?')[0];
+        if (seen.has(urlId)) continue;
+        seen.add(urlId);
+
+        // Extraer título limpiando HTML. En computrabajo suele estar en un h1/h2 con class tc-it
+        const titleMatch = inner.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i) || 
+                           inner.match(/<p[^>]*class="[^"]*tc-it[^"]*"[^>]*>([\s\S]*?)<\/p>/i);
+                           
+        const title = titleFromCard(inner, titleMatch ? titleMatch[1] : inner);
+        if (!title || title.length < 3) continue;
+
+        jobs.push({ title, url, company: companyFromCard(cardHtml, entry.name), location: 'Colombia' });
+        fresh++;
+        if (jobs.length >= maxJobs) break;
+      }
+
+      // Fallback a artículos (<article>) si las anclas fallaron (a veces el h1/h2 no está DENTRO de la a, sino al lado)
+      if (fresh === 0) {
+         const articles = html.matchAll(/<article[^>]*>([\s\S]*?)<\/article>/gi);
+         for (const match of articles) {
+            const articleHtml = match[1];
+            const aMatch = articleHtml.match(/<a[^>]*href="([^"]+)"/i);
+            if (!aMatch) continue;
+            
+            const href = aMatch[1];
+            if (!href.includes('/ofertas-de-trabajo/') && !href.includes('/trabajo-de-')) continue;
+            
+            let url;
+            try { url = new URL(href, origin).href; } catch { continue; }
+            
+            const urlId = url.split('?')[0];
+            if (seen.has(urlId)) continue;
+            seen.add(urlId);
+            
+            const titleMatch = articleHtml.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i);
+            const title = titleMatch ? clean(titleMatch[1]) : '';
+            if (!title) continue;
+
+            const company = companyFromCard(articleHtml, entry.name);
+            
+            jobs.push({ title, url, company, location: 'Colombia' });
+            fresh++;
+            if (jobs.length >= maxJobs) break;
+         }
+      }
+
+      if (fresh === 0 || jobs.length >= maxJobs) break;
+    }
+
+    return jobs.slice(0, maxJobs);
+  }
+};

--- a/providers/elempleo.mjs
+++ b/providers/elempleo.mjs
@@ -1,0 +1,125 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+const MAX_PAGES = 5;
+const DEFAULT_MAX_JOBS = 50;
+
+import { decodeEntities } from './_html-entities.mjs';
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim());
+}
+
+/** @type {Provider} */
+export default {
+  id: 'elempleo',
+
+  detect(entry) {
+    if (entry.provider === 'elempleo') return { url: entry.api || entry.careers_url };
+    const raw = entry.api || entry.careers_url || '';
+    if (raw.includes('elempleo.com')) return { url: raw };
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const listUrl = entry.api || entry.careers_url;
+    if (!listUrl) throw new Error(`elempleo: no URL provided for ${entry.name}`);
+
+    const origin = new URL(listUrl).origin;
+    const maxPages = entry.max_pages || MAX_PAGES;
+    const maxJobs = entry.max_jobs || DEFAULT_MAX_JOBS;
+    const jobs = [];
+    const seen = new Set();
+    
+    // Función de espera 
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+
+    for (let page = 1; page <= maxPages; page++) {
+      if (page > 1) await wait(1000 + Math.random() * 1500); 
+      
+      const pageUrl = listUrl.includes('?') ? `${listUrl}&pagina=${page}` : `${listUrl}?pagina=${page}`;
+      
+      let html;
+      try {
+        html = await ctx.fetchText(pageUrl, {
+          headers: {
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+          }
+        });
+      } catch (err) {
+        if (page === 1) throw err;
+        break; // Stop paginating on error
+      }
+
+      const anchors = html.matchAll(/<a[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi);
+      let fresh = 0;
+
+      for (const match of anchors) {
+        let href = match[1];
+        const inner = match[2];
+
+        // Normalizamos la ruta ya que a veces tienen rutas relativas que empiezan sin slash
+        if (!href.startsWith('http') && !href.startsWith('/')) href = '/' + href;
+
+        // Filtramos para asegurar que es un trabajo (Elempleo usa /co/ofertas-trabajo/)
+        if (!href.includes('/ofertas-trabajo/')) continue;
+        
+        let url;
+        try {
+          url = new URL(href, origin).href;
+        } catch {
+          continue;
+        }
+
+        const urlId = url.split('?')[0];
+        if (seen.has(urlId)) continue;
+        seen.add(urlId);
+
+        // Extraer título limpiando HTML. Elempleo suele poner el título en h2 class text-ellipsis
+        const titleMatch = inner.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i) || 
+                           inner.match(/<span[^>]*class="[^"]*text-ellipsis[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
+        
+        const title = clean(titleMatch ? titleMatch[1] : inner);
+        if (!title || title.length < 3) continue;
+
+        jobs.push({ title, url, company: entry.name, location: 'Colombia' });
+        fresh++;
+        if (jobs.length >= maxJobs) break;
+      }
+
+      // Estructura alternativa basada en divs (si las anclas están estructuradas diferente)
+      if (fresh === 0) {
+         const resultItems = html.matchAll(/<div[^>]*class="[^"]*result-item[^"]*"[^>]*>([\s\S]*?)<\/div>/gi);
+         for (const itemMatch of resultItems) {
+            const itemHtml = itemMatch[1];
+            const aMatch = itemHtml.match(/<a[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/i);
+            if (!aMatch) continue;
+
+            let href = aMatch[1];
+            if (!href.startsWith('http') && !href.startsWith('/')) href = '/' + href;
+            if (!href.includes('/ofertas-trabajo/')) continue;
+
+            let url;
+            try { url = new URL(href, origin).href; } catch { continue; }
+
+            const urlId = url.split('?')[0];
+            if (seen.has(urlId)) continue;
+            seen.add(urlId);
+
+            const title = clean(aMatch[2]);
+            if (!title || title.length < 3) continue;
+
+            jobs.push({ title, url, company: entry.name, location: 'Colombia' });
+            fresh++;
+            if (jobs.length >= maxJobs) break;
+         }
+      }
+
+      if (fresh === 0 || jobs.length >= maxJobs) break;
+    }
+
+    return jobs.slice(0, maxJobs);
+  }
+};

--- a/providers/magneto.mjs
+++ b/providers/magneto.mjs
@@ -1,0 +1,121 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+const MAX_PAGES = 5;
+const DEFAULT_MAX_JOBS = 100;
+
+/** @param {string} s */
+function clean(s) {
+  return s.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/** @type {Provider} */
+export default {
+  id: 'magneto',
+
+  detect(entry) {
+    if (entry.provider === 'magneto') return { url: entry.api || entry.careers_url };
+    const raw = entry.api || entry.careers_url || '';
+    if (raw.includes('magneto365.com')) return { url: raw };
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const listUrl = entry.api || entry.careers_url;
+    if (!listUrl) throw new Error(`magneto: no URL provided for ${entry.name}`);
+
+    const origin = new URL(listUrl).origin;
+    const maxPages = entry.max_pages || MAX_PAGES;
+    const maxJobs = entry.max_jobs || DEFAULT_MAX_JOBS;
+    const jobs = [];
+    const seen = new Set();
+    
+    // Función de espera para evitar bloqueos
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+
+    for (let page = 1; page <= maxPages; page++) {
+      if (page > 1) await wait(1000 + Math.random() * 1000); // 1-2s delay
+      
+      const pageUrl = listUrl.includes('?') ? `${listUrl}&page=${page}` : `${listUrl}?page=${page}`;
+      
+      let html;
+      try {
+        html = await ctx.fetchText(pageUrl, {
+          headers: {
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+          }
+        });
+      } catch (err) {
+        if (page === 1) throw err;
+        break; // Stop paginating on error
+      }
+
+      // Buscar anclas de trabajos en Magneto365
+      const anchors = html.matchAll(/<a[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi);
+      let fresh = 0;
+
+      for (const match of anchors) {
+        const href = match[1];
+        const inner = match[2];
+
+        // Filtramos para asegurar que es un trabajo (Magneto usa /empleos/, /ofertas/ o /trabajos/)
+        if (!href.includes('/empleos/') && !href.includes('/ofertas/') && !href.includes('/trabajo')) continue;
+        
+        let url;
+        try {
+          url = new URL(href, origin).href;
+        } catch {
+          continue;
+        }
+
+        // Deduplicar
+        const urlId = url.split('?')[0];
+        if (seen.has(urlId)) continue;
+        seen.add(urlId);
+
+        // Extraer título limpiando HTML
+        const titleMatch = inner.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i) || 
+                           inner.match(/<span[^>]*class="[^"]*title[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
+        
+        const title = clean(titleMatch ? titleMatch[1] : inner);
+        if (!title || title.length < 3) continue;
+
+        jobs.push({ title, url, company: entry.name, location: 'Colombia' });
+        fresh++;
+        if (jobs.length >= maxJobs) break;
+      }
+
+      // Si Magneto usa una API JSON expuesta en el tag script id="__NEXT_DATA__"
+      if (fresh === 0 && html.includes('__NEXT_DATA__')) {
+         const nextDataMatch = html.match(/<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/);
+         if (nextDataMatch) {
+            try {
+               const data = JSON.parse(nextDataMatch[1]);
+               // Intentar ubicar los empleos en el state de Next.js
+               const offers = data.props?.pageProps?.initialState?.jobs?.data || data.props?.pageProps?.jobs || [];
+               for (const offer of offers) {
+                  const url = offer.slug ? new URL(`/co/empleos/${offer.slug}`, origin).href : null;
+                  if (!url || seen.has(url)) continue;
+                  seen.add(url);
+                  jobs.push({
+                     title: clean(offer.title || ''),
+                     url,
+                     company: clean(offer.company?.name || entry.name),
+                     location: clean(offer.location?.name || 'Colombia')
+                  });
+                  fresh++;
+                  if (jobs.length >= maxJobs) break;
+               }
+            } catch(e) {
+               // Ignorar fallo de parseo JSON fallback
+            }
+         }
+      }
+
+      if (fresh === 0 || jobs.length >= maxJobs) break;
+    }
+
+    return jobs.slice(0, maxJobs);
+  }
+};

--- a/tests/computrabajo-provider.test.mjs
+++ b/tests/computrabajo-provider.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import provider from '../providers/computrabajo.mjs';
+
+function pageHtml(page) {
+  return `
+    <article class="box_offer">
+      <h2><a href="/ofertas-de-trabajo/oferta-${page}">Ingeniero de integraci&#243;n ${page} &amp; IA</a></h2>
+      <p class="fs16 fc_base">Empresa ${page} &amp; Co</p>
+    </article>
+  `;
+}
+
+test('Computrabajo keeps the real employer, decodes entities, and enforces crawl caps', async () => {
+  const requested = [];
+  const jobs = await provider.fetch(
+    {
+      name: 'Computrabajo Colombia',
+      careers_url: 'https://co.computrabajo.com/trabajos-de-sistemas?foo=bar',
+      provider: 'computrabajo',
+      max_pages: 999,
+      max_jobs: 999,
+    },
+    {
+      sleep: async () => {},
+      fetchText: async (url) => {
+        requested.push(url);
+        const page = Number(new URL(url).searchParams.get('p'));
+        return pageHtml(page);
+      },
+    },
+  );
+
+  assert.equal(requested.length, 3);
+  assert.equal(new URL(requested[0]).searchParams.get('foo'), 'bar');
+  assert.deepEqual(jobs.map((job) => job.company), [
+    'Empresa 1 & Co',
+    'Empresa 2 & Co',
+    'Empresa 3 & Co',
+  ]);
+  assert.equal(jobs[0].title, 'Ingeniero de integración 1 & IA');
+});
+
+test('Computrabajo stops cleanly on an anti-bot challenge', async () => {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const jobs = await provider.fetch(
+      {
+        name: 'Computrabajo Colombia',
+        careers_url: 'https://co.computrabajo.com/trabajos-de-sistemas',
+        provider: 'computrabajo',
+      },
+      { sleep: async () => {}, fetchText: async () => '<html>Cloudflare CAPTCHA</html>' },
+    );
+    assert.deepEqual(jobs, []);
+  } finally {
+    console.warn = originalWarn;
+  }
+});

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -1,11 +1,16 @@
 import { spawn } from "node:child_process";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
-import { parseKimiStreamLine, prepareRunArgs } from "@/lib/cli-run.mjs";
+import {
+  noOutputMessage,
+  parseCodexStreamLine,
+  parseKimiStreamLine,
+  prepareAssistantArgs,
+} from "@/lib/cli-run.mjs";
 
 export const runtime = "nodejs"; // child_process (spawn) requires the Node runtime
 export const dynamic = "force-dynamic";
-export const maxDuration = 120;
+export const maxDuration = 300;
 
 const SYSTEM_PREAMBLE = `You are the career-ops assistant — a proactive, friendly career co-pilot for a person who is actively job-hunting. You live inside their LOCAL career-ops web dashboard (a pipeline of evaluated jobs, A–F reports, their CV, analytics) and run on their own AI CLI.
 
@@ -92,6 +97,7 @@ export async function POST(req: Request) {
   // files directly. Scope its tools so it can advise (read) but not blind-write.
   const isClaude = cliId === "claude";
   const isKimi = cliId === "kimi";
+  const isCodex = cliId === "codex";
   // allowedTools must be COMMA-separated; disallowedTools is the hard guardrail
   // so the advisor can read (and WebFetch) but never blind-writes or shells out.
   const args = isClaude
@@ -109,7 +115,7 @@ export async function POST(req: Request) {
         "--disallowedTools",
         "Bash,Write,Edit,NotebookEdit,Task",
       ]
-    : prepareRunArgs(cliId, spec.args(prompt));
+    : prepareAssistantArgs(cliId, spec.args(prompt));
 
   const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
 
@@ -123,13 +129,16 @@ export async function POST(req: Request) {
     start(controller) {
       let buf = "";
       let emitted = false;
+      let timedOut = false;
+      let stderr = "";
       killer = setTimeout(() => {
+        timedOut = true;
         try {
           child.kill("SIGTERM");
         } catch {
           /* ignore */
         }
-      }, 90_000);
+      }, 240_000);
       const safeClose = () => {
         if (!closed) {
           closed = true;
@@ -157,6 +166,17 @@ export async function POST(req: Request) {
 
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isCodex) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            const text = line ? parseCodexStreamLine(line) : null;
+            if (text) emit(text);
+          }
+          return;
+        }
         if (isKimi) {
           buf += d.toString();
           let nl: number;
@@ -192,7 +212,8 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
-        if (isKimi) return; // normal Kimi thinking/tool progress is written here
+        stderr = (stderr + s).slice(-4_000);
+        if (isKimi || isCodex) return; // normal progress and warnings are written here
         if (/error|not found|denied|fatal/i.test(s)) {
           safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
         }
@@ -201,14 +222,19 @@ export async function POST(req: Request) {
         safeEnqueue(`\n[error launching ${spec.name}: ${e.message}]`);
         safeClose();
       });
-      child.on("close", () => {
+      child.on("close", (code) => {
+        if (isCodex && buf.trim()) {
+          const text = parseCodexStreamLine(buf.trim());
+          if (text) emit(text);
+          buf = "";
+        }
         if (isKimi && buf.trim()) {
           const event = parseKimiStreamLine(buf.trim());
           if (event?.text) emit(event.text);
           buf = "";
         }
         if (!emitted) {
-          safeEnqueue("_(no output — is the CLI authenticated?)_");
+          safeEnqueue(`_(${noOutputMessage({ cliName: spec.name, timedOut, code, stderr })})_`);
         }
         safeClose();
       });

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
+import { parseKimiStreamLine, prepareRunArgs } from "@/lib/cli-run.mjs";
 
 export const runtime = "nodejs"; // child_process (spawn) requires the Node runtime
 export const dynamic = "force-dynamic";
@@ -90,6 +91,7 @@ export async function POST(req: Request) {
   // (remember → /api/memory, setStatus → /api/status), never the CLI editing
   // files directly. Scope its tools so it can advise (read) but not blind-write.
   const isClaude = cliId === "claude";
+  const isKimi = cliId === "kimi";
   // allowedTools must be COMMA-separated; disallowedTools is the hard guardrail
   // so the advisor can read (and WebFetch) but never blind-writes or shells out.
   const args = isClaude
@@ -107,7 +109,7 @@ export async function POST(req: Request) {
         "--disallowedTools",
         "Bash,Write,Edit,NotebookEdit,Task",
       ]
-    : spec.args(prompt);
+    : prepareRunArgs(cliId, spec.args(prompt));
 
   const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
 
@@ -155,6 +157,17 @@ export async function POST(req: Request) {
 
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isKimi) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            const event = line ? parseKimiStreamLine(line) : null;
+            if (event?.text) emit(event.text);
+          }
+          return;
+        }
         if (!isClaude) {
           emit(d.toString());
           return;
@@ -179,6 +192,7 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        if (isKimi) return; // normal Kimi thinking/tool progress is written here
         if (/error|not found|denied|fatal/i.test(s)) {
           safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
         }
@@ -188,6 +202,11 @@ export async function POST(req: Request) {
         safeClose();
       });
       child.on("close", () => {
+        if (isKimi && buf.trim()) {
+          const event = parseKimiStreamLine(buf.trim());
+          if (event?.text) emit(event.text);
+          buf = "";
+        }
         if (!emitted) {
           safeEnqueue("_(no output — is the CLI authenticated?)_");
         }

--- a/web/src/app/api/explore/ai/route.ts
+++ b/web/src/app/api/explore/ai/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { assembleDedupContext } from "@/lib/core/discover";
+import { parseKimiStreamLine, prepareRunArgs } from "@/lib/cli-run.mjs";
 
 // AI search orchestrates modes/discover.md by running the USER'S configured CLI
 // headless (CLI-agnostic, like the assistant). Web hunting is slow → generous
@@ -58,6 +59,7 @@ export async function POST(req: Request) {
   const prompt = `${mode}${OUTPUT_CONTRACT}${memoryLine}${knownBlock}\n\n--- USER INTENT ---\n${query}\n`;
 
   const isClaude = cliId === "claude";
+  const isKimi = cliId === "kimi";
   const args = isClaude
     ? [
         "-p",
@@ -73,7 +75,7 @@ export async function POST(req: Request) {
         "--disallowedTools",
         "Bash,Write,Edit,NotebookEdit,Task", // proposer-not-writer, by construction
       ]
-    : spec.args(prompt);
+    : prepareRunArgs(cliId, spec.args(prompt));
 
   const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
 
@@ -121,6 +123,17 @@ export async function POST(req: Request) {
 
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isKimi) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            const event = line ? parseKimiStreamLine(line) : null;
+            if (event?.text) emit(event.text);
+          }
+          return;
+        }
         if (!isClaude) {
           emit(d.toString());
           return;
@@ -144,6 +157,7 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        if (isKimi) return; // normal Kimi thinking/tool progress is written here
         if (/error|not found|denied|fatal/i.test(s)) {
           safeEnqueue(`\n[${spec.name}] ${s.trim()}\n`);
         }
@@ -153,6 +167,11 @@ export async function POST(req: Request) {
         safeClose();
       });
       child.on("close", () => {
+        if (isKimi && buf.trim()) {
+          const event = parseKimiStreamLine(buf.trim());
+          if (event?.text) emit(event.text);
+          buf = "";
+        }
         if (!emitted) safeEnqueue("_(no output — is the CLI authenticated?)_");
         safeClose();
       });

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -5,6 +5,7 @@ import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory, findReportFile } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf } from "@/lib/pdf-render.mjs";
+import { parseKimiStreamLine, prepareRunArgs, runTimeoutMs } from "@/lib/cli-run.mjs";
 import { acquireTrackerWrite, releaseTrackerWrite } from "@/lib/core/run-registry";
 
 export const runtime = "nodejs";
@@ -151,6 +152,7 @@ export async function POST(req: Request) {
   const prompt = buildPrompt({ kind, input, memory: readMemory(), today, pdfPaths });
 
   const isClaude = cliId === "claude";
+  const isKimi = cliId === "kimi";
   // Tool scope by kind (comma-separated lists; disallowedTools is the hard
   // guardrail). 'evaluate'/'fix-portal' run the REAL mode + persist canonical
   // artifacts → they need Write + Bash (reserve-report-num / merge-tracker /
@@ -172,7 +174,7 @@ export async function POST(req: Request) {
        "--permission-mode", "acceptEdits",
        "--allowedTools", tools.allowed,
        "--disallowedTools", tools.disallowed]
-    : spec.args(prompt);
+    : prepareRunArgs(cliId, spec.args(prompt));
 
   // For write-needing kinds, snapshot reports/ so we can verify the worker
   // actually persisted (non-Claude CLIs lack Write auth and silently no-op).
@@ -227,7 +229,7 @@ export async function POST(req: Request) {
       // generate-pdf.mjs mid-render. 600s agent / ~200s render is ample —
       // a Chromium PDF render normally takes low tens of seconds even with a
       // cold Playwright launch.
-      const killMs = kind === "pdf" ? 600_000 : 285_000;
+      const killMs = runTimeoutMs(kind, cliId);
       killer = setTimeout(() => {
         try { child.kill("SIGTERM"); } catch { /* ignore */ }
       }, killMs);
@@ -244,8 +246,28 @@ export async function POST(req: Request) {
         }
       };
 
+      const emitKimiLine = (line: string) => {
+        const event = parseKimiStreamLine(line);
+        if (!event) return;
+        for (const name of event.tools) send({ type: "tool", name });
+        if (event.text) {
+          emittedText = true;
+          send({ type: "text", text: event.text });
+        }
+      };
+
       child.stdout.on("data", (d: Buffer) => {
         if (closed) return;
+        if (isKimi) {
+          buf += d.toString();
+          let nl: number;
+          while ((nl = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            if (line) emitKimiLine(line);
+          }
+          return;
+        }
         if (!isClaude) {
           emittedText = true;
           send({ type: "text", text: d.toString() });
@@ -284,6 +306,9 @@ export async function POST(req: Request) {
       });
       child.stderr.on("data", (d: Buffer) => {
         const s = d.toString();
+        // In print mode Kimi uses stderr for normal thinking/tool progress.
+        // Its structured stdout plus exit code are the reliable error signal.
+        if (isKimi) return;
         // Widened: auth/login/quota failures are the most common real error and
         // the old narrow regex missed them (silent false "success").
         if (/error|denied|fatal|not found|unauthorized|forbidden|auth|login|credential|api[ -]?key|quota|rate limit|not authenticated/i.test(s)) {
@@ -338,6 +363,10 @@ export async function POST(req: Request) {
         // run could still start a brand-new render (and re-touch the tracker)
         // after the stream — and its writeToken guard — is already gone.
         if (closed) return;
+        if (isKimi && buf.trim()) {
+          emitKimiLine(buf.trim());
+          buf = "";
+        }
         const cleanExit = code === 0; // non-zero OR null (killed/signal) = NOT clean
         // Shared by both honesty gates below: a CLI that produced no output at
         // all is the same failure mode whether it was evaluating or tailoring

--- a/web/src/components/assistant-console.tsx
+++ b/web/src/components/assistant-console.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { dispatch, type ActionCtx, type DoneInfo } from "@/app/actions/registry";
 import { scoreNum } from "@/lib/format";
 import { pendingActOpenerStart } from "@/lib/act-envelope.mjs";
+import { CONFIG_CHANGED_EVENT, CONFIG_KEY, readConfiguredCli } from "@/lib/client-config.mjs";
 import { cn } from "@/lib/cn";
 
 // ── message model: messages are PART arrays so a live worker card can render
@@ -28,7 +29,6 @@ type Part =
   | { type: "confirm"; cid: string; summary: string; state: "pending" | "done" | "cancelled" };
 type Msg = { role: "user" | "assistant"; parts: Part[] };
 
-const CONFIG_KEY = "career-ops:config";
 const CHAT_KEY = "career-ops:chat";
 // back-compat shims — the old directives still work, mapped onto the registry
 const NAV_RE = /<<\s*go:\s*(\/[a-z0-9/_-]*)\s*>>/gi;
@@ -163,15 +163,20 @@ export function AssistantConsole() {
   useEffect(() => {
     function read() {
       try {
-        const raw = localStorage.getItem(CONFIG_KEY);
-        setCliId(raw ? JSON.parse(raw).cliId || null : null);
+        setCliId(readConfiguredCli(localStorage.getItem(CONFIG_KEY)));
       } catch {
         setCliId(null);
       }
     }
     read();
     window.addEventListener("storage", read);
-    return () => window.removeEventListener("storage", read);
+    window.addEventListener(CONFIG_CHANGED_EVENT, read);
+    window.addEventListener("focus", read);
+    return () => {
+      window.removeEventListener("storage", read);
+      window.removeEventListener(CONFIG_CHANGED_EVENT, read);
+      window.removeEventListener("focus", read);
+    };
   }, []);
 
   // restore + persist conversation

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { CONFIG_CHANGED_EVENT, CONFIG_KEY, patchClientConfig, readConfiguredCli } from "@/lib/client-config.mjs";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
 
 type Cli = {
@@ -31,8 +32,6 @@ const PROVIDERS = [
   { id: "openrouter", label: "OpenRouter" },
 ] as const;
 
-const STORAGE_KEY = "career-ops:config";
-
 export function ConfigForm() {
   const [mode, setMode] = useState<Mode>("cli");
   const [clis, setClis] = useState<Cli[] | null>(null);
@@ -45,7 +44,7 @@ export function ConfigForm() {
   // Load saved prefs
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(CONFIG_KEY);
       if (raw) {
         const v = JSON.parse(raw);
         // key/manual are not wired yet (nothing reads them) → never restore into
@@ -67,8 +66,19 @@ export function ConfigForm() {
       .then((d) => {
         const list: Cli[] = d.clis ?? [];
         setClis(list);
-        // auto-select first installed if nothing chosen yet
-        setCliId((prev) => prev || list.find((c) => c.installed)?.id || "");
+        const savedCli = readConfiguredCli(localStorage.getItem(CONFIG_KEY));
+        const savedIsInstalled = !!savedCli && list.some((c) => c.installed && c.id === savedCli);
+        const nextCli = savedIsInstalled ? savedCli : list.find((c) => c.installed)?.id || "";
+        setCliId(nextCli);
+        // A visible auto-selection must be real, not cosmetic. Persist it and
+        // notify the persistent assistant mounted outside this page.
+        if (nextCli && nextCli !== savedCli) {
+          localStorage.setItem(
+            CONFIG_KEY,
+            patchClientConfig(localStorage.getItem(CONFIG_KEY), { mode: "cli", cliId: nextCli }),
+          );
+          window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
+        }
       })
       .catch(() => setClis([]));
   }, []);
@@ -77,9 +87,20 @@ export function ConfigForm() {
     // The API key is deliberately NOT persisted: nothing reads it yet (the
     // key/manual panel is unwired) and a secret must never sit in clear-text
     // localStorage. Keys belong in the user's own CLI/provider config.
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode, cliId, provider, logos }));
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ mode, cliId, provider, logos }));
+    window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
+  }
+
+  function selectCli(nextCliId: string) {
+    setCliId(nextCliId);
+    // Selecting an installed CLI should enable the persistent assistant
+    // immediately. The native storage event only fires in OTHER tabs, so emit a
+    // same-tab event as well.
+    const next = patchClientConfig(localStorage.getItem(CONFIG_KEY), { mode: "cli", cliId: nextCliId });
+    localStorage.setItem(CONFIG_KEY, next);
+    window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
   }
 
   const installed = clis?.filter((c) => c.installed) ?? [];
@@ -163,7 +184,7 @@ export function ConfigForm() {
                       <button
                         type="button"
                         disabled={!c.installed}
-                        onClick={() => setCliId(c.id)}
+                        onClick={() => selectCli(c.id)}
                         className={cn(
                           "flex flex-1 items-center gap-2 text-left max-sm:min-h-[44px]",
                           c.installed ? "" : "cursor-default",

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -41,6 +41,40 @@ export function ConfigForm() {
   const [logos, setLogos] = useState(true);
   const [saved, setSaved] = useState(false);
 
+  // Profile states
+  const [country, setCountry] = useState("");
+  const [authorizedIn, setAuthorizedIn] = useState("");
+  const [preferences, setPreferences] = useState("");
+  // Location filter — these write directly to portals.yml (the scanner reads from there)
+  const [locationAllow, setLocationAllow] = useState<string[]>([]);
+  const [locationInput, setLocationInput] = useState("");
+  const [locationBlock, setLocationBlock] = useState<string[]>([]);
+  const [locationBlockInput, setLocationBlockInput] = useState("");
+  const [blockInput, setBlockInput] = useState("");
+
+  // Load saved profile
+  useEffect(() => {
+    fetch("/api/profile")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.location?.country) setCountry(d.location.country);
+        if (d.location?.authorized_in) setAuthorizedIn(d.location.authorized_in.join(", "));
+        if (d.culture_screen?.require) setPreferences(d.culture_screen.require.join("\n"));
+      })
+      .catch(() => {});
+  }, []);
+
+  // Load portals location filter
+  useEffect(() => {
+    fetch("/api/portals")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.location_filter?.allow) setLocationAllow(d.location_filter.allow);
+        if (d.location_filter?.block) setLocationBlock(d.location_filter.block);
+      })
+      .catch(() => {});
+  }, []);
+
   // Load saved prefs
   useEffect(() => {
     try {
@@ -84,11 +118,30 @@ export function ConfigForm() {
   }, []);
 
   function save() {
-    // The API key is deliberately NOT persisted: nothing reads it yet (the
-    // key/manual panel is unwired) and a secret must never sit in clear-text
-    // localStorage. Keys belong in the user's own CLI/provider config.
     localStorage.setItem(CONFIG_KEY, JSON.stringify({ mode, cliId, provider, logos }));
     window.dispatchEvent(new Event(CONFIG_CHANGED_EVENT));
+
+    // Save profile.yml (country, authorized_in, culture_screen)
+    fetch("/api/profile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        country: country.trim() || undefined,
+        authorizedIn: authorizedIn ? authorizedIn.split(",").map(s => s.trim()).filter(Boolean) : undefined,
+        preferences: preferences ? preferences.split("\n").map(s => s.trim()).filter(Boolean) : undefined
+      })
+    }).catch(console.error);
+
+    // Save portals.yml location_filter (this is what the scanner actually reads)
+    fetch("/api/portals", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        location: locationAllow,
+        block: locationBlock,
+      })
+    }).catch(console.error);
+
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   }
@@ -312,6 +365,162 @@ export function ConfigForm() {
           />
         </span>
       </button>
+
+      {/* Profile & Location Filters */}
+      <label className="mt-8 mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+        Dónde buscar
+      </label>
+      <div className="space-y-5 rounded-xl border border-border bg-surface/50 p-5">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-foreground">País de Residencia</label>
+            <input
+              type="text"
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+              placeholder="Ej: Colombia"
+              className="w-full rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm outline-none placeholder:text-faint focus:border-brand/50"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-foreground">Autorizado para trabajar en</label>
+            <input
+              type="text"
+              value={authorizedIn}
+              onChange={(e) => setAuthorizedIn(e.target.value)}
+              placeholder="Ej: Colombia, United States"
+              className="w-full rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm outline-none placeholder:text-faint focus:border-brand/50"
+            />
+            <p className="mt-1 text-[11px] text-faint">Países separados por coma. Penaliza roles que no contraten aquí.</p>
+          </div>
+        </div>
+
+        {/* Location allow chips */}
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">
+            Ubicaciones permitidas en el escáner
+          </label>
+          <p className="mb-2 text-[11px] text-faint">
+            El escáner sólo mostrará vacantes cuya ubicación contenga alguno de estos términos. Añade Ciudad, País, &quot;Remote&quot;, &quot;LATAM&quot;, etc.
+          </p>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {Array.from(new Set(locationAllow)).map((loc) => (
+              <span key={loc} className="inline-flex items-center gap-1 rounded-full border border-brand/30 bg-brand-soft px-2.5 py-1 text-xs font-medium text-brand">
+                {loc}
+                <button type="button" aria-label={`Quitar ${loc}`} onClick={() => setLocationAllow(locationAllow.filter(l => l !== loc))} className="ml-0.5 opacity-60 hover:opacity-100">
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={locationInput}
+              onChange={(e) => setLocationInput(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.key === "Enter" || e.key === ",") && locationInput.trim()) {
+                  e.preventDefault();
+                  const val = locationInput.trim().replace(/,$/, "");
+                  if (val && !locationAllow.includes(val)) setLocationAllow([...locationAllow, val]);
+                  setLocationInput("");
+                }
+              }}
+              placeholder="Colombia, Cali, Remote, LATAM…"
+              className="flex-1 rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm outline-none placeholder:text-faint focus:border-brand/50"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const val = locationInput.trim().replace(/,$/, "");
+                if (val && !locationAllow.includes(val)) setLocationAllow([...locationAllow, val]);
+                setLocationInput("");
+              }}
+              className="rounded-lg border border-border bg-surface/50 px-3 py-2 text-sm hover:bg-surface-hover"
+            >
+              Añadir
+            </button>
+          </div>
+          {/* Quick-add suggestions */}
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {["Colombia", "Cali", "Bogotá", "Medellín", "Remote", "LATAM", "Worldwide"].filter(s => !locationAllow.includes(s)).map(s => (
+              <button key={s} type="button" onClick={() => setLocationAllow([...locationAllow, s])}
+                className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted hover:border-brand/40 hover:text-brand">
+                + {s}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-foreground">
+            Ubicaciones bloqueadas
+          </label>
+          <p className="mb-2 text-[11px] text-faint">
+            Cualquier vacante cuya ubicación contenga alguna de estas palabras será descartada.
+          </p>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {Array.from(new Set(locationBlock)).map((loc) => (
+              <span key={loc} className="inline-flex items-center gap-1 rounded-full border border-red-500/30 bg-red-500/10 px-2.5 py-1 text-xs font-medium text-red-500">
+                {loc}
+                <button type="button" aria-label={`Quitar ${loc}`} onClick={() => setLocationBlock(locationBlock.filter(l => l !== loc))} className="ml-0.5 opacity-60 hover:opacity-100">
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={locationBlockInput}
+              onChange={(e) => setLocationBlockInput(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.key === "Enter" || e.key === ",") && locationBlockInput.trim()) {
+                  e.preventDefault();
+                  const val = locationBlockInput.trim().replace(/,$/, "");
+                  if (val && !locationBlock.includes(val)) setLocationBlock([...locationBlock, val]);
+                  setLocationBlockInput("");
+                }
+              }}
+              placeholder="US, USA, Europe, San Francisco…"
+              className="flex-1 rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm outline-none placeholder:text-faint focus:border-red-500/50"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const val = locationBlockInput.trim().replace(/,$/, "");
+                if (val && !locationBlock.includes(val)) setLocationBlock([...locationBlock, val]);
+                setLocationBlockInput("");
+              }}
+              className="rounded-lg border border-border bg-surface/50 px-3 py-2 text-sm hover:bg-surface-hover"
+            >
+              Añadir
+            </button>
+          </div>
+          {/* Quick-add suggestions */}
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {["US", "USA", "United States", "North America", "Europe", "UK"].filter(s => !locationBlock.includes(s)).map(s => (
+              <button key={s} type="button" onClick={() => setLocationBlock([...locationBlock, s])}
+                className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted hover:border-red-500/40 hover:text-red-500">
+                + {s}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Contract requirements */}
+        <div>
+          <label className="mb-1 block text-sm font-medium text-foreground">Requisitos de Contrato y Empresa (Bilingüe)</label>
+          <textarea
+            value={preferences}
+            onChange={(e) => setPreferences(e.target.value)}
+            placeholder={"Contrato a término indefinido / Full-time indefinite contract\nModalidad 100% Remoto / 100% Remote"}
+            rows={3}
+            className="w-full rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm outline-none placeholder:text-faint focus:border-brand/50"
+          />
+          <p className="mt-1 text-[11px] text-faint">Una regla por línea. Escribe en inglés y español para que la IA entienda ofertas en ambos idiomas.</p>
+        </div>
+      </div>
 
       <CadenceSettings />
 

--- a/web/src/components/explore/explore-provider.tsx
+++ b/web/src/components/explore/explore-provider.tsx
@@ -379,6 +379,7 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setAiCost({ searches: 0, candidates: 0, fetches: 0 });
     try {
       sessionStorage.removeItem(RESULTS_KEY);
+      localStorage.removeItem(RESULTS_KEY);
     } catch {
       /* ignore */
     }
@@ -492,14 +493,15 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setModeState(m);
   }, []);
 
-  // Rehydrate the last settled result set on mount (per-tab sessionStorage), unless a
-  // search is already running. Done in an effect (not a useState initializer) to avoid
-  // an SSR hydration mismatch.
+  // Rehydrate the last settled result set on mount. Prefer this tab's session
+  // snapshot, then fall back to the durable local snapshot so a tab/browser
+  // restart does not discard an expensive scan or AI search.
   useEffect(() => {
     if (runningRef.current) return;
     let snap: ResultSnapshot | null = null;
     try {
-      snap = JSON.parse(sessionStorage.getItem(RESULTS_KEY) || "null") as ResultSnapshot | null;
+      const raw = sessionStorage.getItem(RESULTS_KEY) || localStorage.getItem(RESULTS_KEY);
+      snap = JSON.parse(raw || "null") as ResultSnapshot | null;
     } catch {
       snap = null;
     }
@@ -524,7 +526,8 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setPhase(RUNNING.has(snap.phase) ? (snap.offers.length ? "results" : "idle") : snap.phase);
   }, []);
 
-  // Persist only SETTLED states (never mid-stream) so a reload restores a complete set.
+  // Persist only SETTLED states (never mid-stream). sessionStorage preserves the
+  // current tab; localStorage is the durable fallback across tab/browser restarts.
   useEffect(() => {
     const SETTLED = new Set<Phase>(["results", "empty-current", "empty-loose", "failed", "degraded", "blocked"]);
     if (!SETTLED.has(phase)) return;
@@ -533,9 +536,11 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
         v: 1, mode, phase, offers, matchCount, companiesScanned, companiesAvailable, capHit, droppedNoDate, sources,
         partial, status, error, added: [...added], aiTrace, aiCost, aiIntent,
       };
-      sessionStorage.setItem(RESULTS_KEY, JSON.stringify(snap));
+      const serialized = JSON.stringify(snap);
+      sessionStorage.setItem(RESULTS_KEY, serialized);
+      localStorage.setItem(RESULTS_KEY, serialized);
     } catch {
-      /* sessionStorage full/unavailable — non-fatal */
+      /* browser storage full/unavailable — non-fatal */
     }
   }, [phase, mode, offers, matchCount, companiesScanned, companiesAvailable, capHit, droppedNoDate, sources, partial, status, error, added, aiTrace, aiCost, aiIntent]);
 

--- a/web/src/lib/cli-run.mjs
+++ b/web/src/lib/cli-run.mjs
@@ -1,0 +1,37 @@
+const DEFAULT_RUN_TIMEOUT_MS = 285_000;
+const LONG_RUN_TIMEOUT_MS = 600_000;
+
+export function prepareRunArgs(cliId, args) {
+  return cliId === "kimi" ? [...args, "--output-format", "stream-json"] : args;
+}
+
+export function runTimeoutMs(kind, cliId) {
+  return kind === "pdf" || (kind === "evaluate" && cliId === "kimi") ? LONG_RUN_TIMEOUT_MS : DEFAULT_RUN_TIMEOUT_MS;
+}
+
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part && typeof part === "object" && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+export function parseKimiStreamLine(line) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!event || event.role !== "assistant") return null;
+
+  const tools = Array.isArray(event.tool_calls)
+    ? event.tool_calls
+        .map((call) => call?.function?.name || call?.name)
+        .filter((name) => typeof name === "string" && name.trim())
+    : [];
+
+  return { text: contentText(event.content), tools };
+}

--- a/web/src/lib/cli-run.mjs
+++ b/web/src/lib/cli-run.mjs
@@ -5,6 +5,14 @@ export function prepareRunArgs(cliId, args) {
   return cliId === "kimi" ? [...args, "--output-format", "stream-json"] : args;
 }
 
+export function prepareAssistantArgs(cliId, args) {
+  if (cliId === "kimi") return prepareRunArgs(cliId, args);
+  if (cliId === "codex" && args[0] === "exec") {
+    return ["exec", "--ephemeral", "--json", ...args.slice(1)];
+  }
+  return args;
+}
+
 export function runTimeoutMs(kind, cliId) {
   return kind === "pdf" || (kind === "evaluate" && cliId === "kimi") ? LONG_RUN_TIMEOUT_MS : DEFAULT_RUN_TIMEOUT_MS;
 }
@@ -34,4 +42,31 @@ export function parseKimiStreamLine(line) {
     : [];
 
   return { text: contentText(event.content), tools };
+}
+
+export function parseCodexStreamLine(line) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (event?.type !== "item.completed" || event.item?.type !== "agent_message") return null;
+  return typeof event.item.text === "string" ? event.item.text : null;
+}
+
+export function noOutputMessage({ cliName, timedOut, code, stderr = "" }) {
+  if (timedOut) {
+    return `${cliName} needed more than 4 minutes for this reply. Try again with a shorter request.`;
+  }
+  if (/quota|rate.?limit|too many requests|insufficient.?credits/i.test(stderr)) {
+    return `${cliName} reported a quota or rate-limit error. Check that provider's usage, then try again.`;
+  }
+  if (/unauthorized|forbidden|not authenticated|login|credential|api.?key/i.test(stderr)) {
+    return `${cliName} is installed but not authenticated. Run it once in a terminal and sign in.`;
+  }
+  if (code !== 0) {
+    return `${cliName} exited with code ${code ?? "unknown"} before returning a reply.`;
+  }
+  return `${cliName} finished without returning a reply.`;
 }

--- a/web/src/lib/client-config.mjs
+++ b/web/src/lib/client-config.mjs
@@ -1,0 +1,21 @@
+export const CONFIG_KEY = "career-ops:config";
+export const CONFIG_CHANGED_EVENT = "career-ops:config-changed";
+
+export function parseClientConfig(raw) {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readConfiguredCli(raw) {
+  const cliId = parseClientConfig(raw).cliId;
+  return typeof cliId === "string" && cliId.trim() ? cliId : null;
+}
+
+export function patchClientConfig(raw, patch) {
+  return JSON.stringify({ ...parseClientConfig(raw), ...patch });
+}

--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -18,19 +18,21 @@ export const KNOWN: CliSpec[] = [
   { id: "claude", name: "Claude Code", bin: "claude", run: "claude -p", url: "https://claude.ai/code", args: (p) => ["-p", p] },
   { id: "codex", name: "Codex", bin: "codex", run: "codex exec", url: "https://github.com/openai/codex", args: (p) => ["exec", p] },
   { id: "gemini", name: "Gemini CLI", bin: "gemini", run: "gemini -p", url: "https://github.com/google-gemini/gemini-cli", args: (p) => ["-p", p] },
+  { id: "kimi", name: "Kimi Code CLI", bin: "kimi", run: "kimi -p", url: "https://www.kimi.com/code/docs/en/", args: (p) => ["-p", p] },
   { id: "opencode", name: "OpenCode", bin: "opencode", run: "opencode run", url: "https://opencode.ai", args: (p) => ["run", p] },
   { id: "copilot", name: "GitHub Copilot CLI", bin: "copilot", run: "copilot -p", url: "https://docs.github.com/en/copilot/github-copilot-in-the-cli", args: (p) => ["-p", p] },
   { id: "qwen", name: "Qwen CLI", bin: "qwen", run: "qwen -p", url: "https://qwen.ai/qwencode", args: (p) => ["-p", p] },
   { id: "antigravity", name: "Antigravity CLI", bin: "agy", run: "agy -p", url: "https://antigravity.google", args: (p) => ["-p", p] },
 ];
 
-function searchDirs(): string[] {
+export function searchDirs(): string[] {
   const home = os.homedir();
   const extra = [
     path.join(home, ".local/bin"),
     path.join(home, ".npm-global/bin"),
     path.join(home, ".bun/bin"),
     path.join(home, ".deno/bin"),
+    path.join(home, ".kimi-code/bin"),
     "/opt/homebrew/bin",
     "/usr/local/bin",
     "/usr/bin",

--- a/web/src/lib/core/portals.ts
+++ b/web/src/lib/core/portals.ts
@@ -28,29 +28,69 @@ function listFrom(v: unknown): string[] {
 /** Serialize filters into a minimal, valid portals.yml. Scalars go through
  *  JSON.stringify (a valid YAML double-quoted scalar) so arbitrary keywords —
  *  colons, quotes, leading dashes — can never break the document or inject YAML. */
-export function serializePortals(f: FilterLists): string {
-  const block = (key: string, items: string[]) =>
-    items.length ? `  ${key}:\n` + items.map((k) => `    - ${JSON.stringify(k)}`).join("\n") + "\n" : "";
+export function serializePortals(f: FilterLists, baseYaml?: string): string {
+  let doc: any = {};
+  let baseLf: any = null; // location_filter from portals.yml (used as fallback)
 
-  let out = "# Ephemeral Explorer filters — generated per-search, safe to delete.\n";
+  let baseTf: any = null;
+
+  if (baseYaml) {
+    try {
+      const base = yaml.load(baseYaml) as any;
+      if (base && typeof base === "object") {
+        // Copy ONLY the non-filter sections (companies, search_queries, job boards, etc.)
+        for (const key of Object.keys(base)) {
+          if (key !== "title_filter" && key !== "location_filter") {
+            doc[key] = base[key];
+          }
+        }
+        // Keep a reference to the saved location_filter as fallback
+        if (base.location_filter && typeof base.location_filter === "object") {
+          baseLf = base.location_filter;
+        }
+        if (base.title_filter && typeof base.title_filter === "object") {
+          baseTf = base.title_filter;
+        }
+      }
+    } catch {}
+  }
+
+  // title_filter: UI always wins
   if (f.positive.length || f.negative.length) {
-    out += "title_filter:\n";
-    out += block("positive", f.positive);
-    out += block("negative", f.negative);
+    baseTf = baseTf || {};
+    doc.title_filter = {
+      positive: Array.from(new Set([...f.positive, ...(Array.isArray(baseTf.positive) ? baseTf.positive : typeof baseTf.positive === 'string' ? [baseTf.positive] : [])])),
+      negative: Array.from(new Set([...f.negative, ...(Array.isArray(baseTf.negative) ? baseTf.negative : typeof baseTf.negative === 'string' ? [baseTf.negative] : [])]))
+    };
   }
+
+  // location_filter: UI wins when non-empty; otherwise fall back to portals.yml
+  // so the saved "Dónde buscar" config is always the default for zero-config searches.
   if (f.allow.length || f.block.length || f.alwaysAllow.length) {
-    out += "location_filter:\n";
-    out += block("always_allow", f.alwaysAllow);
-    out += block("allow", f.allow);
-    out += block("block", f.block);
+    doc.location_filter = {
+      always_allow: Array.from(new Set([...f.alwaysAllow, ...(Array.isArray(baseLf?.always_allow) ? baseLf.always_allow : typeof baseLf?.always_allow === 'string' ? [baseLf.always_allow] : [])])),
+      allow: Array.from(new Set([...f.allow, ...(Array.isArray(baseLf?.allow) ? baseLf.allow : typeof baseLf?.allow === 'string' ? [baseLf.allow] : [])])),
+      block: Array.from(new Set([...f.block, ...(Array.isArray(baseLf?.block) ? baseLf.block : typeof baseLf?.block === 'string' ? [baseLf.block] : [])]))
+    };
+  } else if (baseLf) {
+    // No UI override → use the portals.yml location_filter as-is
+    doc.location_filter = baseLf;
   }
-  return out;
+  // If neither exists → no location restriction (find everything)
+
+  return "# Ephemeral Explorer filters — generated per-search, safe to delete.\n" + yaml.dump(doc);
 }
+
+
 
 /** Write the ephemeral filter file to a temp path; caller cleans it up. */
 export function writeTempPortals(f: FilterLists): string {
   const file = path.join(os.tmpdir(), `career-ops-explore-${randomUUID()}.yml`);
-  fs.writeFileSync(file, serializePortals(f), "utf8");
+  let base = "";
+  try {
+    base = fs.readFileSync(path.join(careerOpsRoot(), "portals.yml"), "utf8");
+  } catch {}
+  fs.writeFileSync(file, serializePortals(f, base), "utf8");
   return file;
 }
 
@@ -93,16 +133,30 @@ export function seedExploreFilters(): { filters: ExploreFilters; seededFrom: str
     if (filters.positive.length || filters.allow.length || filters.block.length) seededFrom.push("portals.yml");
   }
 
-  if (filters.positive.length === 0) {
-    const profile = loadYaml("config/profile.yml");
-    const roles = (profile?.target_roles ?? {}) as Record<string, unknown>;
-    const fromRoles = listFrom([
-      ...(typeof roles.primary === "string" ? [roles.primary] : []),
-      ...(Array.isArray(roles.archetypes) ? roles.archetypes : []),
-    ]);
-    if (fromRoles.length) {
-      filters.positive = fromRoles;
-      seededFrom.push("profile.yml");
+  const profile = loadYaml("config/profile.yml");
+  if (profile) {
+    if (filters.positive.length === 0) {
+      const roles = (profile.target_roles ?? {}) as Record<string, unknown>;
+      const fromRoles = listFrom([
+        ...(Array.isArray(roles.primary) ? roles.primary : typeof roles.primary === "string" ? [roles.primary] : []),
+        ...(Array.isArray(roles.archetypes) ? roles.archetypes.map((a: any) => typeof a === 'object' && a !== null ? a.name : a) : []),
+      ]);
+      if (fromRoles.length) {
+        filters.positive = fromRoles;
+        if (!seededFrom.includes("profile.yml")) seededFrom.push("profile.yml");
+      }
+    }
+
+    if (filters.allow.length === 0) {
+      const loc = (profile.location ?? {}) as Record<string, unknown>;
+      const fromLoc = listFrom([
+        ...(typeof loc.country === "string" ? [loc.country] : []),
+        ...(Array.isArray(loc.authorized_in) ? loc.authorized_in : [])
+      ]);
+      if (fromLoc.length) {
+        filters.allow = Array.from(new Set(fromLoc));
+        if (!seededFrom.includes("profile.yml")) seededFrom.push("profile.yml");
+      }
     }
   }
 

--- a/web/tests/lib/cli-run.test.mjs
+++ b/web/tests/lib/cli-run.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseKimiStreamLine, prepareRunArgs, runTimeoutMs } from "../../src/lib/cli-run.mjs";
+import {
+  noOutputMessage,
+  parseCodexStreamLine,
+  parseKimiStreamLine,
+  prepareAssistantArgs,
+  prepareRunArgs,
+  runTimeoutMs,
+} from "../../src/lib/cli-run.mjs";
 
 test("adds Kimi's structured JSONL output flag without changing other CLIs", () => {
   const base = ["-p", "hello"];
@@ -16,6 +23,11 @@ test("gives Kimi evaluations enough time while preserving existing limits", () =
   assert.equal(runTimeoutMs("evaluate", "codex"), 285_000);
   assert.equal(runTimeoutMs("research", "kimi"), 285_000);
   assert.equal(runTimeoutMs("pdf", "kimi"), 600_000);
+});
+
+test("uses structured ephemeral output for Codex assistant turns", () => {
+  assert.deepEqual(prepareAssistantArgs("codex", ["exec", "hello"]), ["exec", "--ephemeral", "--json", "hello"]);
+  assert.deepEqual(prepareAssistantArgs("kimi", ["-p", "hello"]), ["-p", "hello", "--output-format", "stream-json"]);
 });
 
 test("parses Kimi assistant text and tool calls", () => {
@@ -36,4 +48,20 @@ test("joins structured text content and ignores tool/meta records", () => {
   assert.equal(parseKimiStreamLine(JSON.stringify({ role: "tool", content: "large tool result" })), null);
   assert.equal(parseKimiStreamLine(JSON.stringify({ role: "meta", type: "session.resume_hint" })), null);
   assert.equal(parseKimiStreamLine("not json"), null);
+});
+
+test("parses only completed Codex agent messages", () => {
+  assert.equal(
+    parseCodexStreamLine(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "hello" } })),
+    "hello",
+  );
+  assert.equal(parseCodexStreamLine(JSON.stringify({ type: "turn.started" })), null);
+  assert.equal(parseCodexStreamLine("not json"), null);
+});
+
+test("explains timeout, quota, authentication and exit failures without raw stderr", () => {
+  assert.match(noOutputMessage({ cliName: "Kimi", timedOut: true, code: null }), /more than 4 minutes/);
+  assert.match(noOutputMessage({ cliName: "Kimi", timedOut: false, code: 1, stderr: "quota exceeded" }), /quota/);
+  assert.match(noOutputMessage({ cliName: "Codex", timedOut: false, code: 1, stderr: "not authenticated" }), /not authenticated/);
+  assert.match(noOutputMessage({ cliName: "Codex", timedOut: false, code: 7 }), /code 7/);
 });

--- a/web/tests/lib/cli-run.test.mjs
+++ b/web/tests/lib/cli-run.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseKimiStreamLine, prepareRunArgs, runTimeoutMs } from "../../src/lib/cli-run.mjs";
+
+test("adds Kimi's structured JSONL output flag without changing other CLIs", () => {
+  const base = ["-p", "hello"];
+
+  assert.deepEqual(prepareRunArgs("kimi", base), ["-p", "hello", "--output-format", "stream-json"]);
+  assert.deepEqual(prepareRunArgs("codex", base), base);
+  assert.deepEqual(base, ["-p", "hello"]);
+});
+
+test("gives Kimi evaluations enough time while preserving existing limits", () => {
+  assert.equal(runTimeoutMs("evaluate", "kimi"), 600_000);
+  assert.equal(runTimeoutMs("evaluate", "codex"), 285_000);
+  assert.equal(runTimeoutMs("research", "kimi"), 285_000);
+  assert.equal(runTimeoutMs("pdf", "kimi"), 600_000);
+});
+
+test("parses Kimi assistant text and tool calls", () => {
+  const event = JSON.stringify({
+    role: "assistant",
+    content: "Checking the posting...",
+    tool_calls: [{ function: { name: "Read", arguments: "{}" } }, { name: "Bash" }],
+  });
+
+  assert.deepEqual(parseKimiStreamLine(event), { text: "Checking the posting...", tools: ["Read", "Bash"] });
+});
+
+test("joins structured text content and ignores tool/meta records", () => {
+  assert.deepEqual(
+    parseKimiStreamLine(JSON.stringify({ role: "assistant", content: [{ type: "text", text: "one" }, { type: "text", text: " two" }] })),
+    { text: "one two", tools: [] },
+  );
+  assert.equal(parseKimiStreamLine(JSON.stringify({ role: "tool", content: "large tool result" })), null);
+  assert.equal(parseKimiStreamLine(JSON.stringify({ role: "meta", type: "session.resume_hint" })), null);
+  assert.equal(parseKimiStreamLine("not json"), null);
+});

--- a/web/tests/lib/client-config.test.mjs
+++ b/web/tests/lib/client-config.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { patchClientConfig, readConfiguredCli } from "../../src/lib/client-config.mjs";
+
+test("reads a configured CLI and rejects malformed or empty values", () => {
+  assert.equal(readConfiguredCli('{"cliId":"kimi"}'), "kimi");
+  assert.equal(readConfiguredCli('{"cliId":""}'), null);
+  assert.equal(readConfiguredCli('{"cliId":42}'), null);
+  assert.equal(readConfiguredCli("not-json"), null);
+});
+
+test("patching a CLI preserves unrelated browser preferences", () => {
+  const next = JSON.parse(patchClientConfig('{"logos":false,"provider":"google"}', { mode: "cli", cliId: "kimi" }));
+
+  assert.deepEqual(next, { logos: false, provider: "google", mode: "cli", cliId: "kimi" });
+});

--- a/web/tests/lib/clis.test.mjs
+++ b/web/tests/lib/clis.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const sourcePath = fileURLToPath(new URL("../../src/lib/clis.ts", import.meta.url));
+const source = fs.readFileSync(sourcePath, "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  fileName: sourcePath,
+}).outputText;
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString("base64")}`;
+const { KNOWN, searchDirs } = await import(moduleUrl);
+
+test("registers Kimi Code CLI for headless prompts", () => {
+  const kimi = KNOWN.find((cli) => cli.id === "kimi");
+
+  assert.ok(kimi);
+  assert.equal(kimi.name, "Kimi Code CLI");
+  assert.equal(kimi.bin, "kimi");
+  assert.equal(kimi.run, "kimi -p");
+  assert.deepEqual(kimi.args("hello"), ["-p", "hello"]);
+});
+
+test("searches the official Kimi Code installation directory", () => {
+  const expected = path.join(os.homedir(), ".kimi-code", "bin");
+
+  assert.ok(searchDirs().includes(expected));
+});


### PR DESCRIPTION
**feat(latam): fix ElEmpleo encoding, update Magneto URL, harden location filters & add Computrabajo**

This PR introduces critical fixes for the LATAM market and solidifies the location-blocking UX:

1. **Computrabajo:** Added a robust provider (computrabajo.mjs) with automated tests, strict pagination/delay rules (to prevent bans), and entity decoding.
2. **ElEmpleo Colombia:** Added HTML entity decoding to properly match Spanish accented characters (Mec&#225;nico -> Mecánico).
3. **Magneto365:** Updated the scraper URL endpoints to /trabajos/buscar/tecnologia.
4. **Location Block UI & Cache Hardening:** Added a UI panel to manage blocked locations and refactored serializePortals so that the backend strictly merges portals.yml manual rules, preventing the frontend cache from bypassing blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job listings support for Computrabajo, Elempleo, and Magneto, including pagination, duplicate removal, and standardized Colombia job results.
  * Added Kimi Code CLI support across assistant, exploration, and run experiences.
  * Added profile, location, and contract-preference settings with persistent saving.
  * Added improved CLI selection and synchronization across the app.
  * Preserved exploration results for recovery after session changes.

* **Bug Fixes**
  * Improved timeout handling, stream processing, and error messages for CLI runs.
  * Enhanced handling of pagination failures, anti-bot pages, and incomplete job listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->