### PR TITLE
fix(web): keep Rejected and Discarded rows from hiding an employer's whole board

### DIFF
--- a/web/src/app/api/whats-new/route.ts
+++ b/web/src/app/api/whats-new/route.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { careerOpsRoot, readApplications } from "@/lib/career-ops";
 import { getNormalizeTextKey } from "@/lib/core/text-key";
+import { suppressesCompany } from "@/lib/whats-new-suppression.mjs";
 import type { DiscoveredOffer } from "@/lib/explore";
 
 export const runtime = "nodejs";
@@ -30,7 +31,16 @@ export async function GET(req: Request) {
   // Companies already evaluated → don't resurface as "new".
   const normalizeTextKey = await getNormalizeTextKey();
   const norm = (s: string) => normalizeTextKey(s, " ");
-  const evaluated = new Set(readApplications().map((a) => norm(a.company)).filter(Boolean));
+  // A Rejected or Discarded row is not an "already evaluated" company: the first
+  // is the employer's verdict on ONE role, the second is the candidate's own pass
+  // on ONE role, and neither says anything about that employer's other postings.
+  // Suppressing on them hid live roles at companies still being actively targeted.
+  const evaluated = new Set(
+    readApplications()
+      .filter((a) => suppressesCompany(a.status))
+      .map((a) => norm(a.company))
+      .filter(Boolean),
+  );
 
   const toOffer = (c: string[]): DiscoveredOffer | null => {
     const [url, firstSeen, portal, title, company, status, location] = c;

--- a/web/src/lib/whats-new-suppression.mjs
+++ b/web/src/lib/whats-new-suppression.mjs
@@ -1,0 +1,23 @@
+/**
+ * Which tracker rows suppress their company from "new matches this week".
+ *
+ * The supply loop (api/whats-new) hides an offer when its company already appears
+ * in data/applications.md, so the user is not shown employers they have already
+ * assessed. Two canonical states do not mean that:
+ *
+ *   - Rejected  — the company's verdict on ONE role. It says nothing about the
+ *                 employer's other openings, which are routinely different teams
+ *                 with different requirements.
+ *   - Discarded — the candidate's own pass on ONE role (wrong function, wrong
+ *                 location, posting closed). Role-scoped, not employer-scoped.
+ *
+ * Every other canonical state (Evaluated, Applied, Responded, Interview, Offer,
+ * Hired, SKIP) reflects either an assessment still in flight or a standing
+ * decision, so those keep suppressing. See templates/states.yml for the list.
+ */
+const ROLE_SCOPED_OUTCOMES = /^\s*(rejected|discarded)\s*$/i;
+
+/** True when a tracker row in this status should hide its company from "new". */
+export function suppressesCompany(status) {
+  return !ROLE_SCOPED_OUTCOMES.test(status || "");
+}

--- a/web/tests/lib/whats-new-suppression.test.mjs
+++ b/web/tests/lib/whats-new-suppression.test.mjs
@@ -1,0 +1,43 @@
+// Tests for the "new matches this week" company-suppression predicate.
+//
+// The supply loop hides an offer whose company already sits in the tracker. The
+// bug this guards against: the predicate used to ignore `status` entirely, so a
+// Rejected row (the employer's verdict on ONE role) or a Discarded row (the
+// candidate's own pass on ONE role) hid every other posting at that employer,
+// including ones published later on different teams.
+//
+// Run:  node --test tests/lib/whats-new-suppression.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { suppressesCompany } from "../../src/lib/whats-new-suppression.mjs";
+
+test("Rejected and Discarded do not suppress the employer", () => {
+  assert.equal(suppressesCompany("Rejected"), false);
+  assert.equal(suppressesCompany("Discarded"), false);
+});
+
+test("every other canonical state still suppresses", () => {
+  for (const s of ["Evaluated", "Applied", "Responded", "Interview", "Offer", "Hired", "SKIP"]) {
+    assert.equal(suppressesCompany(s), true, `${s} should suppress`);
+  }
+});
+
+test("matching is case- and whitespace-insensitive", () => {
+  for (const s of ["rejected", "REJECTED", "  Rejected  ", "\tdiscarded\n"]) {
+    assert.equal(suppressesCompany(s), false, `${JSON.stringify(s)} should not suppress`);
+  }
+});
+
+test("a missing or empty status suppresses (unknown rows stay hidden)", () => {
+  for (const s of ["", "   ", undefined, null]) {
+    assert.equal(suppressesCompany(s), true);
+  }
+});
+
+test("substring lookalikes are not treated as Rejected/Discarded", () => {
+  // Guards against a bare /rejected/ test: a status column carrying extra text
+  // is non-canonical and must not silently unsuppress.
+  assert.equal(suppressesCompany("Rejected after interview"), true);
+  assert.equal(suppressesCompany("Not rejected"), true);
+});


### PR DESCRIPTION
## What does this PR do?

`web/src/app/api/whats-new/route.ts` hides an offer when its company already appears in `data/applications.md`, but it built that set from every tracker row without ever reading the `status` column:

```js
// Companies already evaluated → don't resurface as "new".
const evaluated = new Set(readApplications().map((a) => norm(a.company)).filter(Boolean));
```

So a `Rejected` row (the employer's verdict on **one** role) or a `Discarded` row (the candidate's own pass on **one** role) suppressed every other posting at that employer, including ones published later by different teams. The comment says *"Companies already evaluated"*; the code implemented *"companies ever touched"*. This makes the behaviour match the stated intent.

Two ways it bites in normal use:

- A role is rejected over a requirement specific to that posting (a language gate, a seniority band). Every later opening at that employer is hidden, including ones the candidate would clear.
- The candidate marks a role `Discarded` themselves because the *function* is wrong, not the company. That self-filed pass hides the employer's other openings too.

Because the filtering is silent, "no new matches" is indistinguishable from "matches exist but are suppressed".

## Related issue

None — bug fix, which CONTRIBUTING.md exempts from issue-first.

A **separate issue** covers a different defect in the same function: suppression is keyed on company name rather than job URL, so evaluating one role hides an employer's whole board. That one is a design question, not a bug, so it is filed separately and is independent of this PR.

## Type of change

- [x] Bug fix

## Scope

Deliberately narrow. Only `Rejected` and `Discarded` stop suppressing. Every other canonical state (`Evaluated`, `Applied`, `Responded`, `Interview`, `Offer`, `Hired`, `SKIP`) behaves exactly as before.

`SKIP` was the one judgement call. It reads as a standing "doesn't fit, don't apply" rather than an outcome for a single role, so I left it suppressing — but it is arguably role-scoped too. Happy to change it if you read it the other way.

The predicate lives in `web/src/lib/whats-new-suppression.mjs` rather than inline, following the existing `src/lib/*.mjs` + `tests/lib/*.test.mjs` convention (`cv-envelope`, `clean-chips`, `tracker-table`), so the route and its test cannot drift apart.

## Verification

- `node test-all.mjs` → **3277 passed, 0 failed, 0 warnings**
- `npm test` in `web/` → **128 passed, 0 failed**
- `npm run typecheck` in `web/` → clean
- 5 new unit tests covering: `Rejected`/`Discarded` do not suppress; all other canonical states still do; case- and whitespace-insensitive matching; missing/empty status still suppresses; and substring lookalikes (`"Rejected after interview"`, `"Not rejected"`) are *not* treated as canonical, so a non-canonical status can never silently unsuppress.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (3277 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rejected or discarded applications no longer hide other job postings from the same company.
  - Other application statuses continue to apply company-level suppression as expected.
  - Status matching now handles capitalization and surrounding spaces consistently.
  - Unknown or incomplete statuses remain safely hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->