### PR TITLE
feat: resolve LinkedIn postings to the employer's real application URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday/iCIMS), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
 | `scan-interamt.mjs` | Playwright browser scanner for Interamt.de (German public sector portal — Apache Wicket, no REST API) |
+| `linkedin-apply.mjs` | Resolves a LinkedIn posting to the employer's real ATS application URL (LinkedIn's guest endpoint says whether a job applies offsite but not where). Reads company + title from the guest page, finds the board via `discover-ats.mjs`, matches the posting via `jd-similarity.mjs`. Zero tokens, no auth, no browser. Refuses rather than guesses: resolves only on a unique high-confidence title match, a seniority difference disqualifies outright, everything else returns ranked candidates (JSON or `--summary`) |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |
@@ -418,6 +419,8 @@ One TSV file per evaluation at `batch/tracker-additions/{num}-{company-slug}.tsv
 1. **NEVER edit applications.md to ADD new entries** -- write TSV in `batch/tracker-additions/` and let `merge-tracker.mjs` merge.
 2. **UPDATE status/notes of existing entries via `node set-status.mjs <report#|company> <State> [--note]`** — the canonical (locked, validated, atomic) write path. Do not hand-edit the table.
 3. All reports MUST include `**URL:**` in the header (between Score and PDF), and `**Legitimacy:** {tier}` (see Block G in `modes/oferta.md`).
+   - `**Apply URL:**` is an OPTIONAL extra header line holding the link to the actual application form, for postings where that is not the same page as `**URL:**` (LinkedIn). `**URL:**` keeps its meaning as the canonical link the tracker records; never overwrite it with the apply link. Written by `linkedin-apply.mjs` (only on a confident resolve, or when the user picks/pastes one) and preferred by the web Apply button.
+   - Reaching a LinkedIn **Easy Apply** posting is a different problem: its form lives on LinkedIn, so there is no external URL to reconstruct. That case is served by the opt-in signed-in browser profile (`apply.signed_in_profile` in `config/profile.yml`, toggled from web Config), which runs the apply session in a dedicated browser profile the user signs into themselves. Never the user's everyday Chrome profile, and career-ops never handles the password.
 4. All statuses MUST be canonical (see `templates/states.yml`).
 5. Health check: `node verify-pipeline.mjs` · Normalize statuses: `node normalize-statuses.mjs` · Dedup: `node dedup-tracker.mjs`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday/iCIMS), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
 | `scan-interamt.mjs` | Playwright browser scanner for Interamt.de (German public sector portal — Apache Wicket, no REST API) |
+| `linkedin-apply.mjs` | Resolves a LinkedIn posting to the employer's real ATS application URL (LinkedIn's guest endpoint says whether a job applies offsite but not where). Reads company + title from the guest page, finds the board via `discover-ats.mjs`, matches the posting via `jd-similarity.mjs`. Zero tokens, no auth, no browser. Refuses rather than guesses: resolves only on a unique high-confidence title match, a seniority difference disqualifies outright, everything else returns ranked candidates (JSON or `--summary`) |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |
@@ -472,6 +473,8 @@ One TSV file per evaluation at `batch/tracker-additions/{num}-{company-slug}.tsv
 1. **NEVER edit applications.md to ADD new entries** -- write TSV in `batch/tracker-additions/` and let `merge-tracker.mjs` merge.
 2. **UPDATE status/notes of existing entries via `node set-status.mjs <report#|company> <State> [--note]`** — the canonical (locked, validated, atomic) write path. Do not hand-edit the table.
 3. All reports MUST include `**URL:**` in the header (between Score and PDF), and `**Legitimacy:** {tier}` (see Block G in `modes/oferta.md`).
+   - `**Apply URL:**` is an OPTIONAL extra header line holding the link to the actual application form, for postings where that is not the same page as `**URL:**` (LinkedIn). `**URL:**` keeps its meaning as the canonical link the tracker records; never overwrite it with the apply link. Written by `linkedin-apply.mjs` (only on a confident resolve, or when the user picks/pastes one) and preferred by the web Apply button.
+   - Reaching a LinkedIn **Easy Apply** posting is a different problem: its form lives on LinkedIn, so there is no external URL to reconstruct. That case is served by the opt-in signed-in browser profile (`apply.signed_in_profile` in `config/profile.yml`, toggled from web Config), which runs the apply session in a dedicated browser profile the user signs into themselves. Never the user's everyday Chrome profile, and career-ops never handles the password.
 4. All statuses MUST be canonical (see `templates/states.yml`).
 5. Health check: `node verify-pipeline.mjs` · Normalize statuses: `node normalize-statuses.mjs` · Dedup: `node dedup-tracker.mjs`
 

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -319,3 +319,24 @@ cover_letter:
 #     cross_role_bucket: "all_EM_roles"
 #     applied_to: ["Senior Software Engineer"]
 #     last_apply_date: "2026-01-01"
+
+# ── Apply: signed-in browser profile ───────────────────────────────────────
+#
+# The web Apply flow normally browses SIGNED OUT (a fresh, cookie-less context),
+# which is right for a public ATS form and wrong for a gated one: LinkedIn shows
+# its login wall, so an "Easy Apply" posting (whose form lives on LinkedIn, with
+# no external ATS link to reconstruct) can never be reached.
+#
+# Turning this on makes the apply flow use a DEDICATED browser profile that you
+# sign into once, from Config in the web app. It is not your everyday Chrome
+# profile, so it only ever holds the sites you deliberately add to it, and it
+# never fights a Chrome you already have open. career-ops never sees, types or
+# stores your password: you sign in yourself in a real window.
+#
+#   signed_in_profile: off unless true. Default (key absent): false.
+#   profile_dir:       where that profile lives. Default (key absent):
+#                       .career-ops-web/browser-profile (gitignored).
+#
+# apply:
+#   signed_in_profile: false
+#   profile_dir: ""

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -336,6 +336,13 @@ cover_letter:
 #   signed_in_profile: off unless true. Default (key absent): false.
 #   profile_dir:       where that profile lives. Default (key absent):
 #                       .career-ops-web/browser-profile (gitignored).
+#                      Relative to the career-ops folder, and it must stay
+#                      inside it. A path that escapes (for example
+#                      "../../Library/Application Support/Google/Chrome") is
+#                      refused and the default is used, because pointing this
+#                      at your real browser profile is exactly what a dedicated
+#                      profile exists to prevent. The web Config page tells you
+#                      when a value was refused.
 #
 # apply:
 #   signed_in_profile: false

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -290,3 +290,24 @@ cover_letter:
 #     cross_role_bucket: "all_EM_roles"
 #     applied_to: ["Senior Software Engineer"]
 #     last_apply_date: "2026-01-01"
+
+# ── Apply: signed-in browser profile ───────────────────────────────────────
+#
+# The web Apply flow normally browses SIGNED OUT (a fresh, cookie-less context),
+# which is right for a public ATS form and wrong for a gated one: LinkedIn shows
+# its login wall, so an "Easy Apply" posting (whose form lives on LinkedIn, with
+# no external ATS link to reconstruct) can never be reached.
+#
+# Turning this on makes the apply flow use a DEDICATED browser profile that you
+# sign into once, from Config in the web app. It is not your everyday Chrome
+# profile, so it only ever holds the sites you deliberately add to it, and it
+# never fights a Chrome you already have open. career-ops never sees, types or
+# stores your password: you sign in yourself in a real window.
+#
+#   signed_in_profile: off unless true. Default (key absent): false.
+#   profile_dir:       where that profile lives. Default (key absent):
+#                       .career-ops-web/browser-profile (gitignored).
+#
+# apply:
+#   signed_in_profile: false
+#   profile_dir: ""

--- a/linkedin-apply.mjs
+++ b/linkedin-apply.mjs
@@ -1,0 +1,774 @@
+#!/usr/bin/env node
+/**
+ * linkedin-apply.mjs - resolve a LinkedIn posting to the employer's real ATS application URL.
+ *
+ * WHY THIS EXISTS
+ * A LinkedIn posting URL is not applyable. `openSession()` in the web app opens a
+ * fresh, cookie-less browser context, so linkedin.com/jobs/view/<id> serves the
+ * authwall and the apply flow dead-ends (issue #7).
+ *
+ * The obvious fix does not work. LinkedIn's public guest endpoint returns the full
+ * posting with no auth, and it does say WHETHER a job applies offsite, but it does
+ * not expose WHERE: the destination sits behind the contextual sign-in modal, and
+ * the page carries no JSON-LD. So the apply URL has to be reconstructed, not read.
+ *
+ * This module reconstructs it from the two things the guest page does give us, the
+ * employer and the job title, by reusing machinery career-ops already ships:
+ *   1. guest endpoint            -> company, title, location, offsite-apply flag
+ *   2. discover-ats resolveCompany -> the employer's live Greenhouse/Ashby/Lever board
+ *   3. that board's provider       -> its current job list
+ *   4. title matching here         -> the one posting that corresponds
+ * Zero LLM tokens, zero auth, no browser.
+ *
+ * MATCHING IS DELIBERATELY CONSERVATIVE. A false match sends a real application to
+ * the wrong role, which is worse than not resolving at all. This never auto-picks a
+ * merely-plausible candidate: it returns `ambiguous` with a ranked list and lets a
+ * human choose. See pickMatch() for the exact policy.
+ *
+ * Run: node linkedin-apply.mjs <linkedin-job-url> [--json|--summary]
+ *      node linkedin-apply.mjs --self-test
+ *
+ * Issue #7 - github.com/EliRobinson/career-ops
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+
+import { isMainModule } from './lib/is-main-module.mjs';
+import { makeHttpCtx } from './providers/_http.mjs';
+import { resolveCompany, deriveSlug, SLUG_RE } from './discover-ats.mjs';
+import { jaccardSimilarity, hardMismatch } from './jd-similarity.mjs';
+import greenhouse from './providers/greenhouse.mjs';
+import ashby from './providers/ashby.mjs';
+import lever from './providers/lever.mjs';
+import workday from './providers/workday.mjs';
+
+/** vendor id (as returned by resolveCompany) -> the provider that reads its board. */
+const PROVIDERS = {
+  greenhouse,
+  ashby,
+  lever,
+  workday,
+};
+
+/** Guest endpoint for one posting. `id` is digits-only by construction (see
+ *  linkedInJobId), so nothing user-supplied is ever spliced into the host. */
+const GUEST_POSTING_URL = (id) => `https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/${id}`;
+
+/** A posting page is ~80KB; this bounds a hostile or runaway response. */
+const MAX_GUEST_BYTES = 2_000_000;
+
+// ── Matching thresholds ───────────────────────────────────────────────
+// Tuned to refuse rather than guess. ACCEPT is the floor for calling a match
+// resolved; MARGIN is how far clear of the runner-up the winner must be, so a
+// board listing "Senior Engineer, Payments" and "Senior Engineer, Risk" against a
+// LinkedIn title of "Senior Engineer" stays ambiguous instead of coin-flipping.
+const ACCEPT_THRESHOLD = 0.75;
+const ACCEPT_MARGIN = 0.15;
+/** Below this a candidate is not even worth showing the user. */
+const CANDIDATE_FLOOR = 0.3;
+
+// ── Guest page parsing (pure) ─────────────────────────────────────────
+
+/**
+ * The numeric LinkedIn job id, or null when the URL is not one posting.
+ *
+ * Mirrors `linkedInJobId` in web/src/lib/job-url.mjs. Kept as its own copy on
+ * purpose: root scripts and the Next app cannot share a module (Next's bundler
+ * statically traces root .mjs literals and fails the production build), and this
+ * is small enough that a duplicated regex beats a build-breaking import. The
+ * self-test below pins the shared cases so the two cannot drift silently.
+ *
+ * @param {string} raw
+ * @returns {string|null}
+ */
+export function linkedInJobId(raw) {
+  let u;
+  try {
+    u = new URL(String(raw ?? '').trim());
+  } catch {
+    return null;
+  }
+  if (!/(^|\.)linkedin\.com$/i.test(u.hostname)) return null;
+  const seg = u.pathname.match(/\/jobs\/view\/([^/]+)/i);
+  if (seg) {
+    if (/^\d+$/.test(seg[1])) return seg[1];
+    // "senior-ai-engineer-at-acme-4434693435": the id is the trailing number.
+    // 6+ digits so a title ending in "-2" cannot be read as a job id.
+    const tail = seg[1].match(/-(\d{6,})$/);
+    if (tail) return tail[1];
+  }
+  // Collections and search views carry the id only in the query string.
+  const cur = u.searchParams.get('currentJobId');
+  return cur && /^\d+$/.test(cur) ? cur : null;
+}
+
+/** The named entities LinkedIn actually emits in topcard text. */
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+
+/**
+ * Decode HTML entities in ONE pass.
+ *
+ * Deliberately a single regex rather than a chain of .replace() calls. Chaining
+ * double-unescapes: decoding `&amp;` first rewrites `&amp;lt;` to `&lt;`, which
+ * the next replacement then turns into `<`, so a company literally named
+ * "A&lt;B" would come out as "A<B" (CodeQL js/double-escaping). One pass
+ * consumes each entity exactly once and never re-scans its own output.
+ *
+ * An unrecognized or out-of-range entity is left verbatim: this text becomes a
+ * company name and a job title used for matching, where a wrong character is
+ * worse than an undecoded one.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function decodeEntities(s) {
+  return String(s ?? '').replace(
+    /&(?:#(\d{1,7})|#[xX]([0-9a-fA-F]{1,6})|([a-zA-Z][a-zA-Z0-9]{1,31}));/g,
+    (match, dec, hex, name) => {
+      if (dec !== undefined || hex !== undefined) {
+        const code = dec !== undefined ? Number.parseInt(dec, 10) : Number.parseInt(hex, 16);
+        // Valid Unicode scalar values only; surrogates and out-of-range are left as-is.
+        if (!Number.isFinite(code) || code <= 0 || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff)) return match;
+        return String.fromCodePoint(code);
+      }
+      const named = NAMED_ENTITIES[name.toLowerCase()];
+      return named === undefined ? match : named;
+    },
+  );
+}
+
+function collapse(s) {
+  return decodeEntities(s).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Strip em dashes from text that reaches the user.
+ *
+ * `reason` strings are passed through from discover-ats, whose own messages use
+ * em dashes. They surface verbatim in --summary output and in the web UI later,
+ * and AGENTS.md bans the em dash in anything the user reads. Sanitizing here at
+ * the boundary keeps the rule without editing a shared system-layer file.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function noEmDash(s) {
+  return String(s ?? '').replace(/\s*—\s*/g, ': ').replace(/:\s*:/g, ':');
+}
+
+/**
+ * Pull the fields we need out of a guest posting page.
+ *
+ * Selectors verified against live guest responses: the title is an <h2> carrying
+ * `topcard__title`, the employer is the `topcard__org-name-link` anchor (whose
+ * href carries the company slug), the location is the `topcard__flavor--bullet`
+ * span, and an offsite apply is marked by `apply-button__offsite-apply-icon-svg`
+ * / a `public_jobs_apply-link-offsite` impression id.
+ *
+ * Regex rather than a DOM parser because the repo has no HTML-parsing dependency
+ * and these four anchors are stable, well-delimited attributes. Every field is
+ * independently optional: a layout change degrades one field rather than throwing.
+ *
+ * @param {string} html
+ * @returns {{title: string, company: string, companySlug: string, location: string, offsiteApply: boolean}}
+ */
+export function parseGuestPosting(html) {
+  const h = String(html ?? '');
+  const title = collapse((h.match(/<h2[^>]*\btopcard__title\b[^>]*>([\s\S]{0,300}?)<\/h2>/i) || [])[1] || '');
+  const orgAnchor = h.match(/<a[^>]*\btopcard__org-name-link\b[^>]*>([\s\S]{0,200}?)<\/a>/i);
+  const company = collapse((orgAnchor || [])[1] || '');
+  const slugMatch = h.match(/linkedin\.com\/company\/([A-Za-z0-9._-]+)/i);
+  const companySlug = slugMatch ? slugMatch[1] : '';
+  const location = collapse(
+    (h.match(/<span[^>]*\btopcard__flavor--bullet\b[^>]*>([\s\S]{0,200}?)<\/span>/i) || [])[1] || '',
+  );
+  const offsiteApply = /apply-button__offsite-apply-icon-svg|public_jobs_apply-link-offsite/i.test(h);
+  return { title, company, companySlug, location, offsiteApply };
+}
+
+// ── Title matching (pure) ─────────────────────────────────────────────
+
+/**
+ * Strip the decoration that differs between how LinkedIn renders a title and how
+ * the employer's own board does, so the two become comparable:
+ * bracketed asides ("(Remote)", "(m/w/d)"), a trailing req id, and separator
+ * noise. What survives is the role words.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+export function normalizeTitle(title) {
+  return decodeEntities(String(title ?? ''))
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')       // (Remote), (m/w/d), (Contract)
+    .replace(/\[[^\]]*\]/g, ' ')      // [Amsterdam]
+    .replace(/\b(?:req|job|posting|ref)[\s#:-]*[a-z0-9-]*\d[a-z0-9-]*\b/g, ' ')
+    .replace(/[^a-z0-9+#./ ]+/g, ' ') // keep c++, .net, ci/cd
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * How well two titles correspond, in [0, 1].
+ *
+ * Exact match after normalization scores 1. Otherwise this is token Jaccard, which
+ * handles the common real difference (a board title carrying an extra team or
+ * location word) without treating word order as meaningful.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function titleScore(a, b) {
+  const na = normalizeTitle(a);
+  const nb = normalizeTitle(b);
+  if (!na || !nb) return 0;
+  if (na === nb) return 1;
+  return jaccardSimilarity(na, nb);
+}
+
+/**
+ * Choose the board posting that corresponds to a LinkedIn title, or refuse.
+ *
+ * Policy, in order:
+ *  - A seniority difference (jd-similarity's hardMismatch) DISQUALIFIES a candidate
+ *    outright. "Senior Data Engineer" must never resolve to "Staff Data Engineer";
+ *    that is the single most damaging wrong answer this function could give.
+ *  - Candidates below CANDIDATE_FLOOR are dropped as noise.
+ *  - `resolved` requires BOTH a score at or above ACCEPT_THRESHOLD AND a lead of at
+ *    least ACCEPT_MARGIN over the runner-up. A strong score alone is not enough,
+ *    because two sibling postings can both match a vague LinkedIn title well.
+ *  - Anything else is `ambiguous`: ranked candidates, no pick.
+ *
+ * Location breaks a near-tie only. It never disqualifies, because LinkedIn and the
+ * employer's board routinely disagree about how to spell the same place ("Remote"
+ * vs "Seattle, WA" vs "United States").
+ *
+ * @param {string} linkedInTitle
+ * @param {Array<{title: string, url: string, location?: string}>} jobs
+ * @param {{location?: string}} [opts]
+ * @returns {{status: 'resolved'|'ambiguous'|'unresolved', match: object|null, candidates: object[], reason: string}}
+ */
+export function pickMatch(linkedInTitle, jobs, opts = {}) {
+  const list = Array.isArray(jobs) ? jobs : [];
+  if (!linkedInTitle || list.length === 0) {
+    return { status: 'unresolved', match: null, candidates: [], reason: 'no board postings to match against' };
+  }
+
+  const wantLoc = normalizeTitle(opts.location || '');
+  const scored = list
+    .filter((j) => j && j.title && j.url)
+    .map((j) => {
+      const score = titleScore(linkedInTitle, j.title);
+      // A shared location token is worth a nudge, never a verdict.
+      const jl = normalizeTitle(j.location || '');
+      const locBonus = wantLoc && jl && (jl.includes(wantLoc) || wantLoc.includes(jl)) ? 0.05 : 0;
+      return {
+        title: j.title,
+        url: j.url,
+        location: j.location || '',
+        score: Math.min(1, score + locBonus),
+        levelMismatch: hardMismatch(linkedInTitle, j.title),
+      };
+    })
+    .filter((c) => !c.levelMismatch && c.score >= CANDIDATE_FLOOR)
+    .sort((a, b) => b.score - a.score);
+
+  if (scored.length === 0) {
+    return { status: 'unresolved', match: null, candidates: [], reason: 'no posting on the board resembles this title' };
+  }
+
+  const [best, runnerUp] = scored;
+  const margin = best.score - (runnerUp ? runnerUp.score : 0);
+  if (best.score >= ACCEPT_THRESHOLD && margin >= ACCEPT_MARGIN) {
+    return { status: 'resolved', match: best, candidates: scored.slice(0, 5), reason: 'unique high-confidence title match' };
+  }
+  return {
+    status: 'ambiguous',
+    match: null,
+    candidates: scored.slice(0, 5),
+    reason:
+      best.score < ACCEPT_THRESHOLD
+        ? 'closest posting is below the confidence floor, so it is listed rather than chosen'
+        : 'several postings match this title closely, so none was chosen automatically',
+  };
+}
+
+// ── Live resolution ───────────────────────────────────────────────────
+
+/**
+ * Fetch a guest posting page.
+ * @param {string} jobId digits only
+ * @param {object} ctx makeHttpCtx()
+ * @returns {Promise<string>}
+ */
+export async function fetchGuestPosting(jobId, ctx) {
+  const text = await ctx.fetchText(GUEST_POSTING_URL(jobId));
+  return String(text ?? '').slice(0, MAX_GUEST_BYTES);
+}
+
+/**
+ * Corporate-form suffixes LinkedIn appends to disambiguate a company vanity URL
+ * ("whatnot-inc"). Safe to strip because they denote legal form rather than brand.
+ * Deliberately NOT stripping things like "ai" or "hq": those are part of the brand
+ * (assembledhq IS the Ashby board slug), so removing them loses real matches.
+ */
+const CORPORATE_SUFFIX = /-(?:inc|llc|ltd|limited|corp|gmbh|bv|ag|sa|plc)$/i;
+
+/**
+ * Slugs worth probing for one posting, most likely first, deduped.
+ *
+ * Two independent sources, and each one wins cases the other loses:
+ *  - the display name ("Gradial" -> "gradial") resolves boards whose LinkedIn
+ *    vanity URL carries a suffix ("gradialai")
+ *  - the LinkedIn company slug resolves boards the display name cannot
+ *    ("Assembled" -> "assembled" 404s, but "assembledhq" is the live Ashby board)
+ * Trying only one of them, which is all `resolveCompany` does per call, silently
+ * loses whichever half the other would have caught.
+ *
+ * @param {{company: string, companySlug?: string}} posting
+ * @returns {string[]}
+ */
+export function candidateSlugs(posting) {
+  const out = [];
+  const add = (s) => {
+    if (s && SLUG_RE.test(s) && !out.includes(s)) out.push(s);
+  };
+  add(deriveSlug(posting.company || ''));
+  const li = String(posting.companySlug || '').toLowerCase();
+  add(li);
+  if (CORPORATE_SUFFIX.test(li)) add(li.replace(CORPORATE_SUFFIX, ''));
+  return out;
+}
+
+/**
+ * Find the employer's live board, trying each candidate slug in turn.
+ *
+ * @param {{company: string, companySlug?: string}} posting
+ * @param {object} ctx
+ * @returns {Promise<{resolved: object|null, reason: string}>}
+ */
+export async function resolveBoard(posting, ctx) {
+  const slugs = candidateSlugs(posting);
+  let lastReason = 'no usable company slug could be derived';
+  for (const slug of slugs) {
+    // `ctx` is required, not optional: resolveCompany has no default for it (only
+    // runDiscovery supplies one), and omitting it fails every probe with an opaque
+    // "cannot read properties of undefined" rather than a network error.
+    const { resolved, unresolved } = await resolveCompany({ name: posting.company, slug }, { ctx });
+    if (resolved) return { resolved, reason: `resolved via slug "${slug}"` };
+    lastReason = unresolved?.reason ?? lastReason;
+  }
+  return { resolved: null, reason: noEmDash(`tried slug(s) ${slugs.map((s) => `"${s}"`).join(', ') || '(none)'}: ${lastReason}`) };
+}
+
+/**
+ * Read the employer's live board through the same provider `scan.mjs` uses, so a
+ * URL resolved here is one the rest of the pipeline already knows how to handle.
+ *
+ * @param {{name: string, vendor: string, slug: string, careers_url: string, api?: string}} board
+ * @param {object} ctx
+ * @returns {Promise<Array<{title: string, url: string, location?: string}>>}
+ */
+export async function fetchBoardJobs(board, ctx) {
+  const provider = PROVIDERS[board.vendor];
+  if (!provider) return [];
+  const entry = { name: board.name, careers_url: board.careers_url };
+  if (board.api) entry.api = board.api;
+  const jobs = await provider.fetch(entry, ctx);
+  return Array.isArray(jobs) ? jobs : [];
+}
+
+/**
+ * Full pipeline: LinkedIn URL -> the employer's real application URL.
+ *
+ * Never throws for an expected failure; every outcome is a status the caller can
+ * render. `status` is one of:
+ *   resolved   applyUrl is set and safe to use
+ *   ambiguous  candidates[] is set, a human should pick
+ *   unresolved nothing usable, `reason` says why
+ *
+ * @param {string} url a linkedin.com job posting URL
+ * @param {{ctx?: object}} [opts]
+ */
+export async function resolveApplyUrl(url, opts = {}) {
+  const ctx = opts.ctx || makeHttpCtx();
+  const jobId = linkedInJobId(url);
+  if (!jobId) {
+    return { ok: false, status: 'unresolved', reason: 'that is not a single LinkedIn job posting URL', posting: null, board: null, applyUrl: null, candidates: [] };
+  }
+
+  let html;
+  try {
+    html = await fetchGuestPosting(jobId, ctx);
+  } catch (error) {
+    return { ok: false, status: 'unresolved', reason: `could not read the LinkedIn guest posting: ${error.message}`, posting: null, board: null, applyUrl: null, candidates: [] };
+  }
+
+  const posting = { jobId, ...parseGuestPosting(html) };
+  if (!posting.company || !posting.title) {
+    return { ok: false, status: 'unresolved', reason: 'the guest posting did not carry a company and title (LinkedIn may have changed its markup)', posting, board: null, applyUrl: null, candidates: [] };
+  }
+
+  const { resolved, reason: boardReason } = await resolveBoard(posting, ctx);
+  if (!resolved) {
+    return {
+      ok: false,
+      status: 'unresolved',
+      reason: `no Greenhouse, Ashby or Lever board found for ${posting.company}: ${boardReason}`,
+      posting,
+      board: null,
+      applyUrl: null,
+      candidates: [],
+    };
+  }
+
+  let jobs;
+  try {
+    jobs = await fetchBoardJobs(resolved, ctx);
+  } catch (error) {
+    return { ok: false, status: 'unresolved', reason: `found ${posting.company}'s ${resolved.vendor} board but could not read it: ${error.message}`, posting, board: resolved, applyUrl: null, candidates: [] };
+  }
+
+  const picked = pickMatch(posting.title, jobs, { location: posting.location });
+  return {
+    ok: picked.status === 'resolved',
+    status: picked.status,
+    reason: picked.reason,
+    posting,
+    board: { vendor: resolved.vendor, slug: resolved.slug, careers_url: resolved.careers_url, jobCount: resolved.jobCount },
+    applyUrl: picked.match ? picked.match.url : null,
+    confidence: picked.match ? Number(picked.match.score.toFixed(3)) : 0,
+    candidates: picked.candidates.map((c) => ({ title: c.title, url: c.url, location: c.location, score: Number(c.score.toFixed(3)) })),
+  };
+}
+
+// ── Report persistence ────────────────────────────────────────────────
+
+export const APPLY_URL_LABEL = 'Apply URL';
+
+/**
+ * Upsert `**Apply URL:** <url>` into a report's HEADER block.
+ *
+ * Separate from the existing `**URL:**` on purpose. `**URL:**` keeps its meaning
+ * as the canonical, human-clickable posting link that the tracker and report
+ * header record; `**Apply URL:**` is where the fillable form actually lives. For
+ * a LinkedIn posting those are two different places, which is the whole reason
+ * this module exists, and collapsing them would lose the link the user recognizes.
+ *
+ * Header-only by construction: the scan stops at the first `---` or `## `, so a
+ * body that happens to mention a URL is never rewritten. Idempotent, and it
+ * preserves every other byte of the report (reports are user-layer).
+ *
+ * @param {string} md report markdown
+ * @param {string} applyUrl
+ * @returns {string} the updated markdown
+ */
+export function upsertApplyUrl(md, applyUrl) {
+  const url = String(applyUrl ?? '').trim();
+  if (!/^https?:\/\//i.test(url)) throw new Error('an http(s) apply URL is required');
+  const lines = String(md ?? '').split('\n');
+  const line = `**${APPLY_URL_LABEL}:** ${url}`;
+
+  // The header ends at the first horizontal rule or the first `## ` section.
+  let end = lines.findIndex((l, i) => i > 0 && (/^\s*-{3,}\s*$/.test(l) || /^##\s/.test(l)));
+  if (end === -1) end = Math.min(lines.length, 10);
+
+  const existing = lines.findIndex((l, i) => i < end && new RegExp(`^\\s*\\*\\*${APPLY_URL_LABEL}:\\*\\*`, 'i').test(l));
+  if (existing !== -1) {
+    lines[existing] = line;
+    return lines.join('\n');
+  }
+
+  // Prefer sitting directly under **URL:**, so the two links read as a pair.
+  const afterUrl = lines.findIndex((l, i) => i < end && /^\s*\*\*URL:\*\*/i.test(l));
+  const at = afterUrl !== -1 ? afterUrl + 1 : Math.max(0, end);
+  lines.splice(at, 0, line);
+  return lines.join('\n');
+}
+
+/**
+ * Read the `**Apply URL:**` already recorded on a report, or "".
+ * @param {string} md
+ * @returns {string}
+ */
+export function readApplyUrl(md) {
+  const lines = String(md ?? '').split('\n');
+  let end = lines.findIndex((l, i) => i > 0 && (/^\s*-{3,}\s*$/.test(l) || /^##\s/.test(l)));
+  if (end === -1) end = Math.min(lines.length, 10);
+  for (let i = 0; i < end; i++) {
+    const m = lines[i].match(new RegExp(`^\\s*\\*\\*${APPLY_URL_LABEL}:\\*\\*\\s*(\\S+)`, 'i'));
+    if (m) return m[1];
+  }
+  return '';
+}
+
+// ── Output ────────────────────────────────────────────────────────────
+
+function printSummary(result) {
+  const p = result.posting;
+  console.log(`\n${'='.repeat(72)}`);
+  console.log('  LinkedIn apply URL resolution');
+  console.log(`${'='.repeat(72)}`);
+  if (p) {
+    console.log(`  Posting   : ${p.title || '(unknown title)'}`);
+    console.log(`  Company   : ${p.company || '(unknown)'}${p.location ? ` (${p.location})` : ''}`);
+    console.log(`  Applies   : ${p.offsiteApply ? 'offsite (employer ATS)' : 'on LinkedIn (Easy Apply)'}`);
+  }
+  if (result.board) console.log(`  Board     : ${result.board.vendor} / ${result.board.slug} (${result.board.jobCount} open)`);
+  console.log(`  Status    : ${result.status}`);
+  console.log(`  Why       : ${result.reason}`);
+  if (result.applyUrl) console.log(`\n  Apply URL : ${result.applyUrl}  [confidence ${result.confidence}]`);
+  if (result.candidates?.length && !result.applyUrl) {
+    console.log('\n  Candidates (pick one yourself):');
+    for (const c of result.candidates) console.log(`    ${String(c.score).padStart(5)}  ${c.title}${c.location ? ` (${c.location})` : ''}\n           ${c.url}`);
+  }
+  console.log('');
+}
+
+const HELP = `
+linkedin-apply.mjs - resolve a LinkedIn posting to the employer's real application URL
+
+Usage:
+  node linkedin-apply.mjs <linkedin-job-url>            JSON (default)
+  node linkedin-apply.mjs <linkedin-job-url> --summary  human-readable
+  node linkedin-apply.mjs <url> --report <report.md>    resolve, then record **Apply URL:**
+  node linkedin-apply.mjs --report <report.md> --set <url>   record a URL you chose
+  node linkedin-apply.mjs --self-test                   inline test suite
+  node linkedin-apply.mjs --help
+
+--report writes only on a confident resolve; an ambiguous run records nothing, so
+a guess never lands in the report where it would be acted on later.
+
+LinkedIn's guest endpoint says whether a posting applies offsite but not where.
+This reconstructs the destination from the employer plus the job title, using the
+same ATS providers scan.mjs reads, so the result is a URL the apply flow can fill.
+
+Matching refuses rather than guesses: a posting only resolves on a unique
+high-confidence title match, and a seniority difference disqualifies outright.
+Anything less comes back as ranked candidates for you to choose from.
+`;
+
+// ── Self-test ─────────────────────────────────────────────────────────
+
+function runSelfTest() {
+  let pass = 0;
+  let fail = 0;
+  const check = (cond, label) => {
+    if (cond) { pass += 1; } else { fail += 1; console.error(`  FAIL: ${label}`); }
+  };
+
+  // linkedInJobId - shared cases pinned against web/src/lib/job-url.mjs
+  check(linkedInJobId('https://www.linkedin.com/jobs/view/4446829641/') === '4446829641', 'jobId from a canonical view URL');
+  check(linkedInJobId('https://www.linkedin.com/jobs/view/senior-software-engineer-at-gradial-4446829641') === '4446829641', 'jobId from a slugged view URL');
+  check(linkedInJobId('https://www.linkedin.com/jobs/collections/recommended/?currentJobId=4446829641') === '4446829641', 'jobId from a collections URL');
+  check(linkedInJobId('https://www.linkedin.com/jobs/view/some-role-at-acme-2') === null, 'a 1-digit tail is not a job id');
+  check(linkedInJobId('https://example.com/jobs/view/4446829641') === null, 'non-LinkedIn host rejected');
+  check(linkedInJobId('not a url') === null, 'garbage input rejected');
+
+  // parseGuestPosting - markup shaped like the live guest response
+  const html = `
+    <a class="topcard__link"><h2 class="top-card-layout__title topcard__title">Senior Software Engineer</h2></a>
+    <span class="topcard__flavor">
+      <a class="topcard__org-name-link topcard__flavor--black-link" href="https://www.linkedin.com/company/gradialai?trk=x">
+        Gradial
+      </a>
+    </span>
+    <span class="topcard__flavor topcard__flavor--bullet">Seattle, WA</span>
+    <icon data-svg-class-name="apply-button__offsite-apply-icon-svg"></icon>`;
+  const parsed = parseGuestPosting(html);
+  check(parsed.title === 'Senior Software Engineer', 'parseGuestPosting reads the title');
+  check(parsed.company === 'Gradial', 'parseGuestPosting reads the company');
+  check(parsed.companySlug === 'gradialai', 'parseGuestPosting reads the company slug');
+  check(parsed.location === 'Seattle, WA', 'parseGuestPosting reads the location');
+  check(parsed.offsiteApply === true, 'parseGuestPosting detects an offsite apply');
+  const easy = parseGuestPosting('<h2 class="topcard__title">Analyst</h2>');
+  check(easy.offsiteApply === false, 'parseGuestPosting reports Easy Apply as not offsite');
+  check(parseGuestPosting('').title === '' && parseGuestPosting(null).company === '', 'parseGuestPosting never throws on empty input');
+  check(parseGuestPosting('<h2 class="topcard__title">R&amp;D Engineer</h2>').title === 'R&D Engineer', 'parseGuestPosting decodes entities');
+  // Entity decoding must not re-scan its own output (CodeQL js/double-escaping).
+  // Chained .replace() calls turned "&amp;lt;" into "<"; one pass yields "&lt;".
+  check(parseGuestPosting('<h2 class="topcard__title">A&amp;lt;B</h2>').title === 'A&lt;B', 'decodeEntities does not double-unescape');
+  check(parseGuestPosting('<h2 class="topcard__title">A&amp;amp;B</h2>').title === 'A&amp;B', 'decodeEntities decodes a doubled ampersand exactly once');
+  check(parseGuestPosting('<h2 class="topcard__title">caf&#233; Lead</h2>').title === 'café Lead', 'decodeEntities decodes a decimal entity');
+  check(parseGuestPosting('<h2 class="topcard__title">caf&#xE9; Lead</h2>').title === 'café Lead', 'decodeEntities decodes a hex entity');
+  check(parseGuestPosting('<h2 class="topcard__title">100&#37; Remote</h2>').title === '100% Remote', 'decodeEntities handles a numeric entity mid-string');
+  check(parseGuestPosting('<h2 class="topcard__title">Sales &amp;lt;3 Ops</h2>').title === 'Sales &lt;3 Ops', 'decodeEntities leaves an escaped entity escaped');
+  check(parseGuestPosting('<h2 class="topcard__title">R&nosuchentity; Dev</h2>').title === 'R&nosuchentity; Dev', 'decodeEntities leaves an unknown entity verbatim');
+  check(parseGuestPosting('<h2 class="topcard__title">Bad&#xD800; Dev</h2>').title === 'Bad&#xD800; Dev', 'decodeEntities refuses a surrogate code point');
+
+  // candidateSlugs - each source rescues cases the other loses (verified live:
+  // "Gradial"/gradialai resolves from the name, "Assembled"/assembledhq only
+  // from the LinkedIn slug).
+  check(JSON.stringify(candidateSlugs({ company: 'Gradial', companySlug: 'gradialai' })) === '["gradial","gradialai"]', 'candidateSlugs tries the name slug then the LinkedIn slug');
+  check(JSON.stringify(candidateSlugs({ company: 'Assembled', companySlug: 'assembledhq' })) === '["assembled","assembledhq"]', 'candidateSlugs keeps a branded LinkedIn slug intact');
+  check(candidateSlugs({ company: 'Whatnot', companySlug: 'whatnot-inc' }).includes('whatnot-inc'), 'candidateSlugs keeps the raw LinkedIn slug');
+  check(JSON.stringify(candidateSlugs({ company: 'Acme', companySlug: 'acme' })) === '["acme"]', 'candidateSlugs dedupes identical slugs');
+  check(candidateSlugs({ company: 'Acme', companySlug: 'bad/slug' }).length === 1, 'candidateSlugs rejects an unsafe slug');
+  check(candidateSlugs({ company: '' }).length === 0, 'candidateSlugs handles a missing company');
+
+  // upsertApplyUrl - reports are user-layer, so this must be surgical.
+  const report = [
+    '# Evaluation: Acme',
+    '**Date:** 2026-08-13',
+    '**Score:** 4.2/5',
+    '**URL:** https://www.linkedin.com/jobs/view/123/',
+    '**PDF:** ✅',
+    '',
+    '---',
+    '',
+    '## A) Role Summary',
+    'Body text mentioning **URL:** style prose.',
+  ].join('\n');
+  const written = upsertApplyUrl(report, 'https://job-boards.greenhouse.io/acme/jobs/1');
+  check(written.includes('**Apply URL:** https://job-boards.greenhouse.io/acme/jobs/1'), 'upsertApplyUrl writes the field');
+  check(written.split('\n')[4] === '**Apply URL:** https://job-boards.greenhouse.io/acme/jobs/1', 'upsertApplyUrl places it directly under **URL:**');
+  check(written.includes('## A) Role Summary') && written.includes('Body text mentioning'), 'upsertApplyUrl leaves the body untouched');
+  const twice = upsertApplyUrl(written, 'https://job-boards.greenhouse.io/acme/jobs/2');
+  check((twice.match(/\*\*Apply URL:\*\*/g) || []).length === 1, 'upsertApplyUrl replaces rather than duplicating');
+  check(twice.includes('/jobs/2') && !twice.includes('/jobs/1'), 'upsertApplyUrl updates the value');
+  check(upsertApplyUrl(report, 'https://x/1').split('\n').length === report.split('\n').length + 1, 'upsertApplyUrl adds exactly one line');
+  let threw = false;
+  try { upsertApplyUrl(report, 'javascript:alert(1)'); } catch { threw = true; }
+  check(threw, 'upsertApplyUrl refuses a non-http URL');
+  const noUrlField = upsertApplyUrl('# Evaluation: Acme\n**Score:** 4.0/5\n\n---\n\n## A) X\n', 'https://x/1');
+  check(noUrlField.includes('**Apply URL:**') && noUrlField.indexOf('**Apply URL:**') < noUrlField.indexOf('## A)'), 'upsertApplyUrl still lands in the header when **URL:** is absent');
+
+  // readApplyUrl
+  check(readApplyUrl(written) === 'https://job-boards.greenhouse.io/acme/jobs/1', 'readApplyUrl reads the field back');
+  check(readApplyUrl(report) === '', 'readApplyUrl returns empty when unset');
+  check(readApplyUrl('# X\n\n---\n\n## A\n**Apply URL:** https://body/1\n') === '', 'readApplyUrl ignores a body line outside the header');
+
+  // House rule: no em dash reaches the user, including pass-through upstream text.
+  check(!noEmDash('board found — but empty').includes('—'), 'noEmDash strips a pass-through em dash');
+  check(noEmDash('a — b') === 'a: b', 'noEmDash reads cleanly as a colon');
+
+  // normalizeTitle
+  check(normalizeTitle('Senior Engineer (Remote)') === 'senior engineer', 'normalizeTitle drops bracketed asides');
+  check(normalizeTitle('Data Engineer (m/w/d)') === 'data engineer', 'normalizeTitle drops gender markers');
+  check(normalizeTitle('  Staff   SRE  ') === 'staff sre', 'normalizeTitle collapses whitespace');
+  check(normalizeTitle('C++ Developer') === 'c++ developer', 'normalizeTitle keeps c++');
+
+  // titleScore
+  check(titleScore('Senior Software Engineer', 'senior software engineer') === 1, 'titleScore is case-insensitive');
+  check(titleScore('Senior Software Engineer', 'Senior Software Engineer (Remote)') === 1, 'titleScore ignores a bracketed aside');
+  check(titleScore('Senior Software Engineer', 'Account Executive') < 0.2, 'titleScore separates unrelated roles');
+  check(titleScore('', 'Anything') === 0, 'titleScore handles an empty side');
+
+  // pickMatch - the safety-critical policy
+  const unique = pickMatch('Senior Software Engineer', [
+    { title: 'Senior Software Engineer', url: 'https://job-boards.greenhouse.io/acme/jobs/1' },
+    { title: 'Account Executive', url: 'https://job-boards.greenhouse.io/acme/jobs/2' },
+  ]);
+  check(unique.status === 'resolved' && unique.match.url.endsWith('/1'), 'pickMatch resolves a unique exact match');
+
+  const siblings = pickMatch('Senior Engineer', [
+    { title: 'Senior Engineer, Payments', url: 'https://x/1' },
+    { title: 'Senior Engineer, Risk', url: 'https://x/2' },
+  ]);
+  check(siblings.status === 'ambiguous' && siblings.match === null, 'pickMatch refuses to choose between sibling postings');
+  check(siblings.candidates.length === 2, 'pickMatch still lists the siblings as candidates');
+
+  const levels = pickMatch('Senior Data Engineer', [{ title: 'Staff Data Engineer', url: 'https://x/1' }]);
+  check(levels.status === 'unresolved', 'pickMatch disqualifies a seniority mismatch outright');
+
+  const nothing = pickMatch('Senior Software Engineer', [{ title: 'Office Manager', url: 'https://x/1' }]);
+  check(nothing.status === 'unresolved' && nothing.candidates.length === 0, 'pickMatch reports no resemblance rather than a weak pick');
+  check(pickMatch('Anything', []).status === 'unresolved', 'pickMatch handles an empty board');
+  check(pickMatch('', [{ title: 'X', url: 'https://x/1' }]).status === 'unresolved', 'pickMatch handles a missing LinkedIn title');
+
+  // Location is a tiebreaker, never a disqualifier.
+  const loc = pickMatch('Senior Software Engineer', [{ title: 'Senior Software Engineer', url: 'https://x/1', location: 'Remote' }], { location: 'Seattle, WA' });
+  check(loc.status === 'resolved', 'pickMatch does not reject a match on a location disagreement');
+
+  // A candidate missing a url is not offerable.
+  const noUrl = pickMatch('Senior Software Engineer', [{ title: 'Senior Software Engineer', url: '' }]);
+  check(noUrl.status === 'unresolved', 'pickMatch drops a posting with no URL');
+
+  console.log(`\n  linkedin-apply self-test: ${pass} passed, ${fail} failed\n`);
+  if (fail > 0) process.exit(1);
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────
+
+const KNOWN_FLAGS = ['--json', '--summary', '--self-test', '--help', '-h', '--report', '--set'];
+
+/** Read `--flag value`, or "" when absent. Rejects a missing value loudly. */
+function optValue(args, flag) {
+  const i = args.indexOf(flag);
+  if (i === -1) return '';
+  const v = args[i + 1];
+  if (!v || v.startsWith('-')) {
+    console.error(`${flag} needs a value.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((a) => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknown.length) {
+    console.error(`Unknown option(s): ${unknown.join(', ')}\n${HELP}`);
+    process.exit(1);
+  }
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(HELP);
+    return;
+  }
+  if (args.includes('--self-test')) {
+    runSelfTest();
+    return;
+  }
+
+  const reportPath = optValue(args, '--report');
+  const setUrl = optValue(args, '--set');
+
+  // `--set` records a URL the user chose (an ambiguous pick, or one they pasted)
+  // without re-resolving anything. Separate path because there is nothing to
+  // resolve: the answer is already known and only needs persisting.
+  if (setUrl) {
+    if (!reportPath) {
+      console.error('--set needs --report <path> to write to.');
+      process.exit(1);
+    }
+    const md = readFileSync(reportPath, 'utf8');
+    writeFileSync(reportPath, upsertApplyUrl(md, setUrl));
+    console.log(JSON.stringify({ ok: true, status: 'resolved', applyUrl: setUrl, written: reportPath, source: 'manual' }, null, 2));
+    return;
+  }
+
+  // A value-carrying flag's value must not be mistaken for the positional URL.
+  const consumed = new Set([reportPath, setUrl].filter(Boolean));
+  const url = args.find((a) => !a.startsWith('-') && !consumed.has(a));
+  if (!url) {
+    console.error(`A LinkedIn job posting URL is required.\n${HELP}`);
+    process.exit(1);
+  }
+
+  const result = await resolveApplyUrl(url);
+
+  // Persist only a confident answer. An ambiguous or failed run must not write a
+  // guess into the report: a wrong Apply URL is silently acted on later.
+  if (reportPath && result.status === 'resolved' && result.applyUrl) {
+    try {
+      writeFileSync(reportPath, upsertApplyUrl(readFileSync(reportPath, 'utf8'), result.applyUrl));
+      result.written = reportPath;
+    } catch (error) {
+      result.writeError = error.message;
+    }
+  }
+
+  if (args.includes('--summary')) printSummary(result);
+  else console.log(JSON.stringify(result, null, 2));
+  // Exit non-zero only when nothing usable came back, so a caller can branch on it.
+  // `ambiguous` exits 0: candidates ARE a useful result.
+  if (result.status === 'unresolved') process.exit(2);
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`linkedin-apply: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/linkedin-apply.mjs
+++ b/linkedin-apply.mjs
@@ -1,0 +1,774 @@
+#!/usr/bin/env node
+/**
+ * linkedin-apply.mjs - resolve a LinkedIn posting to the employer's real ATS application URL.
+ *
+ * WHY THIS EXISTS
+ * A LinkedIn posting URL is not applyable. `openSession()` in the web app opens a
+ * fresh, cookie-less browser context, so linkedin.com/jobs/view/<id> serves the
+ * authwall and the apply flow dead-ends (issue #7).
+ *
+ * The obvious fix does not work. LinkedIn's public guest endpoint returns the full
+ * posting with no auth, and it does say WHETHER a job applies offsite, but it does
+ * not expose WHERE: the destination sits behind the contextual sign-in modal, and
+ * the page carries no JSON-LD. So the apply URL has to be reconstructed, not read.
+ *
+ * This module reconstructs it from the two things the guest page does give us, the
+ * employer and the job title, by reusing machinery career-ops already ships:
+ *   1. guest endpoint            -> company, title, location, offsite-apply flag
+ *   2. discover-ats resolveCompany -> the employer's live Greenhouse/Ashby/Lever board
+ *   3. that board's provider       -> its current job list
+ *   4. title matching here         -> the one posting that corresponds
+ * Zero LLM tokens, zero auth, no browser.
+ *
+ * MATCHING IS DELIBERATELY CONSERVATIVE. A false match sends a real application to
+ * the wrong role, which is worse than not resolving at all. This never auto-picks a
+ * merely-plausible candidate: it returns `ambiguous` with a ranked list and lets a
+ * human choose. See pickMatch() for the exact policy.
+ *
+ * Run: node linkedin-apply.mjs <linkedin-job-url> [--json|--summary]
+ *      node linkedin-apply.mjs --self-test
+ *
+ * Issue #7 - github.com/EliRobinson/career-ops
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { pathToFileURL } from 'url';
+
+import { makeHttpCtx } from './providers/_http.mjs';
+import { resolveCompany, deriveSlug, SLUG_RE } from './discover-ats.mjs';
+import { jaccardSimilarity, hardMismatch } from './jd-similarity.mjs';
+import greenhouse from './providers/greenhouse.mjs';
+import ashby from './providers/ashby.mjs';
+import lever from './providers/lever.mjs';
+import workday from './providers/workday.mjs';
+
+/** vendor id (as returned by resolveCompany) -> the provider that reads its board. */
+const PROVIDERS = {
+  greenhouse,
+  ashby,
+  lever,
+  workday,
+};
+
+/** Guest endpoint for one posting. `id` is digits-only by construction (see
+ *  linkedInJobId), so nothing user-supplied is ever spliced into the host. */
+const GUEST_POSTING_URL = (id) => `https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/${id}`;
+
+/** A posting page is ~80KB; this bounds a hostile or runaway response. */
+const MAX_GUEST_BYTES = 2_000_000;
+
+// ── Matching thresholds ───────────────────────────────────────────────
+// Tuned to refuse rather than guess. ACCEPT is the floor for calling a match
+// resolved; MARGIN is how far clear of the runner-up the winner must be, so a
+// board listing "Senior Engineer, Payments" and "Senior Engineer, Risk" against a
+// LinkedIn title of "Senior Engineer" stays ambiguous instead of coin-flipping.
+const ACCEPT_THRESHOLD = 0.75;
+const ACCEPT_MARGIN = 0.15;
+/** Below this a candidate is not even worth showing the user. */
+const CANDIDATE_FLOOR = 0.3;
+
+// ── Guest page parsing (pure) ─────────────────────────────────────────
+
+/**
+ * The numeric LinkedIn job id, or null when the URL is not one posting.
+ *
+ * Mirrors `linkedInJobId` in web/src/lib/job-url.mjs. Kept as its own copy on
+ * purpose: root scripts and the Next app cannot share a module (Next's bundler
+ * statically traces root .mjs literals and fails the production build), and this
+ * is small enough that a duplicated regex beats a build-breaking import. The
+ * self-test below pins the shared cases so the two cannot drift silently.
+ *
+ * @param {string} raw
+ * @returns {string|null}
+ */
+export function linkedInJobId(raw) {
+  let u;
+  try {
+    u = new URL(String(raw ?? '').trim());
+  } catch {
+    return null;
+  }
+  if (!/(^|\.)linkedin\.com$/i.test(u.hostname)) return null;
+  const seg = u.pathname.match(/\/jobs\/view\/([^/]+)/i);
+  if (seg) {
+    if (/^\d+$/.test(seg[1])) return seg[1];
+    // "senior-ai-engineer-at-acme-4434693435": the id is the trailing number.
+    // 6+ digits so a title ending in "-2" cannot be read as a job id.
+    const tail = seg[1].match(/-(\d{6,})$/);
+    if (tail) return tail[1];
+  }
+  // Collections and search views carry the id only in the query string.
+  const cur = u.searchParams.get('currentJobId');
+  return cur && /^\d+$/.test(cur) ? cur : null;
+}
+
+/** The named entities LinkedIn actually emits in topcard text. */
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+
+/**
+ * Decode HTML entities in ONE pass.
+ *
+ * Deliberately a single regex rather than a chain of .replace() calls. Chaining
+ * double-unescapes: decoding `&amp;` first rewrites `&amp;lt;` to `&lt;`, which
+ * the next replacement then turns into `<`, so a company literally named
+ * "A&lt;B" would come out as "A<B" (CodeQL js/double-escaping). One pass
+ * consumes each entity exactly once and never re-scans its own output.
+ *
+ * An unrecognized or out-of-range entity is left verbatim: this text becomes a
+ * company name and a job title used for matching, where a wrong character is
+ * worse than an undecoded one.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function decodeEntities(s) {
+  return String(s ?? '').replace(
+    /&(?:#(\d{1,7})|#[xX]([0-9a-fA-F]{1,6})|([a-zA-Z][a-zA-Z0-9]{1,31}));/g,
+    (match, dec, hex, name) => {
+      if (dec !== undefined || hex !== undefined) {
+        const code = dec !== undefined ? Number.parseInt(dec, 10) : Number.parseInt(hex, 16);
+        // Valid Unicode scalar values only; surrogates and out-of-range are left as-is.
+        if (!Number.isFinite(code) || code <= 0 || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff)) return match;
+        return String.fromCodePoint(code);
+      }
+      const named = NAMED_ENTITIES[name.toLowerCase()];
+      return named === undefined ? match : named;
+    },
+  );
+}
+
+function collapse(s) {
+  return decodeEntities(s).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Strip em dashes from text that reaches the user.
+ *
+ * `reason` strings are passed through from discover-ats, whose own messages use
+ * em dashes. They surface verbatim in --summary output and in the web UI later,
+ * and AGENTS.md bans the em dash in anything the user reads. Sanitizing here at
+ * the boundary keeps the rule without editing a shared system-layer file.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function noEmDash(s) {
+  return String(s ?? '').replace(/\s*—\s*/g, ': ').replace(/:\s*:/g, ':');
+}
+
+/**
+ * Pull the fields we need out of a guest posting page.
+ *
+ * Selectors verified against live guest responses: the title is an <h2> carrying
+ * `topcard__title`, the employer is the `topcard__org-name-link` anchor (whose
+ * href carries the company slug), the location is the `topcard__flavor--bullet`
+ * span, and an offsite apply is marked by `apply-button__offsite-apply-icon-svg`
+ * / a `public_jobs_apply-link-offsite` impression id.
+ *
+ * Regex rather than a DOM parser because the repo has no HTML-parsing dependency
+ * and these four anchors are stable, well-delimited attributes. Every field is
+ * independently optional: a layout change degrades one field rather than throwing.
+ *
+ * @param {string} html
+ * @returns {{title: string, company: string, companySlug: string, location: string, offsiteApply: boolean}}
+ */
+export function parseGuestPosting(html) {
+  const h = String(html ?? '');
+  const title = collapse((h.match(/<h2[^>]*\btopcard__title\b[^>]*>([\s\S]{0,300}?)<\/h2>/i) || [])[1] || '');
+  const orgAnchor = h.match(/<a[^>]*\btopcard__org-name-link\b[^>]*>([\s\S]{0,200}?)<\/a>/i);
+  const company = collapse((orgAnchor || [])[1] || '');
+  const slugMatch = h.match(/linkedin\.com\/company\/([A-Za-z0-9._-]+)/i);
+  const companySlug = slugMatch ? slugMatch[1] : '';
+  const location = collapse(
+    (h.match(/<span[^>]*\btopcard__flavor--bullet\b[^>]*>([\s\S]{0,200}?)<\/span>/i) || [])[1] || '',
+  );
+  const offsiteApply = /apply-button__offsite-apply-icon-svg|public_jobs_apply-link-offsite/i.test(h);
+  return { title, company, companySlug, location, offsiteApply };
+}
+
+// ── Title matching (pure) ─────────────────────────────────────────────
+
+/**
+ * Strip the decoration that differs between how LinkedIn renders a title and how
+ * the employer's own board does, so the two become comparable:
+ * bracketed asides ("(Remote)", "(m/w/d)"), a trailing req id, and separator
+ * noise. What survives is the role words.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+export function normalizeTitle(title) {
+  return decodeEntities(String(title ?? ''))
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')       // (Remote), (m/w/d), (Contract)
+    .replace(/\[[^\]]*\]/g, ' ')      // [Amsterdam]
+    .replace(/\b(?:req|job|posting|ref)[\s#:-]*[a-z0-9-]*\d[a-z0-9-]*\b/g, ' ')
+    .replace(/[^a-z0-9+#./ ]+/g, ' ') // keep c++, .net, ci/cd
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * How well two titles correspond, in [0, 1].
+ *
+ * Exact match after normalization scores 1. Otherwise this is token Jaccard, which
+ * handles the common real difference (a board title carrying an extra team or
+ * location word) without treating word order as meaningful.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function titleScore(a, b) {
+  const na = normalizeTitle(a);
+  const nb = normalizeTitle(b);
+  if (!na || !nb) return 0;
+  if (na === nb) return 1;
+  return jaccardSimilarity(na, nb);
+}
+
+/**
+ * Choose the board posting that corresponds to a LinkedIn title, or refuse.
+ *
+ * Policy, in order:
+ *  - A seniority difference (jd-similarity's hardMismatch) DISQUALIFIES a candidate
+ *    outright. "Senior Data Engineer" must never resolve to "Staff Data Engineer";
+ *    that is the single most damaging wrong answer this function could give.
+ *  - Candidates below CANDIDATE_FLOOR are dropped as noise.
+ *  - `resolved` requires BOTH a score at or above ACCEPT_THRESHOLD AND a lead of at
+ *    least ACCEPT_MARGIN over the runner-up. A strong score alone is not enough,
+ *    because two sibling postings can both match a vague LinkedIn title well.
+ *  - Anything else is `ambiguous`: ranked candidates, no pick.
+ *
+ * Location breaks a near-tie only. It never disqualifies, because LinkedIn and the
+ * employer's board routinely disagree about how to spell the same place ("Remote"
+ * vs "Seattle, WA" vs "United States").
+ *
+ * @param {string} linkedInTitle
+ * @param {Array<{title: string, url: string, location?: string}>} jobs
+ * @param {{location?: string}} [opts]
+ * @returns {{status: 'resolved'|'ambiguous'|'unresolved', match: object|null, candidates: object[], reason: string}}
+ */
+export function pickMatch(linkedInTitle, jobs, opts = {}) {
+  const list = Array.isArray(jobs) ? jobs : [];
+  if (!linkedInTitle || list.length === 0) {
+    return { status: 'unresolved', match: null, candidates: [], reason: 'no board postings to match against' };
+  }
+
+  const wantLoc = normalizeTitle(opts.location || '');
+  const scored = list
+    .filter((j) => j && j.title && j.url)
+    .map((j) => {
+      const score = titleScore(linkedInTitle, j.title);
+      // A shared location token is worth a nudge, never a verdict.
+      const jl = normalizeTitle(j.location || '');
+      const locBonus = wantLoc && jl && (jl.includes(wantLoc) || wantLoc.includes(jl)) ? 0.05 : 0;
+      return {
+        title: j.title,
+        url: j.url,
+        location: j.location || '',
+        score: Math.min(1, score + locBonus),
+        levelMismatch: hardMismatch(linkedInTitle, j.title),
+      };
+    })
+    .filter((c) => !c.levelMismatch && c.score >= CANDIDATE_FLOOR)
+    .sort((a, b) => b.score - a.score);
+
+  if (scored.length === 0) {
+    return { status: 'unresolved', match: null, candidates: [], reason: 'no posting on the board resembles this title' };
+  }
+
+  const [best, runnerUp] = scored;
+  const margin = best.score - (runnerUp ? runnerUp.score : 0);
+  if (best.score >= ACCEPT_THRESHOLD && margin >= ACCEPT_MARGIN) {
+    return { status: 'resolved', match: best, candidates: scored.slice(0, 5), reason: 'unique high-confidence title match' };
+  }
+  return {
+    status: 'ambiguous',
+    match: null,
+    candidates: scored.slice(0, 5),
+    reason:
+      best.score < ACCEPT_THRESHOLD
+        ? 'closest posting is below the confidence floor, so it is listed rather than chosen'
+        : 'several postings match this title closely, so none was chosen automatically',
+  };
+}
+
+// ── Live resolution ───────────────────────────────────────────────────
+
+/**
+ * Fetch a guest posting page.
+ * @param {string} jobId digits only
+ * @param {object} ctx makeHttpCtx()
+ * @returns {Promise<string>}
+ */
+export async function fetchGuestPosting(jobId, ctx) {
+  const text = await ctx.fetchText(GUEST_POSTING_URL(jobId));
+  return String(text ?? '').slice(0, MAX_GUEST_BYTES);
+}
+
+/**
+ * Corporate-form suffixes LinkedIn appends to disambiguate a company vanity URL
+ * ("whatnot-inc"). Safe to strip because they denote legal form rather than brand.
+ * Deliberately NOT stripping things like "ai" or "hq": those are part of the brand
+ * (assembledhq IS the Ashby board slug), so removing them loses real matches.
+ */
+const CORPORATE_SUFFIX = /-(?:inc|llc|ltd|limited|corp|gmbh|bv|ag|sa|plc)$/i;
+
+/**
+ * Slugs worth probing for one posting, most likely first, deduped.
+ *
+ * Two independent sources, and each one wins cases the other loses:
+ *  - the display name ("Gradial" -> "gradial") resolves boards whose LinkedIn
+ *    vanity URL carries a suffix ("gradialai")
+ *  - the LinkedIn company slug resolves boards the display name cannot
+ *    ("Assembled" -> "assembled" 404s, but "assembledhq" is the live Ashby board)
+ * Trying only one of them, which is all `resolveCompany` does per call, silently
+ * loses whichever half the other would have caught.
+ *
+ * @param {{company: string, companySlug?: string}} posting
+ * @returns {string[]}
+ */
+export function candidateSlugs(posting) {
+  const out = [];
+  const add = (s) => {
+    if (s && SLUG_RE.test(s) && !out.includes(s)) out.push(s);
+  };
+  add(deriveSlug(posting.company || ''));
+  const li = String(posting.companySlug || '').toLowerCase();
+  add(li);
+  if (CORPORATE_SUFFIX.test(li)) add(li.replace(CORPORATE_SUFFIX, ''));
+  return out;
+}
+
+/**
+ * Find the employer's live board, trying each candidate slug in turn.
+ *
+ * @param {{company: string, companySlug?: string}} posting
+ * @param {object} ctx
+ * @returns {Promise<{resolved: object|null, reason: string}>}
+ */
+export async function resolveBoard(posting, ctx) {
+  const slugs = candidateSlugs(posting);
+  let lastReason = 'no usable company slug could be derived';
+  for (const slug of slugs) {
+    // `ctx` is required, not optional: resolveCompany has no default for it (only
+    // runDiscovery supplies one), and omitting it fails every probe with an opaque
+    // "cannot read properties of undefined" rather than a network error.
+    const { resolved, unresolved } = await resolveCompany({ name: posting.company, slug }, { ctx });
+    if (resolved) return { resolved, reason: `resolved via slug "${slug}"` };
+    lastReason = unresolved?.reason ?? lastReason;
+  }
+  return { resolved: null, reason: noEmDash(`tried slug(s) ${slugs.map((s) => `"${s}"`).join(', ') || '(none)'}: ${lastReason}`) };
+}
+
+/**
+ * Read the employer's live board through the same provider `scan.mjs` uses, so a
+ * URL resolved here is one the rest of the pipeline already knows how to handle.
+ *
+ * @param {{name: string, vendor: string, slug: string, careers_url: string, api?: string}} board
+ * @param {object} ctx
+ * @returns {Promise<Array<{title: string, url: string, location?: string}>>}
+ */
+export async function fetchBoardJobs(board, ctx) {
+  const provider = PROVIDERS[board.vendor];
+  if (!provider) return [];
+  const entry = { name: board.name, careers_url: board.careers_url };
+  if (board.api) entry.api = board.api;
+  const jobs = await provider.fetch(entry, ctx);
+  return Array.isArray(jobs) ? jobs : [];
+}
+
+/**
+ * Full pipeline: LinkedIn URL -> the employer's real application URL.
+ *
+ * Never throws for an expected failure; every outcome is a status the caller can
+ * render. `status` is one of:
+ *   resolved   applyUrl is set and safe to use
+ *   ambiguous  candidates[] is set, a human should pick
+ *   unresolved nothing usable, `reason` says why
+ *
+ * @param {string} url a linkedin.com job posting URL
+ * @param {{ctx?: object}} [opts]
+ */
+export async function resolveApplyUrl(url, opts = {}) {
+  const ctx = opts.ctx || makeHttpCtx();
+  const jobId = linkedInJobId(url);
+  if (!jobId) {
+    return { ok: false, status: 'unresolved', reason: 'that is not a single LinkedIn job posting URL', posting: null, board: null, applyUrl: null, candidates: [] };
+  }
+
+  let html;
+  try {
+    html = await fetchGuestPosting(jobId, ctx);
+  } catch (error) {
+    return { ok: false, status: 'unresolved', reason: `could not read the LinkedIn guest posting: ${error.message}`, posting: null, board: null, applyUrl: null, candidates: [] };
+  }
+
+  const posting = { jobId, ...parseGuestPosting(html) };
+  if (!posting.company || !posting.title) {
+    return { ok: false, status: 'unresolved', reason: 'the guest posting did not carry a company and title (LinkedIn may have changed its markup)', posting, board: null, applyUrl: null, candidates: [] };
+  }
+
+  const { resolved, reason: boardReason } = await resolveBoard(posting, ctx);
+  if (!resolved) {
+    return {
+      ok: false,
+      status: 'unresolved',
+      reason: `no Greenhouse, Ashby or Lever board found for ${posting.company}: ${boardReason}`,
+      posting,
+      board: null,
+      applyUrl: null,
+      candidates: [],
+    };
+  }
+
+  let jobs;
+  try {
+    jobs = await fetchBoardJobs(resolved, ctx);
+  } catch (error) {
+    return { ok: false, status: 'unresolved', reason: `found ${posting.company}'s ${resolved.vendor} board but could not read it: ${error.message}`, posting, board: resolved, applyUrl: null, candidates: [] };
+  }
+
+  const picked = pickMatch(posting.title, jobs, { location: posting.location });
+  return {
+    ok: picked.status === 'resolved',
+    status: picked.status,
+    reason: picked.reason,
+    posting,
+    board: { vendor: resolved.vendor, slug: resolved.slug, careers_url: resolved.careers_url, jobCount: resolved.jobCount },
+    applyUrl: picked.match ? picked.match.url : null,
+    confidence: picked.match ? Number(picked.match.score.toFixed(3)) : 0,
+    candidates: picked.candidates.map((c) => ({ title: c.title, url: c.url, location: c.location, score: Number(c.score.toFixed(3)) })),
+  };
+}
+
+// ── Report persistence ────────────────────────────────────────────────
+
+export const APPLY_URL_LABEL = 'Apply URL';
+
+/**
+ * Upsert `**Apply URL:** <url>` into a report's HEADER block.
+ *
+ * Separate from the existing `**URL:**` on purpose. `**URL:**` keeps its meaning
+ * as the canonical, human-clickable posting link that the tracker and report
+ * header record; `**Apply URL:**` is where the fillable form actually lives. For
+ * a LinkedIn posting those are two different places, which is the whole reason
+ * this module exists, and collapsing them would lose the link the user recognizes.
+ *
+ * Header-only by construction: the scan stops at the first `---` or `## `, so a
+ * body that happens to mention a URL is never rewritten. Idempotent, and it
+ * preserves every other byte of the report (reports are user-layer).
+ *
+ * @param {string} md report markdown
+ * @param {string} applyUrl
+ * @returns {string} the updated markdown
+ */
+export function upsertApplyUrl(md, applyUrl) {
+  const url = String(applyUrl ?? '').trim();
+  if (!/^https?:\/\//i.test(url)) throw new Error('an http(s) apply URL is required');
+  const lines = String(md ?? '').split('\n');
+  const line = `**${APPLY_URL_LABEL}:** ${url}`;
+
+  // The header ends at the first horizontal rule or the first `## ` section.
+  let end = lines.findIndex((l, i) => i > 0 && (/^\s*-{3,}\s*$/.test(l) || /^##\s/.test(l)));
+  if (end === -1) end = Math.min(lines.length, 10);
+
+  const existing = lines.findIndex((l, i) => i < end && new RegExp(`^\\s*\\*\\*${APPLY_URL_LABEL}:\\*\\*`, 'i').test(l));
+  if (existing !== -1) {
+    lines[existing] = line;
+    return lines.join('\n');
+  }
+
+  // Prefer sitting directly under **URL:**, so the two links read as a pair.
+  const afterUrl = lines.findIndex((l, i) => i < end && /^\s*\*\*URL:\*\*/i.test(l));
+  const at = afterUrl !== -1 ? afterUrl + 1 : Math.max(0, end);
+  lines.splice(at, 0, line);
+  return lines.join('\n');
+}
+
+/**
+ * Read the `**Apply URL:**` already recorded on a report, or "".
+ * @param {string} md
+ * @returns {string}
+ */
+export function readApplyUrl(md) {
+  const lines = String(md ?? '').split('\n');
+  let end = lines.findIndex((l, i) => i > 0 && (/^\s*-{3,}\s*$/.test(l) || /^##\s/.test(l)));
+  if (end === -1) end = Math.min(lines.length, 10);
+  for (let i = 0; i < end; i++) {
+    const m = lines[i].match(new RegExp(`^\\s*\\*\\*${APPLY_URL_LABEL}:\\*\\*\\s*(\\S+)`, 'i'));
+    if (m) return m[1];
+  }
+  return '';
+}
+
+// ── Output ────────────────────────────────────────────────────────────
+
+function printSummary(result) {
+  const p = result.posting;
+  console.log(`\n${'='.repeat(72)}`);
+  console.log('  LinkedIn apply URL resolution');
+  console.log(`${'='.repeat(72)}`);
+  if (p) {
+    console.log(`  Posting   : ${p.title || '(unknown title)'}`);
+    console.log(`  Company   : ${p.company || '(unknown)'}${p.location ? ` (${p.location})` : ''}`);
+    console.log(`  Applies   : ${p.offsiteApply ? 'offsite (employer ATS)' : 'on LinkedIn (Easy Apply)'}`);
+  }
+  if (result.board) console.log(`  Board     : ${result.board.vendor} / ${result.board.slug} (${result.board.jobCount} open)`);
+  console.log(`  Status    : ${result.status}`);
+  console.log(`  Why       : ${result.reason}`);
+  if (result.applyUrl) console.log(`\n  Apply URL : ${result.applyUrl}  [confidence ${result.confidence}]`);
+  if (result.candidates?.length && !result.applyUrl) {
+    console.log('\n  Candidates (pick one yourself):');
+    for (const c of result.candidates) console.log(`    ${String(c.score).padStart(5)}  ${c.title}${c.location ? ` (${c.location})` : ''}\n           ${c.url}`);
+  }
+  console.log('');
+}
+
+const HELP = `
+linkedin-apply.mjs - resolve a LinkedIn posting to the employer's real application URL
+
+Usage:
+  node linkedin-apply.mjs <linkedin-job-url>            JSON (default)
+  node linkedin-apply.mjs <linkedin-job-url> --summary  human-readable
+  node linkedin-apply.mjs <url> --report <report.md>    resolve, then record **Apply URL:**
+  node linkedin-apply.mjs --report <report.md> --set <url>   record a URL you chose
+  node linkedin-apply.mjs --self-test                   inline test suite
+  node linkedin-apply.mjs --help
+
+--report writes only on a confident resolve; an ambiguous run records nothing, so
+a guess never lands in the report where it would be acted on later.
+
+LinkedIn's guest endpoint says whether a posting applies offsite but not where.
+This reconstructs the destination from the employer plus the job title, using the
+same ATS providers scan.mjs reads, so the result is a URL the apply flow can fill.
+
+Matching refuses rather than guesses: a posting only resolves on a unique
+high-confidence title match, and a seniority difference disqualifies outright.
+Anything less comes back as ranked candidates for you to choose from.
+`;
+
+// ── Self-test ─────────────────────────────────────────────────────────
+
+function runSelfTest() {
+  let pass = 0;
+  let fail = 0;
+  const check = (cond, label) => {
+    if (cond) { pass += 1; } else { fail += 1; console.error(`  FAIL: ${label}`); }
+  };
+
+  // linkedInJobId - shared cases pinned against web/src/lib/job-url.mjs
+  check(linkedInJobId('https://www.linkedin.com/jobs/view/4446829641/') === '4446829641', 'jobId from a canonical view URL');
+  check(linkedInJobId('https://www.linkedin.com/jobs/view/senior-software-engineer-at-gradial-4446829641') === '4446829641', 'jobId from a slugged view URL');
+  check(linkedInJobId('https://www.linkedin.com/jobs/collections/recommended/?currentJobId=4446829641') === '4446829641', 'jobId from a collections URL');
+  check(linkedInJobId('https://www.linkedin.com/jobs/view/some-role-at-acme-2') === null, 'a 1-digit tail is not a job id');
+  check(linkedInJobId('https://example.com/jobs/view/4446829641') === null, 'non-LinkedIn host rejected');
+  check(linkedInJobId('not a url') === null, 'garbage input rejected');
+
+  // parseGuestPosting - markup shaped like the live guest response
+  const html = `
+    <a class="topcard__link"><h2 class="top-card-layout__title topcard__title">Senior Software Engineer</h2></a>
+    <span class="topcard__flavor">
+      <a class="topcard__org-name-link topcard__flavor--black-link" href="https://www.linkedin.com/company/gradialai?trk=x">
+        Gradial
+      </a>
+    </span>
+    <span class="topcard__flavor topcard__flavor--bullet">Seattle, WA</span>
+    <icon data-svg-class-name="apply-button__offsite-apply-icon-svg"></icon>`;
+  const parsed = parseGuestPosting(html);
+  check(parsed.title === 'Senior Software Engineer', 'parseGuestPosting reads the title');
+  check(parsed.company === 'Gradial', 'parseGuestPosting reads the company');
+  check(parsed.companySlug === 'gradialai', 'parseGuestPosting reads the company slug');
+  check(parsed.location === 'Seattle, WA', 'parseGuestPosting reads the location');
+  check(parsed.offsiteApply === true, 'parseGuestPosting detects an offsite apply');
+  const easy = parseGuestPosting('<h2 class="topcard__title">Analyst</h2>');
+  check(easy.offsiteApply === false, 'parseGuestPosting reports Easy Apply as not offsite');
+  check(parseGuestPosting('').title === '' && parseGuestPosting(null).company === '', 'parseGuestPosting never throws on empty input');
+  check(parseGuestPosting('<h2 class="topcard__title">R&amp;D Engineer</h2>').title === 'R&D Engineer', 'parseGuestPosting decodes entities');
+  // Entity decoding must not re-scan its own output (CodeQL js/double-escaping).
+  // Chained .replace() calls turned "&amp;lt;" into "<"; one pass yields "&lt;".
+  check(parseGuestPosting('<h2 class="topcard__title">A&amp;lt;B</h2>').title === 'A&lt;B', 'decodeEntities does not double-unescape');
+  check(parseGuestPosting('<h2 class="topcard__title">A&amp;amp;B</h2>').title === 'A&amp;B', 'decodeEntities decodes a doubled ampersand exactly once');
+  check(parseGuestPosting('<h2 class="topcard__title">caf&#233; Lead</h2>').title === 'café Lead', 'decodeEntities decodes a decimal entity');
+  check(parseGuestPosting('<h2 class="topcard__title">caf&#xE9; Lead</h2>').title === 'café Lead', 'decodeEntities decodes a hex entity');
+  check(parseGuestPosting('<h2 class="topcard__title">100&#37; Remote</h2>').title === '100% Remote', 'decodeEntities handles a numeric entity mid-string');
+  check(parseGuestPosting('<h2 class="topcard__title">Sales &amp;lt;3 Ops</h2>').title === 'Sales &lt;3 Ops', 'decodeEntities leaves an escaped entity escaped');
+  check(parseGuestPosting('<h2 class="topcard__title">R&nosuchentity; Dev</h2>').title === 'R&nosuchentity; Dev', 'decodeEntities leaves an unknown entity verbatim');
+  check(parseGuestPosting('<h2 class="topcard__title">Bad&#xD800; Dev</h2>').title === 'Bad&#xD800; Dev', 'decodeEntities refuses a surrogate code point');
+
+  // candidateSlugs - each source rescues cases the other loses (verified live:
+  // "Gradial"/gradialai resolves from the name, "Assembled"/assembledhq only
+  // from the LinkedIn slug).
+  check(JSON.stringify(candidateSlugs({ company: 'Gradial', companySlug: 'gradialai' })) === '["gradial","gradialai"]', 'candidateSlugs tries the name slug then the LinkedIn slug');
+  check(JSON.stringify(candidateSlugs({ company: 'Assembled', companySlug: 'assembledhq' })) === '["assembled","assembledhq"]', 'candidateSlugs keeps a branded LinkedIn slug intact');
+  check(candidateSlugs({ company: 'Whatnot', companySlug: 'whatnot-inc' }).includes('whatnot-inc'), 'candidateSlugs keeps the raw LinkedIn slug');
+  check(JSON.stringify(candidateSlugs({ company: 'Acme', companySlug: 'acme' })) === '["acme"]', 'candidateSlugs dedupes identical slugs');
+  check(candidateSlugs({ company: 'Acme', companySlug: 'bad/slug' }).length === 1, 'candidateSlugs rejects an unsafe slug');
+  check(candidateSlugs({ company: '' }).length === 0, 'candidateSlugs handles a missing company');
+
+  // upsertApplyUrl - reports are user-layer, so this must be surgical.
+  const report = [
+    '# Evaluation: Acme',
+    '**Date:** 2026-08-13',
+    '**Score:** 4.2/5',
+    '**URL:** https://www.linkedin.com/jobs/view/123/',
+    '**PDF:** ✅',
+    '',
+    '---',
+    '',
+    '## A) Role Summary',
+    'Body text mentioning **URL:** style prose.',
+  ].join('\n');
+  const written = upsertApplyUrl(report, 'https://job-boards.greenhouse.io/acme/jobs/1');
+  check(written.includes('**Apply URL:** https://job-boards.greenhouse.io/acme/jobs/1'), 'upsertApplyUrl writes the field');
+  check(written.split('\n')[4] === '**Apply URL:** https://job-boards.greenhouse.io/acme/jobs/1', 'upsertApplyUrl places it directly under **URL:**');
+  check(written.includes('## A) Role Summary') && written.includes('Body text mentioning'), 'upsertApplyUrl leaves the body untouched');
+  const twice = upsertApplyUrl(written, 'https://job-boards.greenhouse.io/acme/jobs/2');
+  check((twice.match(/\*\*Apply URL:\*\*/g) || []).length === 1, 'upsertApplyUrl replaces rather than duplicating');
+  check(twice.includes('/jobs/2') && !twice.includes('/jobs/1'), 'upsertApplyUrl updates the value');
+  check(upsertApplyUrl(report, 'https://x/1').split('\n').length === report.split('\n').length + 1, 'upsertApplyUrl adds exactly one line');
+  let threw = false;
+  try { upsertApplyUrl(report, 'javascript:alert(1)'); } catch { threw = true; }
+  check(threw, 'upsertApplyUrl refuses a non-http URL');
+  const noUrlField = upsertApplyUrl('# Evaluation: Acme\n**Score:** 4.0/5\n\n---\n\n## A) X\n', 'https://x/1');
+  check(noUrlField.includes('**Apply URL:**') && noUrlField.indexOf('**Apply URL:**') < noUrlField.indexOf('## A)'), 'upsertApplyUrl still lands in the header when **URL:** is absent');
+
+  // readApplyUrl
+  check(readApplyUrl(written) === 'https://job-boards.greenhouse.io/acme/jobs/1', 'readApplyUrl reads the field back');
+  check(readApplyUrl(report) === '', 'readApplyUrl returns empty when unset');
+  check(readApplyUrl('# X\n\n---\n\n## A\n**Apply URL:** https://body/1\n') === '', 'readApplyUrl ignores a body line outside the header');
+
+  // House rule: no em dash reaches the user, including pass-through upstream text.
+  check(!noEmDash('board found — but empty').includes('—'), 'noEmDash strips a pass-through em dash');
+  check(noEmDash('a — b') === 'a: b', 'noEmDash reads cleanly as a colon');
+
+  // normalizeTitle
+  check(normalizeTitle('Senior Engineer (Remote)') === 'senior engineer', 'normalizeTitle drops bracketed asides');
+  check(normalizeTitle('Data Engineer (m/w/d)') === 'data engineer', 'normalizeTitle drops gender markers');
+  check(normalizeTitle('  Staff   SRE  ') === 'staff sre', 'normalizeTitle collapses whitespace');
+  check(normalizeTitle('C++ Developer') === 'c++ developer', 'normalizeTitle keeps c++');
+
+  // titleScore
+  check(titleScore('Senior Software Engineer', 'senior software engineer') === 1, 'titleScore is case-insensitive');
+  check(titleScore('Senior Software Engineer', 'Senior Software Engineer (Remote)') === 1, 'titleScore ignores a bracketed aside');
+  check(titleScore('Senior Software Engineer', 'Account Executive') < 0.2, 'titleScore separates unrelated roles');
+  check(titleScore('', 'Anything') === 0, 'titleScore handles an empty side');
+
+  // pickMatch - the safety-critical policy
+  const unique = pickMatch('Senior Software Engineer', [
+    { title: 'Senior Software Engineer', url: 'https://job-boards.greenhouse.io/acme/jobs/1' },
+    { title: 'Account Executive', url: 'https://job-boards.greenhouse.io/acme/jobs/2' },
+  ]);
+  check(unique.status === 'resolved' && unique.match.url.endsWith('/1'), 'pickMatch resolves a unique exact match');
+
+  const siblings = pickMatch('Senior Engineer', [
+    { title: 'Senior Engineer, Payments', url: 'https://x/1' },
+    { title: 'Senior Engineer, Risk', url: 'https://x/2' },
+  ]);
+  check(siblings.status === 'ambiguous' && siblings.match === null, 'pickMatch refuses to choose between sibling postings');
+  check(siblings.candidates.length === 2, 'pickMatch still lists the siblings as candidates');
+
+  const levels = pickMatch('Senior Data Engineer', [{ title: 'Staff Data Engineer', url: 'https://x/1' }]);
+  check(levels.status === 'unresolved', 'pickMatch disqualifies a seniority mismatch outright');
+
+  const nothing = pickMatch('Senior Software Engineer', [{ title: 'Office Manager', url: 'https://x/1' }]);
+  check(nothing.status === 'unresolved' && nothing.candidates.length === 0, 'pickMatch reports no resemblance rather than a weak pick');
+  check(pickMatch('Anything', []).status === 'unresolved', 'pickMatch handles an empty board');
+  check(pickMatch('', [{ title: 'X', url: 'https://x/1' }]).status === 'unresolved', 'pickMatch handles a missing LinkedIn title');
+
+  // Location is a tiebreaker, never a disqualifier.
+  const loc = pickMatch('Senior Software Engineer', [{ title: 'Senior Software Engineer', url: 'https://x/1', location: 'Remote' }], { location: 'Seattle, WA' });
+  check(loc.status === 'resolved', 'pickMatch does not reject a match on a location disagreement');
+
+  // A candidate missing a url is not offerable.
+  const noUrl = pickMatch('Senior Software Engineer', [{ title: 'Senior Software Engineer', url: '' }]);
+  check(noUrl.status === 'unresolved', 'pickMatch drops a posting with no URL');
+
+  console.log(`\n  linkedin-apply self-test: ${pass} passed, ${fail} failed\n`);
+  if (fail > 0) process.exit(1);
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────
+
+const KNOWN_FLAGS = ['--json', '--summary', '--self-test', '--help', '-h', '--report', '--set'];
+
+/** Read `--flag value`, or "" when absent. Rejects a missing value loudly. */
+function optValue(args, flag) {
+  const i = args.indexOf(flag);
+  if (i === -1) return '';
+  const v = args[i + 1];
+  if (!v || v.startsWith('-')) {
+    console.error(`${flag} needs a value.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((a) => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknown.length) {
+    console.error(`Unknown option(s): ${unknown.join(', ')}\n${HELP}`);
+    process.exit(1);
+  }
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(HELP);
+    return;
+  }
+  if (args.includes('--self-test')) {
+    runSelfTest();
+    return;
+  }
+
+  const reportPath = optValue(args, '--report');
+  const setUrl = optValue(args, '--set');
+
+  // `--set` records a URL the user chose (an ambiguous pick, or one they pasted)
+  // without re-resolving anything. Separate path because there is nothing to
+  // resolve: the answer is already known and only needs persisting.
+  if (setUrl) {
+    if (!reportPath) {
+      console.error('--set needs --report <path> to write to.');
+      process.exit(1);
+    }
+    const md = readFileSync(reportPath, 'utf8');
+    writeFileSync(reportPath, upsertApplyUrl(md, setUrl));
+    console.log(JSON.stringify({ ok: true, status: 'resolved', applyUrl: setUrl, written: reportPath, source: 'manual' }, null, 2));
+    return;
+  }
+
+  // A value-carrying flag's value must not be mistaken for the positional URL.
+  const consumed = new Set([reportPath, setUrl].filter(Boolean));
+  const url = args.find((a) => !a.startsWith('-') && !consumed.has(a));
+  if (!url) {
+    console.error(`A LinkedIn job posting URL is required.\n${HELP}`);
+    process.exit(1);
+  }
+
+  const result = await resolveApplyUrl(url);
+
+  // Persist only a confident answer. An ambiguous or failed run must not write a
+  // guess into the report: a wrong Apply URL is silently acted on later.
+  if (reportPath && result.status === 'resolved' && result.applyUrl) {
+    try {
+      writeFileSync(reportPath, upsertApplyUrl(readFileSync(reportPath, 'utf8'), result.applyUrl));
+      result.written = reportPath;
+    } catch (error) {
+      result.writeError = error.message;
+    }
+  }
+
+  if (args.includes('--summary')) printSummary(result);
+  else console.log(JSON.stringify(result, null, 2));
+  // Exit non-zero only when nothing usable came back, so a caller can branch on it.
+  // `ambiguous` exits 0: candidates ARE a useful result.
+  if (result.status === 'unresolved') process.exit(2);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`linkedin-apply: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/linkedin-apply.mjs
+++ b/linkedin-apply.mjs
@@ -467,6 +467,11 @@ export const APPLY_URL_LABEL = 'Apply URL';
 export function upsertApplyUrl(md, applyUrl) {
   const url = String(applyUrl ?? '').trim();
   if (!/^https?:\/\//i.test(url)) throw new Error('an http(s) apply URL is required');
+  // A URL is ONE line, and this writes into a line-oriented header block. Without
+  // this check a newline inside `url` emits a second header line, which can forge
+  // a `**URL:**` and overwrite the canonical posting link the whole point of this
+  // function is to leave alone. Control characters go for the same reason.
+  if (/[\s\u0000-\u001f\u007f]/.test(url)) throw new Error('an apply URL must be a single line with no whitespace');
   const lines = String(md ?? '').split('\n');
   const line = `**${APPLY_URL_LABEL}:** ${url}`;
 
@@ -631,6 +636,14 @@ function runSelfTest() {
   let threw = false;
   try { upsertApplyUrl(report, 'javascript:alert(1)'); } catch { threw = true; }
   check(threw, 'upsertApplyUrl refuses a non-http URL');
+  // A newline would emit a SECOND header line and could forge a **URL:**, which
+  // is the one field this module promises never to overwrite.
+  let injected = false;
+  try { upsertApplyUrl(report, 'https://evil.test/x\n**URL:** https://evil.test/phish'); } catch { injected = true; }
+  check(injected, 'upsertApplyUrl refuses a URL carrying a newline');
+  check((() => { try { upsertApplyUrl(report, 'https://evil.test/x **URL:** https://evil.test/p'); return false; } catch { return true; } })(), 'upsertApplyUrl refuses a URL carrying a space');
+  check((() => { try { upsertApplyUrl(report, 'https://evil.test/x\ty'); return false; } catch { return true; } })(), 'upsertApplyUrl refuses a URL carrying a tab');
+  check(upsertApplyUrl(report, '  https://x/1  ').includes('**Apply URL:** https://x/1'), 'upsertApplyUrl still trims surrounding whitespace');
   const noUrlField = upsertApplyUrl('# Evaluation: Acme\n**Score:** 4.0/5\n\n---\n\n## A) X\n', 'https://x/1');
   check(noUrlField.includes('**Apply URL:**') && noUrlField.indexOf('**Apply URL:**') < noUrlField.indexOf('## A)'), 'upsertApplyUrl still lands in the header when **URL:** is absent');
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -271,6 +271,7 @@ const scripts = [
   { name: 'detect-reposts.mjs --self-test', expectExit: 0 },
   { name: 'rank-pipeline.mjs --self-test', expectExit: 0 },
   { name: 'discover-ats.mjs --self-test', expectExit: 0 },
+  { name: 'linkedin-apply.mjs --self-test', expectExit: 0 },
   { name: 'process-quality.mjs --self-test', expectExit: 0 },
   { name: 'company-history.mjs --self-test', expectExit: 0 },
   { name: 'rejection-latency.mjs --self-test', expectExit: 0 },

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -335,6 +335,7 @@ const scripts = [
   { name: 'detect-reposts.mjs --self-test', expectExit: 0 },
   { name: 'rank-pipeline.mjs --self-test', expectExit: 0 },
   { name: 'discover-ats.mjs --self-test', expectExit: 0 },
+  { name: 'linkedin-apply.mjs --self-test', expectExit: 0 },
   { name: 'process-quality.mjs --self-test', expectExit: 0 },
   { name: 'company-history.mjs --self-test', expectExit: 0 },
   { name: 'rejection-latency.mjs --self-test', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -250,6 +250,7 @@ const SYSTEM_PATHS = [
   'openrouter-runner.mjs',
   'jd-similarity.mjs',
   'jd-similarity.test.mjs',
+  'linkedin-apply.mjs',
   'test-all.mjs',
   'detect-reposts.test.mjs',
   'test-salary-filter.mjs',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -272,6 +272,7 @@ const SYSTEM_PATHS = [
   'openrouter-runner.mjs',
   'jd-similarity.mjs',
   'tests/jd-similarity.test.mjs',
+  'linkedin-apply.mjs',
   'test-all.mjs',
   'tests/detect-reposts.test.mjs',
   'tests/salary-filter.test.mjs',

--- a/web/src/app/api/apply/profile/route.ts
+++ b/web/src/app/api/apply/profile/route.ts
@@ -72,8 +72,8 @@ function setSignedInProfile(value: boolean): void {
 }
 
 export async function GET() {
-  const { enabled, dir } = profileConfig();
-  return Response.json({ enabled, dir, exists: profileExists(dir) });
+  const { enabled, dir, dirRejected } = profileConfig();
+  return Response.json({ enabled, dir, exists: profileExists(dir), dirRejected });
 }
 
 export async function POST(req: Request) {
@@ -84,7 +84,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "bad json" }, { status: 400 });
   }
 
-  const { enabled, dir } = profileConfig();
+  const { enabled, dir, dirRejected } = profileConfig();
 
   if (body.action === "close") {
     await closePersistentContext();
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
     // Turning it off should not leave the profile browser running with a live
     // session attached to a feature the user just disabled.
     if (!want) await closePersistentContext();
-    return Response.json({ ok: true, enabled: want, dir, exists: profileExists(dir) });
+    return Response.json({ ok: true, enabled: want, dir, exists: profileExists(dir), dirRejected });
   }
 
   if (body.action !== "open") {

--- a/web/src/app/api/apply/profile/route.ts
+++ b/web/src/app/api/apply/profile/route.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import path from "node:path";
+import * as yaml from "js-yaml";
+import { careerOpsRoot } from "@/lib/career-ops";
+import { atomicWriteWithBackup } from "@/lib/core/safe-write";
+import { profileConfig, profileExists, persistentContext, closePersistentContext, showProfileWindow } from "@/lib/apply/profile";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Manage the opt-in signed-in browser profile used by the apply flow.
+//
+// GET   → whether it is enabled, where it lives, whether it has been set up
+// POST {action:"enable"|"disable"} → flip apply.signed_in_profile in profile.yml
+// POST {action:"open"}  → opens that profile in a real, on-screen window so the
+//                         user can sign in to LinkedIn (or anywhere else) THEMSELVES
+// POST {action:"close"} → closes it, persisting the session to disk
+//
+// career-ops never sees, types, or stores a password. This route only opens a
+// browser window; every keystroke in it is the user's own.
+//
+// Enabling grants nothing on its own: the profile directory starts empty, and it
+// only ever holds what the user deliberately signs into. The meaningful consent
+// moment is the sign-in, not the toggle, which is why the toggle is allowed here
+// rather than forced to be a hand edit.
+
+/** Where the sign-in window lands. Fixed allowlist: an attacker-supplied URL here
+ *  would be a phishing page opened in the user's genuinely-signed-in browser. */
+const SIGN_IN_TARGETS: Record<string, string> = {
+  linkedin: "https://www.linkedin.com/login",
+};
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Flip `apply.signed_in_profile` without disturbing the rest of the profile.
+ *
+ * Same data-loss guard as /api/followups/cadence: a profile.yml that EXISTS but
+ * cannot be parsed is never overwritten, because doing so would replace the
+ * user's targeting, comp and narrative with a one-key file.
+ */
+function setSignedInProfile(value: boolean): void {
+  const file = path.join(careerOpsRoot(), "config", "profile.yml");
+  let base: Record<string, unknown> = {};
+  let header = "";
+  if (fs.existsSync(file)) {
+    const raw = fs.readFileSync(file, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = yaml.load(raw);
+    } catch {
+      throw new Error("config/profile.yml exists but could not be read as YAML, so it was left untouched.");
+    }
+    base = isObj(parsed) ? parsed : {};
+    // yaml.dump drops every comment. Carrying the leading comment block across
+    // keeps the file's own title//explanation, which is the part a user actually
+    // reads when they open it. Comments further down are still lost, so this
+    // stays a targeted mitigation rather than a claim of full fidelity.
+    const lead: string[] = [];
+    for (const line of raw.split("\n")) {
+      if (/^\s*#/.test(line) || line.trim() === "") lead.push(line);
+      else break;
+    }
+    if (lead.some((l) => l.trim())) header = `${lead.join("\n").replace(/\s+$/, "")}\n`;
+  }
+  const apply = isObj(base.apply) ? base.apply : {};
+  const merged = { ...base, apply: { ...apply, signed_in_profile: value } };
+  atomicWriteWithBackup(file, header + yaml.dump(merged, { lineWidth: 100, noRefs: true }));
+}
+
+export async function GET() {
+  const { enabled, dir } = profileConfig();
+  return Response.json({ enabled, dir, exists: profileExists(dir) });
+}
+
+export async function POST(req: Request) {
+  let body: { action?: string; target?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "bad json" }, { status: 400 });
+  }
+
+  const { enabled, dir } = profileConfig();
+
+  if (body.action === "close") {
+    await closePersistentContext();
+    return Response.json({ ok: true, exists: profileExists(dir) });
+  }
+
+  if (body.action === "enable" || body.action === "disable") {
+    const want = body.action === "enable";
+    try {
+      setSignedInProfile(want);
+    } catch (e) {
+      return Response.json({ error: e instanceof Error ? e.message : "write failed" }, { status: 500 });
+    }
+    // Turning it off should not leave the profile browser running with a live
+    // session attached to a feature the user just disabled.
+    if (!want) await closePersistentContext();
+    return Response.json({ ok: true, enabled: want, dir, exists: profileExists(dir) });
+  }
+
+  if (body.action !== "open") {
+    return Response.json({ error: "action must be 'enable', 'disable', 'open' or 'close'" }, { status: 400 });
+  }
+
+  if (!enabled) {
+    return Response.json(
+      {
+        error:
+          "The signed-in browser profile is off. Turn it on first, then try again.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const target = SIGN_IN_TARGETS[String(body.target ?? "linkedin")];
+  if (!target) return Response.json({ error: "unknown sign-in target" }, { status: 400 });
+
+  try {
+    const ctx = await persistentContext(true);
+    // Reuse the profile's existing tab when it has one, so repeated clicks do not
+    // pile up windows the user then has to close by hand.
+    const page = ctx.pages()[0] ?? (await ctx.newPage());
+    await page.goto(target, { waitUntil: "domcontentloaded", timeout: 30_000 }).catch(() => {});
+    // The context may already be running off-screen from an apply session, so the
+    // window has to be moved, not merely focused.
+    await showProfileWindow(page);
+    return Response.json({ ok: true, dir, opened: target });
+  } catch (e) {
+    return Response.json({ error: e instanceof Error ? e.message.slice(0, 200) : "could not open the profile" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/apply/resolve/route.ts
+++ b/web/src/app/api/apply/resolve/route.ts
@@ -48,6 +48,21 @@ function reportField(file: string, label: string): string {
   }
 }
 
+/** The resolver's JSON answer, or null when it did not produce a readable one.
+ *  Parsed rather than string-matched: `"ok": true` only appears verbatim under
+ *  the current 2-space pretty-print, so a formatting change on the resolver side
+ *  would silently turn every successful write into a 500. */
+function resolverJson(stdout: string): Record<string, unknown> | null {
+  const start = stdout.indexOf("{");
+  if (start === -1) return null;
+  try {
+    const parsed: unknown = JSON.parse(stdout.slice(start));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Run the core resolver. Never rejects: a failure becomes an unresolved answer. */
 function runResolver(args: string[]): Promise<{ stdout: string; stderr: string }> {
   const script = rootScript("linkedin-apply");
@@ -84,8 +99,16 @@ export async function POST(req: Request) {
     if (!/^https?:\/\//i.test(pick)) {
       return Response.json({ error: "an http(s) application URL is required" }, { status: 400 });
     }
+    // A URL is ONE line. `pick` is written into the report's line-oriented header,
+    // where an embedded newline emits a second line and can forge a `**URL:**`,
+    // the one field this feature promises never to overwrite. upsertApplyUrl
+    // refuses it too; rejecting here makes it a 400 the UI can show rather than a
+    // 500 raised from inside the resolver.
+    if (/[\s\u0000-\u001f\u007f]/.test(pick)) {
+      return Response.json({ error: "an application URL must be a single line with no whitespace" }, { status: 400 });
+    }
     const { stdout, stderr } = await runResolver(["--report", file, "--set", pick]);
-    if (!stdout.includes('"ok": true')) {
+    if (resolverJson(stdout)?.ok !== true) {
       return Response.json({ error: `could not record that URL: ${(stderr || stdout).slice(0, 200)}` }, { status: 500 });
     }
     return Response.json({ status: "resolved", applyUrl: pick, source: "manual" } satisfies Resolution);

--- a/web/src/app/api/apply/resolve/route.ts
+++ b/web/src/app/api/apply/resolve/route.ts
@@ -1,0 +1,151 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { careerOpsRoot, rootScript, findReportFile } from "@/lib/career-ops";
+import { parseReport } from "@/lib/format";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// Resolve a report's APPLY target before the apply session opens.
+//
+// A LinkedIn posting URL is not applyable: openSession() browses in a fresh,
+// cookie-less context, so linkedin.com/jobs/view/<id> serves the authwall and the
+// flow dead-ends. The core's linkedin-apply.mjs reconstructs the employer's real
+// ATS URL from the guest page (company + title) and records it on the report as
+// **Apply URL:**, which is what the Apply button then opens.
+//
+// Everything expensive is skipped when it can be: a report that already carries
+// **Apply URL:** answers from disk, and a non-LinkedIn posting is returned as-is
+// without spawning anything.
+
+type Resolution = {
+  status: "resolved" | "ambiguous" | "unresolved";
+  applyUrl: string | null;
+  /** Where the answer came from, so the UI can explain itself. */
+  source: "recorded" | "direct" | "resolved" | "manual";
+  reason?: string;
+  candidates?: { title: string; url: string; location: string; score: number }[];
+  posting?: { title?: string; company?: string; location?: string; offsiteApply?: boolean };
+  board?: { vendor?: string; slug?: string; jobCount?: number };
+};
+
+function isLinkedIn(url: string): boolean {
+  try {
+    const h = new URL(url).hostname.toLowerCase();
+    return h === "linkedin.com" || h.endsWith(".linkedin.com");
+  } catch {
+    return false;
+  }
+}
+
+function reportField(file: string, label: string): string {
+  try {
+    const meta = parseReport(fs.readFileSync(file, "utf8"));
+    return meta.fields.find((f) => f.label === label)?.value ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** Run the core resolver. Never rejects: a failure becomes an unresolved answer. */
+function runResolver(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const script = rootScript("linkedin-apply");
+  return new Promise((resolve) => {
+    execFile(
+      "node",
+      [script, ...args],
+      { cwd: careerOpsRoot(), timeout: 110_000, maxBuffer: 4_000_000 },
+      (_err, stdout, stderr) => resolve({ stdout: stdout || "", stderr: stderr || "" }),
+    );
+  });
+}
+
+export async function POST(req: Request) {
+  let body: { n?: string; pick?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "bad json" }, { status: 400 });
+  }
+
+  const n = String(body.n ?? "").trim();
+  if (!n) return Response.json({ error: "a report number is required" }, { status: 400 });
+
+  // findReportFile enforces containment under the project root, so `n` can never
+  // walk the caller out of the reports directory.
+  const file = findReportFile(n);
+  if (!file) return Response.json({ error: `no report found for #${n}` }, { status: 404 });
+
+  // A URL the user chose themselves (an ambiguous pick, or one they pasted).
+  // Recorded verbatim, never re-resolved.
+  const pick = String(body.pick ?? "").trim();
+  if (pick) {
+    if (!/^https?:\/\//i.test(pick)) {
+      return Response.json({ error: "an http(s) application URL is required" }, { status: 400 });
+    }
+    const { stdout, stderr } = await runResolver(["--report", file, "--set", pick]);
+    if (!stdout.includes('"ok": true')) {
+      return Response.json({ error: `could not record that URL: ${(stderr || stdout).slice(0, 200)}` }, { status: 500 });
+    }
+    return Response.json({ status: "resolved", applyUrl: pick, source: "manual" } satisfies Resolution);
+  }
+
+  // Already recorded: answer from disk, no network, no spawn.
+  const recorded = reportField(file, "Apply URL");
+  if (recorded && /^https?:\/\//i.test(recorded)) {
+    return Response.json({ status: "resolved", applyUrl: recorded, source: "recorded" } satisfies Resolution);
+  }
+
+  const url = reportField(file, "URL");
+  if (!url || !/^https?:\/\//i.test(url)) {
+    return Response.json({
+      status: "unresolved",
+      applyUrl: null,
+      source: "direct",
+      reason: "this report has no posting URL to apply through",
+    } satisfies Resolution);
+  }
+
+  // Not LinkedIn: the posting URL IS the apply target, which is the common case.
+  if (!isLinkedIn(url)) {
+    return Response.json({ status: "resolved", applyUrl: url, source: "direct" } satisfies Resolution);
+  }
+
+  const { stdout, stderr } = await runResolver([url, "--report", file]);
+  const start = stdout.indexOf("{");
+  if (start === -1) {
+    return Response.json({
+      status: "unresolved",
+      applyUrl: null,
+      source: "resolved",
+      reason: `the resolver produced no result: ${(stderr || "no output").slice(0, 200)}`,
+    } satisfies Resolution);
+  }
+  try {
+    const parsed = JSON.parse(stdout.slice(start)) as {
+      status: Resolution["status"];
+      applyUrl: string | null;
+      reason?: string;
+      candidates?: Resolution["candidates"];
+      posting?: Resolution["posting"];
+      board?: Resolution["board"];
+    };
+    return Response.json({
+      status: parsed.status,
+      applyUrl: parsed.applyUrl,
+      source: "resolved",
+      reason: parsed.reason,
+      candidates: parsed.candidates ?? [],
+      posting: parsed.posting,
+      board: parsed.board,
+    } satisfies Resolution);
+  } catch {
+    return Response.json({
+      status: "unresolved",
+      applyUrl: null,
+      source: "resolved",
+      reason: "the resolver's answer could not be read",
+    } satisfies Resolution);
+  }
+}

--- a/web/src/components/apply-button.tsx
+++ b/web/src/components/apply-button.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Send, Lock } from "lucide-react";
+import { Send, Lock, Loader2, X, ExternalLink } from "lucide-react";
 import { useJobs } from "@/components/jobs/job-store";
 import { useApply } from "@/components/apply/apply-provider";
 
@@ -9,43 +10,249 @@ import { useApply } from "@/components/apply/apply-provider";
 // for THIS offer is ready (the tracker's PDF column is ✅, or a pdf worker for
 // this #n just finished). On click it opens the apply form-proxy for the offer
 // (where the user reviews and submits it themselves — never auto-submit).
-export function ApplyButton({ n, url, company, pdfReady }: { n: string; url?: string; company: string; pdfReady: boolean }) {
+//
+// A LinkedIn posting cannot be applied to directly: the apply session browses in a
+// fresh, cookie-less context, so LinkedIn serves its authwall and the flow dies.
+// So the click first asks /api/apply/resolve for the real application URL, which
+// reconstructs the employer's ATS link and records it on the report. That call is
+// cheap once recorded (answered from disk) and skipped entirely for non-LinkedIn
+// postings, so the common case still feels like a plain button.
+//
+// Resolution deliberately refuses to guess between look-alike postings, so this
+// has to handle three outcomes, not one: resolved (go), ambiguous (the user picks
+// from ranked candidates), and unresolved (the user pastes the link themselves).
+
+type Candidate = { title: string; url: string; location: string; score: number };
+type Resolution = {
+  status: "resolved" | "ambiguous" | "unresolved";
+  applyUrl: string | null;
+  source?: string;
+  reason?: string;
+  candidates?: Candidate[];
+  posting?: { title?: string; company?: string };
+  error?: string;
+};
+
+export function ApplyButton({
+  n,
+  url,
+  applyUrl,
+  company,
+  pdfReady,
+}: {
+  n: string;
+  /** The canonical posting link (what the tracker records). */
+  url?: string;
+  /** An already-recorded **Apply URL:**, if this offer has been resolved before. */
+  applyUrl?: string;
+  company: string;
+  pdfReady: boolean;
+}) {
   const router = useRouter();
   const { jobs } = useJobs();
   const apply = useApply();
 
+  const [resolving, setResolving] = useState(false);
+  const [choice, setChoice] = useState<Resolution | null>(null);
+  const [pasted, setPasted] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
   const pdfJobDone = jobs.some((j) => j.kind === "pdf" && j.input === n && j.status === "done");
+  // Either link is a usable starting point: the recorded apply URL goes straight
+  // to the form, and the posting URL is what resolution works from.
   const hasUrl = !!url && /^https?:\/\//i.test(url);
-  const ready = (pdfReady || pdfJobDone) && hasUrl;
+  const hasApplyUrl = !!applyUrl && /^https?:\/\//i.test(applyUrl);
+  const ready = (pdfReady || pdfJobDone) && (hasUrl || hasApplyUrl);
+
+  const openApply = (applyUrl: string) => {
+    // n + from ride along so the Apply page can mark this row Applied and
+    // return the user to the page they left. Read straight off the handler's
+    // own location: usePathname() drops the query and hash, which is where
+    // the list filter and the row anchor live.
+    const { pathname, search, hash } = window.location;
+    apply.open(applyUrl, { prefill: true, company, n, from: `${pathname}${search}${hash}` });
+    router.push("/apply");
+  };
+
+  const start = async () => {
+    setResolving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/apply/resolve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ n }),
+      });
+      const j = (await res.json().catch(() => ({}))) as Resolution;
+      if (!res.ok || j.error) {
+        setError(typeof j.error === "string" ? j.error : "Could not work out where to apply.");
+        return;
+      }
+      if (j.status === "resolved" && j.applyUrl) {
+        openApply(j.applyUrl);
+        return;
+      }
+      // Ambiguous or unresolved: hand the decision to the user rather than guessing.
+      setChoice(j);
+    } catch {
+      setError("Could not work out where to apply.");
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  // Record the user's choice on the report, then open it. Persisting means the
+  // next apply for this offer skips resolution entirely.
+  const choose = async (applyUrl: string) => {
+    setResolving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/apply/resolve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ n, pick: applyUrl }),
+      });
+      const j = (await res.json().catch(() => ({}))) as Resolution;
+      if (!res.ok || j.error) {
+        setError(typeof j.error === "string" ? j.error : "Could not save that link.");
+        return;
+      }
+      setChoice(null);
+      openApply(applyUrl);
+    } catch {
+      setError("Could not save that link.");
+    } finally {
+      setResolving(false);
+    }
+  };
 
   if (!ready) {
     return (
       <button
         type="button"
         disabled
-        title={!hasUrl ? "No application URL on this report" : "Generate the tailored CV (PDF) first to apply"}
+        title={!hasUrl && !hasApplyUrl ? "No application URL on this report" : "Generate the tailored CV (PDF) first to apply"}
         className="inline-flex cursor-not-allowed items-center justify-center gap-1.5 rounded-full border border-border bg-surface/40 px-3.5 py-1 text-xs font-medium text-faint max-sm:min-h-[44px]"
       >
         <Lock className="size-3.5" /> Apply
       </button>
     );
   }
+
   return (
-    <button
-      type="button"
-      onClick={() => {
-        // n + from ride along so the Apply page can mark this row Applied and
-        // return the user to the page they left. Read straight off the handler's
-        // own location: usePathname() drops the query and hash, which is where
-        // the list filter and the row anchor live.
-        const { pathname, search, hash } = window.location;
-        apply.open(url!, { prefill: true, company, n, from: `${pathname}${search}${hash}` });
-        router.push("/apply");
-      }}
-      className="inline-flex items-center justify-center gap-1.5 rounded-full bg-brand px-3.5 py-1 text-xs font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-200 max-sm:min-h-[44px]"
-      title="Apply — opens the form pre-filled, you review and submit yourself"
-    >
-      <Send className="size-3.5" /> Apply
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={start}
+        disabled={resolving}
+        className="inline-flex items-center justify-center gap-1.5 rounded-full bg-brand px-3.5 py-1 text-xs font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-200 disabled:opacity-70 max-sm:min-h-[44px]"
+        title="Apply: opens the form pre-filled, you review and submit yourself"
+      >
+        {resolving ? <Loader2 className="size-3.5 animate-spin" /> : <Send className="size-3.5" />}
+        {resolving ? "Finding the form…" : "Apply"}
+      </button>
+
+      {error && !choice && <span className="ml-2 text-xs text-rose-400">{error}</span>}
+
+      {choice && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4 pt-[10vh]"
+          onClick={() => setChoice(null)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Choose the application form"
+            className="w-full max-w-lg rounded-2xl border border-border bg-surface p-5 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="font-display text-lg">
+                  {choice.status === "ambiguous" ? "Which posting is this?" : "Where should this apply?"}
+                </h2>
+                <p className="mt-1 text-sm text-muted">
+                  {choice.status === "ambiguous"
+                    ? "LinkedIn hides the employer's application link, so this was matched against their careers board. Several postings match closely enough that picking for you could send this to the wrong role."
+                    : "LinkedIn hides the employer's application link and their careers board could not be matched automatically."}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setChoice(null)}
+                aria-label="Close"
+                className="rounded-md p-1 text-faint transition-colors hover:text-foreground"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            {choice.reason && <p className="mt-2 text-xs text-faint">{choice.reason}</p>}
+
+            {!!choice.candidates?.length && (
+              <ul className="mt-4 space-y-2">
+                {choice.candidates.map((c) => (
+                  <li key={c.url}>
+                    <button
+                      type="button"
+                      onClick={() => choose(c.url)}
+                      disabled={resolving}
+                      className="w-full rounded-lg border border-border bg-bg/60 px-3 py-2 text-left transition-colors hover:border-brand/50 disabled:opacity-60"
+                    >
+                      <span className="block text-sm text-foreground">{c.title}</span>
+                      {c.location && <span className="mt-0.5 block text-xs text-muted">{c.location}</span>}
+                      <span className="mt-1 block truncate font-mono text-[11px] text-faint">{c.url}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="mt-4">
+              <label htmlFor={`apply-url-${n}`} className="text-xs text-muted">
+                Or paste the application link yourself
+              </label>
+              <input
+                id={`apply-url-${n}`}
+                value={pasted}
+                onChange={(e) => setPasted(e.target.value)}
+                placeholder="https://job-boards.greenhouse.io/acme/jobs/123"
+                className="mt-1.5 w-full rounded-lg border border-border bg-bg/60 px-3 py-2 font-mono text-xs outline-none transition-colors placeholder:text-faint focus:border-brand/50"
+              />
+              {url && (
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-2 inline-flex items-center gap-1 text-xs text-muted transition-colors hover:text-brand"
+                >
+                  Open the LinkedIn posting to find it <ExternalLink className="size-3" />
+                </a>
+              )}
+            </div>
+
+            {error && <p className="mt-2 text-xs text-rose-400">{error}</p>}
+
+            <div className="mt-4 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => choose(pasted.trim())}
+                disabled={resolving || !/^https?:\/\//i.test(pasted.trim())}
+                className="inline-flex items-center gap-1.5 rounded-full bg-brand px-3.5 py-1.5 text-xs font-medium text-brand-foreground transition-colors hover:bg-brand-200 disabled:opacity-50"
+              >
+                {resolving ? <Loader2 className="size-3.5 animate-spin" /> : <Send className="size-3.5" />} Use this link
+              </button>
+              <button
+                type="button"
+                onClick={() => setChoice(null)}
+                className="rounded-full border border-border px-3.5 py-1.5 text-xs text-muted transition-colors hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/web/src/components/apply/signed-in-browser.tsx
+++ b/web/src/components/apply/signed-in-browser.tsx
@@ -16,7 +16,14 @@ import { cn } from "@/lib/cn";
 // browser. They sign in themselves in a real window; career-ops never sees a
 // password.
 
-type Status = { enabled: boolean; dir: string; exists: boolean };
+type Status = {
+  enabled: boolean;
+  dir: string;
+  exists: boolean;
+  /** Set when `apply.profile_dir` pointed outside the project and was refused,
+   *  so the path shown below is the default rather than the one they wrote. */
+  dirRejected?: string;
+};
 
 export function SignedInBrowser() {
   const [status, setStatus] = useState<Status | null>(null);
@@ -133,6 +140,14 @@ export function SignedInBrowser() {
           {opened && (
             <p className="mt-2 text-xs text-muted">
               The window is open. Sign in, then come back and close it here.
+            </p>
+          )}
+          {status.dirRejected && (
+            <p className="mt-2 text-xs text-amber-400">
+              Your <span className="font-mono">apply.profile_dir</span> (
+              <span className="font-mono break-all">{status.dirRejected}</span>) points outside the
+              career-ops folder, so it was not used. The profile must stay inside the project, which
+              is what keeps it separate from your everyday browser profile. Using the default below.
             </p>
           )}
           <p className="mt-2 break-all font-mono text-[11px] text-faint">{status.dir}</p>

--- a/web/src/components/apply/signed-in-browser.tsx
+++ b/web/src/components/apply/signed-in-browser.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, ExternalLink, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+// Opt-in signed-in browser profile for the apply flow.
+//
+// The apply session normally browses in a fresh cookie-less context, which is
+// right for a public ATS form and wrong for a gated one: LinkedIn shows its
+// authwall, so an Easy Apply posting (whose form lives ON LinkedIn, with no
+// external ATS link to resolve) can never be reached.
+//
+// The profile is a DEDICATED directory, not the user's real Chrome profile, so it
+// carries only what they deliberately sign into and never fights their everyday
+// browser. They sign in themselves in a real window; career-ops never sees a
+// password.
+
+type Status = { enabled: boolean; dir: string; exists: boolean };
+
+export function SignedInBrowser() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [busy, setBusy] = useState<null | "toggle" | "open" | "close">(null);
+  const [error, setError] = useState<string | null>(null);
+  const [opened, setOpened] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setStatus((await (await fetch("/api/apply/profile")).json()) as Status);
+    } catch {
+      /* best-effort: the section simply stays hidden */
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const act = async (action: "enable" | "disable" | "open" | "close", busyAs: "toggle" | "open" | "close") => {
+    setBusy(busyAs);
+    setError(null);
+    try {
+      const res = await fetch("/api/apply/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok || j.error) {
+        setError(typeof j.error === "string" ? j.error : "That did not work.");
+        return;
+      }
+      if (action === "open") setOpened(true);
+      if (action === "close") setOpened(false);
+      await load();
+    } catch {
+      setError("That did not work.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (!status) return null;
+
+  return (
+    <section className="mt-8">
+      <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+        Signed-in browser
+      </label>
+
+      <button
+        type="button"
+        onClick={() => act(status.enabled ? "disable" : "enable", "toggle")}
+        disabled={busy !== null}
+        className="flex w-full items-center justify-between gap-4 rounded-xl border border-border bg-surface/50 px-4 py-3 text-left transition-colors hover:bg-surface-hover disabled:opacity-70"
+      >
+        <span className="min-w-0">
+          <span className="block text-sm font-medium text-foreground">Use a signed-in browser profile</span>
+          <span className="mt-0.5 block text-xs text-faint">
+            Apply normally browses signed out, so LinkedIn shows its login wall and an Easy Apply
+            posting can never be reached. This uses a separate browser profile you sign into once. It
+            is not your everyday Chrome profile, so it only ever holds the sites you add to it.
+          </span>
+        </span>
+        <span
+          className={cn(
+            "relative h-6 w-11 shrink-0 rounded-full transition-colors",
+            status.enabled ? "bg-brand" : "bg-surface-hover",
+          )}
+        >
+          <span
+            className={cn(
+              "absolute top-0.5 size-5 rounded-full bg-white shadow transition-transform",
+              status.enabled ? "translate-x-[1.375rem]" : "translate-x-0.5",
+            )}
+          />
+        </span>
+      </button>
+
+      {status.enabled && (
+        <div className="mt-3 rounded-xl border border-border bg-surface/30 p-4">
+          <p className="flex items-start gap-2 text-xs text-muted">
+            <ShieldCheck className="mt-0.5 size-3.5 shrink-0 text-brand" />
+            <span>
+              Opens a real browser window. Sign in there yourself: career-ops never sees, types or
+              stores your password. Close the window when you are done and the session is remembered
+              for future applications.
+            </span>
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => act("open", "open")}
+              disabled={busy !== null}
+              className="inline-flex items-center gap-1.5 rounded-full bg-brand px-3.5 py-1.5 text-xs font-medium text-brand-foreground transition-colors hover:bg-brand-200 disabled:opacity-60"
+            >
+              {busy === "open" ? <Loader2 className="size-3.5 animate-spin" /> : <ExternalLink className="size-3.5" />}
+              {status.exists ? "Open to check or re-sign in" : "Open and sign in to LinkedIn"}
+            </button>
+            {opened && (
+              <button
+                type="button"
+                onClick={() => act("close", "close")}
+                disabled={busy !== null}
+                className="rounded-full border border-border px-3.5 py-1.5 text-xs text-muted transition-colors hover:text-foreground disabled:opacity-60"
+              >
+                {busy === "close" ? "Closing…" : "Done, close it"}
+              </button>
+            )}
+          </div>
+
+          {opened && (
+            <p className="mt-2 text-xs text-muted">
+              The window is open. Sign in, then come back and close it here.
+            </p>
+          )}
+          <p className="mt-2 break-all font-mono text-[11px] text-faint">{status.dir}</p>
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-xs text-rose-400">{error}</p>}
+    </section>
+  );
+}

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
+import { SignedInBrowser } from "@/components/apply/signed-in-browser";
 
 type Cli = {
   id: string;
@@ -291,6 +292,8 @@ export function ConfigForm() {
           />
         </span>
       </button>
+
+      <SignedInBrowser />
 
       <CadenceSettings />
 

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from "@/lib/cn";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
 import { persistCliId, readSavedCliId } from "@/lib/saved-cli";
+import { SignedInBrowser } from "@/components/apply/signed-in-browser";
 
 type Cli = {
   id: string;
@@ -299,6 +300,8 @@ export function ConfigForm() {
           />
         </span>
       </button>
+
+      <SignedInBrowser />
 
       <CadenceSettings />
 

--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -66,6 +66,10 @@ export function ReportView({
   const date = app?.date || field("Date");
   const archetype = field("Archetype");
   const url = field("URL");
+  // Where the fillable form lives, when it differs from the posting link (LinkedIn).
+  // Recorded by linkedin-apply.mjs once resolved, so the Apply button can skip
+  // resolution on every later visit.
+  const applyUrl = field("Apply URL");
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-8">
@@ -98,7 +102,13 @@ export function ReportView({
           {meta?.legitimacy && <Badge tone={legitimacyTone(meta.legitimacy)}>{meta.legitimacy}</Badge>}
           {app && <StatusSelect n={id} current={app.status} />}
           <GeneratePdfButton n={id} company={app?.company ?? meta?.title ?? id} pdfReady={(app?.pdf ?? "").includes("✅")} />
-          <ApplyButton n={id} url={url && url.startsWith("http") ? url : undefined} company={app?.company ?? meta?.title ?? id} pdfReady={(app?.pdf ?? "").includes("✅")} />
+          <ApplyButton
+            n={id}
+            url={url && url.startsWith("http") ? url : undefined}
+            applyUrl={applyUrl && applyUrl.startsWith("http") ? applyUrl : undefined}
+            company={app?.company ?? meta?.title ?? id}
+            pdfReady={(app?.pdf ?? "").includes("✅")}
+          />
         </div>
 
         {app && canDelete && (
@@ -119,6 +129,19 @@ export function ReportView({
                 className="inline-flex items-center justify-center gap-1 text-brand hover:underline max-sm:min-h-[44px]"
               >
                 posting <ExternalLink className="size-3" />
+              </a>
+            )}
+            {/* Shown only when it differs from the posting link, which in practice
+                means LinkedIn: the user should be able to see where Apply will
+                actually send them before they click it. */}
+            {applyUrl && applyUrl.startsWith("http") && applyUrl !== url && (
+              <a
+                href={applyUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center gap-1 text-brand hover:underline max-sm:min-h-[44px]"
+              >
+                application form <ExternalLink className="size-3" />
               </a>
             )}
           </div>

--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -71,6 +71,10 @@ export function ReportView({
   const url = field("URL");
   const pdfReady = (app?.pdf ?? "").includes("✅") || pdfReadyFromIndex;
   const company = app ? companyPresentation(app) : null;
+  // Where the fillable form lives, when it differs from the posting link (LinkedIn).
+  // Recorded by linkedin-apply.mjs once resolved, so the Apply button can skip
+  // resolution on every later visit.
+  const applyUrl = field("Apply URL");
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-8">
@@ -103,7 +107,13 @@ export function ReportView({
           {meta?.legitimacy && <Badge tone={legitimacyTone(meta.legitimacy)}>{meta.legitimacy}</Badge>}
           {app && <StatusSelect n={id} current={app.status} />}
           <GeneratePdfButton n={id} company={app?.company ?? meta?.title ?? id} pdfReady={pdfReady} />
-          <ApplyButton n={id} url={url && url.startsWith("http") ? url : undefined} company={app?.company ?? meta?.title ?? id} pdfReady={pdfReady} />
+          <ApplyButton
+            n={id}
+            url={url && url.startsWith("http") ? url : undefined}
+            applyUrl={applyUrl && applyUrl.startsWith("http") ? applyUrl : undefined}
+            company={app?.company ?? meta?.title ?? id}
+            pdfReady={pdfReady}
+          />
         </div>
 
         {app && canDelete && (
@@ -124,6 +134,19 @@ export function ReportView({
                 className="inline-flex items-center justify-center gap-1 text-brand hover:underline max-sm:min-h-[44px]"
               >
                 posting <ExternalLink className="size-3" />
+              </a>
+            )}
+            {/* Shown only when it differs from the posting link, which in practice
+                means LinkedIn: the user should be able to see where Apply will
+                actually send them before they click it. */}
+            {applyUrl && applyUrl.startsWith("http") && applyUrl !== url && (
+              <a
+                href={applyUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center gap-1 text-brand hover:underline max-sm:min-h-[44px]"
+              >
+                application form <ExternalLink className="size-3" />
               </a>
             )}
           </div>

--- a/web/src/lib/apply/profile.ts
+++ b/web/src/lib/apply/profile.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs";
+import path from "node:path";
+import * as yaml from "js-yaml";
+import { chromium, type BrowserContext, type Page } from "playwright-core";
+import { careerOpsRoot } from "@/lib/career-ops";
+
+// A SIGNED-IN browser profile for the apply flow (opt-in, off by default).
+//
+// WHY: openSession() calls browser.newContext(), which is a fresh cookie-less
+// profile every time. That is correct for a public ATS form and wrong for a gated
+// site: LinkedIn serves its authwall, so an Easy Apply posting (whose form lives
+// ON LinkedIn and has no external ATS URL to resolve) can never be reached.
+// linkedin-apply.mjs solves the offsite case by reconstructing the employer's ATS
+// link; it structurally cannot solve the Easy Apply case. This can.
+//
+// WHY A DEDICATED PROFILE, NOT THE USER'S REAL CHROME PROFILE: pointing Playwright
+// at ~/Library/.../Chrome/Default would hand the automation every session the user
+// has anywhere (bank, email, everything), and Chrome refuses to open a profile
+// directory a running Chrome already holds, so it would also break whenever their
+// browser is open. A dedicated directory carries only the sessions the user
+// deliberately signs into, and never fights their day-to-day browser.
+//
+// The user signs in THEMSELVES in a real window. career-ops never sees, types, or
+// stores a password.
+
+export type ProfileConfig = { enabled: boolean; dir: string };
+
+/** Where the dedicated profile lives when the user has not named a directory.
+ *  `.career-ops-web/` is already gitignored and already holds apply logs. */
+export function defaultProfileDir(): string {
+  return path.join(careerOpsRoot(), ".career-ops-web", "browser-profile");
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Read the opt-in from config/profile.yml (user layer):
+ *
+ *   apply:
+ *     signed_in_profile: true
+ *     profile_dir: ""        # optional, defaults to defaultProfileDir()
+ *
+ * Absent, malformed, or unreadable config all mean "off". This feature changes
+ * what a browser session can see, so it must never switch itself on by accident.
+ */
+export function profileConfig(): ProfileConfig {
+  const file = path.join(careerOpsRoot(), "config", "profile.yml");
+  let apply: Record<string, unknown> = {};
+  try {
+    const parsed = yaml.load(fs.readFileSync(file, "utf8"));
+    if (isObj(parsed) && isObj(parsed.apply)) apply = parsed.apply;
+  } catch {
+    /* missing or malformed → disabled */
+  }
+  const enabled = apply.signed_in_profile === true;
+  const raw = typeof apply.profile_dir === "string" ? apply.profile_dir.trim() : "";
+  return { enabled, dir: raw ? path.resolve(careerOpsRoot(), raw) : defaultProfileDir() };
+}
+
+/** Whether the profile directory has been created (i.e. ever launched). Not a
+ *  claim that any particular site is signed in. Only the user can confirm that,
+ *  by opening the window. */
+export function profileExists(dir: string): boolean {
+  try {
+    return fs.existsSync(dir) && fs.readdirSync(dir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __coProfileContext: BrowserContext | undefined;
+}
+
+/** Off-screen during fill; moved on-screen at handoff (same as the normal path). */
+const OFFSCREEN_ARGS = ["--window-position=-3200,-3200", "--window-size=1280,940"];
+
+/**
+ * The singleton persistent context for the signed-in profile.
+ *
+ * One profile directory can back exactly one browser, so unlike the normal path
+ * this context is SHARED by every concurrent apply session. Callers must close
+ * their own page, never this context (see closeSurface in session.ts) or one
+ * finished session would tear down the others and drop the sign-in.
+ *
+ * @param onScreen true for the sign-in window the user interacts with directly.
+ */
+export async function persistentContext(onScreen = false): Promise<BrowserContext> {
+  const existing = globalThis.__coProfileContext;
+  // A persistent context has no .browser(); liveness shows up as a closed context,
+  // which throws on use, so probe it cheaply instead of trusting the handle.
+  if (existing) {
+    try {
+      existing.pages();
+      return existing;
+    } catch {
+      globalThis.__coProfileContext = undefined;
+    }
+  }
+
+  const { dir } = profileConfig();
+  fs.mkdirSync(dir, { recursive: true });
+
+  const opts = {
+    headless: false,
+    viewport: { width: 1280, height: 900 },
+    args: onScreen ? ["--window-size=1280,940"] : OFFSCREEN_ARGS,
+  };
+  let ctx: BrowserContext;
+  try {
+    ctx = await chromium.launchPersistentContext(dir, { channel: "chrome", ...opts });
+  } catch (first) {
+    // Two very different failures land here, and the message has to tell them
+    // apart: no system Chrome (retry on bundled Chromium), or the profile is
+    // already open in another process (retrying cannot help).
+    const msg = first instanceof Error ? first.message : String(first);
+    if (/ProcessSingleton|SingletonLock|already (in use|running)|profile.*in use/i.test(msg)) {
+      throw new Error("That browser profile is already open in another window. Close it, then try again.");
+    }
+    try {
+      ctx = await chromium.launchPersistentContext(dir, opts);
+    } catch {
+      throw new Error("The signed-in browser profile needs Google Chrome. Install Chrome (or run: pnpm exec playwright install chromium) and try again.");
+    }
+  }
+  globalThis.__coProfileContext = ctx;
+  return ctx;
+}
+
+/**
+ * Move the profile's window on-screen and focus it.
+ *
+ * Required, not cosmetic. `persistentContext(true)` returns an ALREADY-RUNNING
+ * context when an apply session opened one first, and that one was launched with
+ * --window-position=-3200,-3200. The onScreen argument only affects a fresh
+ * launch, so without this the sign-in window would sit off-screen and the button
+ * would look like it did nothing. bringToFront() alone cannot fix that: it
+ * focuses a tab, it does not move a window.
+ */
+export async function showProfileWindow(page: Page): Promise<void> {
+  try {
+    const cdp = await page.context().newCDPSession(page);
+    const { windowId } = (await cdp.send("Browser.getWindowForTarget")) as { windowId: number };
+    await cdp.send("Browser.setWindowBounds", {
+      windowId,
+      bounds: { left: 80, top: 60, width: 1280, height: 920, windowState: "normal" },
+    });
+    await cdp.detach().catch(() => {});
+  } catch {
+    /* CDP unavailable → bringToFront below still raises it where it can */
+  }
+  await page.bringToFront().catch(() => {});
+}
+
+/** Close the shared profile browser (idle cleanup, or the user finishing sign-in). */
+export async function closePersistentContext(): Promise<void> {
+  const ctx = globalThis.__coProfileContext;
+  globalThis.__coProfileContext = undefined;
+  await ctx?.close().catch(() => {});
+}

--- a/web/src/lib/apply/profile.ts
+++ b/web/src/lib/apply/profile.ts
@@ -23,7 +23,13 @@ import { careerOpsRoot } from "@/lib/career-ops";
 // The user signs in THEMSELVES in a real window. career-ops never sees, types, or
 // stores a password.
 
-export type ProfileConfig = { enabled: boolean; dir: string };
+export type ProfileConfig = {
+  enabled: boolean;
+  dir: string;
+  /** The user's `profile_dir` verbatim, when it was refused for escaping the
+   *  project root and `dir` fell back to the default. Absent otherwise. */
+  dirRejected?: string;
+};
 
 /** Where the dedicated profile lives when the user has not named a directory.
  *  `.career-ops-web/` is already gitignored and already holds apply logs. */
@@ -36,6 +42,53 @@ function isObj(v: unknown): v is Record<string, unknown> {
 }
 
 /**
+ * Canonicalize `p` as far as it exists on disk.
+ *
+ * `realpathSync` throws on a path whose leaf is not created yet, which the
+ * profile directory usually is not. Resolving the deepest ancestor that DOES
+ * exist and re-joining the rest is what makes the containment check below see
+ * through a symlink, rather than being satisfied by a repo-relative spelling
+ * that points somewhere else entirely.
+ */
+function realpathAsFarAsItGoes(p: string): string {
+  let cur = path.resolve(p);
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      return path.join(fs.realpathSync(cur), ...tail);
+    } catch {
+      const parent = path.dirname(cur);
+      if (parent === cur) return path.resolve(p);
+      tail.unshift(path.basename(cur));
+      cur = parent;
+    }
+  }
+}
+
+/**
+ * The directory a user-supplied `profile_dir` may actually use.
+ *
+ * Containment under the project root is the whole safety story of this feature.
+ * A DEDICATED profile is only meaningful while it cannot become the user's real
+ * one, and `profile_dir: "../../Library/Application Support/Google/Chrome"`
+ * would hand the automation every session they have anywhere. `path.resolve`
+ * does not stop that, so a value landing outside the root is refused and the
+ * default is used instead.
+ *
+ * Refused, not silently ignored: the caller gets the rejected value back so the
+ * UI can say why the path on screen is not the one in their config.
+ */
+function containedProfileDir(raw: string): { dir: string; dirRejected?: string } {
+  const root = realpathAsFarAsItGoes(careerOpsRoot());
+  const resolved = realpathAsFarAsItGoes(path.resolve(careerOpsRoot(), raw));
+  const rel = path.relative(root, resolved);
+  // rel === "" is the project root itself, which is not a place to put a
+  // browser profile either.
+  const contained = rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+  return contained ? { dir: resolved } : { dir: defaultProfileDir(), dirRejected: raw };
+}
+
+/**
  * Read the opt-in from config/profile.yml (user layer):
  *
  *   apply:
@@ -44,6 +97,9 @@ function isObj(v: unknown): v is Record<string, unknown> {
  *
  * Absent, malformed, or unreadable config all mean "off". This feature changes
  * what a browser session can see, so it must never switch itself on by accident.
+ *
+ * `profile_dir` is resolved against the project root and must stay inside it;
+ * see containedProfileDir for why, and for what happens when it does not.
  */
 export function profileConfig(): ProfileConfig {
   const file = path.join(careerOpsRoot(), "config", "profile.yml");
@@ -56,7 +112,8 @@ export function profileConfig(): ProfileConfig {
   }
   const enabled = apply.signed_in_profile === true;
   const raw = typeof apply.profile_dir === "string" ? apply.profile_dir.trim() : "";
-  return { enabled, dir: raw ? path.resolve(careerOpsRoot(), raw) : defaultProfileDir() };
+  if (!raw) return { enabled, dir: defaultProfileDir() };
+  return { enabled, ...containedProfileDir(raw) };
 }
 
 /** Whether the profile directory has been created (i.e. ever launched). Not a

--- a/web/src/lib/apply/session.ts
+++ b/web/src/lib/apply/session.ts
@@ -3,6 +3,7 @@ import { extractForm, type ApplyField, type ExtractedForm } from "./extract";
 import { parseGreenhouse, fetchGreenhouseSchema } from "./greenhouse";
 import { statusBlock, dismissConsent, tryApplyTrigger, dropNewTabs, classifyEmpty, captchaWarning, multiStepInfo, verifyFill, type ApplyIssue } from "./diagnose";
 import { agentInterpretForm } from "./agent-interpret";
+import { profileConfig, persistentContext, closePersistentContext } from "./profile";
 
 /** The frame with the most interactive controls — where the agentic interpreter
  *  should look when deterministic extraction found nothing usable. */
@@ -110,7 +111,20 @@ async function enrichFromAts(url: string, fields: ApplyField[]): Promise<void> {
 // so we can: extract → (user verifies pre-filled answers) → FILL the real form →
 // bringToFront() for the human to submit it themselves. Headed (channel:chrome) =
 // the user's own Chrome on their residential IP (best ATS success); never submits.
-type Session = { id: string; url: string; title: string; fields: ApplyField[]; context: BrowserContext; page: Page; frame: Frame; createdAt: number; formShot?: string };
+type Session = {
+  id: string;
+  url: string;
+  title: string;
+  fields: ApplyField[];
+  context: BrowserContext;
+  page: Page;
+  frame: Frame;
+  createdAt: number;
+  formShot?: string;
+  /** True when `context` is the SHARED signed-in profile, which several sessions
+   *  use at once. Such a session owns only its page, never the context. */
+  shared: boolean;
+};
 
 declare global {
   // eslint-disable-next-line no-var
@@ -145,6 +159,32 @@ async function headedBrowser(): Promise<Browser> {
   return nb;
 }
 
+/**
+ * A browser context to run one apply session in.
+ *
+ * Two shapes, and the difference matters at close time. The default is a fresh
+ * cookie-less context per session (right for a public ATS form). When the user
+ * has opted into a signed-in profile, every session instead SHARES the one
+ * persistent context that profile directory backs, because a profile can only
+ * back one browser. `shared` records which, so closeSurface knows whether the
+ * context belongs to this session or to all of them.
+ */
+async function applySurface(): Promise<{ context: BrowserContext; shared: boolean }> {
+  if (profileConfig().enabled) {
+    return { context: await persistentContext(), shared: true };
+  }
+  const browser = await headedBrowser();
+  return { context: await browser.newContext({ viewport: { width: 1280, height: 900 } }), shared: false };
+}
+
+/** Release a session's browser resources: its page when the context is shared,
+ *  otherwise the whole context. Closing a shared context here would tear down
+ *  every other live session and drop the user's sign-in. */
+async function closeSurface(s: { context: BrowserContext; page: Page; shared: boolean }): Promise<void> {
+  if (s.shared) await s.page.close().catch(() => {});
+  else await s.context.close().catch(() => {});
+}
+
 /** Close the headed Chrome once no sessions have been active for a while, so we
  *  don't leak a browser process. Re-armed on every prune/close; cancelled on open. */
 function scheduleIdleClose() {
@@ -154,6 +194,9 @@ function scheduleIdleClose() {
       const b = globalThis.__coHeadedBrowser;
       globalThis.__coHeadedBrowser = undefined;
       void b?.close().catch(() => {});
+      // The signed-in profile browser is a separate process from the throwaway
+      // one, so idle cleanup has to release it too or it outlives every session.
+      void closePersistentContext();
     }
   }, 5 * 60_000);
 }
@@ -176,12 +219,11 @@ async function nudgeScroll(page: Page): Promise<void> {
 export async function openSession(url: string, cliId?: string, forceAgent?: boolean, noApplyBtn?: boolean): Promise<{ id: string; title: string; fields: ApplyField[]; shots: string[]; issues: ApplyIssue[]; needsDrive?: boolean }> {
   prune();
   if (globalThis.__coIdleTimer) clearTimeout(globalThis.__coIdleTimer); // someone's active
-  const browser = await headedBrowser();
-  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const { context, shared } = await applySurface();
   context.setDefaultTimeout(8000); // no single action hangs the whole open/fill
   const page = await context.newPage();
   const abort = async (msg: string): Promise<never> => {
-    await context.close().catch(() => {});
+    await closeSurface({ context, page, shared });
     if (SESSIONS.size === 0) scheduleIdleClose();
     throw new Error(msg);
   };
@@ -262,7 +304,7 @@ export async function openSession(url: string, cliId?: string, forceAgent?: bool
     if (cliId && why.code === "no-form") {
       const id = `apply-${crypto.randomUUID()}`;
       const title = form.title || (await page.title().catch(() => "")) || "Application";
-      SESSIONS.set(id, { id, url, title, fields: [], context, page, frame, createdAt: Date.now(), formShot: shots[shots.length - 1] });
+      SESSIONS.set(id, { id, url, title, fields: [], context, page, frame, createdAt: Date.now(), formShot: shots[shots.length - 1], shared });
       return { id, title, fields: [], shots, issues: [], needsDrive: true };
     }
     return abort(why.message);
@@ -278,7 +320,7 @@ export async function openSession(url: string, cliId?: string, forceAgent?: bool
   if (unlabeled > 0) issues.push({ level: "warn", code: "unlabeled-fields", message: `${unlabeled} field${unlabeled > 1 ? "s" : ""} couldn't be labelled cleanly — double-check ${unlabeled > 1 ? "them" : "it"} before submitting.` });
 
   const id = `apply-${crypto.randomUUID()}`;
-  SESSIONS.set(id, { id, url, title: form.title, fields: form.fields, context, page, frame, createdAt: Date.now(), formShot: shots[shots.length - 1] });
+  SESSIONS.set(id, { id, url, title: form.title, fields: form.fields, context, page, frame, createdAt: Date.now(), formShot: shots[shots.length - 1], shared });
   return { id, title: form.title, fields: form.fields, shots, issues };
 }
 
@@ -288,16 +330,17 @@ export function getSession(id: string): Session | undefined {
 
 /** Open a bare headed page on a URL (for the agentic drive loop / validation),
  *  without the full extract pipeline. Caller must close the context. */
-export async function newDrivePage(url: string): Promise<{ page: Page; context: BrowserContext }> {
+export async function newDrivePage(url: string): Promise<{ page: Page; context: BrowserContext; shared: boolean }> {
   if (globalThis.__coIdleTimer) clearTimeout(globalThis.__coIdleTimer);
-  const browser = await headedBrowser();
-  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  // Same surface rule as a real session: `shared` is returned so the caller
+  // closes the page rather than the context when the profile is shared.
+  const { context, shared } = await applySurface();
   context.setDefaultTimeout(8000);
   const page = await context.newPage();
   await gotoResilient(page, url);
   await dismissConsent(page).catch(() => {});
   await page.waitForTimeout(1000);
-  return { page, context };
+  return { page, context, shared };
 }
 
 /** Extract+enrich the current page (used after the drive loop reaches a form). */
@@ -343,7 +386,7 @@ export async function finalizeDrivenSession(id: string, cliId?: string): Promise
 export async function closeSession(id: string): Promise<void> {
   const s = SESSIONS.get(id);
   SESSIONS.delete(id);
-  await s?.context.close().catch(() => {});
+  if (s) await closeSurface(s);
   if (SESSIONS.size === 0) scheduleIdleClose();
 }
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -112,6 +112,10 @@ const FIELD_KEYS: Record<string, string> = {
   date: "Date",
   fecha: "Date",
   url: "URL",
+  // Where the fillable form actually lives, which for a LinkedIn posting is not
+  // the same place as `url` (the canonical link the tracker records). Written by
+  // linkedin-apply.mjs; read by the Apply button, which prefers it over `url`.
+  "apply url": "Apply URL",
   archetype: "Archetype",
   arquetipo: "Archetype",
   score: "Score",

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -78,6 +78,10 @@ const FIELD_KEYS: Record<string, string> = {
   date: "Date",
   fecha: "Date",
   url: "URL",
+  // Where the fillable form actually lives, which for a LinkedIn posting is not
+  // the same place as `url` (the canonical link the tracker records). Written by
+  // linkedin-apply.mjs; read by the Apply button, which prefers it over `url`.
+  "apply url": "Apply URL",
   archetype: "Archetype",
   arquetipo: "Archetype",
   score: "Score",


### PR DESCRIPTION
## Related issue

Addresses #2993.

## What does this PR do?

Resolves a LinkedIn posting to the employer's real ATS application URL, so the web Apply flow can reach a form instead of an authwall.

`linkedin-apply.mjs` reads company + title from LinkedIn's public guest page, finds the board via the existing `discover-ats.mjs`, and matches the posting via the existing `jd-similarity.mjs`. Zero tokens, no auth, no browser.

This started as one worked example so #2993 had something concrete to react to, and it is still open to a different structure. Per @santifer's note above, URL resolution to the employer's real application page sits on the welcome side of the boundary written down in #2998 (the system resolves, captures, drafts and pre-fills; only the human submits), so it has graduated from draft. The three questions in #2993 are still genuine, and answering them may still change this code.

## The design decision worth reviewing

**It refuses rather than guesses.** It resolves only on a unique high-confidence title match; a seniority difference disqualifies outright; everything else returns ranked candidates for the user to pick from. Sending an application to the wrong requisition is worse than asking a question.

That is why the UI handles three outcomes rather than one: resolved (go), ambiguous (pick from candidates), unresolved (paste the link yourself). If you would rather it guessed more aggressively and asked less, that is a one-line policy change plus a lot less UI.

## Where the resolved link is recorded

A confident resolve, or a user's pick, is written to the report as an optional `**Apply URL:**` header line, so the next apply for that offer skips resolution entirely. `**URL:**` keeps its meaning as the canonical link the tracker records and is never overwritten.

This is question 1 in the issue. If you want it in the tracker or the Machine Summary instead, the writer is one function.

## Easy Apply

Out of scope for the resolver: the form lives on LinkedIn, so there is no external URL to reconstruct. Included here is an opt-in signed-in browser profile (`apply.signed_in_profile`, toggled from web Config) which runs the apply session in a dedicated profile the user signs into themselves. Never the user's everyday Chrome profile, and career-ops never sees, types or stores the password.

**This half is the most separable part of the PR.** It is question 3 in the issue, and if you would rather it were a plugin, or simply not now, I will strip it out and the resolver stands on its own.

## Rebase notes

Rebased onto current `main`. Four things adapted rather than taken as-is:

- `apply-button.tsx` picked up `n` / `from` on `apply.open()` from main, so the resolve flow passes them through; the Apply page still marks the row Applied and returns the user where they were.
- `report-view.tsx` picked up `pdfReadyFromIndex` and `companyPresentation()` from main; `ApplyButton` now takes main's `pdfReady` alongside the new `applyUrl`.
- `update-system.mjs`: main moved `jd-similarity.test.mjs` under `tests/`, so `SYSTEM_PATHS` keeps main's path and adds `linkedin-apply.mjs` beside it.
- `linkedin-apply.mjs` adopts `isMainModule(import.meta.url)` from `lib/is-main-module.mjs` rather than hand-rolling the entry-path comparison, per the convention `tests/main-guard-convention.test.mjs` now enforces (#3170).

`js-yaml` is imported as `import * as yaml`, per main's guard against the default-import form.

## Tests

- `node linkedin-apply.mjs --self-test` → 58 passed, 0 failed
- `node test-all.mjs` → 7691 passed, 0 failed (13 pre-existing warnings, all unrelated: missing local user data and `santifer.io` strings in `dashboard/`, `funding.json`, `HIRED.md`)
- `web`: `pnpm test` → 463 passed, 0 failed; `tsc --noEmit` and `next build` clean

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I opened an issue first (#2993)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (system-layer files only)
- [x] My changes align with the project roadmap
