### PR TITLE
perf(analytics): shared stat-validated reports-index cache (#2385)

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -30,6 +30,7 @@ These files contain your personal data, customizations, and work product. Update
 | `plugins.lock` | Integrity pins + recorded consent for your enabled plugins (generated; never auto-updated) |
 | `data/applications.md` | Your application tracker (source of truth) |
 | `data/applications.db` | Derived query index over `applications.md` (SQLite, rebuilt by `node tracker.mjs sync` — safe to delete) |
+| `data/reports-index.json` | Derived Machine-Summary cache over `reports/*` (stat-validated + rebuilt by `analyze-patterns.mjs`/`upskill.mjs`/`salary-gap.mjs`; disposable — safe to delete any time) |
 | `data/pipeline.md` | Your URL inbox |
 | `data/scan-history.tsv` | Your scan history (tab-separated, append-only trailing columns; col 8: local SimHash JD fingerprint for cross-listing detection, col 9: posting date, cols 10-11: trust score/flags, col 12: normalized company key for repost/name matching). Older rows may have fewer columns — readers index by position and tolerate the absence. |
 | `data/scan-runs.tsv` | Your per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -15,47 +15,15 @@
 
 import { readFileSync, existsSync, realpathSync, writeFileSync, symlinkSync, rmSync } from 'fs';
 import { join, dirname, relative, sep } from 'path';
-import { fileURLToPath } from 'url';
-import { load as yamlLoad } from 'js-yaml';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { resolveColumns, parseTrackerRow, normalizeVia } from './tracker-parse.mjs';
+import { parseMachineSummary, splitEntry, loadReportsIndex } from './reports-index.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
   ? join(CAREER_OPS, 'data/applications.md')
   : join(CAREER_OPS, 'applications.md');
 const REPORTS_DIR = join(CAREER_OPS, 'reports');
-
-const MACHINE_SUMMARY_FIELDS = new Set([
-  'company',
-  'role',
-  'score',
-  'legitimacy_tier',
-  'archetype',
-  'final_decision',
-  'hard_stops',
-  'soft_gaps',
-  'top_strengths',
-  'risk_level',
-  'confidence',
-  'next_action',
-  // Optional context fields accepted for future reports.
-  'domain',
-  'seniority',
-  'remote',
-  'team_size',
-  // Issue 1380: predicted skip/discard reasons from the agent.
-  'discard_reasons',
-  'advertised_comp',
-  'via',
-  'company_confidential',
-  'risk_summary',
-  // Work-authorization / visa-sponsorship tier from Block A (report + Machine
-  // Summary only). Allowlisted so it round-trips; no consumer logic yet.
-  'work_auth',
-  // Reporting line stated by the JD, verbatim (report + Machine Summary only).
-  // Allowlisted so it round-trips; no consumer logic yet.
-  'reports_to',
-]);
 
 // --- CLI args ---
 const args = process.argv.slice(2);
@@ -158,23 +126,10 @@ function normalizeScalar(value) {
   return null;
 }
 
-function parseMachineSummary(content) {
-  const fenceMatch = content.match(/##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n([\s\S]*?)\n```/i);
-  if (!fenceMatch) return null;
-
-  const raw = fenceMatch[1].trim();
-  if (!raw) return null;
-
-  try {
-    const parsed = yamlLoad(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-    return Object.fromEntries(
-      Object.entries(parsed).filter(([key]) => MACHINE_SUMMARY_FIELDS.has(key))
-    );
-  } catch {
-    return null;
-  }
-}
+// The canonical Machine-Summary parser + core allowlist now live in
+// reports-index.mjs (imported above). parseMachineSummary returns the FULL
+// object; splitEntry(parsed).summary applies the CORE_SUMMARY_FIELDS filter this
+// script historically relied on.
 
 // --- Via channel analysis (#1596 follow-up) ---
 // Pure: group submitted applications by their Via channel (agency/recruiter
@@ -623,7 +578,10 @@ function readTextIfExists(path) {
 }
 
 // --- Parse a single report file ---
-function parseReport(reportPath) {
+// `index` (optional): a loadReportsIndex() handle. When provided, the Machine
+// Summary comes from the stat-validated cache (no re-parse); the report body is
+// still read for the Block A table, scoring table, URL, and Gap table below.
+function parseReport(reportPath, index) {
   const content = readTextIfExists(reportPath);
   if (content === null) return null;
   const report = {
@@ -647,7 +605,14 @@ function parseReport(reportPath) {
     gaps: [],
   };
 
-  const machineSummary = parseMachineSummary(content);
+  const entry = index ? index.get(reportPath) : null;
+  let machineSummary;
+  if (entry) {
+    machineSummary = entry.summary; // core-filtered (may be null for no-fence reports)
+  } else {
+    const parsed = parseMachineSummary(content);
+    machineSummary = parsed ? splitEntry(parsed).summary : null;
+  }
   if (machineSummary) {
     report.machineSummary = machineSummary;
     report.company = normalizeScalar(machineSummary.company) || report.company;
@@ -927,12 +892,17 @@ function buildPatternSignals(enriched) {
 }
 
 // --- Main analysis ---
-function analyze() {
+function analyze(options = {}) {
   const entries = parseTracker();
 
   if (entries.length === 0) {
     return { error: 'No applications found in tracker.' };
   }
+
+  // Shared, stat-validated Machine-Summary cache over reports/ — one parser and
+  // one on-disk cache across analyze-patterns/upskill/salary-gap. --no-cache
+  // threads through to skip both reading and writing the JSON.
+  const index = loadReportsIndex({ noCache: options.noCache });
 
   // Enrich entries with report data and classification
   const enriched = entries.map(e => {
@@ -950,7 +920,7 @@ function analyze() {
       ]);
       for (const candidate of candidates) {
         if (!withinReports(candidate)) continue;
-        reportData = parseReport(candidate);
+        reportData = parseReport(candidate, index);
         if (reportData) break;
       }
     }
@@ -1397,16 +1367,20 @@ function printSummary(result) {
 }
 
 // --- Run ---
-if (args.includes('--self-test')) {
-  runSelfTest();
+// isMain guard so importing this module (e.g. from a test) is side-effect-free.
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+  if (args.includes('--self-test')) {
+    runSelfTest();
+  }
+
+  const result = analyze({ noCache: args.includes('--no-cache') });
+
+  if (summaryMode) {
+    printSummary(result);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+
+  if (result.error) process.exit(1);
 }
-
-const result = analyze();
-
-if (summaryMode) {
-  printSummary(result);
-} else {
-  console.log(JSON.stringify(result, null, 2));
-}
-
-if (result.error) process.exit(1);

--- a/reports-index.mjs
+++ b/reports-index.mjs
@@ -74,6 +74,9 @@ export const CORE_SUMMARY_FIELDS = new Set([
   // Work-authorization / visa-sponsorship tier from Block A (report + Machine
   // Summary only). Allowlisted so it round-trips; no consumer logic yet.
   'work_auth',
+  // Reporting line stated by the JD, verbatim (report + Machine Summary only).
+  // Allowlisted so it round-trips; no consumer logic yet.
+  'reports_to',
 ]);
 
 // Report filename shape — same as salary-gap.mjs's REPORT_FILE_RE, so sentinels

--- a/reports-index.mjs
+++ b/reports-index.mjs
@@ -30,6 +30,7 @@ import {
   readdirSync,
   statSync,
   existsSync,
+  realpathSync,
 } from 'fs';
 import { join, dirname, relative, isAbsolute, resolve, basename, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -163,6 +164,39 @@ function toRelKey(p, reportsDir) {
   return rel;
 }
 
+// realpath-containment guard for every on-disk read this module performs. The
+// filename filter (REPORT_FILE_RE) and toRelKey() are LEXICAL only: a symlink
+// planted inside reportsDir (e.g. reports/042-evil-2026-01-01.md → /etc/passwd)
+// has a perfectly valid lexical path, so statSync()/readFileSync() would follow
+// it and splice an out-of-tree file's Machine Summary into the shared index and
+// data/reports-index.json. Canonicalize the candidate with realpathSync and
+// require it to stay inside the canonical reportsDir before any read (#2762).
+// realRoot is resolved once per load; a candidate whose realpath cannot be
+// resolved (broken/dangling link) is rejected. Mirrors withinReports() in
+// analyze-patterns.mjs / upskill.mjs, applied here at the read site.
+function realRootOf(reportsDir) {
+  try {
+    return realpathSync(reportsDir);
+  } catch {
+    return null;
+  }
+}
+
+function withinRealRoot(abs, realRoot) {
+  if (!realRoot) return false;
+  let real;
+  try {
+    real = realpathSync(abs);
+  } catch {
+    // ENOENT/ENOTDIR (missing or broken symlink) or any resolve failure: do not
+    // read it. Enumeration already filtered to existing dir entries, so this is
+    // an escaping/broken link, not a normal missing file.
+    return false;
+  }
+  const rootWithSep = realRoot.endsWith(sep) ? realRoot : realRoot + sep;
+  return real === realRoot || real.startsWith(rootWithSep);
+}
+
 function serializeIndex(entries) {
   const obj = { version: INDEX_VERSION, entries: {} };
   // Sorted keys → deterministic on-disk bytes across runs.
@@ -178,6 +212,28 @@ function serializeIndex(entries) {
   return JSON.stringify(obj, null, 2) + '\n';
 }
 
+// A cache entry is only safe to reuse if BOTH its stat metadata AND its nested
+// payload are well-formed. Top-level version/shape checks are not enough: a
+// stat-matching entry with a malformed `summary` or a missing
+// `extras.salaryGap.advertised_comp` would be trusted and then crash a consumer
+// (salary-gap.mjs reads `entry.extras.salaryGap.advertised_comp` directly). One
+// bad entry poisons the whole cache, so any malformed entry forces a full
+// rebuild rather than a silent per-entry repair (#2762).
+function isValidCacheEntry(e) {
+  if (!e || typeof e !== 'object' || Array.isArray(e)) return false;
+  if (typeof e.mtimeMs !== 'number' || !Number.isFinite(e.mtimeMs)) return false;
+  if (typeof e.size !== 'number' || !Number.isFinite(e.size)) return false;
+  // summary is either null (no usable Machine Summary) or a plain object.
+  if (e.summary !== null && (typeof e.summary !== 'object' || Array.isArray(e.summary))) return false;
+  // extras must carry salaryGap.advertised_comp (value-or-null) so salary-gap's
+  // `entry.extras.salaryGap.advertised_comp` read never dereferences undefined.
+  const sg = e.extras && typeof e.extras === 'object' && !Array.isArray(e.extras)
+    ? e.extras.salaryGap
+    : null;
+  if (!sg || typeof sg !== 'object' || Array.isArray(sg) || !('advertised_comp' in sg)) return false;
+  return true;
+}
+
 function readCache(cachePath) {
   try {
     const parsed = JSON.parse(readFileSync(cachePath, 'utf-8'));
@@ -188,6 +244,11 @@ function readCache(cachePath) {
       parsed.entries &&
       typeof parsed.entries === 'object'
     ) {
+      // Validate every entry's nested shape before trusting ANY of them; a
+      // single malformed entry rejects the whole cache (force rebuild).
+      for (const key of Object.keys(parsed.entries)) {
+        if (!isValidCacheEntry(parsed.entries[key])) return null;
+      }
       return parsed.entries;
     }
   } catch {
@@ -218,12 +279,17 @@ export function loadReportsIndex({
   }
 
   const cache = noCache ? null : readCache(cachePath);
+  const realRoot = realRootOf(reportsDir);
 
   const entries = new Map();
   let reused = 0;
   let parsed = 0;
   for (const file of files) {
     const abs = join(reportsDir, file);
+    // Reject a symlinked candidate whose realpath escapes reportsDir BEFORE any
+    // stat/read — a lexically-valid filename is not proof the bytes live inside
+    // reports/ (#2762).
+    if (!withinRealRoot(abs, realRoot)) continue;
     let stat;
     try {
       stat = statSync(abs);
@@ -282,6 +348,10 @@ export function loadReportsIndex({
       if (key === null) return null;
       if (entries.has(key)) return entries.get(key);
       const abs = join(reportsDir, key);
+      // Same realpath-containment guard as the enumeration loop: toRelKey is
+      // lexical, so an on-demand lookup of a symlink escaping reports/ must not
+      // be read either (#2762).
+      if (!withinRealRoot(abs, realRoot)) return null;
       let stat;
       let content;
       try {
@@ -500,6 +570,73 @@ advertised_comp: "${adv}"
       if (!CORE_SUMMARY_FIELDS.has('via') || !CORE_SUMMARY_FIELDS.has('company_confidential')) failures.push('7: CORE_SUMMARY_FIELDS must contain via + company_confidential');
       if (CORE_SUMMARY_FIELDS.has('advertised_comp')) failures.push('7: CORE_SUMMARY_FIELDS must NOT contain advertised_comp');
     }
+
+    // ── 8. Symlink escaping reportsDir is never stat/read into the index ─────
+    // A lexically-valid report filename that is really a symlink whose target
+    // lives OUTSIDE reportsDir must be rejected before any read, so an out-of-
+    // tree file's Machine Summary never enters the shared index or the on-disk
+    // cache (#2762). symlinkSync needs privilege on Windows — skip (do not fail)
+    // the assertion when the platform refuses.
+    {
+      const ws = makeWorkspace();
+      const real = join(ws.reportsDir, '001-real-2026-01-01.md');
+      writeFileSync(real, canonicalReport('RealCo'));
+      const outsideFile = join(ws.root, 'secret.md');
+      writeFileSync(outsideFile, canonicalReport('LEAKED-SECRET'));
+      const link = join(ws.reportsDir, '999-leak-2026-01-01.md');
+      let linked = false;
+      try {
+        fs.symlinkSync(outsideFile, link);
+        linked = true;
+      } catch (err) {
+        if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOSYS') {
+          console.log(`reports-index self-test: skipping symlink-escape assertion (platform refused symlink: ${err.code})`);
+        } else {
+          throw err;
+        }
+      }
+      if (linked) {
+        const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+        const names = [...idx].map(([k]) => k);
+        if (names.includes('999-leak-2026-01-01.md')) failures.push('8: symlink escaping reportsDir was read into the index (#2762)');
+        if (idx.get(link) !== null) failures.push('8: get() followed a symlink escaping reportsDir (#2762)');
+        if (!names.includes('001-real-2026-01-01.md')) failures.push('8: real in-tree report wrongly dropped alongside the symlink guard');
+        const onDisk = JSON.parse(fs.readFileSync(ws.cachePath, 'utf-8'));
+        if ('999-leak-2026-01-01.md' in onDisk.entries) failures.push('8: symlink escape leaked into the on-disk cache (#2762)');
+      }
+    }
+
+    // ── 9. A malformed cache entry rejects the WHOLE cache (rebuild) ─────────
+    // Valid JSON, correct version, stat-matching entry — but its nested payload
+    // is malformed (extras.salaryGap missing). Trusting it would later crash
+    // salary-gap's `entry.extras.salaryGap.advertised_comp` read, so a single
+    // bad entry must force a full rebuild from disk (#2762).
+    {
+      const ws = makeWorkspace();
+      const file = join(ws.reportsDir, '042-acme-2026-01-01.md');
+      writeFileSync(file, canonicalReport('Acme', '80-90k EUR'));
+      const st = fs.statSync(file);
+      const malformed = {
+        version: INDEX_VERSION,
+        entries: {
+          '042-acme-2026-01-01.md': {
+            summary: { company: 'STALE' },
+            extras: {}, // salaryGap.advertised_comp missing → malformed
+            mtimeMs: st.mtimeMs,
+            size: st.size,
+          },
+        },
+      };
+      writeFileSync(ws.cachePath, JSON.stringify(malformed));
+      const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const e = idx.get(file);
+      if (e?.summary?.company !== 'Acme') failures.push('9: malformed cache entry was trusted instead of forcing a rebuild (#2762)');
+      if (e?.extras?.salaryGap?.advertised_comp !== '80-90k EUR') failures.push('9: rebuilt entry missing advertised_comp after malformed-cache rejection');
+      if (idx.meta.parsed !== 1 || idx.meta.reused !== 0) failures.push('9: expected a full rebuild (parsed=1 reused=0) after a malformed cache entry');
+      // The rewritten cache must now be well-formed and reusable next load.
+      const idx2 = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      if (idx2.meta.reused !== 1) failures.push('9: rebuilt cache was not reused on the subsequent load');
+    }
   } finally {
     for (const root of tmpRoots) {
       try {
@@ -514,7 +651,7 @@ advertised_comp: "${adv}"
     console.error(`reports-index self-test failed: ${failures.join('; ')}`);
     process.exit(1);
   }
-  console.log('reports-index self-test OK (fresh build + stat-trust/invalidate + deletion + version bump + no-cache + fence variants + split contract)');
+  console.log('reports-index self-test OK (fresh build + stat-trust/invalidate + deletion + version bump + no-cache + fence variants + split contract + symlink-escape guard + malformed-cache rebuild)');
   process.exit(0);
 }
 

--- a/reports-index.mjs
+++ b/reports-index.mjs
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+/**
+ * reports-index.mjs — shared, stat-validated Machine-Summary cache over reports/
+ *
+ * Three analytics scripts (analyze-patterns.mjs, upskill.mjs, salary-gap.mjs)
+ * each parsed every report's `## Machine Summary` fence with their own private
+ * copy of the same fence regex + js-yaml load. That is three parsers to keep in
+ * sync and O(reports) YAML parses on every run of every script. This module is
+ * the ONE canonical parser plus a disposable on-disk cache keyed by (mtimeMs,
+ * size): a report whose file stat is unchanged since it was last indexed is
+ * trusted from cache and never re-read/re-parsed.
+ *
+ * The cache (data/reports-index.json) is a derived user-layer artifact: it is
+ * never a source of truth, is safe to delete at any time, and is rebuilt on the
+ * next run. Bumping INDEX_VERSION invalidates every on-disk entry.
+ *
+ * Schema split (per maintainer directive, #2385):
+ *   - `summary`  = the parsed object filtered to CORE_SUMMARY_FIELDS — the
+ *                  fields the pattern/upskill analyses consume.
+ *   - `extras.salaryGap.advertised_comp` = namespaced out of the core allowlist
+ *                  because only salary-gap.mjs reads it. Keeping it out of
+ *                  `summary` means a new salary-only field never widens the core
+ *                  allowlist the batch-prompt cross-check guards.
+ *
+ * Run: node reports-index.mjs --self-test
+ */
+
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+} from 'fs';
+import { join, dirname, relative, isAbsolute, resolve, basename, sep } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { load as yamlLoad } from 'js-yaml';
+import { writeFileAtomic } from './tracker-utils.mjs';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+
+// Bump to invalidate the entire on-disk cache. Any structural change to what an
+// entry stores (fields, extras shape, stat semantics) MUST bump this so a stale
+// cache from an older layout is rebuilt rather than trusted.
+export const INDEX_VERSION = 1;
+
+// The single source of truth for the core Machine-Summary allowlist. This is
+// analyze-patterns.mjs's historical MACHINE_SUMMARY_FIELDS MINUS `advertised_comp`
+// (now namespaced under extras.salaryGap). It MUST keep `via` and
+// `company_confidential` — test-all.mjs's batch-prompt↔allowlist cross-check
+// reads this set and asserts both are present.
+export const CORE_SUMMARY_FIELDS = new Set([
+  'company',
+  'role',
+  'score',
+  'legitimacy_tier',
+  'archetype',
+  'final_decision',
+  'hard_stops',
+  'soft_gaps',
+  'top_strengths',
+  'risk_level',
+  'confidence',
+  'next_action',
+  // Optional context fields accepted for future reports.
+  'domain',
+  'seniority',
+  'remote',
+  'team_size',
+  // Issue 1380: predicted skip/discard reasons from the agent.
+  'discard_reasons',
+  'via',
+  'company_confidential',
+  'risk_summary',
+  // Work-authorization / visa-sponsorship tier from Block A (report + Machine
+  // Summary only). Allowlisted so it round-trips; no consumer logic yet.
+  'work_auth',
+]);
+
+// Report filename shape — same as salary-gap.mjs's REPORT_FILE_RE, so sentinels
+// ({n}-RESERVED.md) and other junk in reports/ are skipped by enumeration.
+export const REPORT_FILE_RE = /^(\d{3})-.*-(\d{4}-\d{2}-\d{2})\.md$/;
+
+const DEFAULT_REPORTS_DIR = join(CAREER_OPS, 'reports');
+const DEFAULT_CACHE_PATH = join(CAREER_OPS, 'data', 'reports-index.json');
+
+/**
+ * The ONE canonical Machine-Summary parser. Fence accepts yaml/yml/json (JSON
+ * is a YAML subset, so js-yaml loads all three). Returns the FULL parsed object
+ * unfiltered, or null on: no fence, empty fence, parse error, or a non-object
+ * (scalar/array) top level.
+ *
+ * @param {string} content - Full report file content.
+ * @returns {object|null} Parsed Machine-Summary object, or null.
+ */
+export function parseMachineSummary(content) {
+  const fenceMatch = String(content ?? '').match(
+    /##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n([\s\S]*?)\n```/i,
+  );
+  if (!fenceMatch) return null;
+  const raw = fenceMatch[1].trim();
+  if (!raw) return null;
+  try {
+    const parsed = yamlLoad(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Split a parsed Machine Summary into the core `summary` (filtered to
+ * CORE_SUMMARY_FIELDS) and `extras` (currently just salary-gap's namespaced
+ * advertised_comp). Deterministic: extras.salaryGap.advertised_comp is always
+ * emitted, value-or-null.
+ *
+ * @param {object} parsed - Output of parseMachineSummary (a non-null object).
+ * @returns {{summary: object, extras: {salaryGap: {advertised_comp: *}}}}
+ */
+export function splitEntry(parsed) {
+  const summary = {};
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    for (const [key, value] of Object.entries(parsed)) {
+      if (CORE_SUMMARY_FIELDS.has(key)) summary[key] = value;
+    }
+  }
+  return {
+    summary,
+    extras: { salaryGap: { advertised_comp: parsed?.advertised_comp ?? null } },
+  };
+}
+
+// An entry for a report with no usable Machine Summary: summary is null so
+// consumers can tell "no summary" apart from "empty summary object".
+function emptyExtras() {
+  return { salaryGap: { advertised_comp: null } };
+}
+
+function buildEntry(content, stat) {
+  const parsed = parseMachineSummary(content);
+  const split = parsed ? splitEntry(parsed) : { summary: null, extras: emptyExtras() };
+  return {
+    summary: split.summary,
+    extras: split.extras,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+  };
+}
+
+// Resolve an absolute-or-relative report path to the key the index uses (the
+// bare filename). Returns null when the path does not live directly inside
+// reportsDir — the same containment intent as analyze-patterns' lexical guard.
+function toRelKey(p, reportsDir) {
+  if (!p || typeof p !== 'string') return null;
+  const abs = isAbsolute(p) ? p : join(reportsDir, basename(p));
+  const rel = relative(reportsDir, resolve(abs));
+  if (!rel || rel.startsWith('..') || isAbsolute(rel) || rel.includes('/') || rel.includes(sep)) {
+    return null;
+  }
+  return rel;
+}
+
+function serializeIndex(entries) {
+  const obj = { version: INDEX_VERSION, entries: {} };
+  // Sorted keys → deterministic on-disk bytes across runs.
+  for (const key of [...entries.keys()].sort()) {
+    const e = entries.get(key);
+    obj.entries[key] = {
+      summary: e.summary,
+      extras: e.extras,
+      mtimeMs: e.mtimeMs,
+      size: e.size,
+    };
+  }
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+function readCache(cachePath) {
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.version === INDEX_VERSION &&
+      parsed.entries &&
+      typeof parsed.entries === 'object'
+    ) {
+      return parsed.entries;
+    }
+  } catch {
+    // Missing/corrupt/version-mismatch → rebuild from scratch.
+  }
+  return null;
+}
+
+/**
+ * Load (or build) the stat-validated reports index.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.reportsDir] - Directory of report files (default: <CAREER_OPS>/reports).
+ * @param {string} [opts.cachePath] - On-disk cache path (default: <CAREER_OPS>/data/reports-index.json).
+ * @param {boolean} [opts.noCache=false] - When true, never read and never write the JSON.
+ * @returns {{get: Function, entries: Function, meta: object, [Symbol.iterator]: Function}}
+ */
+export function loadReportsIndex({
+  reportsDir = DEFAULT_REPORTS_DIR,
+  cachePath = DEFAULT_CACHE_PATH,
+  noCache = false,
+} = {}) {
+  let files = [];
+  try {
+    files = readdirSync(reportsDir).filter((f) => REPORT_FILE_RE.test(f));
+  } catch {
+    files = [];
+  }
+
+  const cache = noCache ? null : readCache(cachePath);
+
+  const entries = new Map();
+  let reused = 0;
+  let parsed = 0;
+  for (const file of files) {
+    const abs = join(reportsDir, file);
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      continue;
+    }
+    const cached = cache?.[file];
+    // Trust the cache ONLY when BOTH mtimeMs and size match the fresh stat.
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      entries.set(file, {
+        summary: cached.summary ?? null,
+        extras: cached.extras ?? emptyExtras(),
+        mtimeMs: cached.mtimeMs,
+        size: cached.size,
+      });
+      reused += 1;
+      continue;
+    }
+    let content;
+    try {
+      content = readFileSync(abs, 'utf-8');
+    } catch {
+      continue;
+    }
+    entries.set(file, buildEntry(content, stat));
+    parsed += 1;
+  }
+
+  // Entries for files that no longer exist on disk are simply never added above,
+  // so they drop out of both the in-memory index and the rewritten cache.
+  if (!noCache) {
+    try {
+      writeFileAtomic(cachePath, serializeIndex(entries));
+    } catch {
+      // A read-only or missing data/ dir must not break analysis — the cache is
+      // an optimization, not a requirement. Fall through with the in-memory map.
+    }
+  }
+
+  return {
+    meta: {
+      version: INDEX_VERSION,
+      count: entries.size,
+      reused,
+      parsed,
+      reportsDir,
+      cachePath: noCache ? null : cachePath,
+    },
+    /**
+     * Entry for a report under reportsDir, parsing on demand if the path is in
+     * reportsDir but not yet indexed. Returns null when the path is outside
+     * reportsDir or the file cannot be read.
+     */
+    get(p) {
+      const key = toRelKey(p, reportsDir);
+      if (key === null) return null;
+      if (entries.has(key)) return entries.get(key);
+      const abs = join(reportsDir, key);
+      let stat;
+      let content;
+      try {
+        stat = statSync(abs);
+        content = readFileSync(abs, 'utf-8');
+      } catch {
+        return null;
+      }
+      const entry = buildEntry(content, stat);
+      entries.set(key, entry);
+      return entry;
+    },
+    entries() {
+      return entries.entries();
+    },
+    [Symbol.iterator]() {
+      return entries.entries();
+    },
+  };
+}
+
+// ─────────────────────────────── Self-test ───────────────────────────────
+
+async function _selfTest() {
+  const fs = await import('fs');
+  const os = await import('os');
+  const { mkdtempSync, writeFileSync, appendFileSync, rmSync, mkdirSync, unlinkSync } = fs;
+  const failures = [];
+  const tmpRoots = [];
+
+  const makeWorkspace = () => {
+    const root = mkdtempSync(join(os.tmpdir(), 'reports-index-selftest-'));
+    tmpRoots.push(root);
+    const reportsDir = join(root, 'reports');
+    const dataDir = join(root, 'data');
+    mkdirSync(reportsDir, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    return { root, reportsDir, cachePath: join(dataDir, 'reports-index.json') };
+  };
+
+  const canonicalReport = (company = 'Acme', adv = '80-90k EUR') => `# 042 - ${company}
+
+Some prose.
+
+## Machine Summary
+
+\`\`\`yaml
+company: "${company}"
+role: "Staff AI Engineer"
+score: 4.4
+via: "Hays"
+company_confidential: true
+advertised_comp: "${adv}"
+\`\`\`
+`;
+
+  try {
+    // ── 1. Fresh build parses a canonical report ────────────────────────────
+    {
+      const ws = makeWorkspace();
+      const file = join(ws.reportsDir, '042-acme-2026-01-01.md');
+      writeFileSync(file, canonicalReport());
+      const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const entry = idx.get(file);
+      if (!entry) failures.push('1: fresh build returned no entry');
+      if (entry?.summary?.company !== 'Acme') failures.push('1: core field company not parsed into summary');
+      if (entry?.summary?.role !== 'Staff AI Engineer') failures.push('1: non-salary field role missing from summary');
+      if (entry?.summary?.score !== 4.4) failures.push('1: numeric score not parsed');
+      if (entry?.summary?.via !== 'Hays') failures.push('1: via not preserved in core summary');
+      if (entry?.summary?.company_confidential !== true) failures.push('1: company_confidential not preserved in core summary');
+      if ('advertised_comp' in (entry?.summary ?? {})) failures.push('1: advertised_comp must NOT be in core summary');
+      if (entry?.extras?.salaryGap?.advertised_comp !== '80-90k EUR') failures.push('1: advertised_comp not extracted into extras.salaryGap');
+    }
+
+    // ── 2. Cache-trust proof: stat-match ⇒ trust; stat-mismatch ⇒ reparse ───
+    {
+      const ws = makeWorkspace();
+      const file = join(ws.reportsDir, '042-acme-2026-01-01.md');
+      writeFileSync(file, canonicalReport('Acme', '80-90k EUR'));
+      const st = fs.statSync(file);
+      // Cache entry with a deliberately WRONG summary + WRONG advertised_comp,
+      // but the file's REAL mtimeMs+size.
+      const poisoned = {
+        version: INDEX_VERSION,
+        entries: {
+          '042-acme-2026-01-01.md': {
+            summary: { company: 'WRONG-CACHED', role: 'stale', score: 0.1 },
+            extras: { salaryGap: { advertised_comp: '999k WRONG' } },
+            mtimeMs: st.mtimeMs,
+            size: st.size,
+          },
+        },
+      };
+      writeFileSync(ws.cachePath, JSON.stringify(poisoned));
+      const idx1 = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const e1 = idx1.get(file);
+      if (e1?.summary?.company !== 'WRONG-CACHED') failures.push('2: stat-match did not trust cache (reparsed instead of trusting)');
+      if (e1?.extras?.salaryGap?.advertised_comp !== '999k WRONG') failures.push('2: stat-match did not trust cached advertised_comp');
+      if (idx1.meta.reused !== 1 || idx1.meta.parsed !== 0) failures.push('2: expected reused=1 parsed=0 on stat-match');
+
+      // Modify the file so size changes → cache entry must be invalidated.
+      appendFileSync(file, '\nAppended bytes to change size.\n');
+      const idx2 = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const e2 = idx2.get(file);
+      if (e2?.summary?.company !== 'Acme') failures.push('2: stat-mismatch did not trigger reparse (still cached wrong summary)');
+      if (e2?.extras?.salaryGap?.advertised_comp !== '80-90k EUR') failures.push('2: stat-mismatch did not reparse advertised_comp');
+      if (idx2.meta.parsed !== 1) failures.push('2: expected parsed=1 after stat-mismatch');
+    }
+
+    // ── 3. Deleted report drops from index and rewritten cache ──────────────
+    {
+      const ws = makeWorkspace();
+      const keep = join(ws.reportsDir, '001-keep-2026-01-01.md');
+      const gone = join(ws.reportsDir, '002-gone-2026-01-02.md');
+      writeFileSync(keep, canonicalReport('KeepCo'));
+      writeFileSync(gone, canonicalReport('GoneCo'));
+      loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath }); // seeds cache with both
+      unlinkSync(gone);
+      const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const names = [...idx].map(([k]) => k);
+      if (names.includes('002-gone-2026-01-02.md')) failures.push('3: deleted report still present in loaded index');
+      if (!names.includes('001-keep-2026-01-01.md')) failures.push('3: surviving report missing from index');
+      const onDisk = JSON.parse(fs.readFileSync(ws.cachePath, 'utf-8'));
+      if ('002-gone-2026-01-02.md' in onDisk.entries) failures.push('3: deleted report not dropped from rewritten cache');
+    }
+
+    // ── 4. Version bump rebuilds (stale entries ignored) ────────────────────
+    {
+      const ws = makeWorkspace();
+      const file = join(ws.reportsDir, '042-acme-2026-01-01.md');
+      writeFileSync(file, canonicalReport('Acme'));
+      const st = fs.statSync(file);
+      const stale = {
+        version: INDEX_VERSION - 1,
+        entries: {
+          '042-acme-2026-01-01.md': {
+            summary: { company: 'STALE-VERSION' },
+            extras: { salaryGap: { advertised_comp: null } },
+            mtimeMs: st.mtimeMs,
+            size: st.size,
+          },
+        },
+      };
+      writeFileSync(ws.cachePath, JSON.stringify(stale));
+      const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const e = idx.get(file);
+      if (e?.summary?.company !== 'Acme') failures.push('4: version mismatch did not force a full rebuild');
+      if (idx.meta.parsed !== 1) failures.push('4: version mismatch should reparse, not reuse');
+    }
+
+    // ── 5. noCache: never reads, never writes ───────────────────────────────
+    {
+      const ws = makeWorkspace();
+      const file = join(ws.reportsDir, '042-acme-2026-01-01.md');
+      writeFileSync(file, canonicalReport('Acme'));
+      const st = fs.statSync(file);
+      // A wrong cache that noCache must ignore, and must NOT overwrite.
+      const wrongCacheBytes = JSON.stringify({
+        version: INDEX_VERSION,
+        entries: {
+          '042-acme-2026-01-01.md': {
+            summary: { company: 'SHOULD-BE-IGNORED' },
+            extras: { salaryGap: { advertised_comp: null } },
+            mtimeMs: st.mtimeMs,
+            size: st.size,
+          },
+        },
+      });
+      writeFileSync(ws.cachePath, wrongCacheBytes);
+      const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath, noCache: true });
+      const e = idx.get(file);
+      if (e?.summary?.company !== 'Acme') failures.push('5: noCache read the on-disk cache instead of reparsing');
+      if (fs.readFileSync(ws.cachePath, 'utf-8') !== wrongCacheBytes) failures.push('5: noCache wrote/overwrote the cache file');
+
+      // And when no cache exists, noCache must not create one.
+      const ws2 = makeWorkspace();
+      const file2 = join(ws2.reportsDir, '042-acme-2026-01-01.md');
+      writeFileSync(file2, canonicalReport('Acme'));
+      const idx2 = loadReportsIndex({ reportsDir: ws2.reportsDir, cachePath: ws2.cachePath, noCache: true });
+      if (idx2.get(file2)?.summary?.company !== 'Acme') failures.push('5: noCache fresh build produced wrong data');
+      if (fs.existsSync(ws2.cachePath)) failures.push('5: noCache wrote a cache file where none existed');
+    }
+
+    // ── 6. Fence variants + malformed input ─────────────────────────────────
+    {
+      const ws = makeWorkspace();
+      const write = (name, body) => writeFileSync(join(ws.reportsDir, name), body);
+      write('010-yaml-2026-01-01.md', '## Machine Summary\n\n```yaml\ncompany: "YamlCo"\n```\n');
+      write('011-yml-2026-01-01.md', '## Machine Summary\n\n```yml\ncompany: "YmlCo"\n```\n');
+      write('012-json-2026-01-01.md', '## Machine Summary\n\n```json\n{"company": "JsonCo", "advertised_comp": "100k EUR"}\n```\n');
+      write('013-nofence-2026-01-01.md', '# No machine summary here at all\n\nJust prose.\n');
+      write('014-empty-2026-01-01.md', '## Machine Summary\n\n```yaml\n\n```\n');
+      write('015-malformed-2026-01-01.md', '## Machine Summary\n\n```yaml\ncompany: "Unterminated\n  - : : bad\n```\n');
+      const idx = loadReportsIndex({ reportsDir: ws.reportsDir, cachePath: ws.cachePath });
+      const g = (n) => idx.get(join(ws.reportsDir, n));
+      if (g('010-yaml-2026-01-01.md')?.summary?.company !== 'YamlCo') failures.push('6: yaml fence not parsed');
+      if (g('011-yml-2026-01-01.md')?.summary?.company !== 'YmlCo') failures.push('6: yml fence not parsed');
+      if (g('012-json-2026-01-01.md')?.summary?.company !== 'JsonCo') failures.push('6: json fence not parsed');
+      if (g('012-json-2026-01-01.md')?.extras?.salaryGap?.advertised_comp !== '100k EUR') failures.push('6: json fence advertised_comp not extracted');
+      if (g('013-nofence-2026-01-01.md')?.summary !== null) failures.push('6: missing fence must yield summary null');
+      if (g('014-empty-2026-01-01.md')?.summary !== null) failures.push('6: empty fence must yield summary null');
+      if (g('015-malformed-2026-01-01.md')?.summary !== null) failures.push('6: malformed yaml must yield summary null (no throw)');
+    }
+
+    // ── 7. parseMachineSummary/splitEntry direct contract ───────────────────
+    {
+      if (parseMachineSummary('no fence here') !== null) failures.push('7: parseMachineSummary should return null on no fence');
+      if (parseMachineSummary('## Machine Summary\n\n```yaml\n- a\n- b\n```\n') !== null) failures.push('7: array top-level must be null');
+      const { summary, extras } = splitEntry({ company: 'X', advertised_comp: '5k', not_a_field: 'drop' });
+      if (summary.company !== 'X') failures.push('7: splitEntry dropped a core field');
+      if ('not_a_field' in summary) failures.push('7: splitEntry kept a non-core field');
+      if ('advertised_comp' in summary) failures.push('7: splitEntry leaked advertised_comp into summary');
+      if (extras.salaryGap.advertised_comp !== '5k') failures.push('7: splitEntry did not namespace advertised_comp');
+      if (splitEntry({ company: 'Y' }).extras.salaryGap.advertised_comp !== null) failures.push('7: splitEntry must emit advertised_comp=null when absent');
+      // CORE_SUMMARY_FIELDS invariants the test-all cross-check depends on.
+      if (!CORE_SUMMARY_FIELDS.has('via') || !CORE_SUMMARY_FIELDS.has('company_confidential')) failures.push('7: CORE_SUMMARY_FIELDS must contain via + company_confidential');
+      if (CORE_SUMMARY_FIELDS.has('advertised_comp')) failures.push('7: CORE_SUMMARY_FIELDS must NOT contain advertised_comp');
+    }
+  } finally {
+    for (const root of tmpRoots) {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`reports-index self-test failed: ${failures.join('; ')}`);
+    process.exit(1);
+  }
+  console.log('reports-index self-test OK (fresh build + stat-trust/invalidate + deletion + version bump + no-cache + fence variants + split contract)');
+  process.exit(0);
+}
+
+// ─────────────────────────────── CLI ─────────────────────────────────────
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+  if (process.argv.slice(2).includes('--self-test')) {
+    _selfTest();
+  } else {
+    // Default: rebuild/refresh the on-disk cache and print a one-line summary.
+    const idx = loadReportsIndex({ noCache: process.argv.slice(2).includes('--no-cache') });
+    console.log(JSON.stringify(idx.meta, null, 2));
+  }
+}

--- a/salary-gap.mjs
+++ b/salary-gap.mjs
@@ -27,18 +27,19 @@
  *      node salary-gap.mjs --self-test
  */
 
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
+import { parseMachineSummary, splitEntry, loadReportsIndex, REPORT_FILE_RE } from './reports-index.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const OBS_PATH = join(CAREER_OPS, 'data/salary-observations.tsv');
-const REPORTS_DIR = join(CAREER_OPS, 'reports');
 
 const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
+const noCache = args.includes('--no-cache');
 const statedForFlagIdx = args.indexOf('--stated-for');
 const statedForNum = statedForFlagIdx !== -1 ? args[statedForFlagIdx + 1] : null;
 
@@ -115,42 +116,40 @@ export function getStatedObservations(observations, num) {
     .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 }
 
-// Like analyze-patterns.mjs:110 but WITHOUT `json`: analyze-patterns feeds the fence
-// body to a real YAML parser (JSON is a YAML subset, so json fences parse fine there),
-// while yamlStr below only extracts `key: value` lines — a json fence would "match"
-// and silently yield null company/role/advertised_comp. Rejecting it outright means
-// the report falls back to the legacy no-Machine-Summary path instead.
-const FENCE_RE = /##\s*Machine Summary\s*\n+```(?:yaml|yml)?\s*\n([\s\S]*?)\n```/i;
-const yamlStr = (body, key) => {
-  const m = body.match(new RegExp(`^${key}:\\s*(.*)$`, 'm'));
-  if (!m) return null;
-  const v = m[1].trim().replace(/^["']|["']$/g, '');
-  return v === 'null' || v === '' ? null : v;
-};
-
 // --- Report-derived advertised observations ---
-// Extracts advertised_comp + company + role from one report's Machine Summary.
-// num/date come from the filename ({###}-{slug}-{YYYY-MM-DD}.md).
-export function reportToObservation(content, num, date) {
-  const fence = String(content || '').match(FENCE_RE);
-  if (!fence) return null;
-  const body = fence[1];
-  const company = yamlStr(body, 'company');
-  const role = yamlStr(body, 'role');
-  const adv = yamlStr(body, 'advertised_comp');
+// Shape an advertised observation from already-parsed Machine Summary fields.
+// Shared by reportToObservation (parses raw content) and collectSources (reads
+// the stat-validated reports index). company/role/advertised_comp are normalized
+// so an empty string folds to null exactly as the old hand-rolled yamlStr did.
+const advNorm = (v) => (v === null || v === undefined || v === '' ? null : String(v));
+
+function shapeAdvertisedObservation(company, role, advRaw, num, date) {
+  const adv = advNorm(advRaw);
   // Currency = first standalone UPPERCASE 3-letter token, case-SENSITIVE on
   // purpose: lowercase 3-letter English words in sloppy values ("per", "and")
   // must not register as currencies. Tradeoff: a lowercase "100k eur" yields
   // UNKNOWN (excluded from gap math, surfaced in currencyMismatches) — acceptable;
   // a corrective TSV observation with an explicit currency overrides it.
-  const currencyGuess = adv ? (adv.match(/\b[A-Z]{3}\b/)?.[0] ?? 'UNKNOWN') : null;
+  const currencyGuess = adv !== null ? (adv.match(/\b[A-Z]{3}\b/)?.[0] ?? 'UNKNOWN') : null;
   return {
-    company, role,
+    company: advNorm(company),
+    role: advNorm(role),
     observation: adv === null ? null : {
       num, date, type: 'advertised', amount: adv, currency: currencyGuess,
       source: 'jd', note: 'from report Machine Summary', parsed: parseAmount(adv),
     },
   };
+}
+
+// Extracts advertised_comp + company + role from one report's Machine Summary
+// using the shared canonical parser (#2385). num/date come from the filename
+// ({###}-{slug}-{YYYY-MM-DD}.md). Unlike the old hand-rolled matcher, a JSON
+// fence now parses (JSON is a YAML subset) instead of being rejected.
+export function reportToObservation(content, num, date) {
+  const parsed = parseMachineSummary(content);
+  if (!parsed) return null;
+  const { summary, extras } = splitEntry(parsed);
+  return shapeAdvertisedObservation(summary.company, summary.role, extras.salaryGap.advertised_comp, num, date);
 }
 
 const pctDelta = (from, to) => ((to - from) / from) * 100;
@@ -417,7 +416,12 @@ function selfTest() {
   assert(reportToObservation(REPORT_FIXTURE_003, '003', '2026-06-26').observation === null, 'null advertised_comp -> no obs');
   assert(reportToObservation('no machine summary', '009', '2026-06-01') === null, 'no fence -> null');
   const jsonReport = '# Eval: JsonCo — Eng\n\n## Machine Summary\n\n```json\n{"company": "JsonCo", "role": "Eng", "advertised_comp": "100k EUR"}\n```\n';
-  assert(reportToObservation(jsonReport, '010', '2026-06-30') === null, 'json fence rejected (yamlStr cannot extract from JSON — see FENCE_RE comment)');
+  // #2385: the shared canonical parser accepts JSON fences (JSON ⊂ YAML), where
+  // the old hand-rolled yamlStr rejected them. A json fence now yields a proper
+  // advertised observation.
+  const rJson = reportToObservation(jsonReport, '010', '2026-06-30');
+  assert(rJson?.company === 'JsonCo' && rJson?.role === 'Eng', 'json fence company/role extracted via shared parser');
+  assert(rJson?.observation?.currency === 'EUR' && rJson?.observation?.parsed?.mid === 100000, 'json fence advertised_comp parsed');
   // generic ISO detection: any uppercase 3-letter token, not a hardcoded allowlist
   const plnReport = '# Eval: PlnCo — Eng\n\n## Machine Summary\n\n```yaml\ncompany: "PlnCo"\nrole: "Eng"\nadvertised_comp: "450-500k PLN"\n```\n';
   const rPln = reportToObservation(plnReport, '011', '2026-07-01');
@@ -537,29 +541,29 @@ function selfTest() {
 }
 
 // --- Real sources ---
-const REPORT_FILE_RE = /^(\d{3})-.*-(\d{4}-\d{2}-\d{2})\.md$/;
-
-function collectSources() {
+function collectSources(options = {}) {
   const apps = {};
   const observations = [];
 
-  if (existsSync(REPORTS_DIR)) {
-    for (const file of readdirSync(REPORTS_DIR)) {
-      const m = file.match(REPORT_FILE_RE);
-      if (!m) continue;
-      const [, num, date] = m;
-      let content;
-      try { content = readFileSync(join(REPORTS_DIR, file), 'utf-8'); } catch { continue; }
-      const r = reportToObservation(content, num, date);
-      if (r) {
-        apps[num] = { company: r.company, role: r.role };
-        if (r.observation) observations.push(r.observation);
-      } else {
-        // report exists but has no Machine Summary (legacy) — still a valid
-        // tracker row, so log observations against it are NOT orphans
-        apps[num] = { company: null, role: null };
-      }
+  // Reports feed advertised observations through the shared, stat-validated
+  // index (#2385): the Machine Summary is parsed once and cached across runs and
+  // across analyze-patterns/upskill/salary-gap. --no-cache skips read+write.
+  const index = loadReportsIndex({ noCache: options.noCache });
+  for (const [file, entry] of index) {
+    const m = file.match(REPORT_FILE_RE);
+    if (!m) continue;
+    const [, num, date] = m;
+    if (!entry.summary) {
+      // report exists but has no Machine Summary (legacy) — still a valid
+      // tracker row, so log observations against it are NOT orphans
+      apps[num] = { company: null, role: null };
+      continue;
     }
+    const r = shapeAdvertisedObservation(
+      entry.summary.company, entry.summary.role, entry.extras.salaryGap.advertised_comp, num, date,
+    );
+    apps[num] = { company: r.company, role: r.role };
+    if (r.observation) observations.push(r.observation);
   }
 
   if (existsSync(OBS_PATH)) {
@@ -673,13 +677,13 @@ function main() {
       console.error('Usage: node salary-gap.mjs --stated-for <tracker#>');
       process.exit(1);
     }
-    const { observations } = collectSources();
+    const { observations } = collectSources({ noCache });
     const stated = getStatedObservations(observations, statedForNum);
     console.log(JSON.stringify({ num: statedForNum, stated }, null, 2));
     return;
   }
 
-  const { apps, observations } = collectSources();
+  const { apps, observations } = collectSources({ noCache });
   const result = fold(observations, apps, loadProfileDesired());
 
   if (summaryMode) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -296,6 +296,7 @@ const scripts = [
   { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
+  { name: 'reports-index.mjs --self-test', expectExit: 0 },
   { name: 'check-table-freshness.mjs --self-test', expectExit: 0 },
   { name: 'upskill.mjs --self-test', expectExit: 0 },
   { name: 'detect-reposts.mjs --self-test', expectExit: 0 },
@@ -2347,7 +2348,11 @@ if (/\{\{REPORT_NUM\}\}\\t\{\{DATE\}\}/.test(batchTrackerStep) && !/Compute `\{n
 }
 
 const batchMachineSummary = batchPrompt.match(/#### Machine Summary[\s\S]*?### Step 3 \u2014 Save the Report/)?.[0] ?? '';
-const patternsMachineFields = readFile('analyze-patterns.mjs').match(/const MACHINE_SUMMARY_FIELDS = new Set\(\[([\s\S]*?)\]\);/)?.[1] ?? '';
+// The core Machine-Summary allowlist now lives in reports-index.mjs's
+// CORE_SUMMARY_FIELDS (the single source shared by analyze-patterns/upskill/
+// salary-gap since #2385). advertised_comp moved to extras.salaryGap, but via +
+// company_confidential must still round-trip through the core parser.
+const patternsMachineFields = readFile('reports-index.mjs').match(/export const CORE_SUMMARY_FIELDS = new Set\(\[([\s\S]*?)\]\);/)?.[1] ?? '';
 if (
   /^via:/m.test(batchMachineSummary) &&
   /^company_confidential:/m.test(batchMachineSummary) &&

--- a/tests/upskill-empty-summary-gaps.test.mjs
+++ b/tests/upskill-empty-summary-gaps.test.mjs
@@ -1,0 +1,122 @@
+// tests/upskill-empty-summary-gaps.test.mjs — regression coverage for #2762:
+// an empty-list Machine Summary must not swallow the body Gap table.
+//
+// The aggregate path reads gaps from two sources: the cached Machine Summary's
+// hard_stops/soft_gaps, and — as a FALLBACK when the summary can't supply them —
+// the report body's Gap table. The bug: the fallback was gated on KEY PRESENCE
+// (`'hard_stops' in summary || 'soft_gaps' in summary`). But the canonical
+// Machine Summary emits `hard_stops: []` / `soft_gaps: []` when empty
+// (batch/batch-prompt.md:323), so the keys are present-but-empty. Presence was
+// true, the fallback body read was skipped, and a report whose gaps live only in
+// its Gap table contributed ZERO gaps — silently, with no error and no failing
+// test. The fix gates on NON-EMPTY length after normalizeList().
+//
+// This suite exercises the real analyze() aggregate path (imported via the
+// documented appsFile/cvFile/profileFile test seams, mirroring
+// reports-index.mjs's reportsDir/cachePath) against a planted fixture report.
+// The report lives in the real reports/ dir because analyze()'s containment
+// guard (withinReports) is rooted there; it carries a unique pid-tagged name and
+// is removed in finally. cvFile/profileFile point at absent paths so no real CV
+// skill can suppress the fixture's gaps.
+//
+// Auto-discovered by test-all.mjs and imported in-process, so it must NEVER exit
+// the process itself — only pass()/fail() from ./helpers.mjs.
+import { pass, fail, ROOT, NODE, rmSync } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nupskill.mjs aggregate: empty-list Machine Summary falls through to the Gap table (#2762)');
+
+const tag = `co2762-${process.pid}-${Date.now()}`;
+const reportName = `909-${tag}-2026-01-01.md`;
+const reportPath = join(ROOT, 'reports', reportName);
+const sandbox = mkdtempSync(join(tmpdir(), 'co-upskill-emptygaps-'));
+
+try {
+  const { analyze } = await import(pathToFileURL(join(ROOT, 'upskill.mjs')).href);
+  if (typeof analyze !== 'function') {
+    fail('upskill.mjs does not export analyze() — the #2762 regression test cannot drive the aggregate path');
+  } else {
+    // A report whose Machine Summary lists NO gaps (canonical empty `[]`), but
+    // whose body Gap table names two real ones. main's path recovers both from
+    // the table; the buggy presence-gated path recovers zero.
+    const report = [
+      `# 909 - Contoso Platform Engineer`,
+      '',
+      'Assessment narrative here.',
+      '',
+      '| Gap | Severity | Mitigation |',
+      '|-----|----------|------------|',
+      '| Kubernetes cluster operations | hard stop | Ramp on K8s |',
+      '| Terraform module authoring | soft gap | Study IaC |',
+      '',
+      '## Machine Summary',
+      '',
+      '```yaml',
+      'company: Contoso',
+      'score: 3.0',
+      'hard_stops: []',
+      'soft_gaps: []',
+      '```',
+      '',
+    ].join('\n');
+    writeFileSync(reportPath, report);
+
+    // Temp tracker linking ONLY to the fixture report (root-relative link, the
+    // form analyze() resolves against CAREER_OPS).
+    const tracker = [
+      '# Applications Tracker',
+      '',
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+      '|---|------|---------|------|-------|--------|-----|--------|-------|',
+      `| 909 | 2026-01-01 | Contoso | Platform Engineer | 3.0/5 | Evaluated | ❌ | [909](reports/${reportName}) | fixture |`,
+      '',
+    ].join('\n');
+    const trackerPath = join(sandbox, 'applications.md');
+    writeFileSync(trackerPath, tracker);
+
+    const result = analyze(1, {
+      noCache: true,
+      appsFile: trackerPath,
+      cvFile: join(sandbox, 'no-such-cv.md'),
+      profileFile: join(sandbox, 'no-such-profile.yml'),
+    });
+
+    const gapSkills = (result.gaps || []).map(g => g.skill);
+    const hasK8s = gapSkills.includes('Kubernetes');
+    const hasTerraform = gapSkills.includes('Terraform');
+
+    if (result.error) {
+      fail(`analyze() returned an error instead of a gap map: ${result.error}`);
+    } else if (hasK8s && hasTerraform) {
+      // The load-bearing assertion: BOTH body-table gaps survive an empty-list
+      // Machine Summary. Reverting the fix (presence check) makes gaps === [],
+      // reddening this line — the mutation check.
+      pass('both Gap-table gaps (Kubernetes, Terraform) recovered despite hard_stops:[] / soft_gaps:[] in the Machine Summary');
+    } else {
+      fail(`empty-list summary swallowed the Gap table (#2762): gaps=[${gapSkills.join(', ')}]`);
+    }
+  }
+
+  // Bonus (#2762 rebase collision): `--no-cache` must be a recognized flag in
+  // upskill.mjs's strict validateFlags gate, not rejected before it is read.
+  {
+    const res = spawnSync(NODE, [join(ROOT, 'upskill.mjs'), '--no-cache'], {
+      cwd: ROOT, encoding: 'utf-8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const stderr = res.stderr || '';
+    if (!/unrecognized flag/i.test(stderr)) {
+      pass('`upskill.mjs --no-cache` is accepted by validateFlags (not rejected as an unrecognized flag)');
+    } else {
+      fail(`\`upskill.mjs --no-cache\` was rejected as unrecognized: ${JSON.stringify(stderr.slice(0, 200))}`);
+    }
+  }
+} catch (e) {
+  fail(`upskill empty-summary-gaps tests crashed: ${e.stack || e.message}`);
+} finally {
+  rmSync(reportPath, { force: true });
+  rmSync(sandbox, { recursive: true, force: true });
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -220,6 +220,7 @@ const SYSTEM_PATHS = [
   'browser-extract.mjs',
   'analyze-patterns.mjs',
   'upskill.mjs',
+  'reports-index.mjs',
   'skill-extract.mjs',
   'intake.mjs',
   'stats.mjs',

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -400,22 +400,23 @@ function analyze(minReports, options = {}) {
     reportsLinked += 1;
     // Tracker links are normalized relative to the tracker file's directory
     // (see merge-tracker.mjs); resolve against it, with a root-relative fallback.
-    // The read is attempted directly instead of probing with existsSync first,
-    // which costs a full stat per report and races with the read (#2385).
+    // Resolve each contained candidate through the shared, stat-validated index
+    // FIRST: a cache hit yields the Machine Summary with NO body read, which is
+    // the whole point of #2385. The report body is read only as a fallback below
+    // (#2762 — reading it up front here defeated the read-reduction).
     const candidates = new Set([join(dirname(APPS_FILE), linkMatch[1]), join(CAREER_OPS, linkMatch[1])]);
-    let content = null;
+    let entry = null;
     let reportPath = null;
     for (const p of candidates) {
       if (!withinReports(p)) continue;
-      content = readTextIfExists(p);
-      if (content !== null) { reportPath = p; break; }
+      const e = index.get(p);
+      if (e) { entry = e; reportPath = p; break; }
     }
-    if (content === null) continue;
+    if (!entry) continue;
     reportsRead += 1;
 
-    // Machine Summary comes from the shared, stat-validated index (no re-parse);
-    // the already-read body is the fallback for score/gaps the summary can't supply.
-    const summary = index.get(reportPath)?.summary ?? null;
+    // Machine Summary comes from the shared index (no re-parse, no re-read).
+    const summary = entry.summary ?? null;
     let score = null;
     let hasMachineSummary = false;
     let haveSummaryGaps = false;
@@ -428,17 +429,20 @@ function analyze(minReports, options = {}) {
         gapDescriptions.push(...normalizeList(summary.hard_stops), ...normalizeList(summary.soft_gaps));
       }
     }
-    // Fallback: parse the body only when the summary can't supply the score or
-    // the gap descriptions (legacy reports, or a Machine Summary missing keys).
-    // Reuse the body already read under the containment guard — no second read.
+    // Fallback: read + parse the body only when the summary can't supply the
+    // score or the gap descriptions (legacy reports, or a Machine Summary
+    // missing keys). This is the ONLY path that reads the report body.
     if (score === null || !haveSummaryGaps) {
-      const fb = parseReportGaps(content);
-      if (fb.hasMachineSummary) hasMachineSummary = true;
-      if (score === null && Number.isFinite(fb.score)) score = fb.score;
-      // parseReportGaps re-adds the summary's hard_stops/soft_gaps; only take
-      // its text when we haven't already sourced gaps from the cached summary,
-      // so a report with summary gaps isn't double-counted.
-      if (!haveSummaryGaps && fb.gapText) gapDescriptions.push(fb.gapText);
+      const content = readTextIfExists(reportPath);
+      if (content !== null) {
+        const fb = parseReportGaps(content);
+        if (fb.hasMachineSummary) hasMachineSummary = true;
+        if (score === null && Number.isFinite(fb.score)) score = fb.score;
+        // parseReportGaps re-adds the summary's hard_stops/soft_gaps; only take
+        // its text when we haven't already sourced gaps from the cached summary,
+        // so a report with summary gaps isn't double-counted.
+        if (!haveSummaryGaps && fb.gapText) gapDescriptions.push(fb.gapText);
+      }
     }
 
     if (hasMachineSummary) reportsWithMachineSummary += 1;
@@ -629,6 +633,30 @@ soft_gaps:
     }
     if (!/compactText\(targetText\)/.test(selfSrc)) {
       failures.push('url-text: fetched text should be normalized with compactText (string->string), #1894');
+    }
+  }
+
+  // Read-reduction ordering (#2385 / #2762): the aggregate loop must resolve
+  // each linked report through the shared, stat-validated index BEFORE reading
+  // its body, so a cache hit skips the body read entirely. Reading the body up
+  // front (the old `content = readTextIfExists(p)` in the candidate loop)
+  // silently defeated #2385. Guard the ordering at the source level, matching
+  // the #1894 regression check above.
+  {
+    const src = readFileSync(fileURLToPath(import.meta.url), 'utf-8');
+    const start = src.indexOf('function analyze(');
+    const end = src.indexOf('function printSummary(', start);
+    const analyzeSrc = start >= 0 && end > start ? src.slice(start, end) : '';
+    const idxGetAt = analyzeSrc.indexOf('index.get(');
+    const bodyReadAt = analyzeSrc.indexOf('readTextIfExists(');
+    if (idxGetAt < 0) {
+      failures.push('read-reduction: analyze() no longer resolves reports through index.get() (#2385)');
+    }
+    if (idxGetAt >= 0 && bodyReadAt >= 0 && idxGetAt > bodyReadAt) {
+      failures.push('read-reduction: analyze() reads the report body before consulting the index — defeats #2385 (#2762)');
+    }
+    if (/readTextIfExists\(\s*p\s*\)/.test(analyzeSrc)) {
+      failures.push('read-reduction: analyze() still reads the body straight off a candidate path before the index (#2762)');
     }
   }
 

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -374,12 +374,19 @@ export function computeTargetedGaps(jdText, knownText) {
 }
 
 // --- Main ---
-function analyze(minReports, options = {}) {
-  if (!existsSync(APPS_FILE)) {
+export function analyze(minReports, options = {}) {
+  // Test seams (mirroring reports-index.mjs's documented reportsDir/cachePath):
+  // each defaults to the module's real path, so production behavior is
+  // unchanged. Overridable so the aggregate gap-derivation can be exercised
+  // against fixtures without a live tracker/CV — see the #2762 regression test.
+  const appsFile = options.appsFile ?? APPS_FILE;
+  const cvFile = options.cvFile ?? CV_FILE;
+  const profileFile = options.profileFile ?? PROFILE_FILE;
+  if (!existsSync(appsFile)) {
     return { error: 'No applications tracker found. Run some evaluations first.' };
   }
 
-  const lines = readFileSync(APPS_FILE, 'utf-8').split('\n');
+  const lines = readFileSync(appsFile, 'utf-8').split('\n');
   const colmap = resolveColumns(lines);
   const rows = lines.map(l => parseTrackerRow(l, colmap)).filter(Boolean);
 
@@ -404,7 +411,7 @@ function analyze(minReports, options = {}) {
     // FIRST: a cache hit yields the Machine Summary with NO body read, which is
     // the whole point of #2385. The report body is read only as a fallback below
     // (#2762 — reading it up front here defeated the read-reduction).
-    const candidates = new Set([join(dirname(APPS_FILE), linkMatch[1]), join(CAREER_OPS, linkMatch[1])]);
+    const candidates = new Set([join(dirname(appsFile), linkMatch[1]), join(CAREER_OPS, linkMatch[1])]);
     let entry = null;
     let reportPath = null;
     for (const p of candidates) {
@@ -424,9 +431,15 @@ function analyze(minReports, options = {}) {
     if (summary) {
       hasMachineSummary = true;
       if (typeof summary.score === 'number' && Number.isFinite(summary.score)) score = summary.score;
-      if ('hard_stops' in summary || 'soft_gaps' in summary) {
+      // Condition on NON-EMPTY gaps, not key presence: the canonical Machine
+      // Summary emits `hard_stops: []` / `soft_gaps: []` when empty (batch-prompt
+      // #323), so a presence check would set haveSummaryGaps for a report that
+      // actually lists its gaps only in the body Gap table — suppressing the
+      // fallback body read below and silently dropping those gaps (#2762).
+      const summaryGaps = [...normalizeList(summary.hard_stops), ...normalizeList(summary.soft_gaps)];
+      if (summaryGaps.length > 0) {
         haveSummaryGaps = true;
-        gapDescriptions.push(...normalizeList(summary.hard_stops), ...normalizeList(summary.soft_gaps));
+        gapDescriptions.push(...summaryGaps);
       }
     }
     // Fallback: read + parse the body only when the summary can't supply the
@@ -464,8 +477,8 @@ function analyze(minReports, options = {}) {
   }
 
   const knownText = knownSkillsText(
-    readOptionalText(CV_FILE),
-    readOptionalText(PROFILE_FILE),
+    readOptionalText(cvFile),
+    readOptionalText(profileFile),
     warnProfileUnparseable,
   );
   const knownSkills = extractSkills(knownText);
@@ -904,7 +917,7 @@ const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv
 // Handled via lib/cli-flags.mjs's validateFlags() (#2775), same shape as
 // doctor.mjs (#2874) — checked before --self-test/--url-text/--min-reports
 // are read, and before --help, so `--help --bogus` still errors.
-const KNOWN_FLAGS = ['--min-reports', '--summary', '--url-text', '--self-test', '--help', '-h'];
+const KNOWN_FLAGS = ['--min-reports', '--summary', '--url-text', '--no-cache', '--self-test', '--help', '-h'];
 
 // Only --min-reports and --url-text take their value as the next argv token.
 const VALUE_FLAGS = ['--min-reports', '--url-text'];

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { load as yamlLoad } from 'js-yaml';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
+import { parseMachineSummary, loadReportsIndex } from './reports-index.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -245,22 +246,9 @@ export function readOptionalText(filePath) {
   }
 }
 
-// --- Machine Summary + Gap table parsing ---
-// Mirrors analyze-patterns.mjs (duplicated by design, see header comment).
-function parseMachineSummary(content) {
-  const fenceMatch = content.match(/##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n([\s\S]*?)\n```/i);
-  if (!fenceMatch) return null;
-  const raw = fenceMatch[1].trim();
-  if (!raw) return null;
-  try {
-    const parsed = yamlLoad(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
+// --- Gap table parsing ---
+// The canonical Machine-Summary parser now lives in reports-index.mjs (imported
+// above) — one parser shared across analyze-patterns/upskill/salary-gap.
 function normalizeList(value) {
   if (Array.isArray(value)) return value.map(v => String(v).trim()).filter(Boolean);
   if (value === null || value === undefined || value === '') return [];
@@ -386,7 +374,7 @@ export function computeTargetedGaps(jdText, knownText) {
 }
 
 // --- Main ---
-function analyze(minReports) {
+function analyze(minReports, options = {}) {
   if (!existsSync(APPS_FILE)) {
     return { error: 'No applications tracker found. Run some evaluations first.' };
   }
@@ -394,6 +382,12 @@ function analyze(minReports) {
   const lines = readFileSync(APPS_FILE, 'utf-8').split('\n');
   const colmap = resolveColumns(lines);
   const rows = lines.map(l => parseTrackerRow(l, colmap)).filter(Boolean);
+
+  // Shared, stat-validated Machine-Summary cache over reports/. The summary
+  // supplies score + hard_stops/soft_gaps without re-parsing YAML; we only read
+  // the report body as a FALLBACK (the Gap table and `| Global |` score row)
+  // when the summary can't supply the score or the gap keys — see #2385.
+  const index = loadReportsIndex({ noCache: options.noCache });
 
   let reportsLinked = 0;
   let reportsRead = 0;
@@ -410,20 +404,49 @@ function analyze(minReports) {
     // which costs a full stat per report and races with the read (#2385).
     const candidates = new Set([join(dirname(APPS_FILE), linkMatch[1]), join(CAREER_OPS, linkMatch[1])]);
     let content = null;
+    let reportPath = null;
     for (const p of candidates) {
       if (!withinReports(p)) continue;
       content = readTextIfExists(p);
-      if (content !== null) break;
+      if (content !== null) { reportPath = p; break; }
     }
     if (content === null) continue;
     reportsRead += 1;
-    const { score, gapText, hasMachineSummary } = parseReportGaps(content);
+
+    // Machine Summary comes from the shared, stat-validated index (no re-parse);
+    // the already-read body is the fallback for score/gaps the summary can't supply.
+    const summary = index.get(reportPath)?.summary ?? null;
+    let score = null;
+    let hasMachineSummary = false;
+    let haveSummaryGaps = false;
+    const gapDescriptions = [];
+    if (summary) {
+      hasMachineSummary = true;
+      if (typeof summary.score === 'number' && Number.isFinite(summary.score)) score = summary.score;
+      if ('hard_stops' in summary || 'soft_gaps' in summary) {
+        haveSummaryGaps = true;
+        gapDescriptions.push(...normalizeList(summary.hard_stops), ...normalizeList(summary.soft_gaps));
+      }
+    }
+    // Fallback: parse the body only when the summary can't supply the score or
+    // the gap descriptions (legacy reports, or a Machine Summary missing keys).
+    // Reuse the body already read under the containment guard — no second read.
+    if (score === null || !haveSummaryGaps) {
+      const fb = parseReportGaps(content);
+      if (fb.hasMachineSummary) hasMachineSummary = true;
+      if (score === null && Number.isFinite(fb.score)) score = fb.score;
+      // parseReportGaps re-adds the summary's hard_stops/soft_gaps; only take
+      // its text when we haven't already sourced gaps from the cached summary,
+      // so a report with summary gaps isn't double-counted.
+      if (!haveSummaryGaps && fb.gapText) gapDescriptions.push(fb.gapText);
+    }
+
     if (hasMachineSummary) reportsWithMachineSummary += 1;
     const trackerScore = parseFloat(row.score);
     parsedReports.push({
       num: row.num,
       score: Number.isFinite(trackerScore) ? trackerScore : score,
-      gapText,
+      gapText: gapDescriptions.join('\n'),
     });
   }
 
@@ -871,6 +894,7 @@ if (isMain) {
   const args = process.argv.slice(2);
   validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   if (args.includes('--self-test')) runSelfTest();
+  const noCache = args.includes('--no-cache');
 
   // ====== SECURE TARGETED MODE PHASE 2a IMPLEMENTATION ======
   const urlTextIdx = args.indexOf('--url-text');
@@ -1008,7 +1032,7 @@ if (isMain) {
       return Number.isNaN(n) || n < 1 ? 5 : n;
     })();
 
-    const result = analyze(MIN_REPORTS);
+    const result = analyze(MIN_REPORTS, { noCache });
     if (args.includes('--summary')) {
       printSummary(result);
     } else {


### PR DESCRIPTION
## What this does

Introduces `reports-index.mjs`: the **one** canonical Machine-Summary parser plus a disposable, stat-validated on-disk cache (`data/reports-index.json`) over `reports/*`. The three analytics scripts (`analyze-patterns.mjs`, `upskill.mjs`, `salary-gap.mjs`) each carried their own copy of the same fence regex + `js-yaml` load and re-parsed every report on every run. They now share one parser and one cache.

An entry is keyed by `(mtimeMs, size)`. On load, each report is `statSync`'d; a cached entry is reused **only** when both mtimeMs **and** size match the fresh stat — otherwise the file is re-read and re-parsed. Entries whose file no longer exists are dropped. A `version` mismatch (bump `INDEX_VERSION`) or a missing/corrupt cache rebuilds from scratch. The cache is written atomically (`writeFileAtomic` from `tracker-utils.mjs`).

## Schema decision: core vs `extras.salaryGap`

Per maintainer directive, the entry splits into:
- `summary` — the parsed object filtered to `CORE_SUMMARY_FIELDS` (the historical `analyze-patterns` `MACHINE_SUMMARY_FIELDS` **minus `advertised_comp`**). This is now the single source for the core allowlist and still contains `via` + `company_confidential`.
- `extras.salaryGap.advertised_comp` — namespaced out of the core allowlist because only `salary-gap.mjs` reads it. Keeping it out of `summary` means a salary-only field never widens the core allowlist that the batch-prompt cross-check guards.

`test-all.mjs`'s batch-prompt↔allowlist cross-check now reads `CORE_SUMMARY_FIELDS` from `reports-index.mjs` (still asserting `via` + `company_confidential` round-trip).

## Stat-always validation + `--no-cache`

Every report is stat-checked on every load — the cache is never trusted blind. All three scripts gain a `--no-cache` flag that skips both reading and writing the JSON (correctness escape hatch; data is still correct, just uncached).

## `upskill` legacy-fallback caveat

`upskill` now sources `score`/`hard_stops`/`soft_gaps` from the cached summary and reads the report **body** only as a fallback (Gap table + `| Global |` score) when the summary can't supply them. Consequence: a report whose Machine Summary already carries the gap keys no longer *also* scrapes its body Gap table. On canonical reports the Machine Summary is the structured form of that table, so this is intended; noted here for transparency.

## Other notes

- `salary-gap`: a JSON fence now parses (JSON ⊂ YAML) where the old hand-rolled `yamlStr` matcher rejected it; its self-test was updated to assert the new behavior.
- `analyze-patterns` and `upskill` gained `isMain` guards so importing them is side-effect-free.
- Output shapes / JSON contracts of all three are unchanged; verified byte-identical across cold, warm-cache, and `--no-cache` runs.
- `data/reports-index.json` is a derived user-layer artifact (already covered by `.gitignore` `data/*`), registered in `DATA_CONTRACT.md`; **not** added to `SYSTEM_PATHS` (the module is).

## Validation

- `reports-index.mjs --self-test`, and all three analyzers' `--self-test`: exit 0.
- Full `node test-all.mjs`: **3432 passed, 0 failed** (1 pre-existing env warning: `cv-sync-check` without user data).

Refs / closes #2385. ADR to follow on #1754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared report indexing for faster analysis and reuse of cached summaries.
  * Added support for JSON-formatted report summaries.
  * Added a `--no-cache` option to refresh report data during analysis.
  * Added self-testing for report indexing and cache behavior.

* **Bug Fixes**
  * Improved consistency of salary and gap observations across analysis tools.
  * Improved recovery of gaps when summary lists are empty.
  * Improved handling of missing, malformed, unreadable, deleted, or invalid reports.
  * Prevented unintended analysis when tools are imported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->