### PR TITLE
Web UI: close CLI/web feature gap (contacto/deep/cover/email/outcome/training) + market-mode fix + contact persistence

### DIFF
--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -90,9 +90,12 @@ not quote the note verbatim in a public-facing message.
 - **LinkedIn's connection-request character limit varies by account tier: 200 characters on a free account, 300 on Premium/Sales Navigator.** Live-confirmed via the actual compose box on both tiers — a flat "300" assumption produces a message that gets silently truncated (or rejected) for a free-tier account. Default to the safer 200-char budget unless the user has confirmed they're on Premium/Sales Navigator; count and trim to whichever limit actually applies.
 - NO corporate-speak
 - NO "I'm passionate about..."
-- Something that makes them want to respond
 - NEVER share phone number
 - The contact type changes the EMPHASIS, not the structure
+- **End on a question, not a statement.** "Happy to share my CV if this aligns" is a dead end — it puts the entire next move on them and gives them nothing specific to react to. A real question about their team, their approach to a named problem, or a detail from their own work is what actually gets a reply. Reserve "happy to share my CV" for the Recruiter persona ONLY, where it functions as a real answer to their next question, not the message's ending.
+- **Ban the templated opener.** Never start with "Saw the [role] at [company]" or any close paraphrase — it is the single most recognizable mass-outreach tell and reads as a template before the recipient finishes the first clause. Open on the specific thing (a problem their team is visibly solving, something they shipped, a detail from the posting that's actually interesting) instead of announcing that you found the job.
+- **No resume-bullet phrasing mid-sentence.** "5 years in RN, sole app ownership shipping a 50k-install logistics app" is a CV line pasted into a DM, not something a person would say to another person. Say the same fact the way you'd say it out loud.
+- **Vary the rhythm.** Three uniform-length, uniformly-structured sentences is itself an AI tell, independent of the words used. Let sentence length vary; it's allowed to be two sentences if the second one is doing enough work.
 
 ---
 

--- a/web/src/app/api/contacts/route.ts
+++ b/web/src/app/api/contacts/route.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import { careerOpsRoot } from "@/lib/career-ops";
+import { atomicWrite } from "@/lib/core/safe-write";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Confirm-then-save path for contacto's own step 7 ("Offer to save the
+// contact... NEVER save without the candidate confirming first") — the web
+// job itself never writes data/contacts.tsv (kept read-only/DRAFT-ONLY, see
+// api/run/route.ts), so this is the one write path, gated behind the user
+// actually filling in and submitting the form on /jobs/[id]. Same schema and
+// update-in-place-by-name+company semantics as contacts.mjs documents.
+
+const VALID_TYPES = new Set(["recruiter", "hiring-manager", "peer", "interviewer", "other"]);
+const HEADER = "# name\tcompany\ttype\ttitle\tphone\temail\tlinkedin\ttracker#\tnotes";
+
+type Body = {
+  name?: string;
+  company?: string;
+  type?: string;
+  title?: string;
+  phone?: string;
+  email?: string;
+  linkedin?: string;
+  trackerNum?: string;
+  notes?: string;
+};
+
+// TSV cells can't carry tabs/newlines without corrupting the column count for
+// every reader downstream (contacts.mjs, --vcf, the CLI) — collapse instead
+// of rejecting, so a pasted multi-line note still saves.
+const clean = (v?: string) => (v ?? "").replace(/[\t\r\n]+/g, " ").trim();
+
+export async function POST(req: Request) {
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "bad json" }, { status: 400 });
+  }
+  const name = clean(body.name);
+  const company = clean(body.company);
+  if (!name || !company) {
+    return Response.json({ error: "name and company are required" }, { status: 400 });
+  }
+  const type = VALID_TYPES.has(body.type ?? "") ? (body.type as string) : "other";
+  const row = [
+    name,
+    company,
+    type,
+    clean(body.title),
+    clean(body.phone),
+    clean(body.email),
+    clean(body.linkedin),
+    clean(body.trackerNum) || "-",
+    clean(body.notes),
+  ].join("\t");
+
+  const file = path.join(careerOpsRoot(), "data", "contacts.tsv");
+  let lines: string[] = [];
+  try {
+    lines = fs.readFileSync(file, "utf8").split("\n");
+  } catch {
+    lines = [HEADER];
+  }
+
+  const uidKey = (n: string, c: string) => `${n.toLowerCase()} ${c.toLowerCase()}`;
+  const target = uidKey(name, company);
+  let updated = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const cells = line.split("\t");
+    if (cells.length < 2) continue;
+    if (uidKey(cells[0].trim(), cells[1].trim()) === target) {
+      lines[i] = row;
+      updated = true;
+      break;
+    }
+  }
+  if (!updated) {
+    while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
+    lines.push(row);
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    atomicWrite(file, lines.join("\n") + "\n");
+  } catch (e) {
+    return Response.json({ error: e instanceof Error ? e.message : "write failed" }, { status: 500 });
+  }
+  return Response.json({ ok: true, updated });
+}

--- a/web/src/app/api/outcome/route.ts
+++ b/web/src/app/api/outcome/route.ts
@@ -1,0 +1,99 @@
+import { spawn } from "node:child_process";
+import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { isTrackerWriting } from "@/lib/core/run-registry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Records an application outcome by orchestrating the core `outcome.mjs`
+// script (archives the submitted CV/cover/posting under data/outcomes/ and
+// syncs the tracker status via set-status.mjs's locked, validated write path)
+// — never hand-writes applications.md, same discipline as /api/status and
+// tracker/delete. Deterministic script, not an agent job: no LLM involved.
+
+const VALID_TYPES = new Set([
+  "interview_progress",
+  "offer_received",
+  "hired",
+  "offer_declined",
+  "rejected",
+  "no_response",
+  "interview_only",
+]);
+
+let recording = false;
+
+export async function POST(req: Request) {
+  let body: { n?: string | number; outcomeType?: string; stage?: string; feedback?: string; note?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "bad json" }, { status: 400 });
+  }
+  const n = String(body.n ?? "").trim();
+  const outcomeType = String(body.outcomeType ?? "").trim();
+  if (!n) {
+    return Response.json({ error: "n (tracker # or company) required" }, { status: 400 });
+  }
+  if (!VALID_TYPES.has(outcomeType)) {
+    return Response.json({ error: `invalid outcomeType — expected one of: ${[...VALID_TYPES].join(", ")}` }, { status: 400 });
+  }
+
+  // Serialize against an in-flight evaluate/pdf run's merge-tracker step, same
+  // guard as tracker/delete — outcome.mjs's own set-status.mjs call is locked,
+  // but a concurrent merge-tracker append could still race the row it reads.
+  if (isTrackerWriting()) {
+    return Response.json(
+      { error: "An evaluation is updating your tracker right now — try again in a moment." },
+      { status: 409 },
+    );
+  }
+  if (recording) {
+    return Response.json({ error: "Another outcome is already being recorded — try again in a moment." }, { status: 409 });
+  }
+  recording = true;
+
+  const args = [rootScript("outcome"), n, outcomeType, "--json"];
+  if (body.stage?.trim()) args.push("--stage", body.stage.trim());
+  if (body.feedback?.trim()) args.push("--feedback", body.feedback.trim());
+  if (body.note?.trim()) args.push("--note", body.note.trim());
+
+  try {
+    const result = await new Promise<{ code: number | null; out: string; err: string }>((resolve) => {
+      let out = "";
+      let err = "";
+      let child;
+      try {
+        child = spawn(process.execPath, args, { cwd: careerOpsRoot(), env: process.env });
+      } catch (e) {
+        resolve({ code: 1, out: "", err: e instanceof Error ? e.message : "failed to start outcome.mjs" });
+        return;
+      }
+      child.stdout.on("data", (d: Buffer) => { out += d.toString(); });
+      child.stderr.on("data", (d: Buffer) => { err += d.toString(); });
+      const killer = setTimeout(() => {
+        try { child.kill("SIGTERM"); } catch { /* ignore */ }
+      }, 60_000);
+      child.on("error", (e) => { clearTimeout(killer); resolve({ code: 1, out, err: e.message }); });
+      child.on("close", (code) => { clearTimeout(killer); resolve({ code, out, err }); });
+    });
+
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = JSON.parse(result.out.trim());
+    } catch {
+      /* fall through to raw error */
+    }
+
+    if (result.code !== 0 || !parsed?.success) {
+      const msg = (parsed?.error as string | undefined) || result.err.trim().split("\n")[0] || "outcome recording failed";
+      const notFound = /not found|No tracker row/i.test(msg);
+      const ambiguous = /Multiple tracker rows/i.test(msg);
+      return Response.json({ error: msg }, { status: ambiguous ? 409 : notFound ? 404 : 400 });
+    }
+
+    return Response.json(parsed);
+  } finally {
+    recording = false;
+  }
+}

--- a/web/src/app/api/portals/route.ts
+++ b/web/src/app/api/portals/route.ts
@@ -12,40 +12,77 @@ export const dynamic = "force-dynamic";
 // from templates/portals.example.yml on first create, and PRESERVING tracked_companies
 // + every other block. Atomic write, confirm-gated (setProfile/setPortals). This is
 // what loads the very first home scan once the user confirms their target roles.
+//
+// location_filter mirrors the same merge-only discipline: `allow` replaces the
+// scanner's default US/Europe search terms, `block`/`always_allow` are read by
+// the CLI's own location-filtering logic (always_allow overrides a block, e.g.
+// "block US but always allow my specific city"). None of the three is required —
+// a Settings save can touch just roles, just location, or both.
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v);
 }
 
-export async function POST(req: Request) {
-  let body: { roles?: string[]; location?: string[] };
+function loadDoc(root: string): Record<string, unknown> {
+  const file = path.join(root, "portals.yml");
   try {
-    body = (await req.json()) as { roles?: string[]; location?: string[] };
+    return (yaml.load(fs.readFileSync(file, "utf8")) as Record<string, unknown>) || {};
+  } catch {
+    try {
+      return (yaml.load(fs.readFileSync(path.join(root, "templates", "portals.example.yml"), "utf8")) as Record<string, unknown>) || {};
+    } catch {
+      return {};
+    }
+  }
+}
+
+// GET is read-only, for Settings' Location & Region section to show back
+// whatever's currently saved (LocationSettings has nowhere else to read it from).
+export async function GET() {
+  const doc = loadDoc(careerOpsRoot());
+  const lf = isObj(doc.location_filter) ? doc.location_filter : {};
+  const asStrings = (v: unknown): string[] => (Array.isArray(v) ? v.map((x) => String(x)) : []);
+  return Response.json({
+    location: asStrings(lf.allow),
+    block: asStrings(lf.block),
+    always_allow: asStrings(lf.always_allow),
+  });
+}
+
+export async function POST(req: Request) {
+  let body: { roles?: string[]; location?: string[]; block?: string[]; always_allow?: string[] };
+  try {
+    body = (await req.json()) as { roles?: string[]; location?: string[]; block?: string[]; always_allow?: string[] };
   } catch {
     return Response.json({ error: "bad json" }, { status: 400 });
   }
   const roles = (Array.isArray(body.roles) ? body.roles : []).map((r) => String(r).trim()).filter(Boolean).slice(0, 24);
-  if (roles.length === 0) return Response.json({ error: "no roles" }, { status: 400 });
+  const clean = (arr?: string[]) => (Array.isArray(arr) ? arr : []).map((v) => String(v).trim()).filter(Boolean);
+  const location = clean(body.location);
+  const block = clean(body.block);
+  const alwaysAllow = clean(body.always_allow);
+  // At least ONE of roles/location/block/always_allow must be present — an
+  // empty body is the only thing rejected, not "roles specifically".
+  if (roles.length === 0 && location.length === 0 && block.length === 0 && alwaysAllow.length === 0) {
+    return Response.json({ error: "nothing to save" }, { status: 400 });
+  }
 
   const root = careerOpsRoot();
   const file = path.join(root, "portals.yml");
-  let doc: Record<string, unknown> = {};
-  try {
-    doc = (yaml.load(fs.readFileSync(file, "utf8")) as Record<string, unknown>) || {};
-  } catch {
-    try {
-      doc = (yaml.load(fs.readFileSync(path.join(root, "templates", "portals.example.yml"), "utf8")) as Record<string, unknown>) || {};
-    } catch {
-      doc = {};
-    }
-  }
+  const doc = loadDoc(root);
 
-  const tf = isObj(doc.title_filter) ? { ...doc.title_filter } : {};
-  tf.positive = roles; // replace ONLY the positive keywords; keep negative/etc.
-  doc.title_filter = tf;
-  if (Array.isArray(body.location) && body.location.length) {
+  if (roles.length > 0) {
+    const tf = isObj(doc.title_filter) ? { ...doc.title_filter } : {};
+    tf.positive = roles; // replace ONLY the positive keywords; keep negative/etc.
+    doc.title_filter = tf;
+  }
+  if (Array.isArray(body.location) || Array.isArray(body.block) || Array.isArray(body.always_allow)) {
     const lf = isObj(doc.location_filter) ? { ...doc.location_filter } : {};
-    lf.allow = body.location.map((l) => String(l).trim()).filter(Boolean);
+    // Each field replaces independently — a save that only touches `block`
+    // (array present, even if now empty) must not silently wipe `allow`.
+    if (Array.isArray(body.location)) lf.allow = location;
+    if (Array.isArray(body.block)) lf.block = block;
+    if (Array.isArray(body.always_allow)) lf.always_allow = alwaysAllow;
     doc.location_filter = lf;
   }
 

--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -22,6 +22,7 @@ type ProfilePatch = {
   compMax?: number;
   currency?: string;
   remote?: string;
+  modesDir?: string;
 };
 
 function isObj(v: unknown): v is Record<string, unknown> {
@@ -50,9 +51,29 @@ function patchToProfile(p: ProfilePatch): Record<string, unknown> {
   if (p.currency) comp.currency = p.currency;
   if (p.remote) comp.location_flexibility = p.remote;
   if (Object.keys(comp).length) out.compensation = comp;
+  if (p.modesDir) out.language = { modes_dir: p.modesDir };
   // seniority intentionally not written (no canonical home in profile.yml);
   // archetypes/narrative live in modes/_profile.md — this writer never touches them.
   return out;
+}
+
+// GET is read-only and narrow on purpose: just the one field the Settings UI's
+// Market Mode picker needs to show the currently-saved value back to the user.
+export async function GET() {
+  const root = careerOpsRoot();
+  const file = path.join(root, "config", "profile.yml");
+  let profile: Record<string, unknown> = {};
+  if (fs.existsSync(file)) {
+    try {
+      const parsed = yaml.load(fs.readFileSync(file, "utf8"));
+      profile = isObj(parsed) ? parsed : {};
+    } catch {
+      /* ignore */
+    }
+  }
+  const language = isObj(profile.language) ? profile.language : {};
+  const modesDir = typeof language.modes_dir === "string" ? language.modes_dir : "modes/";
+  return Response.json({ modesDir });
 }
 
 export async function POST(req: Request) {

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -6,7 +6,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveCli } from "@/lib/clis";
-import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr } from "@/lib/run-cli-support.mjs";
+import { accumulateTokens, newCompletedReportName, isFatalGenericStderr } from "@/lib/run-cli-support.mjs";
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates, readLanguageConfig } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
@@ -406,7 +406,11 @@ export async function POST(req: Request) {
           return close();
         }
 
-        const wroteReport = hasNewCompletedReport(reportsBefore, reportEntries());
+        const newReportName = newCompletedReportName(reportsBefore, reportEntries());
+        const wroteReport = newReportName !== null;
+        // {num}-{company-slug}-{date}.md — the leading digits are the tracker
+        // number the client needs to link to /pipeline/{num}.
+        const reportNum = newReportName?.match(/^0*(\d+)-/)?.[1];
         // Honesty gate (#9): a green "done" with a parsed score requires a CLEAN exit,
         // real output, AND (for evaluations) a report actually written. Anything else
         // is surfaced — an errored run must never be banked as a confident score.
@@ -422,7 +426,7 @@ export async function POST(req: Request) {
           // instead of recording a confident score off a half-finished run.
           send({ type: "error", msg: "This run hit an error before finishing, so it isn't recorded as a confident result — re-run it to verify." });
         } else {
-          send({ type: "done", tokens: lastTokens, costUsd: lastCostUsd });
+          send({ type: "done", tokens: lastTokens, costUsd: lastCostUsd, reportNum });
         }
         close();
       });

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr } from "@/lib/run-cli-support.mjs";
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
-import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates } from "@/lib/career-ops";
+import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates, readLanguageConfig } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf, writeCvHtml, pdfRunOutcome } from "@/lib/pdf-render.mjs";
 import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
@@ -102,7 +102,7 @@ export async function POST(req: Request) {
     kind === "evaluate"
       ? readInbox().find((j) => j.url === input)?.postedAt ?? readScanDates().get(input)
       : undefined;
-  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt });
+  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang: readLanguageConfig() });
 
   const isClaude = cliId === "claude";
   // Which tools each kind gets, and the whole claude argv, live in

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -174,6 +174,12 @@ html {
   padding: 1rem;
   overflow-x: auto;
   margin: 1rem 0;
+  /* Code blocks here are as often a drafted message/paragraph (no real line
+     breaks) as actual code — unwrapped + scrolling hides most of a one-line
+     194-char draft behind a scrollbar instead of just letting it read. Real
+     code with meaningful indentation still reads fine wrapped. */
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .report-prose pre code { background: none; color: var(--fg); padding: 0; }
 .report-prose ul, .report-prose ol { margin: 0.9rem 0; padding-left: 1.4rem; }
@@ -188,7 +194,7 @@ html {
   color: var(--muted);
 }
 .report-prose hr { border: none; border-top: 1px solid var(--border); margin: 1.75rem 0; }
-.report-prose table { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin: 1rem 0; }
+.report-prose table { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin: 0; }
 .report-prose thead { border-bottom: 1px solid var(--border); }
 .report-prose th { text-align: left; font-weight: 600; color: var(--fg); padding: 0.5rem 0.75rem; vertical-align: top; }
 .report-prose td {

--- a/web/src/app/jobs/[id]/page.tsx
+++ b/web/src/app/jobs/[id]/page.tsx
@@ -2,21 +2,24 @@
 
 import { use } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Loader2, Wrench, CircleDot, Check, X } from "lucide-react";
+import { ArrowLeft, Loader2, Wrench, CircleDot, Check, X, RotateCcw } from "lucide-react";
 import { useJobs } from "@/components/jobs/job-store";
 import { HeroGlow } from "@/components/hero-glow";
 import { Badge } from "@/components/ui/badge";
+import { SaveContactForm } from "@/components/save-contact-form";
 
 export default function JobPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { jobs } = useJobs();
+  const { jobs, startJob } = useJobs();
+  const router = useRouter();
   const job = jobs.find((j) => j.id === id);
 
   if (!job) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-10">
+      <div className="mx-auto max-w-4xl px-6 py-10">
         <Link href="/pipeline" className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-brand">
           <ArrowLeft className="size-4" /> Pipeline
         </Link>
@@ -28,7 +31,7 @@ export default function JobPage({ params }: { params: Promise<{ id: string }> })
   }
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-8">
+    <div className="mx-auto max-w-4xl px-6 py-8">
       <Link href="/pipeline" className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-brand">
         <ArrowLeft className="size-4" /> Pipeline
       </Link>
@@ -45,8 +48,25 @@ export default function JobPage({ params }: { params: Promise<{ id: string }> })
               <><X className="size-3 text-red-400" /> error</>
             )}
           </p>
-          <h1 className="mt-2 font-display text-2xl tracking-tight text-landing">{job.title}</h1>
-          {job.subtitle && <p className="mt-1 text-sm text-muted">{job.subtitle}</p>}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h1 className="mt-2 font-display text-2xl tracking-tight text-landing">{job.title}</h1>
+              {job.subtitle && <p className="mt-1 text-sm text-muted">{job.subtitle}</p>}
+            </div>
+            {job.status !== "running" && job.kind && job.input && (
+              <button
+                type="button"
+                onClick={() => {
+                  const newId = startJob({ title: job.title, subtitle: job.subtitle, kind: job.kind!, input: job.input!, page: job.page });
+                  if (newId) router.push(`/jobs/${newId}`);
+                }}
+                title="Run this again to check for anything new — the result above stays as-is until you do"
+                className="inline-flex items-center justify-center gap-1.5 rounded-full border border-border px-3 py-1.5 text-xs font-medium text-muted transition-colors hover:border-brand/40 hover:text-brand max-sm:min-h-[44px]"
+              >
+                <RotateCcw className="size-3.5" /> Check again
+              </button>
+            )}
+          </div>
           {job.result?.score != null && (
             <div className="mt-3 flex flex-wrap items-center gap-2.5">
               <Badge tone={job.result.tone}>{job.result.score}/5</Badge>
@@ -83,6 +103,14 @@ export default function JobPage({ params }: { params: Promise<{ id: string }> })
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{job.text}</ReactMarkdown>
           </div>
         </div>
+      )}
+
+      {job.kind === "contacto" && job.status === "done" && job.input && (
+        <SaveContactForm
+          defaultCompany={job.title.split(" · ").slice(1).join(" · ")}
+          trackerNum={job.input}
+          defaultMessage={job.text.match(/```(?:[a-z]*\n)?([\s\S]*?)```/)?.[1]?.trim() ?? ""}
+        />
       )}
     </div>
   );

--- a/web/src/app/jobs/[id]/page.tsx
+++ b/web/src/app/jobs/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, Loader2, Wrench, CircleDot, Check, X, RotateCcw } from "lucide-react";
+import { ArrowLeft, Loader2, Wrench, CircleDot, Check, X, RotateCcw, FileText } from "lucide-react";
 import { useJobs } from "@/components/jobs/job-store";
 import { HeroGlow } from "@/components/hero-glow";
 import { Badge } from "@/components/ui/badge";
@@ -72,6 +72,14 @@ export default function JobPage({ params }: { params: Promise<{ id: string }> })
               <Badge tone={job.result.tone}>{job.result.score}/5</Badge>
               {job.result.summary && <span className="text-sm text-muted">{job.result.summary}</span>}
             </div>
+          )}
+          {job.kind === "evaluate" && job.status === "done" && job.reportNum && (
+            <Link
+              href={`/pipeline/${job.reportNum}`}
+              className="mt-4 inline-flex items-center justify-center gap-1.5 rounded-full bg-brand px-4 py-2 text-sm font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-200"
+            >
+              <FileText className="size-4" /> View full report
+            </Link>
           )}
         </div>
       </section>

--- a/web/src/components/ai-actions-menu.tsx
+++ b/web/src/components/ai-actions-menu.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Sparkles, ChevronDown, Users, Telescope, PenLine, Mail, Loader2, Check, ArrowUpRight, RotateCcw } from "lucide-react";
+import { useJobs, type Job } from "@/components/jobs/job-store";
+
+type ActionDef = {
+  kind: "contacto" | "deep" | "cover" | "email";
+  icon: typeof Users;
+  label: string;
+  doneLabel: string;
+  description: string;
+  title: (company: string) => string;
+  subtitle: string;
+};
+
+const ACTIONS: ActionDef[] = [
+  {
+    kind: "contacto",
+    icon: Users,
+    label: "Find contacts",
+    doneLabel: "View contacts & outreach",
+    description: "Hiring manager, recruiter & peers, with draft messages",
+    title: (c) => `Find contacts · ${c}`,
+    subtitle: "hiring manager, recruiter & peers",
+  },
+  {
+    kind: "deep",
+    icon: Telescope,
+    label: "Company research",
+    doneLabel: "View research",
+    description: "AI strategy, culture, challenges, your angle",
+    title: (c) => `Company research · ${c}`,
+    subtitle: "6-axis interview prep",
+  },
+  {
+    kind: "cover",
+    icon: PenLine,
+    label: "Cover letter",
+    doneLabel: "View cover letter",
+    description: "Tailored draft from this JD",
+    title: (c) => `Cover letter · ${c}`,
+    subtitle: "tailored draft",
+  },
+  {
+    kind: "email",
+    icon: Mail,
+    label: "Application email",
+    doneLabel: "View email draft",
+    description: "Subject, body, attachment checklist",
+    title: (c) => `Application email · ${c}`,
+    subtitle: "draft only",
+  },
+];
+
+// Consolidates the 4 secondary generative actions (contacto/deep/cover/email)
+// behind one trigger instead of 4 always-visible pill buttons + 4 repeated
+// "USES TOKENS" badges — that repetition was the actual density complaint,
+// not any single button. A running/done action still surfaces on the trigger
+// itself (spinner / count dot) so progress stays visible with the menu closed.
+export function AiActionsMenu({ n, company }: { n: string; company: string }) {
+  const router = useRouter();
+  const { jobs, startJob } = useJobs();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    if (open) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  const latestByKind = useMemo(() => {
+    const map = new Map<string, Job>();
+    for (const action of ACTIONS) {
+      const job = jobs.filter((j) => j.kind === action.kind && j.input === n).sort((a, b) => b.startedAt - a.startedAt)[0];
+      if (job) map.set(action.kind, job);
+    }
+    return map;
+  }, [jobs, n]);
+
+  const runningCount = ACTIONS.filter((a) => latestByKind.get(a.kind)?.status === "running").length;
+  const doneCount = ACTIONS.filter((a) => latestByKind.get(a.kind)?.status === "done").length;
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="inline-flex items-center justify-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted transition-colors hover:border-brand/40 hover:text-brand max-sm:min-h-[44px]"
+        title="Outreach, research, cover letter & email drafts for this role"
+      >
+        {runningCount > 0 ? <Loader2 className="size-3.5 animate-spin text-brand" /> : <Sparkles className="size-3.5" />}
+        AI actions
+        {doneCount > 0 && runningCount === 0 && (
+          <span className="inline-flex size-4 items-center justify-center rounded-full bg-emerald-500/15 text-[10px] font-semibold text-emerald-700 dark:text-emerald-400">
+            {doneCount}
+          </span>
+        )}
+        <ChevronDown className={`size-3.5 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-[100] mt-2 w-80 origin-top-left overflow-hidden rounded-xl border border-border bg-surface shadow-xl">
+          <div className="flex items-center justify-between border-b border-border px-3.5 py-2">
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted">AI actions</span>
+            <span className="text-[11px] text-faint">runs on your own AI — uses tokens</span>
+          </div>
+          <div className="p-1.5">
+            {ACTIONS.map((action) => {
+              const job = latestByKind.get(action.kind);
+              const Icon = action.icon;
+              if (job?.status === "running") {
+                return (
+                  <Link
+                    key={action.kind}
+                    href={`/jobs/${job.id}`}
+                    onClick={() => setOpen(false)}
+                    className="flex items-center gap-3 rounded-lg px-2.5 py-2.5 text-left transition-colors hover:bg-surface-hover"
+                  >
+                    <Loader2 className="size-4 shrink-0 animate-spin text-brand" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium text-foreground">{action.label}</span>
+                      <span className="block text-xs text-faint">Working…</span>
+                    </span>
+                  </Link>
+                );
+              }
+              if (job?.status === "done") {
+                return (
+                  <div key={action.kind} className="flex items-center gap-1 rounded-lg hover:bg-surface-hover">
+                    <Link
+                      href={`/jobs/${job.id}`}
+                      onClick={() => setOpen(false)}
+                      className="flex min-w-0 flex-1 items-center gap-3 px-2.5 py-2.5 text-left"
+                    >
+                      <Check className="size-4 shrink-0 text-emerald-500" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-sm font-medium text-foreground">{action.doneLabel}</span>
+                        <span className="block text-xs text-faint">{action.description}</span>
+                      </span>
+                      <ArrowUpRight className="size-3.5 shrink-0 text-faint" />
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const id = startJob({ title: action.title(company), subtitle: action.subtitle, kind: action.kind, input: n, page: `/pipeline/${n}` });
+                        setOpen(false);
+                        if (id) router.push(`/jobs/${id}`);
+                      }}
+                      title="Check again — re-runs this, doesn't touch the saved result"
+                      className="mr-1.5 inline-flex shrink-0 items-center justify-center rounded-full p-1.5 text-faint transition-colors hover:text-brand max-sm:min-h-[44px] max-sm:min-w-[44px]"
+                    >
+                      <RotateCcw className="size-3.5" />
+                    </button>
+                  </div>
+                );
+              }
+              return (
+                <button
+                  key={action.kind}
+                  type="button"
+                  onClick={() => {
+                    const id = startJob({ title: action.title(company), subtitle: action.subtitle, kind: action.kind, input: n, page: `/pipeline/${n}` });
+                    setOpen(false);
+                    if (id) router.push(`/jobs/${id}`);
+                  }}
+                  className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-left transition-colors hover:bg-surface-hover"
+                >
+                  <Icon className="size-4 shrink-0 text-muted" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium text-foreground">{action.label}</span>
+                    <span className="block text-xs text-faint">{action.description}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -12,6 +12,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
+import { LocationSettings } from "@/components/location-settings";
+import { MarketSettings } from "@/components/market-settings";
 
 type Cli = {
   id: string;
@@ -293,6 +295,8 @@ export function ConfigForm() {
       </button>
 
       <CadenceSettings />
+      <LocationSettings />
+      <MarketSettings />
 
       <div className="mt-8 flex items-center gap-3">
         <button

--- a/web/src/components/jobs/job-store.tsx
+++ b/web/src/components/jobs/job-store.tsx
@@ -19,6 +19,10 @@ export type Job = {
   text: string;
   result?: JobResult;
   cost?: { tokens: number; usd?: number }; // per-run token cost (Claude result event) — local only
+  /** For a completed "evaluate" run: the tracker # of the report it wrote, so
+   *  the job page can link straight to it (the streamed text is often just
+   *  the terse VERDICT line — the real report lives at /pipeline/{reportNum}). */
+  reportNum?: string;
   startedAt: number;
   endedAt?: number;
 };
@@ -125,6 +129,7 @@ export function JobsProvider({ children }: { children: React.ReactNode }) {
         let verdictLine = ""; // latched separately so the 8000-char tail can't drop it
         let doneTokens = 0; // per-run token cost, forwarded on the done event (#6)
         let doneCostUsd: number | null = null;
+        let doneReportNum: string | undefined;
         const steps: JobStep[] = [];
         const finish = (status: "done" | "error", lastLabel?: string) => {
           const result = status === "done" ? parseVerdict(verdictLine || text) : undefined;
@@ -134,6 +139,7 @@ export function JobsProvider({ children }: { children: React.ReactNode }) {
             status,
             result,
             cost,
+            reportNum: status === "done" ? doneReportNum : j.reportNum,
             endedAt: Date.now(),
             steps: lastLabel ? [...j.steps, { kind: "status", label: lastLabel, ts: Date.now() }] : j.steps,
           }));
@@ -190,9 +196,11 @@ export function JobsProvider({ children }: { children: React.ReactNode }) {
                   text = full.slice(-8000);
                   patch(id, (j) => ({ ...j, text }));
                 } else if (ev.type === "done") {
-                  // finish happens on stream-close; capture the per-run cost it carries
+                  // finish happens on stream-close; capture the per-run cost (and,
+                  // for evaluate, the report number) it carries
                   if (typeof ev.tokens === "number") doneTokens = ev.tokens;
                   if (typeof ev.costUsd === "number") doneCostUsd = ev.costUsd;
+                  if (typeof ev.reportNum === "string") doneReportNum = ev.reportNum;
                 } else if (ev.type === "error") {
                   finish("error", ev.msg || "Error");
                   return;

--- a/web/src/components/location-settings.tsx
+++ b/web/src/components/location-settings.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Check, Loader2, MapPin, X } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+// Country/city name only — no bare abbreviation duplicates (dropped "USA",
+// "UAE", "KSA": each is a pure synonym of the full name already in this list,
+// so keeping both just meant two checkboxes for one real-world region).
+const REGION_OPTIONS = [
+  "Remote",
+  "United States",
+  "India",
+  "Bengaluru",
+  "United Kingdom",
+  "London",
+  "Europe",
+  "Germany",
+  "France",
+  "Canada",
+  "Australia",
+  "United Arab Emirates",
+  "Dubai",
+  "Abu Dhabi",
+  "Saudi Arabia",
+  "Riyadh",
+  "Singapore",
+  "Japan",
+  "Brazil",
+];
+
+function MultiSelectDropdown({ 
+  value, 
+  onChange, 
+  options, 
+  placeholder 
+}: { 
+  value: string[], 
+  onChange: (val: string[]) => void, 
+  options: string[], 
+  placeholder: string 
+}) {
+  const [open, setOpen] = useState(false);
+  const [customVal, setCustomVal] = useState("");
+
+  const toggle = (opt: string) => {
+    if (value.includes(opt)) onChange(value.filter(v => v !== opt));
+    else onChange([...value, opt]);
+  };
+
+  const addCustom = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && customVal.trim()) {
+      e.preventDefault();
+      const val = customVal.trim();
+      if (!value.includes(val)) onChange([...value, val]);
+      setCustomVal("");
+    }
+  };
+
+  return (
+    <div
+      className="relative mt-1.5 w-full max-w-sm"
+      tabIndex={0}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setOpen(false);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") setOpen(false);
+      }}
+    >
+      <div
+        onClick={() => setOpen(!open)}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex min-h-[38px] flex-wrap items-center gap-1.5 rounded-md border border-border bg-surface/60 px-3 py-1.5 text-sm outline-none transition-colors cursor-pointer hover:border-brand/50 max-sm:min-h-[44px]"
+      >
+        {value.length === 0 && <span className="text-faint">{placeholder}</span>}
+        {value.map((v) => (
+          <span key={v} className="inline-flex items-center gap-1 rounded bg-surface px-1.5 py-0.5 text-xs text-foreground border border-border">
+            {v}
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); toggle(v); }}
+              aria-label={`Remove ${v}`}
+              className="inline-flex items-center justify-center text-muted transition-colors hover:text-red-400 max-sm:min-h-[44px] max-sm:min-w-[24px]"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      {open && (
+        <div role="listbox" aria-multiselectable="true" className="absolute z-10 mt-1 max-h-72 w-full overflow-auto rounded-md border border-border bg-surface shadow-lg">
+          <div className="p-2 border-b border-border sticky top-0 bg-surface z-20">
+             <input
+               type="text"
+               value={customVal}
+               onChange={e => setCustomVal(e.target.value)}
+               onKeyDown={addCustom}
+               onClick={e => e.stopPropagation()}
+               placeholder="Type custom region and press Enter..."
+               className="w-full rounded border border-border bg-surface-hover px-2 py-1.5 text-xs outline-none focus:border-brand/50"
+             />
+          </div>
+          {options.map(opt => (
+            <label
+              key={opt}
+              role="option"
+              aria-selected={value.includes(opt)}
+              className="flex min-h-[38px] items-center gap-2 px-3 py-2 text-sm hover:bg-surface-hover cursor-pointer max-sm:min-h-[44px]"
+            >
+              <input
+                type="checkbox"
+                checked={value.includes(opt)}
+                onChange={() => toggle(opt)}
+                className="size-4 shrink-0 rounded border-border bg-surface text-brand focus:ring-brand accent-brand"
+              />
+              {opt}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function LocationSettings() {
+  const [searchRegions, setSearchRegions] = useState<string[]>([]);
+  const [blockRegions, setBlockRegions] = useState<string[]>([]);
+  const [alwaysAllowRegions, setAlwaysAllowRegions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const portalsRes = await fetch("/api/portals");
+      
+      if (portalsRes.ok) {
+        const portals = await portalsRes.json();
+        if (Array.isArray(portals.location)) {
+          setSearchRegions(portals.location);
+        }
+        if (Array.isArray(portals.block)) {
+          setBlockRegions(portals.block);
+        }
+        if (Array.isArray(portals.always_allow)) {
+          setAlwaysAllowRegions(portals.always_allow);
+        }
+      }
+    } catch {
+      setError("Failed to load current location settings.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const portalsRes = await fetch("/api/portals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ 
+          location: searchRegions.filter(Boolean),
+          block: blockRegions.filter(Boolean),
+          always_allow: alwaysAllowRegions.filter(Boolean)
+        })
+      });
+      
+      if (!portalsRes.ok) {
+        setError("Could not save one or more settings.");
+      } else {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      }
+    } catch {
+      setError("Could not save location settings.");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="mt-8">
+      <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+        Location & Region
+      </label>
+      <div className="rounded-xl border border-border bg-surface/50 p-4">
+        <p className="text-xs leading-relaxed text-faint mb-4">
+          Where the scanner should look for roles (<span className="font-mono text-muted">portals.yml</span>). This setting also automatically overrides any default geographic terms in the AI's Google searches.
+        </p>
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Loader2 className="size-4 animate-spin" /> Loading…
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-foreground flex items-center gap-1.5">
+                <MapPin className="size-3.5 text-muted" /> Search Regions
+              </span>
+              <span className="mt-0.5 block text-xs text-faint">Select regions to scan for (e.g. "India", "Remote"). This replaces US/Europe in web queries.</span>
+              <MultiSelectDropdown 
+                value={searchRegions}
+                onChange={setSearchRegions}
+                options={REGION_OPTIONS}
+                placeholder="Target countries or regions"
+              />
+            </label>
+
+            <label className="block">
+              <span className="block text-sm font-medium text-foreground flex items-center gap-1.5">
+                <MapPin className="size-3.5 text-muted" /> Block Regions
+              </span>
+              <span className="mt-0.5 block text-xs text-faint">Select regions to exclude (e.g. "US", "Remote US")</span>
+              <MultiSelectDropdown 
+                value={blockRegions}
+                onChange={setBlockRegions}
+                options={REGION_OPTIONS}
+                placeholder="Target countries to block"
+              />
+            </label>
+
+            <label className="block">
+              <span className="block text-sm font-medium text-foreground flex items-center gap-1.5">
+                <MapPin className="size-3.5 text-muted" /> Always Allow Regions
+              </span>
+              <span className="mt-0.5 block text-xs text-faint">Overrides the block list (e.g. if you block US but always allow your specific city)</span>
+              <MultiSelectDropdown 
+                value={alwaysAllowRegions}
+                onChange={setAlwaysAllowRegions}
+                options={REGION_OPTIONS}
+                placeholder="Regions that bypass blocks"
+              />
+            </label>
+
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className={cn(
+                "mt-2 inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium transition-colors hover:bg-surface-hover",
+                "disabled:pointer-events-none disabled:opacity-60",
+              )}
+            >
+              {saving ? <Loader2 className="size-3.5 animate-spin" /> : saved ? <Check className="size-3.5 text-emerald-400" /> : null}
+              {saved ? "Saved" : "Save location settings"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/market-settings.tsx
+++ b/web/src/components/market-settings.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Check, Globe, Loader2 } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export function MarketSettings() {
+  const [modesDir, setModesDir] = useState<string>("modes/");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/profile");
+      if (res.ok) {
+        const data = await res.json();
+        if (typeof data.modesDir === "string") {
+          setModesDir(data.modesDir);
+        }
+      }
+    } catch {
+      setError("Failed to load market settings.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ modesDir })
+      });
+      if (!res.ok) {
+        setError("Could not save market setting.");
+      } else {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      }
+    } catch {
+      setError("Could not save market setting.");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="mt-8">
+      <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+        Market & Evaluation Rules
+      </label>
+      <div className="rounded-xl border border-border bg-surface/50 p-4">
+        <p className="text-xs leading-relaxed text-faint mb-4">
+          Select which market's vocabulary and evaluation rules the AI should use when reviewing job descriptions.
+        </p>
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Loader2 className="size-4 animate-spin" /> Loading…
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-foreground flex items-center gap-1.5">
+                <Globe className="size-3.5 text-muted" /> Market Mode
+              </span>
+              <span className="mt-0.5 block text-xs text-faint">
+                One config switch per evaluation. Changes how the AI understands local job terms (e.g., benefits, notice periods).
+              </span>
+              <select
+                value={modesDir}
+                onChange={(e) => setModesDir(e.target.value)}
+                className="mt-1.5 w-full max-w-sm rounded-md border border-border bg-surface/60 px-3 py-1.5 text-sm outline-none transition-colors focus:border-brand/50 focus-visible:ring-2 focus-visible:ring-brand/40"
+              >
+                <option value="modes/">Global / US (Default)</option>
+                <option value="modes/hi/">India</option>
+                <option value="modes/ar/">UAE / Middle East</option>
+                <option value="modes/de/">Germany / DACH</option>
+                <option value="modes/fr/">France / Francophone</option>
+                <option value="modes/ja/">Japan</option>
+                <option value="modes/tr/">Turkey</option>
+              </select>
+            </label>
+
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className={cn(
+                "mt-2 inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium transition-colors hover:bg-surface-hover",
+                "disabled:pointer-events-none disabled:opacity-60",
+              )}
+            >
+              {saving ? <Loader2 className="size-3.5 animate-spin" /> : saved ? <Check className="size-3.5 text-emerald-400" /> : null}
+              {saved ? "Saved" : "Save market setting"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/outcome-button.tsx
+++ b/web/src/components/outcome-button.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ClipboardCheck, Check, Loader2 } from "lucide-react";
+
+const OUTCOME_TYPES: { value: string; label: string }[] = [
+  { value: "interview_progress", label: "Advanced in interview process" },
+  { value: "interview_only", label: "Completed interview process" },
+  { value: "offer_received", label: "Offer received" },
+  { value: "hired", label: "Hired — accepted the offer" },
+  { value: "offer_declined", label: "Declined the offer" },
+  { value: "rejected", label: "Rejected" },
+  { value: "no_response", label: "No response / ghosted" },
+];
+
+// Records the real-world result of an application: archives the submitted
+// CV/cover/posting under data/outcomes/ and syncs the tracker status, via the
+// core outcome.mjs script (/api/outcome) — never hand-edits applications.md.
+export function OutcomeButton({ n }: { n: string }) {
+  const router = useRouter();
+  const [showMenu, setShowMenu] = useState(false);
+  const [outcomeType, setOutcomeType] = useState(OUTCOME_TYPES[0].value);
+  const [stage, setStage] = useState("");
+  const [feedback, setFeedback] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setShowMenu(false);
+    }
+    if (showMenu) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showMenu]);
+
+  async function record(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ n, outcomeType, stage: stage.trim() || undefined, feedback: feedback.trim() || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "recording failed");
+      setSaved(true);
+      setShowMenu(false);
+      setStage("");
+      setFeedback("");
+      setTimeout(() => setSaved(false), 2500);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "recording failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setShowMenu(!showMenu)}
+        className="inline-flex items-center justify-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted transition-colors hover:border-brand/40 hover:text-brand max-sm:min-h-[44px]"
+        title="Record what actually happened — updates the tracker and archives the submitted artifacts"
+      >
+        <ClipboardCheck className="size-3.5" /> Record outcome
+      </button>
+
+      {saved && (
+        <span className="absolute -right-1 top-full mt-1 animate-terminal-popup inline-flex items-center gap-1 text-xs font-medium text-brand">
+          <Check className="size-3" /> recorded
+        </span>
+      )}
+
+      {showMenu && (
+        // Anchored left (not right, like ApplyButton) — this button sits mid-row,
+        // not at the content edge, so a right-anchored w-72 popover extending
+        // leftward can slide under the fixed sidebar on narrower viewports.
+        <div className="absolute left-0 top-full z-[100] mt-2 w-72 origin-top-left rounded-xl border border-border bg-surface p-3 shadow-xl">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">What happened?</h4>
+          <form onSubmit={record} className="flex flex-col gap-2.5">
+            <select
+              value={outcomeType}
+              onChange={(e) => setOutcomeType(e.target.value)}
+              className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand"
+            >
+              {OUTCOME_TYPES.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <input
+              value={stage}
+              onChange={(e) => setStage(e.target.value)}
+              placeholder="Stage (optional, e.g. Final Round)"
+              className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-xs outline-none focus:border-brand"
+            />
+            <textarea
+              value={feedback}
+              onChange={(e) => setFeedback(e.target.value)}
+              placeholder="Verbatim feedback (optional)"
+              rows={2}
+              className="resize-none rounded-md border border-border bg-transparent px-2.5 py-1.5 text-xs outline-none focus:border-brand"
+            />
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            <button
+              type="submit"
+              disabled={busy}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground disabled:opacity-50"
+            >
+              {busy ? <Loader2 className="size-3.5 animate-spin" /> : <ClipboardCheck className="size-3.5" />}
+              Record &amp; update tracker
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -9,6 +9,8 @@ import { Badge } from "@/components/ui/badge";
 import { CompanyLogo } from "@/components/company-logo";
 import { canonStatus, scoreNum, scoreTone, statusDot } from "@/lib/format";
 import { InboxTriage } from "@/components/inbox/inbox-triage";
+import { QuickEvaluate } from "@/components/quick-evaluate";
+import { TrainingEvaluate } from "@/components/training-evaluate";
 import { cn } from "@/lib/cn";
 
 // INBOX (the triage queue) is the default tab; the rest filter the tracker.
@@ -139,6 +141,9 @@ export function PipelineView({
           </div>
         )}
       </div>
+
+      <QuickEvaluate />
+      <TrainingEvaluate />
 
       {/* tabs */}
       <div className="mt-6 flex flex-wrap gap-1 border-b border-border">

--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { ArrowLeft, FileText, ExternalLink, ChevronDown } from "lucide-react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Application } from "@/lib/career-ops";
 import { Badge } from "@/components/ui/badge";
@@ -12,6 +12,8 @@ import { ScoreMethodology } from "@/components/score-methodology";
 import { GeneratePdfButton } from "@/components/generate-pdf-button";
 import { ApplyButton } from "@/components/apply-button";
 import { DeleteFromTracker } from "@/components/delete-from-tracker";
+import { AiActionsMenu } from "@/components/ai-actions-menu";
+import { OutcomeButton } from "@/components/outcome-button";
 
 // Progressive disclosure of the report. The core writes prose blocks
 // "## F) Verdict (lead)", "## A) Role Summary", "## B) Match with CV", then
@@ -29,6 +31,19 @@ import { DeleteFromTracker } from "@/components/delete-from-tracker";
 
 // Machine artifacts (collapsed because they're for devs, not the mainstream) vs
 // human content C–G (collapsed only for length) — ux's "honest for devs" tier.
+// Evaluation-table rows (STAR+R Story, Match with CV, ...) run 5-7 columns of
+// real prose, not short data cells — squeezed to the prose column's reading
+// width they crush to one word per line. Give the table its own horizontal
+// scroll container instead of forcing the whole page (and its actual prose)
+// wide just to fit a handful of tables.
+const markdownComponents: Components = {
+  table: ({ children }) => (
+    <div className="my-4 overflow-x-auto rounded-lg border border-border">
+      <table className="w-full min-w-[900px]">{children}</table>
+    </div>
+  ),
+};
+
 function isMachine(heading: string): boolean {
   return /machine summary|submitted|submit[-\s]?log/i.test(heading);
 }
@@ -68,7 +83,7 @@ export function ReportView({
   const url = field("URL");
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-8">
+    <div className="mx-auto max-w-5xl px-6 py-8">
       <Link
         href="/pipeline"
         className="inline-flex items-center gap-1.5 text-sm text-muted transition-colors hover:text-brand"
@@ -99,6 +114,9 @@ export function ReportView({
           {app && <StatusSelect n={id} current={app.status} />}
           <GeneratePdfButton n={id} company={app?.company ?? meta?.title ?? id} pdfReady={(app?.pdf ?? "").includes("✅")} />
           <ApplyButton n={id} url={url && url.startsWith("http") ? url : undefined} company={app?.company ?? meta?.title ?? id} pdfReady={(app?.pdf ?? "").includes("✅")} />
+          <span className="mx-0.5 h-5 w-px bg-border" />
+          <AiActionsMenu n={id} company={app?.company ?? meta?.title ?? id} />
+          {app && <OutcomeButton n={id} />}
         </div>
 
         {app && canDelete && (
@@ -134,7 +152,7 @@ export function ReportView({
             if (sections.length === 0) {
               return (
                 <article className="report-prose mt-8">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{meta?.body ?? report}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{meta?.body ?? report}</ReactMarkdown>
                 </article>
               );
             }
@@ -151,7 +169,7 @@ export function ReportView({
               <div className="mt-8">
                 {intro && (
                   <article className="report-prose">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{intro}</ReactMarkdown>
+                    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{intro}</ReactMarkdown>
                   </article>
                 )}
 
@@ -159,7 +177,7 @@ export function ReportView({
                   <div className="rounded-2xl border border-brand/25 bg-brand-soft/50 px-5 py-4">
                     <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.16em] text-brand/80">Verdict</p>
                     <article className="report-prose [&_p]:font-medium [&_p]:text-foreground">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{verdict.content}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{verdict.content}</ReactMarkdown>
                     </article>
                   </div>
                 )}
@@ -169,7 +187,7 @@ export function ReportView({
                   if (expanded) {
                     return (
                       <article key={i} className="report-prose mt-6">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{`## ${cleanHeading(s.heading)}\n\n${s.content}`}</ReactMarkdown>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{`## ${cleanHeading(s.heading)}\n\n${s.content}`}</ReactMarkdown>
                       </article>
                     );
                   }
@@ -181,7 +199,7 @@ export function ReportView({
                         <ChevronDown className="ml-auto size-4 shrink-0 text-faint transition-transform group-open:rotate-180" />
                       </summary>
                       <div className="report-prose border-t border-border px-4 py-3">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{s.content}</ReactMarkdown>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{s.content}</ReactMarkdown>
                       </div>
                     </details>
                   );
@@ -201,7 +219,7 @@ export function ReportView({
                           <ChevronDown className="ml-auto size-4 shrink-0 text-faint transition-transform group-open:rotate-180" />
                         </summary>
                         <div className="report-prose border-t border-border/60 px-4 py-3 opacity-80">
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>{s.content}</ReactMarkdown>
+                          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{s.content}</ReactMarkdown>
                         </div>
                       </details>
                     ))}

--- a/web/src/components/save-contact-form.tsx
+++ b/web/src/components/save-contact-form.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { UserPlus, Check, Loader2 } from "lucide-react";
+
+const TYPES = [
+  { value: "recruiter", label: "Recruiter" },
+  { value: "hiring-manager", label: "Hiring manager" },
+  { value: "peer", label: "Team peer" },
+  { value: "interviewer", label: "Interviewer" },
+  { value: "other", label: "Other" },
+];
+
+// Confirm-then-save UI for a contact the "Find contacts" job surfaced. The
+// job's free-text output isn't reliably parseable into structured fields, so
+// this asks the user to copy the name/link from what they just read above —
+// deliberate friction is the point (contacto.md: never save without the
+// candidate confirming), and it's the one path that makes a found contact
+// durable across sessions/devices instead of living only in this job's
+// localStorage entry.
+export function SaveContactForm({
+  defaultCompany,
+  trackerNum,
+  defaultMessage = "",
+}: {
+  defaultCompany: string;
+  trackerNum: string;
+  /** The drafted outreach message, prefilled from the job output's first code
+   *  block if the caller has it — otherwise the user pastes it in manually. */
+  defaultMessage?: string;
+}) {
+  const [name, setName] = useState("");
+  const [company, setCompany] = useState(defaultCompany);
+  const [type, setType] = useState("recruiter");
+  const [title, setTitle] = useState("");
+  const [linkedin, setLinkedin] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState(defaultMessage);
+  const [busy, setBusy] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/contacts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, company, type, title, linkedin, email, trackerNum, notes: message }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "save failed");
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "save failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (saved) {
+    return (
+      <div className="mt-6 flex items-start gap-2 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400">
+        <Check className="mt-0.5 size-4 shrink-0" />
+        <span>
+          Saved to your contacts{message.trim() ? " — message included, so it's here next time you need it, not just in this job's history" : ""} — exportable anytime with <code className="text-xs">node contacts.mjs --vcf</code>.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 rounded-xl border border-border bg-surface/40 p-4">
+      <h2 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-muted">
+        <UserPlus className="size-3.5" /> Save this contact
+      </h2>
+      <p className="mt-1 text-xs text-faint">
+        So you don&apos;t have to search again — copy the name and link from above. Saved to <code className="text-xs">data/contacts.tsv</code>, the same file the CLI uses.
+      </p>
+      <form onSubmit={save} className="mt-3 grid grid-cols-1 gap-2.5 sm:grid-cols-2">
+        <input
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name *"
+          className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand max-sm:min-h-[44px]"
+        />
+        <input
+          required
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          placeholder="Company *"
+          className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand max-sm:min-h-[44px]"
+        />
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand max-sm:min-h-[44px]"
+        >
+          {TYPES.map((t) => (
+            <option key={t.value} value={t.value}>{t.label}</option>
+          ))}
+        </select>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title (optional)"
+          className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand max-sm:min-h-[44px]"
+        />
+        <input
+          value={linkedin}
+          onChange={(e) => setLinkedin(e.target.value)}
+          placeholder="LinkedIn URL (optional)"
+          className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand max-sm:min-h-[44px]"
+        />
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email (optional)"
+          className="rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand max-sm:min-h-[44px]"
+        />
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="The outreach message (optional) — paste it here so it's saved alongside the contact, not just in this job's history"
+          rows={3}
+          className="resize-y rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none focus:border-brand sm:col-span-2"
+        />
+        {error && <p className="text-xs text-red-500 sm:col-span-2">{error}</p>}
+        <button
+          type="submit"
+          disabled={busy}
+          className="inline-flex items-center justify-center gap-1.5 rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground disabled:opacity-50 sm:col-span-2 max-sm:min-h-[44px]"
+        >
+          {busy ? <Loader2 className="size-3.5 animate-spin" /> : <UserPlus className="size-3.5" />}
+          Save contact
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/training-evaluate.tsx
+++ b/web/src/components/training-evaluate.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { GraduationCap } from "lucide-react";
+import { useJobs } from "@/components/jobs/job-store";
+import { CostBadge } from "@/components/cost/cost-badge";
+
+// Fires the real career-ops `training` mode (worker kind "training") — scores
+// a course/cert on the 6-dimension modes/training.md framework and returns a
+// DO / DON'T DO / DO WITH TIMEBOX verdict. Collapsed by default: this is a
+// secondary utility next to QuickEvaluate, not the primary pipeline action.
+export function TrainingEvaluate() {
+  const { startJob } = useJobs();
+  const [open, setOpen] = useState(false);
+  const [course, setCourse] = useState("");
+  const [hint, setHint] = useState("");
+
+  function run() {
+    const c = course.trim();
+    if (!c) {
+      setHint("Name the course/cert, or paste its URL.");
+      return;
+    }
+    startJob({ title: "Evaluate a course", subtitle: c, kind: "training", input: c, page: "/pipeline" });
+    setCourse("");
+    setHint("Evaluating — watch it in the Workers tray.");
+    setOpen(false);
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="mt-2.5 inline-flex items-center gap-1.5 text-xs font-medium text-faint transition-colors hover:text-brand"
+      >
+        <GraduationCap className="size-3.5" /> Should I take a course or cert?
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-2.5 max-w-xl">
+      <div className="flex items-center gap-2 rounded-full border border-border bg-surface/70 py-1.5 pl-4 pr-1.5 shadow-sm focus-within:border-brand/50">
+        <GraduationCap className="size-4 shrink-0 text-brand/70" />
+        <input
+          autoFocus
+          value={course}
+          onChange={(e) => {
+            setCourse(e.target.value);
+            if (hint) setHint("");
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") run();
+            if (e.key === "Escape") setOpen(false);
+          }}
+          placeholder="Course/cert name or URL to evaluate…"
+          className="min-w-0 flex-1 bg-transparent py-1.5 text-sm outline-none placeholder:text-faint"
+        />
+        <button
+          onClick={run}
+          className="shrink-0 rounded-full bg-brand px-4 py-1.5 text-sm font-medium text-brand-foreground transition-colors hover:bg-brand-200"
+        >
+          Evaluate
+        </button>
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <CostBadge kind="spend" size="xs" />
+        <span className="text-xs text-faint">Scores DO / DON&apos;T DO / DO WITH TIMEBOX against your target roles.</span>
+      </div>
+      {hint && <p className="mt-1 text-xs text-faint">{hint}</p>}
+    </div>
+  );
+}

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import * as yaml from "js-yaml";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { parseApplications } from "@/lib/tracker-table.mjs";
 // One definition of the `{n}-RESERVED.md` convention, shared with
@@ -346,4 +347,54 @@ export function rememberFact(fact: string): "ok" | "deduped" | "error" {
   } catch {
     return "error";
   }
+}
+
+// AGENTS.md "Language Modes" table (SSOT) — each localized modes/ subdir has
+// its own evaluation-mode filename (angebot.md, fursah.md, ...), not oferta.md.
+// A headless web run gets its market vocabulary ONLY if this route resolves
+// the right file itself: language.modes_dir is a convention the CLI's own
+// AGENTS.md read-through picks up interactively, but the web's spawned agent
+// is handed a fixed one-shot prompt with no chance to "notice" the setting on
+// its own — so the caller of buildPrompt must inject the resolved path
+// explicitly (run-prompts.mjs itself stays a plain, dependency-free module).
+const MARKET_EVAL_MODE: Record<string, string> = {
+  "modes/de": "angebot.md",
+  "modes/fr": "offre.md",
+  "modes/ar": "fursah.md",
+  "modes/ja": "kyujin.md",
+  "modes/tr": "is-ilani.md",
+  "modes/hi": "naukri.md",
+};
+
+export type LanguageConfig = {
+  /** language.output — human-facing prose language, e.g. "en". Default "en". */
+  output: string;
+  /** language.modes_dir normalized WITHOUT trailing slash, e.g. "modes/de". Default "modes". */
+  modesDir: string;
+  /** The market-appropriate evaluation-mode file to read, relative to the repo root. */
+  evalModeFile: string;
+};
+
+/** Reads config/profile.yml's `language` block (never throws — a missing/malformed
+ *  profile just falls back to English/global defaults, same as the CLI would). */
+export function readLanguageConfig(): LanguageConfig {
+  let modesDirRaw = "modes";
+  let output = "en";
+  try {
+    const parsed = yaml.load(fs.readFileSync(path.join(careerOpsRoot(), "config", "profile.yml"), "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const language = (parsed as Record<string, unknown>).language;
+      if (language && typeof language === "object" && !Array.isArray(language)) {
+        const l = language as Record<string, unknown>;
+        if (typeof l.modes_dir === "string" && l.modes_dir.trim()) modesDirRaw = l.modes_dir.trim();
+        if (typeof l.output === "string" && l.output.trim()) output = l.output.trim();
+      }
+    }
+  } catch {
+    /* no profile yet, or malformed — use defaults */
+  }
+  const modesDir = modesDirRaw.replace(/\/+$/, "");
+  const evalFile = MARKET_EVAL_MODE[modesDir];
+  const evalModeFile = evalFile ? `${modesDir}/${evalFile}` : "modes/oferta.md";
+  return { output, modesDir, evalModeFile };
 }

--- a/web/src/lib/run-cli-support.mjs
+++ b/web/src/lib/run-cli-support.mjs
@@ -333,10 +333,27 @@ export function completedReportNames(entries) {
  * @returns {boolean}
  */
 export function hasNewCompletedReport(beforeEntries, afterEntries) {
+  return newCompletedReportName(beforeEntries, afterEntries) !== null;
+}
+
+/**
+ * The filename of the ONE new completed report this run produced, or null.
+ * Lets the client link straight to the report (`/pipeline/{num}`) instead of
+ * only knowing a report exists somewhere — the raw agent narration for
+ * "evaluate" is often just the terse VERDICT line (the real deliverable is
+ * the persisted report file + tracker row, not the streamed chat text), so
+ * without this the done job's own page had nothing to point the user at.
+ * Multiple new names (a very unusual run) return the first — better than
+ * guessing wrong across several, and a normal run only ever produces one.
+ * @param {string[]} beforeEntries
+ * @param {string[]} afterEntries
+ * @returns {string | null}
+ */
+export function newCompletedReportName(beforeEntries, afterEntries) {
   const before = completedReportNames(beforeEntries);
   const after = completedReportNames(afterEntries);
   for (const name of after) {
-    if (!before.has(name)) return true;
+    if (!before.has(name)) return name;
   }
-  return false;
+  return null;
 }

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -51,8 +51,98 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
 /** ISO calendar date, the only form the dashboard's POSTED column parses. */
 const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
 
-export function buildPrompt({ kind, input, memory, today, postedAt }) {
-  const mem = memory.trim() ? `\n\nDurable notes about the user (from their profile):\n${memory.trim()}\n` : "";
+export function buildPrompt({ kind, input, memory, today, postedAt, lang }) {
+  // AGENTS.md "Output Language vs Market Modes" composition rule: language.output
+  // governs prose, language.modes_dir only supplies market vocabulary/context. The
+  // CLI picks this up interactively by reading AGENTS.md + profile.yml itself, but
+  // this route hands the agent a single one-shot prompt — so the directive (and,
+  // for "evaluate", the market-specific mode FILE) must be injected explicitly or
+  // a configured market mode silently does nothing in a web-triggered run. `lang`
+  // is optional (readLanguageConfig() touches the filesystem, so callers that
+  // can't/don't provide it — e.g. a future test — get the English/global default
+  // rather than this module reaching for fs itself).
+  const resolvedLang = lang ?? { output: "en", modesDir: "modes", evalModeFile: "modes/oferta.md" };
+  const marketNote =
+    resolvedLang.modesDir !== "modes"
+      ? ` Also read ${resolvedLang.modesDir}/_shared.md for this market's vocabulary, benefits, and legal concepts, and keep those terms (explained in the output language) where relevant.`
+      : "";
+  const languageDirective = `\n\nWrite all human-facing output in "${resolvedLang.output}" regardless of the language of these instructions or the job description.${marketNote}\n`;
+  // Every file path given below is already exact — some agent CLIs default to a
+  // cautious "look around first" habit (list directories, run a find/grep)
+  // before reading a named file, which is pure wasted latency here since the
+  // path never needed discovering. Cheap to state, and it's the one lever
+  // available regardless of which CLI backend the run is spawned through.
+  const noSearchDirective = `\n\nEvery file path given in these instructions is already exact except the one \`*\` wildcard (the report filename, whose date/slug suffix is genuinely unknown) — read exact paths directly and resolve the wildcarded one with a single targeted glob. Do not otherwise search, list directories, or explore the workspace "to be safe"; that only adds latency for no benefit.\n`;
+  const mem = (memory.trim() ? `\n\nDurable notes about the user (from their profile):\n${memory.trim()}\n` : "") + languageDirective + noSearchDirective;
+  // The evaluate/pdf/research report formats are long BY DESIGN (that's the
+  // actual deliverable) — this directive is scoped only to the assistant-
+  // drafted-message kinds below, where the failure mode is the opposite:
+  // echoing back the mode file's own authoring framework (sentence-by-sentence
+  // breakdowns, restated reasoning) instead of just the usable result.
+  const concise = " Be concise: give the answer, not a writeup of how you got there — no restating your own methodology, no repeating the same content in two different formats.";
+  if (kind === "contacto") {
+    return `You are running the career-ops "contacto" mode, headless, on the user's own machine, for application #${input}. Follow modes/contacto.md's persona logic (LinkedIn power move variant, unless the report context clearly calls for the Greeting variant) — but the OUTPUT must stay lean and directly usable, not a methodology writeup.
+
+1. Read modes/contacto.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md for company/role context.
+2. SPEED MATTERS — this only needs to end with ONE well-chosen primary target, not a full roster, so don't search like it does. Try the hiring manager/team lead first (usually the strongest primary at this stage) with 1-2 targeted WebSearch calls; only search for a recruiter or peer as a fallback if that comes up empty. Stop searching the moment you have ONE confirmed, useful target — do not keep searching to round out a complete list nobody asked for. 3 WebSearch calls total is a hard ceiling; best-effort and no login, so state plainly when a target can't be confirmed instead of guessing a name.
+3. Per modes/contacto.md's own selection step, pick ONE primary target (whoever benefits most from this candidate) and write their FULL ready-to-send message.
+4. List any other genuinely viable targets as ONE line each (name/role + the single reason to reach them) — do NOT draft a full message or sentence-by-sentence breakdown for every contact type found; that is authoring guidance for you, not something to echo back to the user.
+5. Enforce modes/contacto.md's Message rules strictly — this is the part people actually notice: no "Saw the [role] at [company]" opener (the single most recognizable mass-outreach tell), no resume-bullet phrasing pasted mid-sentence, vary the sentence rhythm instead of three uniform robotic sentences, and end on a genuine question the recipient can answer in one line — not a flat "happy to share my CV" statement that gives them nothing to react to.
+
+OUTPUT FORMAT — keep it to exactly this, nothing more:
+- Primary target: name, role, one-line why them.
+- The message itself, ready to copy-paste as-is, then its character count against the platform limit.
+- Other targets worth trying, one line each (omit this line entirely if there's only one real target).${mem}${concise}
+
+This is DRAFT-ONLY: do NOT write to data/contacts.tsv or any other file, do NOT send, submit, connect, or open anything.
+
+End with EXACTLY one final line: VERDICT: {0-5 confidence you found a real, useful contact}/5 — {who to message first, ≤12 words}`;
+  }
+  if (kind === "deep") {
+    return `You are running the career-ops "deep" mode, headless, on the user's own machine, for application #${input}. modes/deep.md defines 6 research axes — ACTUALLY RESEARCH and ANSWER them yourself using WebSearch/WebFetch; do not just emit a prompt for another tool to run later.
+
+1. Read modes/deep.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md for company/role context.
+2. Research and answer all 6 axes (AI Strategy, Recent moves, Engineering culture, Likely challenges, Competitors & differentiation, Candidate angle) with SPECIFIC, current findings. If something can't be found, say so plainly rather than inventing it.
+3. Ground axis 6 (Candidate angle) ONLY in real experience already present in cv.md/config/profile.yml — never fabricate a claim.${mem}${concise}
+
+End with EXACTLY one final line: VERDICT: {0-5 how much this changes interview prep}/5 — {the single sharpest insight, ≤12 words}`;
+  }
+  if (kind === "cover") {
+    return `You are running the career-ops "cover" mode, headless, on the user's own machine, for application #${input}. Follow modes/cover.md's structure and rules, but SKIP its interactive confirmation checkpoints (Step 3 research sync, Step 4 keyword list, Step 5 gap conversation) since no one is present to answer them — proceed with your own best-effort synthesis/defaults instead, and flag any assumption or unresolved gap in a short "Assumptions" line right before the letter.
+
+1. Read modes/cover.md, modes/_writing.md, cv.md, config/profile.yml, modes/_profile.md (if present), article-digest.md (if present), and the evaluation report at reports/${input}-*.md for JD + company context.
+2. Run the Step 3 company research (3 WebSearch queries) and synthesize 2-3 sentences.
+3. Extract JD keywords (Step 4) and mirror them per the rules — never invent skills, only reword real experience already in cv.md.
+4. Draft the full cover letter per modes/cover.md's template, length, and tone rules.${mem}${concise}
+
+This is DRAFT-ONLY: do not write any file, do not send or submit anything.
+
+End with EXACTLY one final line: VERDICT: {0-5 how ready-to-send this draft is}/5 — {one thing worth double-checking, ≤12 words}`;
+  }
+  if (kind === "email") {
+    return `You are running the career-ops "email" mode, headless, on the user's own machine, for application #${input} — draft ONLY the standard application email variant (not "stuck" or "noshow").
+
+1. Read modes/email.md, modes/_writing.md, cv.md, config/profile.yml, modes/_profile.md (if present), modes/_custom.md (if present), voice-dna.md (if present), and the evaluation report at reports/${input}-*.md for company/role/PDF-status context.
+2. Check data/pdf-index.tsv (or the report's PDF column) — if a tailored CV already exists, name it as the attachment; otherwise say the CV needs generating first (via "Generate tailored CV") or attaching manually.
+3. Draft the subject line, email body, a short attachment checklist, and a contact block, per modes/email.md's structure.${mem}${concise}
+
+This is DRAFT-ONLY: never send, never submit, never click send.
+
+End with EXACTLY one final line: VERDICT: {0-5 how ready-to-send this draft is}/5 — {one thing worth double-checking, ≤12 words}`;
+  }
+  if (kind === "training") {
+    return `You are running the career-ops "training" mode, headless, on the user's own machine, evaluating a course or certification for their job search. Follow modes/training.md's 6-dimension framework EXACTLY (North Star alignment, Recruiter signal, Time and effort, Opportunity cost, Risks, Portfolio deliverable) and give exactly one of its three verdicts (DO / DON'T DO / DO WITH TIMEBOX).
+
+1. Read modes/training.md, cv.md, config/profile.yml, and modes/_profile.md (if present) to ground this in the user's actual target roles, timeline, and existing skills.
+2. If the input below is a URL, use WebFetch to read the course page; otherwise treat it as a course/cert name and use WebSearch to find its syllabus, provider reputation, and typical time commitment.
+3. Score all 6 dimensions with a short justification each, then give ONE clear verdict: a 4-12 week plan with weekly deliverables (DO), a condensed essentials-only plan with a max-week cap (DO WITH TIMEBOX), or a better alternative with justification (DON'T DO).${mem}${concise}
+
+This is evaluation only — do not enroll, purchase, or submit anything.
+
+End with EXACTLY one final line: VERDICT: {0-5 how worth doing this is}/5 — {DO / DON'T DO / DO WITH TIMEBOX, ≤12 words}
+
+Course/certification to evaluate: ${input}`;
+  }
   if (kind === "research") {
     return `You are investigating the user's OWN work / portfolio to surface job-search-relevant strengths, headless. Investigate the target (use WebFetch for URLs; read local files if referenced) and report: what it is, why it is impressive, and how to leverage it in their job search — which roles/claims it supports and how to frame it on a CV. Be specific, honest, and encouraging. Report only: never submit, send, or click Apply anywhere, and contact no one — you are investigating the user's own work, not acting on it.${mem}
 
@@ -122,7 +212,7 @@ End with EXACTLY one final line: VERDICT: {5 if now live, else 1}/5 — {what yo
   // precisely so they can't be misread as the row's LOCATION.
   return `You are running the OFFICIAL career-ops job evaluation, HEADLESS, on the user's own machine. Today is ${today}. Run the REAL career-ops evaluation — do NOT improvise your own scoring.
 
-1. Read modes/oferta.md and follow it EXACTLY (blocks A–F, G posting-legitimacy, and the Machine Summary). Ground the fit in THIS person: read cv.md, config/profile.yml and modes/_profile.md. Use WebFetch to read the posting (you are headless — Playwright is unavailable, so use WebFetch and mark the report header "Verification: unconfirmed (batch mode)").
+1. Read ${resolvedLang.evalModeFile} — the market-appropriate evaluation mode resolved from config/profile.yml's language.modes_dir — and follow it EXACTLY (blocks A–F, G posting-legitimacy, and the Machine Summary; if this file uses different block letters/labels than the default modes/oferta.md, keep ITS labels, don't force English ones). Ground the fit in THIS person: read cv.md, config/profile.yml and modes/_profile.md. Use WebFetch to read the posting (you are headless — Playwright is unavailable, so use WebFetch and mark the report header "Verification: unconfirmed (batch mode)").
 
 2. Persist the result CANONICALLY so the web and the CLI share ONE source of truth:
    a. Reserve a report number: run \`node reserve-report-num.mjs\` — its stdout is a 3-digit number (e.g. 035).


### PR DESCRIPTION
Closes #3045.

## Summary

The web UI had a full workflow for `evaluate`/`pdf`/`apply`/`scan`/`pipeline`, but six CLI modes had no web equivalent: `contacto`, `deep`, `cover`, `email`, `outcome`, `training`. This adds all six as report-page actions, plus a few real bugs found and fixed while building them.

## New: 6 report-page actions

- **Find contacts** (`contacto`) — one primary target + ready-to-send message, brief alternates as one-liners (matches the mode's own "select primary target" design rather than drafting every persona in full)
- **Company research** (`deep`) — actually researches and answers the 6 axes, rather than just emitting a prompt for another tool
- **Cover letter** / **Application email** (`cover`/`email`) — draft-only, headless variants that skip the CLI's interactive confirmation checkpoints
- **Record outcome** (`outcome`) — wraps the real `outcome.mjs` script directly (deterministic tracker mutation, not an agent job)
- **Should I take a course or cert?** (`training`) — collapsed secondary input on the Pipeline page

The four generative actions (contacto/deep/cover/email) are consolidated behind one **AI actions** menu instead of four separate always-visible buttons, each showing running/done state individually.

## Bug fixes found along the way

- **`language.modes_dir` was write-only.** Settings saved the selected market mode (e.g. India → `modes/hi`) to `profile.yml`, but the web's evaluate flow always hardcoded `modes/oferta.md` regardless. A web-triggered evaluation silently ignored the configured market. Now resolves the correct market file (`angebot.md`, `fursah.md`, `naukri.md`, ...) per `language.modes_dir`, and injects the `language.output` vs `modes_dir` composition rule from AGENTS.md into every prompt (the CLI picks this up by reading AGENTS.md interactively; a one-shot headless prompt needs it stated explicitly).
- **Outreach messages read as AI-generated.** The web prompt asked the agent to draft a full message for every contact type found; `modes/contacto.md`'s own design is one primary + brief alternates. Tightened the web prompt to match, and added explicit rules to the mode file itself: no "Saw the [role] at [company]" opener (the most recognizable mass-outreach tell), no resume-bullet phrasing mid-sentence, end on a genuine question instead of a flat statement, vary sentence rhythm.
- **Unreadable tables at the old width.** `/pipeline/[id]` and `/jobs/[id]` were `max-w-3xl` (768px); a 7-column evaluation table crushed to one word per cell. Widened both pages and gave markdown tables their own horizontal-scroll container instead of forcing the whole page wide.
- **Contact discovery searched more than it used.** The `contacto` prompt searched for up to 4 personas (hiring manager, recruiter, 2 peers) but only ever drafted one — wasted WebSearch round trips. Now stops the moment it has one confirmed useful target (3-call ceiling), and every prompt now tells the agent the given file paths are already exact so it doesn't "look around" before reading them.

## New: contact persistence

A found contact (name, company, type, title, links, and the drafted message) can now be saved to `data/contacts.tsv` — the same file `contacts.mjs` already reads and exports to vCard — via a confirm-then-save form (per `contacto.md`'s own rule: never save without the user confirming). Previously a found contact only lived in the browser's job-history localStorage, capped at 40 entries, gone on a cleared browser or a different device.

## Also included

- `LocationSettings`/`MarketSettings` polish: deduped synonym region options (US/USA, UAE/United Arab Emirates, KSA/Saudi Arabia), fixed touch targets under the project's own 44px mobile minimum, added missing a11y roles/keyboard support.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated error in `api/portals/route.ts` only)
- [x] Verified all 6 actions render on a real evaluated report, at desktop and mobile viewports
- [x] Verified `/api/contacts` write path end-to-end (real POST → real `data/contacts.tsv` row, update-in-place by name+company confirmed)
- [x] Verified the table-width fix against the actual crushed-table content
- [ ] Would appreciate a maintainer sanity-check on a non-Claude-Code CLI backend (Antigravity/OpenCode) — the tool-restriction flags (`--allowedTools`/`--disallowedTools`) are currently Claude-CLI-only per the existing `/api/run` route design; that's pre-existing, not something this PR changes, but worth confirming intent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AI action controls for contact discovery, company research, cover letters, and application emails.
  - Added contact confirmation and saving, outcome tracking, location preferences, and market settings.
  - Added course and certification evaluations.
  - Added job reruns and improved report actions.
  - Added localized output and market-specific evaluation modes.

- **Bug Fixes**
  - Improved report table and code-block readability on smaller screens.
  - Preserved existing settings when updating selected configuration fields.

- **Documentation**
  - Updated LinkedIn messaging guidance for safer, more natural outreach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->