### PR TITLE
fix(funnel-velocity): validate CLI flags and add a usage block

### DIFF
--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -42,6 +42,7 @@ import { computeFunnel, computeTrackerStats } from './stats.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, loadCanonicalStates, resolveCanonicalState } from './tracker-utils.mjs';
 import { parseAppliedDate, normalizeStatus } from './followup-cadence.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
@@ -49,6 +50,22 @@ const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
 const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
+
+// --help used to fall through to a full analysis and print the JSON report
+// (#2853). Validated in main() via lib/cli-flags.mjs's validateFlags() (#2775),
+// which also rejects unrecognized flags first so `--help --bogus` still errors.
+const KNOWN_FLAGS = ['--summary', '--self-test', '--benchmarks', '--help', '-h'];
+
+// --benchmarks takes its value as the next argv token, so that token must not
+// be mistaken for an unrecognized flag.
+const VALUE_FLAGS = ['--benchmarks'];
+
+const USAGE = `Usage:
+  node funnel-velocity.mjs                       # JSON velocity report
+  node funnel-velocity.mjs --summary             # human-readable table
+  node funnel-velocity.mjs --benchmarks <path>   # override the benchmarks file
+  node funnel-velocity.mjs --self-test           # run the inline self-test
+  node funnel-velocity.mjs --help                # show this message`;
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const VALID_SOURCES = new Set(['set-status', 'correction', 'backfill', 'manual']);
@@ -653,6 +670,7 @@ function flagValue(name) {
 }
 
 function main() {
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   if (selfTestMode) { selfTest(); return; }
 
   let benchmarks;


### PR DESCRIPTION
Closes #2853.

`node funnel-velocity.mjs --help` ran a full analysis and printed the JSON report at exit 0. `--bogus` did the same — a mistyped flag was indistinguishable from a normal run.

## What changed

Argv goes through `validateFlags()` from `lib/cli-flags.mjs` (#2775) rather than a hand-rolled copy. `--benchmarks` is declared in `valueFlags` so a path beginning with a dash is left for the script's own validation instead of being reported as an unrecognized flag.

The call sits at the top of `main()`, not at module scope: `computeFunnel`/`analyze` are imported by other modules, and validating on import would make a library consumer exit the process.

## Acceptance

| Check | Result |
|---|---|
| `node funnel-velocity.mjs --help` | prints usage, exit 0 |
| `node funnel-velocity.mjs --bogus` | `Error: unrecognized flag(s): --bogus. …`, exit 1 |
| normal run byte-identical | ✅ `diff` of stdout before/after is empty, for both the default JSON and `--summary` |
| `node funnel-velocity.mjs --self-test` | OK |

The byte-identical check is the one that matters here, so I ran it explicitly rather than eyeballing: captured stdout on pristine `main`, applied the change, captured again, `diff -q` clean on both output modes.

## Local test run

`node test-all.mjs` does not complete on this machine — `tests/intake.test.mjs:187` calls `fs.symlinkSync`, which Windows refuses without developer mode (`EPERM`). Confirmed pre-existing: pristine `main` fails at the identical line. Nothing in this diff is reachable from that test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added command-line flag validation.
  - Unrecognized or malformed options are now rejected with clear usage guidance.
  - Added support for displaying help information through the command-line validator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->