### PR TITLE
fix(doctor): detect Playwright MCP servers provided by Claude Code plugins

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -6,6 +6,7 @@
  */
 
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
@@ -152,9 +153,11 @@ async function checkPlaywright() {
   }
 }
 
-// Per-CLI MCP config registry.
+// Per-CLI MCP config registry. `plugins: true` marks a CLI whose MCP servers
+// can also arrive from an installed plugin, i.e. from outside the project root
+// (see isPlaywrightMcpFromPlugin).
 const MCP_CONFIGS = [
-  { cli: 'claude',   files: ['.mcp.json', '.claude/settings.json', '.claude/settings.local.json'] },
+  { cli: 'claude',   files: ['.mcp.json', '.claude/settings.json', '.claude/settings.local.json'], plugins: true },
   // opencode.jsonc is JSONC: OpenCode accepts comments and trailing commas
   // there, and JSON.parse throwing on them used to read as "no MCP server
   // configured" (#2252).
@@ -168,21 +171,73 @@ function isPlaywrightServer(server) {
   return blob.includes('@playwright/mcp');
 }
 
+// Any bucket shape that can hold a server map. A plugin's own .mcp.json is a
+// BARE map ({ "playwright": {...} }) rather than the mcpServers/mcp wrapper the
+// project-root configs use, so `cfg` itself is a candidate bucket (#2752).
+function hasPlaywrightIn(cfg, { bare = false } = {}) {
+  if (!cfg || typeof cfg !== 'object') return false;
+  const buckets = [cfg.mcpServers, cfg.mcp, ...(bare ? [cfg] : [])]
+    .filter((b) => b && typeof b === 'object');
+  return buckets.some((servers) => Object.values(servers).some(isPlaywrightServer));
+}
+
+// Missing or malformed file reads as "not configured", never as a crash -
+// matches the pre-existing swallow-and-continue behavior of the project scan.
+function readConfigIfPresent(file) {
+  if (!existsSync(file)) return null;
+  try {
+    return parseConfigByExtension(file, readFileSync(file, 'utf8')) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Claude Code's user config dir. CLAUDE_CONFIG_DIR is the documented override;
+// the tests point it at a tmpdir so this never reads the real machine.
+function claudeConfigDir() {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+}
+
+// A Claude Code plugin declares its MCP servers in its own .mcp.json, which
+// lives under the user's config dir - never in the project root. The
+// project-root scan below therefore reports "not detected" on a machine where
+// Playwright MCP is installed and working, which reads as though the MANDATORY
+// offer-liveness verification in AGENTS.md cannot be met (#2752).
+//
+// Only ENABLED plugins count: an installed-but-disabled plugin still ships its
+// manifest on disk, but registers no server. Enumeration is driven by the two
+// manifests rather than by walking plugins/cache, so a large cache costs
+// nothing and disabled plugins are never read.
+function isPlaywrightMcpFromPlugin() {
+  const configDir = claudeConfigDir();
+
+  const enabled = readConfigIfPresent(join(configDir, 'settings.json'))?.enabledPlugins;
+  if (!enabled || typeof enabled !== 'object') return false;
+
+  const installed = readConfigIfPresent(join(configDir, 'plugins', 'installed_plugins.json'))?.plugins;
+  if (!installed || typeof installed !== 'object') return false;
+
+  return Object.entries(enabled).some(([key, on]) => {
+    if (on !== true) return false;
+    const entries = Array.isArray(installed[key]) ? installed[key] : [];
+    return entries.some(({ installPath } = {}) => {
+      if (typeof installPath !== 'string' || !installPath) return false;
+      return hasPlaywrightIn(readConfigIfPresent(join(installPath, '.mcp.json')), { bare: true });
+    });
+  });
+}
+
 function isPlaywrightMcpConfigured(root, activeCli) {
   const entry = MCP_CONFIGS.find((c) => c.cli === activeCli);
   if (!entry) return false; // known CLI but no MCP file mapping; caller warns
-  return entry.files.some((rel) => {
+  const inProject = entry.files.some((rel) => {
     const file = join(root, ...rel.split('/'));
-    if (!existsSync(file)) return false;
-    try {
-      const cfg = parseConfigByExtension(file, readFileSync(file, 'utf8')) ?? {};
-      const buckets = [cfg.mcpServers, cfg.mcp].filter((b) => b && typeof b === 'object');
-      return buckets.some((servers) => Object.values(servers).some(isPlaywrightServer));
-    } catch {
-      // Malformed config — treat as unconfigured, keep silent (matches prior behavior).
-    }
-    return false;
+    return hasPlaywrightIn(readConfigIfPresent(file));
   });
+  if (inProject) return true;
+  // Gated behind the project scan, so an already-configured project pays no
+  // extra I/O and non-plugin CLIs never touch the user config dir.
+  return entry.plugins === true && isPlaywrightMcpFromPlugin();
 }
 
 // CLI resolution: --cli flag > $CAREER_OPS_CLI > .env (CAREER_OPS_CLI=...) >
@@ -239,10 +294,12 @@ function checkPlaywrightMcp(root, activeCli) {
     warn: true,
     label: `Playwright MCP tools not detected (active CLI: ${activeCli})`,
     fix: [
-      `No project-level MCP config was detected for ${activeCli}.`,
+      entry.plugins
+        ? `No project-level MCP config, and no enabled plugin providing one, was detected for ${activeCli}.`
+        : `No project-level MCP config was detected for ${activeCli}.`,
       activeCli === 'opencode'
         ? 'Add the Playwright MCP server to opencode.json (see opencode.example.json) or pass --cli <name> if you actually run a different CLI.'
-        : `Add the Playwright MCP server to your ${activeCli} config.`,
+        : `Add the Playwright MCP server to your ${activeCli} config, or install a plugin that provides it (e.g. /plugin install playwright@claude-plugins-official).`,
     ],
   };
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10433,10 +10433,20 @@ try {
     fail('doctor Playwright MCP guidance is still Claude-specific or lost config detection');
   }
 
+  // doctor also accepts a Playwright MCP server provided by an installed Claude
+  // Code plugin, which lives in the user's config dir rather than the --target
+  // project (#2752). Pin CLAUDE_CONFIG_DIR at an empty dir so these assertions
+  // describe the fixture and not whichever plugins the developer happens to
+  // have enabled; without it "no MCP config" is false on a real machine and the
+  // warning assertion below fails. Same reasoning as the GIT_CONFIG_* pinning
+  // in section 12c.
+  const emptyClaudeCfg = mkdtempSync(join(tmpdir(), 'co-emptycfg-'));
+  const doctorEnv = { env: { ...process.env, CLAUDE_CONFIG_DIR: emptyClaudeCfg } };
+
   // No project MCP config → doctor surfaces a (non-fatal) warning instead of
   // letting SPA job boards fail silently.
   const noMcp = mkdtempSync(join(tmpdir(), 'co-nomcp-'));
-  const a = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', noMcp]) || '{}');
+  const a = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', noMcp], doctorEnv) || '{}');
   if (Array.isArray(a.warnings) && a.warnings.some((w) => /playwright mcp/i.test(w))) {
     pass('No Playwright MCP config → warning surfaced');
   } else {
@@ -10451,7 +10461,7 @@ try {
     join(withMcp, '.claude', 'settings.json'),
     JSON.stringify({ mcpServers: { playwright: { command: 'npx', args: ['@playwright/mcp', '--headless'] } } }),
   );
-  const b = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', withMcp]) || '{}');
+  const b = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', withMcp], doctorEnv) || '{}');
   if (Array.isArray(b.warnings) && !b.warnings.some((w) => /playwright mcp/i.test(w))) {
     pass('Playwright MCP configured → no warning');
   } else {
@@ -10466,13 +10476,14 @@ try {
     join(withLocalMcp, '.claude', 'settings.local.json'),
     JSON.stringify({ mcpServers: { browser: { command: 'npx', args: ['@playwright/mcp'] } } }),
   );
-  const c = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', withLocalMcp]) || '{}');
+  const c = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', withLocalMcp], doctorEnv) || '{}');
   if (Array.isArray(c.warnings) && !c.warnings.some((w) => /playwright mcp/i.test(w))) {
     pass('Playwright MCP configured via .claude/settings.local.json → no warning');
   } else {
     fail(`Did not expect a Playwright MCP warning for settings.local.json, got: ${JSON.stringify(c.warnings)}`);
   }
   rmSync(withLocalMcp, { recursive: true, force: true });
+  rmSync(emptyClaudeCfg, { recursive: true, force: true });
 } catch (e) {
   fail(`Playwright MCP detection test crashed: ${e.message}`);
 }

--- a/tests/playwright-mcp-detection.test.mjs
+++ b/tests/playwright-mcp-detection.test.mjs
@@ -13,11 +13,21 @@ console.log('\ndoctor.mjs — CLI-aware Playwright MCP detection');
 
 const DOCTOR = join(ROOT, 'doctor.mjs');
 
+// Claude Code can supply an MCP server from an installed plugin, which lives
+// under the user's config dir rather than the project root (#2752). Every
+// scenario therefore pins CLAUDE_CONFIG_DIR at an EMPTY dir by default, so a
+// developer's real machine can never decide the result - the same isolation
+// reasoning as the GIT_CONFIG_* pinning in test-all.mjs section 12c (#2569).
+// Scenarios that exercise the plugin path pass their own CLAUDE_CONFIG_DIR.
+const EMPTY_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'co-mcp-emptycfg-'));
+
 function runDoctor(cwd, args, env) {
   try {
     const out = execFileSync(NODE, [DOCTOR, '--json', '--target', cwd, ...args], {
       cwd,
-      env: { ...process.env, ...env },
+      // Order matters: the empty dir must override an ambient CLAUDE_CONFIG_DIR
+      // from the developer's own shell, while a scenario's explicit env still wins.
+      env: { ...process.env, CLAUDE_CONFIG_DIR: EMPTY_CONFIG_DIR, ...env },
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
     }).trim();
@@ -25,6 +35,22 @@ function runDoctor(cwd, args, env) {
   } catch (e) {
     return { _error: e.message, _stderr: e.stderr ? String(e.stderr) : '' };
   }
+}
+
+// Build a fake Claude Code config dir: settings.json (enabledPlugins) plus
+// plugins/installed_plugins.json (installPath per plugin) plus each plugin's
+// own .mcp.json - the exact three-file shape doctor resolves.
+function makePluginHome({ key, enabled, mcpJson }) {
+  const dir = mkdtempSync(join(tmpdir(), 'co-mcp-home-'));
+  const installPath = join(dir, 'plugins', 'cache', 'marketplace', 'plugin', 'unknown');
+  mkdirSync(installPath, { recursive: true });
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify({ enabledPlugins: { [key]: enabled } }));
+  writeFileSync(
+    join(dir, 'plugins', 'installed_plugins.json'),
+    JSON.stringify({ version: 2, plugins: { [key]: [{ scope: 'user', installPath }] } }),
+  );
+  if (mcpJson !== null) writeFileSync(join(installPath, '.mcp.json'), mcpJson);
+  return dir;
 }
 
 function expectWarn(state, msg) {
@@ -426,6 +452,177 @@ try {
     } finally { rmSync(dir, { recursive: true, force: true }); }
   }
 
+  // ---------------------------------------------------------------------
+  // Plugin-provided MCP servers (#2752). A Claude Code plugin declares its
+  // servers in its own .mcp.json under the user config dir, so none of the
+  // project-root scenarios above can reach this path. Every case below points
+  // CLAUDE_CONFIG_DIR at a synthetic config dir; the project --target stays
+  // empty, so a pass can ONLY come from the plugin scan.
+  // ---------------------------------------------------------------------
+  const PLUGIN_KEY = 'playwright@claude-plugins-official';
+  const PLUGIN_MCP = JSON.stringify({ playwright: { command: 'npx', args: ['@playwright/mcp@latest'] } });
+
+  // 19. Enabled plugin whose .mcp.json is a BARE server map → detected.
+  //     This is the exact shape the official Playwright plugin ships, and the
+  //     case that regressed: doctor reported "not detected" on a machine where
+  //     Playwright MCP was installed, enabled and working.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-19-'));
+    const home = makePluginHome({ key: PLUGIN_KEY, enabled: true, mcpJson: PLUGIN_MCP });
+    try {
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#19 enabled plugin')) {
+        // already failed
+      } else if (state.playwright_mcp?.claude === true
+          && Array.isArray(state.warnings)
+          && !state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('enabled plugin with a bare-map .mcp.json → detected, no warning (#2752)');
+      } else {
+        fail(`#19 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  // 20. Installed but NOT enabled → still warns. The manifest is on disk and
+  //     the .mcp.json is readable, but a disabled plugin registers no server;
+  //     keying off installed_plugins.json alone would pass this wrongly.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-20-'));
+    const home = makePluginHome({ key: PLUGIN_KEY, enabled: false, mcpJson: PLUGIN_MCP });
+    try {
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#20 disabled plugin')) {
+        // already failed
+      } else if (state.playwright_mcp?.claude === false
+          && Array.isArray(state.warnings)
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('installed but DISABLED plugin → still warns (installed !== enabled)');
+      } else {
+        fail(`#20 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  // 21. Enabled plugin that provides some OTHER MCP server → warns. Guards
+  //     against "any enabled plugin with an .mcp.json counts".
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-21-'));
+    const home = makePluginHome({
+      key: 'notion@some-marketplace',
+      enabled: true,
+      mcpJson: JSON.stringify({ notion: { command: 'npx', args: ['@notionhq/mcp'] } }),
+    });
+    try {
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#21 unrelated plugin')) {
+        // already failed
+      } else if (state.playwright_mcp?.claude === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('enabled plugin providing a non-Playwright server → still warns');
+      } else {
+        fail(`#21 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  // 22. Malformed plugin .mcp.json → reads as unconfigured, no crash. Matches
+  //     how a malformed project config is already handled.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-22-'));
+    const home = makePluginHome({ key: PLUGIN_KEY, enabled: true, mcpJson: '{ "playwright": { "command": [ }' });
+    try {
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#22 malformed plugin .mcp.json')) {
+        // already failed
+      } else if (state.playwright_mcp?.claude === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('malformed plugin .mcp.json → unconfigured, doctor does not crash');
+      } else {
+        fail(`#22 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  // 23. Enabled plugin whose entry has NO .mcp.json at all → warns, no crash.
+  //     Most plugins ship only skills/commands; the file is optional.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-23-'));
+    const home = makePluginHome({ key: PLUGIN_KEY, enabled: true, mcpJson: null });
+    try {
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#23 plugin without .mcp.json')) {
+        // already failed
+      } else if (state.playwright_mcp?.claude === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('enabled plugin with no .mcp.json → warns, no crash');
+      } else {
+        fail(`#23 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  // 24. The plugin scan is scoped to CLIs that declare `plugins: true`. With
+  //     --cli opencode the very same enabled Playwright plugin must NOT
+  //     suppress the warning: OpenCode does not load Claude Code plugins.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-24-'));
+    const home = makePluginHome({ key: PLUGIN_KEY, enabled: true, mcpJson: PLUGIN_MCP });
+    try {
+      const state = runDoctor(dir, ['--cli', 'opencode'], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#24 opencode ignores claude plugins')) {
+        // already failed
+      } else if (state.playwright_mcp?.opencode === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w) && /active cli: opencode/i.test(w))) {
+        pass('--cli opencode ignores an enabled Claude Code plugin → still warns');
+      } else {
+        fail(`#24 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  // 25. An empty config dir (no settings.json, no installed_plugins.json) is
+  //     the default every other scenario runs under. Pin that it stays quiet
+  //     and warns rather than throwing, so the isolation added for #2752
+  //     cannot itself become a crash source on a machine with no plugins.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-25-'));
+    const home = mkdtempSync(join(tmpdir(), 'co-mcp-emptyhome-'));
+    try {
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (!expectWarn(state, '#25 empty config dir')) {
+        // already failed
+      } else if (state.playwright_mcp?.claude === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('empty CLAUDE_CONFIG_DIR → warns cleanly, no crash');
+      } else {
+        fail(`#25 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
 } catch (e) {
   fail(`opencode-mcp-detection tests crashed: ${e.message}`);
+} finally {
+  rmSync(EMPTY_CONFIG_DIR, { recursive: true, force: true });
 }


### PR DESCRIPTION
Closes #2752.

`doctor.mjs` reported `Playwright MCP tools not detected` on an install where Playwright MCP was installed, enabled, and working, because the server came from a **Claude Code plugin** and `isPlaywrightMcpConfigured()` only read project-root files. Since `AGENTS.md` makes Playwright verification MANDATORY for offer liveness, the warning read as "you cannot meet the mandate" on a machine that could.

This implements **option A** from the issue. If you would rather keep doctor's read boundary at the project root (option B), say so and I will swap it for the warning-text-only change; the plugin scan is deliberately isolated in one function so backing it out is a small diff.

## What changed

`doctor.mjs`

- `MCP_CONFIGS` gains `plugins: true` on the `claude` entry. Only a CLI carrying that flag ever consults the user config dir, so OpenCode's path is untouched.
- `isPlaywrightMcpFromPlugin()` resolves plugin-provided servers from the two manifests Claude Code already maintains: `settings.json` → `enabledPlugins`, then `plugins/installed_plugins.json` → `installPath`, then `<installPath>/.mcp.json`. No globbing, no directory walk, and disabled plugins are never read.
- `hasPlaywrightIn()` extracts the bucket scan and adds the **bare server map** shape. A plugin `.mcp.json` is `{ "playwright": {...} }`, not wrapped in `mcpServers`/`mcp`, so the previous bucket list parsed it to zero servers even if it had been in range.
- `readConfigIfPresent()` centralizes the missing-or-malformed-reads-as-absent behavior that the project scan already had, so a broken manifest still cannot crash doctor.
- The plugin scan is gated behind the project-root scan, so an already-configured project pays no extra I/O.
- The warning hint now names the plugin route instead of only "add it to your config".

`tests/playwright-mcp-detection.test.mjs`

- `runDoctor()` pins `CLAUDE_CONFIG_DIR` at an empty tmpdir for **every** scenario. Without this the existing 18 cases would start reading the developer's real machine and pass or fail depending on which plugins they happen to have installed. Same isolation reasoning as the `GIT_CONFIG_*` pinning in `test-all.mjs` section 12c. The empty dir is applied after `...process.env` so an ambient `CLAUDE_CONFIG_DIR` in a developer's shell cannot defeat it, and before `...env` so a scenario can still opt in.
- Seven new scenarios (#19-#25) covering the plugin path.

`test-all.mjs` (section 12d)

- The same pin, for the same reason. Section 12d spawns `doctor.mjs --target <empty dir>` and asserts a Playwright MCP warning appears. Once doctor can see plugin-provided servers, that premise is false on any machine with the plugin enabled, and the assertion fails. This is not a workaround for the new behavior: the section was already describing the developer's machine rather than its fixture, and only became visible because doctor learned to look. All three `doctor.mjs` spawns in the section now pass an empty `CLAUDE_CONFIG_DIR`.

## Verification

Both states, the way the issue was proven, on a machine with `playwright@claude-plugins-official` installed and enabled:

| State | Before | After | Expected |
|---|---|---|---|
| Real machine, plugin installed + enabled | `{"claude": false}` | `{"claude": true}` | `true` |
| Empty config dir, no plugin | `{"claude": false}` | `{"claude": false}` | `false` |

Before the fix both states returned `false`, so the check could not distinguish a working install from a missing one. After it, the human-readable run prints `✓ Playwright MCP server configured (claude)` with zero warnings.

Every new assertion was mutation-tested; each mutation broke exactly the scenario it should and nothing else:

| Mutation | Scenario that went red |
|---|---|
| plugin scan disabled | #19 enabled plugin detected |
| `enabled` check removed | #20 installed but disabled |
| bare-map support removed | #19 official plugin ships a bare map |
| per-CLI gate removed | #24 opencode must ignore claude plugins |

Restoring each time returned the file to 25/25 green.

The section 12d pin is proven the same way: with the pin removed the assertion fails on a machine with the plugin enabled (`Expected a Playwright MCP warning, got: []`), and passes with it.

## One thing to flag, unrelated to this PR

`node test-all.mjs` currently hard-aborts on `main` on my machine, before reaching the end:

```
🧪 Testing updater rollback behavior (#2015)...
error: 1Password: failed to fill whole buffer
fatal: failed to write commit object
Error: Command failed: git commit -qm base
    at gitIn (update-system.mjs:509:12)
```

The fixture's `git commit` inherits the developer's global git config, so on any machine with commit signing configured it dies rather than skipping. It is the same class as the `GIT_CONFIG_*` isolation already applied in section 12c. I ran the suite for this PR with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` to get past it. Happy to file it separately if it is not already known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playwright MCP detection now recognizes enabled Claude plugins.
  * Supports plugin configurations using common server configuration formats.
  * Provides clearer guidance when Playwright MCP is unavailable from project settings or enabled plugins.

* **Bug Fixes**
  * Configuration checks now handle missing or malformed files without failing.
  * Existing project-level MCP configuration formats remain supported.

* **Tests**
  * Expanded coverage for enabled, disabled, unrelated, malformed, and missing plugin configurations.
  * Tests now run in isolated temporary configuration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->