### PR TITLE
feat: version persisted application answers

### DIFF
--- a/application-answers.mjs
+++ b/application-answers.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync } from 'fs';
+import { createHash } from 'crypto';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -316,6 +317,64 @@ export function parseApplicationAnswersSection(reportText, { strict = false } = 
   return snapshot;
 }
 
+/**
+ * Derive a content-addressed version for one application-answer snapshot.
+ *
+ * The hash deliberately excludes lifecycle metadata (`date` and `state`). A
+ * filled snapshot can therefore become submitted without changing the answer
+ * version, while any answer, selection, field value, file path, or file
+ * version change produces a new version. Formatting and parsing once first
+ * makes the hash independent of the input aliases accepted by the formatter.
+ */
+export function applicationAnswersVersion(snapshot = {}) {
+  const canonical = parseApplicationAnswersSection(
+    formatApplicationAnswersSection(snapshot),
+    { strict: true },
+  );
+  const content = {
+    freeText: canonical.freeText,
+    selections: canonical.selections,
+    fieldValues: canonical.fieldValues,
+    files: canonical.files,
+  };
+  return `sha256:${createHash('sha256').update(JSON.stringify(content)).digest('hex')}`;
+}
+
+function metadataForSnapshot(report, snapshot) {
+  return {
+    report,
+    present: true,
+    date: snapshot.date,
+    state: snapshot.state,
+    answer_version_hash: applicationAnswersVersion(snapshot),
+    counts: {
+      free_text: snapshot.freeText.length,
+      selections: snapshot.selections.length,
+      field_values: snapshot.fieldValues.length,
+      files: snapshot.files.length,
+    },
+  };
+}
+
+// The library parser names unreadable lines so an interactive caller can
+// repair its own Markdown. The CLI is also used for metadata-only verification,
+// where echoing such a line could disclose an answer. Preserve the structural
+// count while keeping report content out of stdout/stderr.
+function parseApplicationAnswersForCli(reportText) {
+  try {
+    return parseApplicationAnswersSection(reportText, { strict: true });
+  } catch (err) {
+    const unreadable = /^Application Answers section has (\d+) unreadable/.exec(err.message);
+    if (unreadable) {
+      throw new Error(
+        `Application Answers section failed strict verification ` +
+        `(${unreadable[1]} unreadable ${unreadable[1] === '1' ? 'entry' : 'entries'})`,
+      );
+    }
+    throw err;
+  }
+}
+
 export function upsertApplicationAnswersSection(reportText, snapshot = {}) {
   const report = String(reportText ?? '').replace(/\r\n/g, '\n');
   const section = formatApplicationAnswersSection(snapshot).trimEnd();
@@ -355,8 +414,10 @@ function parseArgs(argv) {
 function usage() {
   return [
     'Usage: node application-answers.mjs --report <report.md> --input <answers.json> [--state filled|submitted] [--date YYYY-MM-DD]',
+    '       node application-answers.mjs --verify <report.md>',
     '',
     'The input JSON may contain: freeText, selections, fieldValues, files, date, state.',
+    '--verify reads strictly and prints metadata only; answer values are never printed.',
   ].join('\n');
 }
 
@@ -373,6 +434,27 @@ async function main() {
     console.log(usage());
     return;
   }
+  if (args.verify) {
+    const conflicting = ['report', 'input', 'state', 'date'].filter((key) => args[key]);
+    if (conflicting.length) {
+      throw new Error(`--verify cannot be combined with: ${conflicting.map((key) => `--${key}`).join(', ')}`);
+    }
+    const reportPath = resolve(args.verify);
+    const parsed = parseApplicationAnswersForCli(readFileSync(reportPath, 'utf-8'));
+    if (!parsed) {
+      console.log(JSON.stringify({
+        report: reportPath,
+        present: false,
+        date: null,
+        state: null,
+        answer_version_hash: null,
+        counts: { free_text: 0, selections: 0, field_values: 0, files: 0 },
+      }, null, 2));
+      return;
+    }
+    console.log(JSON.stringify(metadataForSnapshot(reportPath, parsed), null, 2));
+    return;
+  }
   if (!args.report || !args.input) {
     console.error(usage());
     process.exitCode = 1;
@@ -387,11 +469,35 @@ async function main() {
     state: args.state || input.state,
   };
   const reportPath = resolve(args.report);
-  const updated = upsertApplicationAnswersSection(readFileSync(reportPath, 'utf-8'), snapshot);
+  const reportText = readFileSync(reportPath, 'utf-8');
+  const existing = parseApplicationAnswersForCli(reportText);
+  let normalized = normalizeApplicationAnswersSnapshot(snapshot);
+
+  if (existing) {
+    const existingVersion = applicationAnswersVersion(existing);
+    const nextVersion = applicationAnswersVersion(normalized);
+
+    if (existing.state === 'submitted') {
+      if (normalized.state !== 'submitted') {
+        throw new Error('Submitted application answers cannot be downgraded to filled');
+      }
+      if (nextVersion !== existingVersion) {
+        throw new Error('Submitted application answers are immutable; preserve them as history');
+      }
+      // Idempotent replay keeps the original lifecycle date as well as content.
+      normalized = normalizeApplicationAnswersSnapshot(existing);
+    } else if (normalized.state === 'submitted' && nextVersion !== existingVersion) {
+      throw new Error(
+        'Persist changed answers as filled before marking that exact answer version submitted',
+      );
+    }
+  }
+
+  const updated = upsertApplicationAnswersSection(reportText, normalized);
   writeFileSync(reportPath, updated, 'utf-8');
 
-  const normalized = normalizeApplicationAnswersSnapshot(snapshot);
-  console.log(JSON.stringify({ report: reportPath, date: normalized.date, state: normalized.state }, null, 2));
+  const readBack = parseApplicationAnswersForCli(updated);
+  console.log(JSON.stringify(metadataForSnapshot(reportPath, readBack), null, 2));
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -128,7 +128,7 @@ If a field matches, warn the candidate BEFORE generating or filling an answer fo
 1. Extract company name and role title from the page
 2. Search in `reports/` by company name (case-insensitive grep)
 3. If there is a match → load the full report
-4. If there is a Section H or `## Application Answers` → load previous answers as a base
+4. If there is a Section H or `## Application Answers` → load previous answers as a base. Before reusing an `## Application Answers` section, run `node application-answers.mjs --verify <exact-report>` and stop if strict verification fails. Reuse only the exact matched report; never search another report for answer values.
 5. If there is NO match → notify and offer to run a quick auto-pipeline
 
 ## Step 3 — Detect changes in the role
@@ -218,14 +218,17 @@ Use `application-answers.mjs` when possible to format/upsert the section:
 
 ```bash
 node application-answers.mjs --report reports/NNN-company-role-date.md --input answers.json --state filled
+node application-answers.mjs --verify reports/NNN-company-role-date.md
 ```
+
+Retain the emitted `answer_version_hash` with the local apply-session result. The immediate `--verify` readback must return the same hash and counts before the answers are treated as persisted. The hash is derived from the report content and is not a second answer store.
 
 ## Step 9 — Post-apply (optional)
 
 If the candidate confirms that they submitted the application:
 1. Update status to Applied via the canonical CLI: `node set-status.mjs <report#> Applied` (never hand-edit the table). If the candidate submitted on a different day than today, add `--on YYYY-MM-DD` with the actual submission date — the status-log ledger should record when it happened, not when it was typed in.
 2. Seed the follow-up schedule: run `node followup-seed.mjs {num} --json` (where `{num}` is the tracker row number). If the candidate applied on a different day than today, pass `--date YYYY-MM-DD` with the actual submission date. It's idempotent, so re-running is safe. (`--on` and `--date` are the same concept — the real submission date — each under its own script's flag name; pass the same value to both.)
-3. Refresh the report's `## Application Answers` section with the final field values and `**State:** submitted`
+3. Refresh the report's `## Application Answers` section with `**State:** submitted`, preserving the exact `answer_version_hash` verified in Step 8. If any answer or file changed, persist and verify the changed snapshot as `filled` first; the CLI refuses to mutate a submitted version or combine a content change with the state transition.
 4. Suggest next step: run the `contacto` mode (`/career-ops contacto` where available) for LinkedIn outreach
 
 **Confirmed resume-verification failure at this vendor? Check the rest of the pipeline (#1870).** If the candidate confirms the ATS silently dropped or altered resume content that they had submitted (see the SuccessFactors-family quirk below), don't treat it as a one-off. Tracker rows in `data/applications.md` don't carry a canonical ATS-vendor field, so don't grep the tracker text for a vendor name — it will miss rows silently. Instead, resolve the vendor per row from its linked report's `**URL:**` field:

--- a/tests/application-answers.test.mjs
+++ b/tests/application-answers.test.mjs
@@ -36,6 +36,9 @@
 // corpus is asserted to actually produce entries before any equality is checked.
 
 import { pass, fail, ROOT } from './helpers.mjs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 
@@ -44,6 +47,7 @@ console.log('\napplication-answers.mjs — rendered sections parse back into sna
 try {
   const {
     formatApplicationAnswersSection,
+    applicationAnswersVersion,
     parseApplicationAnswersSection,
     upsertApplicationAnswersSection,
   } = await import(pathToFileURL(join(ROOT, 'application-answers.mjs')).href);
@@ -396,6 +400,187 @@ try {
     pass('formatter output is unchanged by the addition of the reader');
   } else {
     fail(`formatter output changed:\n${section}`);
+  }
+
+  // ── 9. answer versions are content-addressed, not lifecycle-addressed ────
+  const normalizedSnapshot = parseApplicationAnswersSection(section, { strict: true });
+  const filledVersion = applicationAnswersVersion({ ...normalizedSnapshot, state: 'filled' });
+  const submittedVersion = applicationAnswersVersion({
+    ...normalizedSnapshot,
+    date: '2030-01-01',
+    state: 'submitted',
+  });
+  const changedVersion = applicationAnswersVersion({
+    ...normalizedSnapshot,
+    freeText: [
+      ...normalizedSnapshot.freeText.slice(0, 1),
+      { ...normalizedSnapshot.freeText[1], answer: 'A materially different answer.' },
+      ...normalizedSnapshot.freeText.slice(2),
+    ],
+  });
+
+  if (
+    /^sha256:[a-f0-9]{64}$/.test(filledVersion) &&
+    filledVersion === submittedVersion &&
+    changedVersion !== filledVersion
+  ) {
+    pass('answer version is stable across date/state changes and changes with answer content');
+  } else {
+    fail(
+      `answer version contract broken: filled=${filledVersion} ` +
+      `submitted=${submittedVersion} changed=${changedVersion}`,
+    );
+  }
+
+  // ── 10. CLI persists, verifies, and seals the exact submitted version ─────
+  const tempRoot = mkdtempSync(join(tmpdir(), 'career-ops-application-answers-'));
+  try {
+    const reportPath = join(tempRoot, 'report.md');
+    const copiedReportPath = join(tempRoot, 'report-copy.md');
+    const inputPath = join(tempRoot, 'answers.json');
+    const changedInputPath = join(tempRoot, 'answers-changed.json');
+    const privateMarker = 'PRIVATE_ANSWER_VALUE_MUST_NOT_REACH_METADATA';
+    const cliSnapshot = {
+      date: '2026-08-18',
+      state: 'filled',
+      freeText: [{ question: 'Private prompt', answer: privateMarker }],
+      selections: [{ question: 'Work mode', selection: 'Remote' }],
+      fieldValues: [],
+      files: [{ field: 'CV', path: 'output/private-cv.pdf', version: 'v1' }],
+    };
+    const changedSnapshot = {
+      ...cliSnapshot,
+      state: 'submitted',
+      freeText: [{ question: 'Private prompt', answer: `${privateMarker}_CHANGED` }],
+    };
+    const baseReport = '# Evaluation: Example - Role\n\n## G) Posting Legitimacy\nActive\n';
+    writeFileSync(reportPath, baseReport, 'utf-8');
+    writeFileSync(inputPath, JSON.stringify(cliSnapshot), 'utf-8');
+    writeFileSync(changedInputPath, JSON.stringify(changedSnapshot), 'utf-8');
+
+    const runCli = (args) => spawnSync(
+      process.execPath,
+      [join(ROOT, 'application-answers.mjs'), ...args],
+      { cwd: ROOT, encoding: 'utf-8' },
+    );
+
+    const filled = runCli(['--report', reportPath, '--input', inputPath, '--state', 'filled']);
+    const filledMeta = filled.status === 0 ? JSON.parse(filled.stdout) : null;
+    const verified = runCli(['--verify', reportPath]);
+    const verifiedMeta = verified.status === 0 ? JSON.parse(verified.stdout) : null;
+    writeFileSync(copiedReportPath, readFileSync(reportPath, 'utf-8'), 'utf-8');
+    const copied = runCli(['--verify', copiedReportPath]);
+    const copiedMeta = copied.status === 0 ? JSON.parse(copied.stdout) : null;
+
+    const metadataSafe = [filled.stdout, verified.stdout, copied.stdout]
+      .every((output) => !output.includes(privateMarker));
+    const writeReadbackMatches =
+      filledMeta?.answer_version_hash === verifiedMeta?.answer_version_hash &&
+      verifiedMeta?.answer_version_hash === copiedMeta?.answer_version_hash &&
+      verifiedMeta?.counts?.free_text === 1 &&
+      verifiedMeta?.counts?.files === 1;
+
+    if (filled.status === 0 && verified.status === 0 && copied.status === 0 &&
+        metadataSafe && writeReadbackMatches) {
+      pass('CLI write/verify/copy readback preserves one version without printing answer values');
+    } else {
+      fail(
+        `CLI metadata/readback contract broken: write=${filled.status} verify=${verified.status} ` +
+        `copy=${copied.status} safe=${metadataSafe} matches=${writeReadbackMatches}`,
+      );
+    }
+
+    const submitted = runCli([
+      '--report', reportPath, '--input', inputPath, '--state', 'submitted', '--date', '2026-08-19',
+    ]);
+    const submittedMeta = submitted.status === 0 ? JSON.parse(submitted.stdout) : null;
+    const sealedReport = readFileSync(reportPath, 'utf-8');
+    const replay = runCli([
+      '--report', reportPath, '--input', inputPath, '--state', 'submitted', '--date', '2030-01-01',
+    ]);
+    const changed = runCli([
+      '--report', reportPath, '--input', changedInputPath, '--state', 'submitted',
+    ]);
+    const downgrade = runCli([
+      '--report', reportPath, '--input', inputPath, '--state', 'filled',
+    ]);
+    const sealedUnchanged = readFileSync(reportPath, 'utf-8') === sealedReport;
+
+    if (
+      submitted.status === 0 &&
+      submittedMeta?.state === 'submitted' &&
+      submittedMeta?.answer_version_hash === verifiedMeta?.answer_version_hash &&
+      replay.status === 0 &&
+      changed.status !== 0 &&
+      downgrade.status !== 0 &&
+      sealedUnchanged &&
+      !changed.stderr.includes(privateMarker)
+    ) {
+      pass('CLI seals a submitted version, permits idempotent replay, and refuses mutation/downgrade');
+    } else {
+      fail(
+        `submitted immutability broken: submit=${submitted.status} replay=${replay.status} ` +
+        `changed=${changed.status} downgrade=${downgrade.status} unchanged=${sealedUnchanged}`,
+      );
+    }
+
+    writeFileSync(reportPath, baseReport, 'utf-8');
+    const refilled = runCli(['--report', reportPath, '--input', inputPath, '--state', 'filled']);
+    const changedTransition = runCli([
+      '--report', reportPath, '--input', changedInputPath, '--state', 'submitted',
+    ]);
+    if (refilled.status === 0 && changedTransition.status !== 0) {
+      pass('CLI requires changed content to be persisted as filled before submitted transition');
+    } else {
+      fail(
+        `filled-to-submitted version gate broken: filled=${refilled.status} ` +
+        `changed-transition=${changedTransition.status}`,
+      );
+    }
+
+    const malformedMarker = 'PRIVATE_MALFORMED_ANSWER_MUST_BE_REDACTED';
+    writeFileSync(reportPath, [
+      baseReport.trimEnd(),
+      '',
+      '## Application Answers',
+      '',
+      '**Date:** 2026-08-18',
+      '**State:** filled',
+      '',
+      '### Free-text answers',
+      '',
+      `> ${malformedMarker}`,
+      '',
+      '### Selections made',
+      '',
+      '- None captured.',
+      '',
+      '### Other field values',
+      '',
+      '- None captured.',
+      '',
+      '### Files used',
+      '',
+      '- None captured.',
+      '',
+    ].join('\n'), 'utf-8');
+    const malformed = runCli(['--verify', reportPath]);
+    if (
+      malformed.status !== 0 &&
+      /1 unreadable entry/.test(malformed.stderr) &&
+      !malformed.stdout.includes(malformedMarker) &&
+      !malformed.stderr.includes(malformedMarker)
+    ) {
+      pass('CLI strict-verification errors report structure without leaking malformed answer text');
+    } else {
+      fail(
+        `CLI strict-verification redaction broken: status=${malformed.status} ` +
+        `stdout-leak=${malformed.stdout.includes(malformedMarker)} ` +
+        `stderr-leak=${malformed.stderr.includes(malformedMarker)}`,
+      );
+    }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
   }
 } catch (e) {
   fail(`application answers round-trip tests crashed: ${e.stack || e.message}`);


### PR DESCRIPTION
## Summary

- add a content-addressed `answer_version_hash` for the existing `## Application Answers` report section
- add strict, metadata-only `--verify` readback without printing answer values
- seal submitted answer versions against mutation or lifecycle downgrade
- require the apply workflow to verify and retain the exact persisted version before reuse

## Why

This addresses the report round-trip and version-binding portion of #2994. The report remains the single answer store; the change adds no service, database, or parallel data file.

## User impact

Career-Ops can prove which exact answer snapshot was persisted and reused. Changed answers must be saved as `filled` before that exact version can become `submitted`, while idempotent replay remains safe.

Sensitive answer values remain out of CLI verification output, and this change adds no form submission behavior.

## Validation

- `node tests/application-answers.test.mjs`
- strict write/verify/copy readback with matching version and counts
- submitted-version immutability, replay, downgrade, and changed-content coverage

The published commit has the same Git tree as the tested local commit; only its author email metadata was changed to GitHub's noreply address so account email-privacy protection remains enabled.
