### PR TITLE
fix(verify-cv-facts): treat a period as a thousands separator too

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -180,11 +180,24 @@ export function stripMarkup(text) {
  *
  * Only a separator followed by EXACTLY three digits is removed, so a decimal
  * comma ("1,2 million") and ordinary prose are left alone.
+ *
+ * The period is in the class for the same reason the comma is, from the other
+ * side of the convention: this repo ships mode sets for markets that group
+ * with a period, so a JD or a portfolio note written "16.181 users" is a
+ * source a CV written "16,181 users" is checked against. Grouping style is not
+ * evidence of a different number, and the gate reported one as invented.
+ *
+ * The three-digit window is what makes this safe to widen: it leaves a genuine
+ * decimal alone at every precision a metric noun realistically carries ("2.5
+ * hours", "99.95 uptime"). It cannot disambiguate a three-place decimal, where
+ * "1.250 million" reads as thousands - an ambiguity the comma branch already
+ * carries in the mirror direction, and one no separator rule can resolve
+ * without knowing the document's locale. allow_metrics covers the rest.
  */
 export function normalizeClaim(claim) {
   return String(claim)
     .toLowerCase()
-    .replace(/(\d)[,\s\u00a0\u202f](?=\d{3}(?!\d))/g, '$1')
+    .replace(/(\d)[,.\s\u00a0\u202f](?=\d{3}(?!\d))/g, '$1')
     .replace(/[,\s]+/g, ' ')
     .trim();
 }
@@ -457,6 +470,19 @@ function runSelfTest() {
   // a digit, so the lookbehind passes at each one (CodeRabbit asked).
   equal('a multi-group number folds completely', auditClaims('Reached 1 234 567 users', 'Reached 1234567 active users.').invented, []);
   equal('an eight-digit multi-group number folds too', auditClaims('Reached 12 345 678 users', 'Reached 12345678 active users.').invented, []);
+  // Period grouping is the convention in several of the markets this repo
+  // ships mode sets for, so a period-grouped source and a comma-grouped CV
+  // describe the same number and must compare equal in both directions.
+  equal('a period-grouped CV matches a comma-grouped source',
+    auditClaims('Reached 16.181 users', foldSource).invented, []);
+  equal('a comma-grouped CV matches a period-grouped source',
+    auditClaims('Reached 16,181 users', 'Reached 16.181 active users.').invented, []);
+  equal('a fabricated period-grouped number is still caught',
+    auditClaims('Reached 94.772 users', foldSource).invented, ['94772 users']);
+  // Widening the class must not eat an ordinary decimal, which is what the
+  // exactly-three-digit window is for.
+  equal('a decimal is not read as grouping',
+    auditClaims('Cut build time to 2.5 hours', 'Cut build time to 2.5 hours.').invented, []);
   // A four-digit left part is a year, not a group: nothing is joined.
   equal('a year is not glued to the next number', auditClaims('Joined in 2026 100 users', foldSource).invented, ['100 users']);
 


### PR DESCRIPTION
The last of the unanswered review comments on #2175, and the one I would most understand you declining. Sending it separately from #2175's other finding for exactly that reason.

`normalizeClaim` already folds comma, space and the two narrow spaces, so the same number compares equal however it is grouped. The period was left out, and it is the grouping convention in several of the markets this repo ships mode sets for. A source written `16.181 users` and a CV written `16,181 users` are the same claim, and the gate reported it as invented: a truthful CV failing over grouping style, which is the failure this normalization exists to prevent.

## The tradeoff, stated plainly

The exactly-three-digit window is what makes the class safe to widen. An ordinary decimal is untouched at every precision a metric noun realistically carries (`2.5 hours`, `99.95 uptime`).

It cannot disambiguate a three-place decimal, where `1.250 million` reads as thousands. That ambiguity is already present in the mirror direction for the comma, no separator rule resolves it without knowing the document's locale, and `allow_metrics` covers the remainder. If you would rather carry the false-invented on the period side than the false-equal on the decimal side, that is a reasonable call and this PR is the one to drop.

The docblock says all of the above at the code, not just here.

## Verification

Four new self-test assertions:

- a period-grouped CV matches a comma-grouped source
- a comma-grouped CV matches a period-grouped source
- a fabricated period-grouped number is still caught
- a decimal is not read as grouping

Seen failing first: dropping the period from the class turns the first three red and leaves the decimal guard green, which is the split that matters.

`verify-cv-facts.mjs --self-test`: 43 passed, 0 failed. Full suite on a clean worktree: 3430 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison of numerical claims using period-based thousands separators.
  * Preserved the correct handling of ordinary decimal values.
  * Added validation coverage for grouped numbers, fabricated values, and decimals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->