### PR TITLE
fix(cli): reject mistyped flags in archive-posting.mjs (#2977)

### DIFF
--- a/archive-posting.mjs
+++ b/archive-posting.mjs
@@ -97,7 +97,10 @@ function parseCliArgs(args) {
   // this file is imported for its exports (test-all.mjs does), and a
   // module-scope call would read the IMPORTER's argv and exit(1) on flags that
   // are perfectly valid for it.
-  validateFlags(args, KNOWN_FLAGS, HELP_TEXT, { valueFlags: VALUE_FLAGS });
+  validateFlags(args, KNOWN_FLAGS, HELP_TEXT, {
+    valueFlags: VALUE_FLAGS,
+    requireOperand: true,
+  });
 
   if (args.length === 0) {
     console.log(HELP_TEXT);

--- a/archive-posting.mjs
+++ b/archive-posting.mjs
@@ -29,10 +29,14 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { reportPrefix } from './jd-capture.mjs';
 import { rejectPrivateOrInvalid, validateUrlSecurity } from './liveness-browser.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const JDS_DIR = join(ROOT, 'jds');
 const PIPELINE_PATH = join(ROOT, 'data', 'pipeline.md');
+
+const KNOWN_FLAGS = ['--company', '--role', '--report', '--pipeline', '--dry-run', '--help', '-h'];
+const VALUE_FLAGS = ['--company', '--role', '--report'];
 
 // ── CLI parsing ──────────────────────────────────────────────────────────────
 
@@ -88,7 +92,14 @@ let reportNum = null;
 // its exports doesn't read process.argv or call process.exit — the repo's
 // standard direct-run guard at the bottom is what invokes it.
 function parseCliArgs(args) {
-  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+  // Reject a mistyped flag (--comany, --reprot) before any work, and handle
+  // --help/-h wherever they appear. Inside the function, not at module scope:
+  // this file is imported for its exports (test-all.mjs does), and a
+  // module-scope call would read the IMPORTER's argv and exit(1) on flags that
+  // are perfectly valid for it.
+  validateFlags(args, KNOWN_FLAGS, HELP_TEXT, { valueFlags: VALUE_FLAGS });
+
+  if (args.length === 0) {
     console.log(HELP_TEXT);
     process.exit(0);
   }

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -1,5 +1,5 @@
-// tests/cli-flag-validation.test.mjs — four reporting CLIs must reject a
-// mistyped flag instead of answering from their defaults (#2919).
+// tests/cli-flag-validation.test.mjs — the CLIs that must reject a mistyped
+// flag instead of answering from their defaults (#2919).
 //
 // The failure class lib/cli-flags.mjs exists to end: an unrecognized flag is
 // ignored, the value flag it was meant to be falls back to its default, and
@@ -7,7 +7,14 @@
 // fixed in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs (#2743/#2745),
 // dedup-tracker.mjs (#2744/#2746), scan.mjs (#2270), doctor.mjs (#2874),
 // check-table-freshness.mjs (#2873), plugin-audit.mjs (#2813) and
-// upskill.mjs.
+// upskill.mjs and archive-posting.mjs (#2977).
+//
+// archive-posting.mjs is the one that does not merely report: a dropped
+// --report writes a capture with no report prefix, findable only by rebuilding
+// the filename from that day's date and the scraped company and role — so it
+// stops resolving the next day, which is the exact failure --report exists to
+// prevent. A dropped --dry-run is worse than a wrong answer: it is a live
+// navigation and a real file, from a run the user asked to be a preview.
 //
 // rejection-latency.mjs is the sharpest case and gets its own fixture: its
 // output is a blacklist suggestion, so the silent failure is a FALSE ALL-CLEAR
@@ -24,7 +31,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -40,16 +47,19 @@ function runScript(script, ...args) {
 }
 
 // Each script paired with a realistic typo of one of ITS OWN value flags —
-// the transposition a user actually makes, not an obviously bogus token.
+// the transposition a user actually makes, not an obviously bogus token. The
+// third element is the pattern its usage block prints, because not every CLI
+// spells that header the same way.
 const SCRIPTS = [
   ['rejection-latency.mjs', '--traker'],
   ['process-quality.mjs', '--fiel'],
   ['detect-reposts.mjs', '--windo'],
   ['weekly-digest.mjs', '--dri'],
   ['upskill.mjs', '--min-report'],
+  ['archive-posting.mjs', '--reprot', /USAGE/],
 ];
 
-for (const [script, typo] of SCRIPTS) {
+for (const [script, typo, usage = /Usage:/i] of SCRIPTS) {
   test(`${script} rejects ${typo} instead of falling back to its default`, () => {
     const r = runScript(script, typo, 'some-value');
     assert.equal(r.status, 1, `${script} ${typo} exited ${r.status}, want 1`);
@@ -60,7 +70,7 @@ for (const [script, typo] of SCRIPTS) {
   test(`${script} --help exits 0 and prints usage`, () => {
     const r = runScript(script, '--help');
     assert.equal(r.status, 0, `${script} --help exited ${r.status}, want 0`);
-    assert.match(r.all, /Usage:/i, `${script} --help printed no usage block`);
+    assert.match(r.all, usage, `${script} --help printed no usage block`);
   });
 
   // CodeRabbit caught the reverse ordering as a bug on #2745 and #2746: the
@@ -72,6 +82,33 @@ for (const [script, typo] of SCRIPTS) {
     assert.match(r.all, /unrecognized flag/i);
   });
 }
+
+// --- archive-posting: the value flag whose operand looks like a flag --------
+
+// --report's operand must reach archive-posting's OWN validator, which says
+// "positive report number" — listing --report in valueFlags is what stops the
+// shared helper from reporting "-1" as an unrecognized flag and burying the
+// real diagnosis. Exits before any navigation, so no browser is launched.
+test('archive-posting --report -1 reaches its own value check', () => {
+  const r = runScript('archive-posting.mjs', '--report', '-1', '--dry-run', 'https://example.com/j');
+  assert.equal(r.status, 1);
+  assert.match(r.all, /positive report number/);
+  assert.doesNotMatch(r.all, /unrecognized flag/i);
+});
+
+// The guard against a validator that passes by rejecting everything: the real
+// vocabulary must still work, in both spellings.
+test('archive-posting still accepts its real flags in both forms', () => {
+  const url = 'https://boards.greenhouse.io/openai/jobs/123';
+  for (const argv of [
+    ['--company=Anthropic', '--role=Engineer', '--report=42', '--dry-run', url],
+    ['--company', 'Anthropic', '--role', 'Engineer', '--report', '42', '--dry-run', url],
+  ]) {
+    const r = runScript('archive-posting.mjs', ...argv);
+    assert.equal(r.status, 0, `rejected a valid flag set: ${r.all.slice(0, 200)}`);
+    assert.doesNotMatch(r.all, /unrecognized flag/i);
+  }
+});
 
 // --- rejection-latency: the false all-clear, and the `=` form (#2401) -------
 
@@ -164,4 +201,23 @@ test('validating importable modules does not break their importers', () => {
   const r2 = runScript('company-history.mjs', '--help');
   assert.equal(r2.status, 0, 'detect-reposts rejected its importer\'s flags');
   assert.doesNotMatch(r2.all, /unrecognized flag/i);
+});
+
+// archive-posting.mjs has no CLI importer to borrow, so the hazard is spelled
+// out directly: test-all.mjs imports archiveUrl/installEgressGuard from it, and
+// a top-level call would read test-all's own argv — `node test-all.mjs --quick`
+// exiting 1 on a flag that is perfectly valid for test-all, the whole suite
+// killed by an unrelated import. The two trailing args reproduce that argv
+// shape, so process.argv.slice(2) sees '--quick' exactly as it would there.
+test('importing archive-posting does not judge its importer\'s argv', () => {
+  const target = JSON.stringify(pathToFileURL(join(ROOT, 'archive-posting.mjs')).href);
+  const r = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', `await import(${target}); console.log('IMPORT OK');`,
+      '--', 'test-all.mjs', '--quick'],
+    { cwd: ROOT, encoding: 'utf-8', timeout: 30_000 },
+  );
+  const all = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+  assert.equal(r.status, 0, `archive-posting rejected its importer's flags: ${all.slice(0, 200)}`);
+  assert.match(all, /IMPORT OK/, 'the probe never completed the import');
 });

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -96,6 +96,28 @@ test('archive-posting --report -1 reaches its own value check', () => {
   assert.doesNotMatch(r.all, /unrecognized flag/i);
 });
 
+// A known value flag followed by another flag has no operand. In particular,
+// --company must not swallow --dry-run and turn a requested preview into a
+// live archive.
+test('archive-posting rejects --company followed by --dry-run', () => {
+  const r = runScript(
+    'archive-posting.mjs',
+    '--company', '--dry-run', 'https://boards.greenhouse.io/openai/jobs/123',
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.all, /--company requires a value/);
+  assert.doesNotMatch(r.all, /Archiving 1 posting/);
+});
+
+// Missing operands are usage errors even when --help follows; validation must
+// report the malformed command before taking the help exit-0 path.
+test('archive-posting rejects --report followed by --help', () => {
+  const r = runScript('archive-posting.mjs', '--report', '--help');
+  assert.equal(r.status, 1);
+  assert.match(r.all, /--report requires a value/);
+  assert.doesNotMatch(r.all, /career-ops — Job Posting Archiver/);
+});
+
 // The guard against a validator that passes by rejecting everything: the real
 // vocabulary must still work, in both spellings.
 test('archive-posting still accepts its real flags in both forms', () => {


### PR DESCRIPTION
## Summary

- Delegate `archive-posting.mjs` flag validation to the shared CLI helper.
- Reject unrecognized flags and missing operands before any archive work.
- Preserve valid space-separated and `--flag=value` forms, help behavior, and script-specific value checks.
- Add regression coverage for importer safety and missing operands, including the `--dry-run` swallowing case.

## Testing

- `node --test tests/cli-flag-validation.test.mjs` — 25 passed
- `node test-all.mjs` — 4,318 passed, 0 failed

Fixes #2977
Related to #3087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line validation for archive posting.
  * Invalid flags and missing option values are now detected consistently.
  * Help options remain available wherever they appear in the command.
  * Empty command-line input is handled separately and more reliably.

* **Tests**
  * Expanded coverage for valid and invalid archive-posting options.
  * Added checks for usage output and safe command importing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->