### PR TITLE
fix(agent-inbox): number resolve against file position, not the pending view

### DIFF
--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -7,13 +7,19 @@
  *   1. A first `add` seeds the header + agent protocol and one pending item.
  *   2. `add` is append-only and multiline text collapses to a single bullet.
  *   3. `list` shows pending only; `list --all` shows resolved items too.
- *   4. `resolve N` ticks the N-th *pending* item and appends a one-line result,
- *      so `list` then `resolve N` line up.
+ *   4. `resolve N` ticks the N-th item and appends a one-line result.
  *   5. An empty `add` fails loudly (exit 1) rather than queuing a blank line.
  *   6. On the default path, a first `add` self-heals .gitignore (idempotent) so
  *      the personal queue isn't accidentally tracked.
  *   7. Concurrent `add` calls all survive — the queue is appended to, never
  *      rewritten, so simultaneous writers cannot clobber each other.
+ *   8. Item numbers are stable file positions: a batch of resolves read off ONE
+ *      `list` all land on the item they named. (Numbering against the pending
+ *      view instead shifted every higher number down per resolve, silently
+ *      stamping results onto the wrong items.)
+ *   9. Re-resolving an already-done item fails loudly instead of re-stamping.
+ *  10. `--expect` aborts when the target doesn't contain the substring, and a
+ *      valueless `--expect` fails rather than silently disabling the guard.
  *
  * Provisions a throwaway queue via CAREER_OPS_INBOX and a temp CWD; never
  * touches real user data.
@@ -49,6 +55,16 @@ function run(inbox, args, opts = {}) {
     stdio: ['pipe', 'pipe', 'pipe'],
     ...opts,
   });
+}
+
+// Run a command expected to fail; returns { status, stderr }.
+function runFail(inbox, args) {
+  try {
+    run(inbox, args);
+    return { status: 0, stderr: '' };
+  } catch (e) {
+    return { status: e.status, stderr: String(e.stderr || '') };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -156,6 +172,69 @@ console.log('7. concurrent adds do not lose items (append, not rewrite)');
   const expected = new Set(Array.from({ length: N }, (_, i) => `item-${i}`));
   const complete = actual.size === expected.size && [...expected].every((item) => actual.has(item));
   check('no item is duplicated or truncated', complete, `actual=${[...actual].join(', ')}`);
+}
+
+// ---------------------------------------------------------------------------
+console.log('8. numbers are stable: a batch of resolves off ONE list stays correct');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  ['alpha', 'bravo', 'charlie', 'delta', 'echo'].forEach((t) => run(inbox, ['add', t]));
+
+  // Snapshot the numbering once, exactly as an agent draining the queue would.
+  const listed = run(inbox, ['list']);
+  const numberOf = (text) => {
+    const m = new RegExp(`^\\s*(\\d+)\\. \\[ \\] .*${text}`, 'm').exec(listed);
+    return m ? Number(m[1]) : -1;
+  };
+  check('list numbers items 1..5 in file order',
+    [1, 2, 3, 4, 5].every((n, i) => numberOf(['alpha', 'bravo', 'charlie', 'delta', 'echo'][i]) === n), listed.trim());
+
+  // Fire the whole batch against that one snapshot — no re-listing between.
+  run(inbox, ['resolve', String(numberOf('bravo')), '--result', 'R-bravo']);
+  run(inbox, ['resolve', String(numberOf('charlie')), '--result', 'R-charlie']);
+  run(inbox, ['resolve', String(numberOf('delta')), '--result', 'R-delta']);
+  run(inbox, ['resolve', String(numberOf('echo')), '--result', 'R-echo']);
+
+  const md = readFileSync(inbox, 'utf8');
+  ['bravo', 'charlie', 'delta', 'echo'].forEach((t) => {
+    check(`${t} carries its own result`, new RegExp(`^- \\[x\\] .*${t} → result: R-${t}$`, 'm').test(md), md);
+  });
+  check('alpha untouched and still pending', /^- \[ \] .*alpha$/m.test(md), md);
+
+  const after = run(inbox, ['list']);
+  check('surviving item keeps its original number (1)', /^\s*1\. \[ \] .*alpha/m.test(after), after.trim());
+  check('list explains the hidden/resolved items', /resolved item\(s\) hidden/.test(after), after.trim());
+}
+// ---------------------------------------------------------------------------
+console.log('9. re-resolving a done item fails loudly instead of re-stamping');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  run(inbox, ['add', 'foxtrot']);
+  run(inbox, ['resolve', '1', '--result', 'first']);
+  const { status, stderr } = runFail(inbox, ['resolve', '1', '--result', 'second']);
+  check('non-zero exit on already-resolved item', status === 1, `exit=${status}`);
+  check('error says why', /already resolved/.test(stderr), stderr.trim());
+  const md = readFileSync(inbox, 'utf8');
+  check('original result preserved', md.includes('→ result: first') && !md.includes('second'), md);
+}
+// ---------------------------------------------------------------------------
+console.log('10. --expect guards the target');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  run(inbox, ['add', 'inquire at Dana-Farber']);
+  run(inbox, ['add', 'apply at Change.org']);
+
+  const wrong = runFail(inbox, ['resolve', '2', '--expect', 'Dana-Farber', '--result', 'oops']);
+  check('mismatched --expect exits 1', wrong.status === 1, `exit=${wrong.status}`);
+  check('error shows the actual item', /Change\.org/.test(wrong.stderr), wrong.stderr.trim());
+  check('nothing written on mismatch', !readFileSync(inbox, 'utf8').includes('oops'));
+
+  const bare = runFail(inbox, ['resolve', '2', '--expect', '--result', 'oops']);
+  check('valueless --expect exits 1 (guard never silently disabled)', bare.status === 1, `exit=${bare.status}`);
+  check('still nothing written', !readFileSync(inbox, 'utf8').includes('oops'));
+
+  run(inbox, ['resolve', '2', '--expect', 'change.org', '--result', 'ok']);
+  check('matching --expect (case-insensitive) resolves', /^- \[x\] .*Change\.org → result: ok$/m.test(readFileSync(inbox, 'utf8')));
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed`);

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -20,10 +20,16 @@
  * this CLI, and any tool (a dashboard, a script, cron) can append to it. The
  * protocol an agent follows is documented in modes/agent-inbox.md.
  *
+ * Item numbers are *file positions*, not positions in the pending list: `add`
+ * only ever appends, so a number never changes meaning once printed. `list`
+ * therefore shows gaps as items get resolved (2, 4, 5) — the gaps are the
+ * receipt that something was already handled, and a whole batch of resolves can
+ * be read off a single `list` without drifting.
+ *
  * Usage:
  *   node agent-inbox.mjs add "evaluate https://acme.com/jobs/42"
  *   node agent-inbox.mjs list [--all]                 # pending only, or every item
- *   node agent-inbox.mjs resolve 1 [--result "scored 4.3 — report 012"]
+ *   node agent-inbox.mjs resolve 1 [--expect "Acme"] [--result "scored 4.3 — report 012"]
  */
 
 import {
@@ -103,13 +109,15 @@ function needsLeadingNewline(path) {
   }
 }
 
-// Parse the checklist into items, in file order.
+// Parse the checklist into items, in file order. `num` is the stable 1-based
+// item number used by `list` and `resolve` — it is the position in the FULL
+// list, so resolving an item never renumbers the others.
 function parseItems() {
   if (!existsSync(PATH)) return [];
   const items = [];
   readFileSync(PATH, 'utf8').split('\n').forEach((line, i) => {
     const m = /^- \[([ xX])\]\s*(.*)$/.exec(line.trim());
-    if (m) items.push({ line: i, done: m[1].toLowerCase() === 'x', text: m[2] });
+    if (m) items.push({ num: items.length + 1, line: i, done: m[1].toLowerCase() === 'x', text: m[2] });
   });
   return items;
 }
@@ -119,6 +127,10 @@ function opt(name, def = '') {
   if (i < 0) return def;
   const v = process.argv[i + 1];
   return v && !v.startsWith('--') ? v : def;
+}
+
+function hasOpt(name) {
+  return process.argv.includes('--' + name);
 }
 
 function add() {
@@ -142,20 +154,46 @@ function add() {
 
 function list() {
   const all = process.argv.includes('--all');
-  const items = parseItems().filter((it) => all || !it.done);
+  const parsed = parseItems();
+  const items = parsed.filter((it) => all || !it.done);
   if (!items.length) return process.stdout.write(all ? 'Inbox is empty.\n' : 'No pending items.\n');
-  items.forEach((it, n) => {
-    process.stdout.write(`${String(n + 1).padStart(2)}. [${it.done ? 'x' : ' '}] ${it.text}\n`);
+  items.forEach((it) => {
+    process.stdout.write(`${String(it.num).padStart(2)}. [${it.done ? 'x' : ' '}] ${it.text}\n`);
   });
+  // Explain the gaps rather than let them read as a display bug.
+  if (items.length < parsed.length) {
+    process.stdout.write(
+      `\n(${parsed.length - items.length} resolved item(s) hidden — numbers are stable file positions, so gaps are expected. \`list --all\` shows everything.)\n`,
+    );
+  }
 }
 
 function resolve() {
   const n = Number(process.argv[3]);
   if (!Number.isInteger(n) || n < 1) fail('resolve needs a 1-based item number (see `list`)');
-  // Number against the pending view, so `list` then `resolve N` line up.
-  const pending = parseItems().filter((it) => !it.done);
-  const target = pending[n - 1];
-  if (!target) fail(`no pending item #${n} (${pending.length} pending)`);
+  // Number against the FULL item list, not the pending subset. `add` only ever
+  // appends, so an item's position is stable for the life of the file and a
+  // batch of resolves read off one `list` stays correct. Numbering against the
+  // pending view instead made each resolve shift every higher number down by
+  // one — silently stamping later results onto the wrong items.
+  const items = parseItems();
+  const target = items[n - 1];
+  if (!target) {
+    const pending = items.filter((it) => !it.done).length;
+    fail(`no item #${n} — inbox has ${items.length} item(s), ${pending} pending. Run \`list --all\`.`);
+  }
+  // Already-resolved is an error, not a silent re-stamp: it is what a stale
+  // number from an older `list` most often lands on.
+  if (target.done) fail(`item #${n} is already resolved — refusing to overwrite it:\n  #${n}: ${target.text}`);
+  // Optional caller-side guard: abort unless the target says what the caller
+  // thinks it says. Catches "right command, wrong target" generally.
+  if (hasOpt('expect')) {
+    const expect = opt('expect');
+    if (!expect) fail('--expect needs a substring, e.g. --expect "Dana-Farber"');
+    if (!target.text.toLowerCase().includes(expect.toLowerCase())) {
+      fail(`item #${n} does not contain --expect ${JSON.stringify(expect)} — refusing to resolve:\n  #${n}: ${target.text}`);
+    }
+  }
   const result = oneLine(opt('result'));
   const lines = readFileSync(PATH, 'utf8').split('\n');
   let updated = lines[target.line].replace('[ ]', '[x]');
@@ -179,6 +217,10 @@ else {
     'Usage:\n' +
     '  node agent-inbox.mjs add "evaluate https://acme.com/jobs/42"\n' +
     '  node agent-inbox.mjs list [--all]\n' +
-    '  node agent-inbox.mjs resolve <n> [--result "..."]\n',
+    '  node agent-inbox.mjs resolve <n> [--expect "substring"] [--result "..."]\n' +
+    '\n' +
+    'Numbers are stable file positions: `list` shows gaps once items are\n' +
+    'resolved, and a batch of resolves read off one `list` stays correct.\n' +
+    '--expect aborts unless the target item contains that substring.\n',
   );
 }

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -942,6 +942,8 @@ These have no `npm run` binding — modes and agents call them with
 | `node process-quality.mjs [--summary]` | Aggregate `[process-friction]` tags from `data/active-interviews.md` per company |
 | `node reserve-report-num.mjs [--count N]` | Atomically reserve report numbers for parallel workers (fixes the #749 race) |
 | `node agent-inbox.mjs add "..."` | Append a request to the queue the agent drains at the next session start |
+| `node agent-inbox.mjs list [--all]` | List pending (or all) queued items by stable number — gaps mean already resolved |
+| `node agent-inbox.mjs resolve <n> [--expect "..."] [--result "..."]` | Tick item `n` and stamp a one-line result; `--expect` aborts unless the item contains that substring |
 | `node generate-latex.mjs <input.tex> [output.pdf]` | Validate and compile a generated `.tex` CV via tectonic or pdflatex |
 | `node classify-tier.mjs` | Classify a job title into intern / entry / mid / senior |
 | `node plugins.mjs list\|run <id> [hook]` | CLI host for non-provider plugin hooks (see [PLUGINS.md](PLUGINS.md)) |

--- a/modes/agent-inbox.md
+++ b/modes/agent-inbox.md
@@ -23,8 +23,20 @@ node agent-inbox.mjs add "run a scan and triage anything new"
 ```bash
 node agent-inbox.mjs list            # pending items
 node agent-inbox.mjs list --all      # include resolved items
-node agent-inbox.mjs resolve 1 --result "scored 4.3 — report 012"
+node agent-inbox.mjs resolve 1 --expect "Acme" --result "scored 4.3 — report 012"
 ```
+
+**Item numbers are stable file positions, not positions in the pending list.**
+`add` only appends, so a number never changes meaning once printed: you can read
+a whole batch off a single `list` and resolve them in any order. `list` shows
+gaps as items get resolved (1, 3, 5) — that is the receipt that something was
+already handled, not a display bug.
+
+Two loud failures protect the write: resolving an item that is already `[x]`
+aborts rather than overwriting its result, and `--expect "<substring>"` aborts
+unless the target item contains that substring (case-insensitive). Prefer
+`--expect` whenever you know what you mean to resolve — it turns "right command,
+wrong row" into an error instead of a plausible-looking wrong result line.
 
 `data/agent-inbox.md` is user-layer (gitignored). Items look like:
 
@@ -40,7 +52,9 @@ node agent-inbox.mjs resolve 1 --result "scored 4.3 — report 012"
 2. Run each **unchecked** item top-to-bottom by routing it to the right mode
    (a URL → `auto-pipeline`; "follow-up" → `followup`; "scan" → `scan`; etc.).
 3. After each, mark it `[x]` and append `→ result: <one line>` — either by hand
-   or with `node agent-inbox.mjs resolve <n> --result "..."`.
+   or with `node agent-inbox.mjs resolve <n> --expect "<distinctive words from
+   the item>" --result "..."`. Pass `--expect` every time: this is a provenance
+   log, and a result stamped onto the wrong item is worse than no result.
 4. Items that need **live user input** (a mock interview, a pasted transcript, a
    decision, anything that would submit an application) → do **not** run them;
    ask the user to start them instead. The inbox never bypasses human review.


### PR DESCRIPTION
### The bug

`resolve N` indexes into the *pending* subset:

```js
// Number against the pending view, so `list` then `resolve N` line up.
const pending = parseItems().filter((it) => !it.done);
const target = pending[n - 1];
```

Every resolve removes an item from that subset, so every higher number shifts down by one.
Read `list` once, then act on what you read, and the results land on the wrong items:

Verbatim run against `main`, five queued items, `list` read once:

```
$ node agent-inbox.mjs list
 1. [ ] alpha
 2. [ ] bravo
 3. [ ] charlie
 4. [ ] delta
 5. [ ] echo

$ node agent-inbox.mjs resolve 2 --result "R-2"
Resolved #2: bravo

$ node agent-inbox.mjs resolve 3 --result "R-3"
Resolved #3: delta            <-- list said #3 was charlie

$ node agent-inbox.mjs resolve 4 --result "R-4"
agent-inbox.mjs: no pending item #4 (3 pending)
```

Resulting queue:

```
- [ ] alpha
- [x] bravo → result: R-2
- [ ] charlie                 <-- skipped, still pending
- [x] delta → result: R-3     <-- carries charlie's result
- [ ] echo
```

Three distinct failures from one snapshot: `charlie` is silently skipped, `delta` is stamped
with a result it did not produce, and the third command dies with `no pending item #4
(3 pending)` moments after `list` displayed five items. The second is the dangerous one — it
prints `Resolved #3` and exits 0.

### Why this is the designed usage, not misuse

`modes/agent-inbox.md` tells the agent to drain the queue top-to-bottom and mark each item as
it goes:

> 2. Run each **unchecked** item top-to-bottom…
> 3. After each, mark it `[x]` and append `→ result: <one line>` — either by hand or with
>    `node agent-inbox.mjs resolve <n> --result "..."`.

An agent reads `list` once into context, works the batch, and resolves against the numbers it
was shown. Re-running `list` between every resolve is the only safe pattern under the old
behavior, and nothing in the docs said so — the code comment claimed the opposite ("so `list`
then `resolve N` line up"), which is true for exactly one resolve.

The failure mode is the worst kind for this file: `data/agent-inbox.md` is a provenance log.
A wrong result line is indistinguishable from a right one after the fact.

### The fix

Number against the full item list. `add` only ever appends, so an item's file position never
changes meaning once printed, and a batch read off one `list` stays correct regardless of
order or how many land in between.

`list` keeps showing pending-only by default, so numbers now have gaps (1, 3, 5) as items
resolve. That reads as a display bug unless you say otherwise, so `list` prints a footer:

```
(3 resolved item(s) hidden — numbers are stable file positions, so gaps are expected. `list --all` shows everything.)
```

### Two guards on the write path

A stale number from an older `list` is the residual risk, so the write refuses in the two
cases where it is most likely wrong:

1. **Re-resolving an already-`[x]` item aborts** instead of overwriting its result. This is
   what a stale number most often lands on, and silently re-stamping destroys the earlier
   provenance line.
2. **`--expect "<substring>"`** aborts unless the target item contains that text
   (case-insensitive). Turns "right command, wrong row" into an error. A valueless `--expect`
   fails rather than silently disabling the guard.

Both print the offending item's text, so the error shows you what you almost hit.

`modes/agent-inbox.md` now instructs the draining agent to pass `--expect` every time.

Happy to split `--expect` into a follow-up PR if you'd rather keep this one purely a fix —
it's bundled because it's the hardening for this specific failure, and the flag is opt-in and
backward-compatible.

### Tests

`agent-inbox-tests.mjs` gains three cases:

- **7 — the regression proper.** Queue five items, snapshot `list` **once**, then fire four
  resolves against that snapshot with no re-listing. Asserts each result landed on the item it
  named, the survivor kept its original number, and the footer explains the gap. Fails against
  the old code with results on the wrong items.
- **8** — re-resolving a done item exits 1, says why, and leaves the original result intact.
- **9** — `--expect` mismatch exits 1 and writes nothing; valueless `--expect` exits 1 and
  writes nothing; a case-insensitive match resolves normally.

Plus a `runFail` helper for exit-code assertions.

`node agent-inbox-tests.mjs` → **33 passed, 0 failed** (16 on `main`).

`node test-all.mjs` on a clean checkout of this branch → **3429 passed, 0 failed**, 2 warnings
(both environmental: no user `cv.md`, and no Go compiler for the dashboard build).

### Relationship to #2614

#2614 (open) fixes a different bug in the same file — concurrent `add` losing items — and
touches only `add` and its test. No logical overlap with this change; a textual conflict is
possible if both land. Happy to rebase on top of it, in either order.

### Docs

`docs/SCRIPTS.md` gains rows for `list` and `resolve` (neither was registered).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable inbox item numbers that remain consistent as earlier items are resolved.
  * Added optional case-insensitive `--expect` validation when resolving items.
  * Added clearer reporting of hidden resolved-item gaps and stamped resolution results.

* **Bug Fixes**
  * Prevented resolving missing or already-completed items.
  * Improved batch resolution behavior using a single list snapshot.

* **Documentation**
  * Documented inbox listing, resolution, stable numbering, validation, result stamping, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->