### PR TITLE
fix(web-logo): companyCacheKey's [^a-z0-9] strip collided distinct non-ASCII company names

### DIFF
--- a/web/src/lib/core/logo-cache-key.mjs
+++ b/web/src/lib/core/logo-cache-key.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { normalizeTextKey } from "./normalize-text-key.mjs";
 
 // Cache identity for name-resolved company logos (see app/api/logo/route.ts).
 //
@@ -13,10 +14,19 @@ import { createHash } from "node:crypto";
 //     them wears the other's logo permanently, with no expiry to correct it.
 
 /** Bump whenever `companyDomains()` in app/api/logo/route.ts changes which
- *  domains it tries, or in what order. The version is part of every key, so
- *  bumping it makes entries written by the previous resolver unreachable.
- *  v2: curated brand domains (notion.so, zoom.us, …) now precede slug guesses. */
-export const COMPANY_KEY_VERSION = "v2";
+ *  domains it tries, or in what order — OR whenever the key derivation itself
+ *  changes, per requirement 1 above: an unchanged version leaves any entry
+ *  poisoned under the old derivation permanently reachable, with nothing to
+ *  correct it. The version is part of every key, so bumping it makes entries
+ *  written by the previous resolver unreachable.
+ *  v2: curated brand domains (notion.so, zoom.us, …) now precede slug guesses.
+ *  v3: normalization switched from `[^a-z0-9]` to the Unicode-safe
+ *  normalizeTextKey (#2369/#2666's own lesson, reintroduced here independently)
+ *  — v2 stripped every non-ASCII letter, so "Škoda" and "Koda" hashed to the
+ *  IDENTICAL key and one silently wore the other's logo forever (requirement 2,
+ *  violated). Bumping discards any v2 entry poisoned this way rather than
+ *  leaving it reachable under an unchanged "koda" key. */
+export const COMPANY_KEY_VERSION = "v3";
 
 /** Cache key for a company name, or null if the name carries nothing to key on.
  *
@@ -24,9 +34,15 @@ export const COMPANY_KEY_VERSION = "v2";
  *  brand and should share one cached favicon across every card, this search and
  *  every future one. The digest is taken over the full normalized name so that
  *  truncating the readable prefix to 40 characters — which keeps cache files
- *  greppable by eye — cannot merge two long legal entity names into one entry. */
+ *  greppable by eye — cannot merge two long legal entity names into one entry.
+ *
+ *  normalizeTextKey (not a bare `[^a-z0-9]` strip) keeps non-ASCII letters —
+ *  "Škoda" and "Koda", or two CJK company names, must NOT collapse onto the
+ *  same key just because an ASCII-only filter would erase what distinguished
+ *  them. See normalize-text-key.mjs's own header for the historical bug this
+ *  reintroduces if reverted. */
 export function companyCacheKey(company) {
-  const normalized = String(company ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  const normalized = normalizeTextKey(company);
   if (!normalized) return null;
   const digest = createHash("sha256").update(normalized).digest("hex").slice(0, 10);
   return `co_${COMPANY_KEY_VERSION}_${normalized.slice(0, 40)}_${digest}`;

--- a/web/src/lib/core/logo-cache-key.mjs
+++ b/web/src/lib/core/logo-cache-key.mjs
@@ -41,9 +41,22 @@ export const COMPANY_KEY_VERSION = "v3";
  *  same key just because an ASCII-only filter would erase what distinguished
  *  them. See normalize-text-key.mjs's own header for the historical bug this
  *  reintroduces if reverted. */
+/** Truncate to at most `n` Unicode CODE POINTS, not UTF-16 code units.
+ *  `String.prototype.slice` counts code units, so it can land mid-surrogate-
+ *  pair for a non-BMP letter (real: rarer Han characters live in the CJK
+ *  Extension blocks, astral-plane code points) — cutting the pair leaves a
+ *  lone surrogate in the key, an invalid UTF-16 string. Spreading a string
+ *  iterates by code point, so the pair is always kept or dropped whole. */
+function truncateCodePoints(s, n) {
+  return [...s].slice(0, n).join("");
+}
+
 export function companyCacheKey(company) {
   const normalized = normalizeTextKey(company);
   if (!normalized) return null;
+  // The digest covers the FULL normalized name (never truncated), so
+  // collision-safety never depended on the prefix — only the prefix's own
+  // validity as a string does.
   const digest = createHash("sha256").update(normalized).digest("hex").slice(0, 10);
-  return `co_${COMPANY_KEY_VERSION}_${normalized.slice(0, 40)}_${digest}`;
+  return `co_${COMPANY_KEY_VERSION}_${truncateCodePoints(normalized, 40)}_${digest}`;
 }

--- a/web/tests/lib/logo-cache-key.test.mjs
+++ b/web/tests/lib/logo-cache-key.test.mjs
@@ -44,11 +44,18 @@ test("keys are filesystem-safe and cannot escape the cache directory", () => {
   // component. The NUL case is written as an escape, never embedded: a raw NUL
   // makes this file binary to grep and every future search of it silently
   // returns nothing (tests/source-no-nul-bytes.test.mjs).
-  const hostile = ["../../etc/passwd", "..\\..\\windows\\system32", "a/b/c", "x y", "x\u0000y", "café/../../root"];
+  //
+  // The prefix allows Unicode letters/numbers (\p{L}\p{N}), not [a-z0-9] only
+  // — normalizeTextKey KEEPS non-ASCII letters on purpose (the collision fix
+  // below), so a real accented/CJK company name legitimately produces a
+  // Unicode prefix. Safety here doesn't come from ASCII-only output; it comes
+  // from \p{L}\p{N} excluding every traversal/separator/control character
+  // (`.`, `/`, `\`, space, NUL) regardless of script.
+  const hostile =["../../etc/passwd", "..\\..\\windows\\system32", "a/b/c", "x y", "x\u0000y", "café/../../root"];
   for (const name of hostile) {
     const key = companyCacheKey(name);
     if (key === null) continue;
-    assert.match(key, /^co_v\d+_[a-z0-9]{1,40}_[0-9a-f]{10}$/, `unsafe key for ${JSON.stringify(name)}: ${key}`);
+    assert.match(key, /^co_v\d+_[\p{L}\p{N}]{1,40}_[0-9a-f]{10}$/u, `unsafe key for ${JSON.stringify(name)}: ${key}`);
   }
 });
 
@@ -64,4 +71,27 @@ test("bumping the version changes every key", () => {
   const key = companyCacheKey("Notion");
   assert.ok(!key.includes("_v0_"), "keys must not carry a stale version token");
   assert.equal(key.split("_")[1], COMPANY_KEY_VERSION);
+});
+
+test("Škoda and Koda do not collide (the [^a-z0-9] regression this fix stops)", () => {
+  // Pre-fix: both stripped to "koda" and hashed identically — one company
+  // silently wore the other's logo forever, with no expiry to correct it
+  // (requirement 2 in this file's own header).
+  assert.notEqual(companyCacheKey("Škoda"), companyCacheKey("Koda"));
+});
+
+test("Zürich Re and a plain-ASCII near-miss do not collide", () => {
+  assert.notEqual(companyCacheKey("Zürich Re"), companyCacheKey("Zurich Re"));
+});
+
+test("CJK company names are cacheable, not rejected as empty", () => {
+  // Pre-fix: [^a-z0-9] erased CJK entirely, so companyCacheKey returned null
+  // and the name was never cached — silently ineligible, not merely slower.
+  const key = companyCacheKey("日本電産");
+  assert.notEqual(key, null);
+  assert.match(key, /^co_v\d+_日本電産_[0-9a-f]{10}$/);
+});
+
+test("two distinct CJK companies get distinct keys", () => {
+  assert.notEqual(companyCacheKey("日本電産"), companyCacheKey("本田技研工業"));
 });

--- a/web/tests/lib/logo-cache-key.test.mjs
+++ b/web/tests/lib/logo-cache-key.test.mjs
@@ -45,17 +45,19 @@ test("keys are filesystem-safe and cannot escape the cache directory", () => {
   // makes this file binary to grep and every future search of it silently
   // returns nothing (tests/source-no-nul-bytes.test.mjs).
   //
-  // The prefix allows Unicode letters/numbers (\p{L}\p{N}), not [a-z0-9] only
-  // — normalizeTextKey KEEPS non-ASCII letters on purpose (the collision fix
-  // below), so a real accented/CJK company name legitimately produces a
-  // Unicode prefix. Safety here doesn't come from ASCII-only output; it comes
-  // from \p{L}\p{N} excluding every traversal/separator/control character
-  // (`.`, `/`, `\`, space, NUL) regardless of script.
-  const hostile =["../../etc/passwd", "..\\..\\windows\\system32", "a/b/c", "x y", "x\u0000y", "café/../../root"];
+  // The prefix allows Unicode letters/marks/numbers (\p{L}\p{M}\p{N}), not
+  // [a-z0-9] only — normalizeTextKey KEEPS non-ASCII letters AND combining
+  // marks on purpose (the collision fix below; a Devanagari name like कंपनी
+  // is letters plus marks, not letters alone, so \p{M} must be included or a
+  // legitimate name is rejected as "unsafe"). Safety here doesn't come from
+  // ASCII-only output; it comes from \p{L}\p{M}\p{N} excluding every
+  // traversal/separator/control character (`.`, `/`, `\`, space, NUL)
+  // regardless of script.
+  const hostile =["../../etc/passwd", "..\\..\\windows\\system32", "a/b/c", "x y", "x\u0000y", "café/../../root", "कंपनी/../../root"];
   for (const name of hostile) {
     const key = companyCacheKey(name);
     if (key === null) continue;
-    assert.match(key, /^co_v\d+_[\p{L}\p{N}]{1,40}_[0-9a-f]{10}$/u, `unsafe key for ${JSON.stringify(name)}: ${key}`);
+    assert.match(key, /^co_v\d+_[\p{L}\p{M}\p{N}]{1,40}_[0-9a-f]{10}$/u, `unsafe key for ${JSON.stringify(name)}: ${key}`);
   }
 });
 

--- a/web/tests/lib/logo-cache-key.test.mjs
+++ b/web/tests/lib/logo-cache-key.test.mjs
@@ -97,3 +97,24 @@ test("CJK company names are cacheable, not rejected as empty", () => {
 test("two distinct CJK companies get distinct keys", () => {
   assert.notEqual(companyCacheKey("日本電産"), companyCacheKey("本田技研工業"));
 });
+
+test("a non-BMP letter landing on the 40-char truncation boundary does not split its surrogate pair", () => {
+  // CJK Extension B is astral-plane (surrogate pair in UTF-16), and real Han
+  // characters live there. String.prototype.slice(0, 40) counts UTF-16 code
+  // UNITS, so it can cut a pair in half and leave a lone surrogate — an
+  // invalid string, not a printable one. Built to land exactly on the
+  // boundary: 39 ASCII letters, then the astral letter at position 40.
+  const astralLetter = "\u{20000}"; // 𠀀 — CJK Extension B, \p{L}
+  const name = "a".repeat(39) + astralLetter + "trailing text past the cut";
+  const key = companyCacheKey(name);
+  assert.notEqual(key, null);
+  // A lone (unpaired) surrogate anywhere in the key means the pair was split.
+  assert.doesNotMatch(
+    key,
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    `key contains an unpaired surrogate: ${JSON.stringify(key)}`,
+  );
+  // The astral letter must survive whole, not be silently dropped either.
+  assert.ok(key.includes(astralLetter), `astral letter was lost, not just split: ${JSON.stringify(key)}`);
+  assert.match(key, /^co_v\d+_[\p{L}\p{M}\p{N}]{1,40}_[0-9a-f]{10}$/u);
+});

--- a/web/tests/lib/logo-cache-key.test.mjs
+++ b/web/tests/lib/logo-cache-key.test.mjs
@@ -79,11 +79,22 @@ test("Škoda and Koda do not collide (the [^a-z0-9] regression this fix stops)",
   // Pre-fix: both stripped to "koda" and hashed identically — one company
   // silently wore the other's logo forever, with no expiry to correct it
   // (requirement 2 in this file's own header).
-  assert.notEqual(companyCacheKey("Škoda"), companyCacheKey("Koda"));
+  const a = companyCacheKey("Škoda");
+  const b = companyCacheKey("Koda");
+  // notEqual(null, "key") also passes, which would hide a DIFFERENT
+  // regression — one side wrongly becoming uncacheable — as if it were this
+  // test's collision guarantee holding. Both sides must be real keys first.
+  assert.notEqual(a, null);
+  assert.notEqual(b, null);
+  assert.notEqual(a, b);
 });
 
 test("Zürich Re and a plain-ASCII near-miss do not collide", () => {
-  assert.notEqual(companyCacheKey("Zürich Re"), companyCacheKey("Zurich Re"));
+  const a = companyCacheKey("Zürich Re");
+  const b = companyCacheKey("Zurich Re");
+  assert.notEqual(a, null);
+  assert.notEqual(b, null);
+  assert.notEqual(a, b);
 });
 
 test("CJK company names are cacheable, not rejected as empty", () => {
@@ -95,7 +106,11 @@ test("CJK company names are cacheable, not rejected as empty", () => {
 });
 
 test("two distinct CJK companies get distinct keys", () => {
-  assert.notEqual(companyCacheKey("日本電産"), companyCacheKey("本田技研工業"));
+  const a = companyCacheKey("日本電産");
+  const b = companyCacheKey("本田技研工業");
+  assert.notEqual(a, null);
+  assert.notEqual(b, null);
+  assert.notEqual(a, b);
 });
 
 test("a non-BMP letter landing on the 40-char truncation boundary does not split its surrogate pair", () => {


### PR DESCRIPTION
`web/src/lib/core/logo-cache-key.mjs`'s `companyCacheKey` normalized with `.toLowerCase().replace(/[^a-z0-9]/g, "")` before hashing — the exact ASCII-only pattern `normalize-text-key.mjs`'s own header comment names by number and warns against reinstating: *"Never reinstate `[^a-z0-9]`: that deleted every non-ASCII letter ('Škoda'→'koda', '日本電産'→''), which both suppressed real offers and resurfaced evaluated ones"* (#2369/#2666). This file reintroduced the same defect independently, in a different feature (logo caching, not tracker/offer dedup).

**Why it's not just cosmetic here.** This module's own docstring states requirement 2 in as many words: *"It must not collide. Two different companies sharing a key means one of them wears the other's logo permanently, with no expiry to correct it."* The logo cache is write-once, never revalidated — a hit or a miss, once written, is served forever.

**Verified by execution:**

```
companyCacheKey("Škoda")      -> co_v2_koda_74b8796bbe
companyCacheKey("Koda")       -> co_v2_koda_74b8796bbe
same key: true

companyCacheKey("日本電産")    -> null   (CJK erased to nothing — never cacheable at all)
```

Two real, distinct companies (Škoda / Koda) share one on-disk cache entry — whichever resolves first silently wins the logo for both, permanently, per the module's own no-expiry design. CJK company names weren't even miscacheable, they were **uncacheable**: `normalized` came back `""`, `companyCacheKey` returned `null`, and `route.ts` treats that as "bad company" (never reaches the cache at all).

## The fix

Delegates to `normalizeTextKey` (`./normalize-text-key.mjs`), already sitting in the same directory, already parity-tested against the core, already the sanctioned fix for exactly this bug class — rather than inventing a second lossy normalizer. `companyCacheKey` only consumes this server-side (`app/api/logo/route.ts`, `runtime = "nodejs"`), so there's no client-bundle constraint pulling toward a hand-rolled ASCII filter here either.

**Filesystem safety is unaffected**, just checked differently: `normalizeTextKey`'s `\p{L}\p{M}\p{N}` allowlist excludes `.`, `/`, `\`, spaces, and NUL just as completely as `[^a-z0-9]` did — traversal characters were never in the letter/mark/number Unicode categories to begin with. The existing `logo-cache-key.test.mjs` hostile-input test (`café/../../root`, `..\..\windows\system32`, embedded NUL, etc.) still passes; I widened its regex from `[a-z0-9]` to `\p{L}\p{N}` since a real accented/CJK company name now legitimately produces a Unicode prefix, and the test's actual safety property was never "ASCII-only," it was "no traversal/separator/control characters" — which `\p{L}\p{N}` guarantees regardless of script.

**Also bumps `COMPANY_KEY_VERSION` to `v3`.** The file's own requirement 1 is explicit about why: *"It must change when candidate generation changes. Otherwise a machine that cached a miss under the old resolver keeps serving that miss forever."* Any install with a warm cache may currently have a `co_v2_koda_...` entry poisoned by whichever of Škoda/Koda resolved first. Without a version bump, "Koda" (no diacritics, so its v2 and v3 normalized forms are identical) would keep reading that same key path and keep serving whatever's there. Bumping discards it cleanly rather than leaving it reachable.

Two-commit shape: the fix, then the tests (widened the existing safety-regex assertion, added direct collision + CJK-cacheability coverage).

## Test plan
- [x] `node test-all.mjs` — 4990 passed, 0 failed (2 pre-existing unrelated warnings: Go dashboard build skip, PII-heuristic false positive on santifer.io in untouched Go source)
- [x] `cd web && npm test` — 331 passed, 0 failed
- [x] `cd web && npm run typecheck` — clean
- [x] All 8 pre-existing `logo-cache-key.test.mjs` tests still pass, including the widened filesystem-safety regex against the same hostile-input corpus
- [x] New tests confirm Škoda/Koda and two distinct CJK names no longer collide, and CJK names are cacheable (non-null) again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company logo caching for names containing accented, non-ASCII, CJK, and other Unicode characters.
  * Preserved distinctions between international company names that previously could produce identical cache entries.
  * Ensured long or complex company names remain safely and consistently cacheable.
  * Continued blocking unsafe characters, path separators, spaces, and control characters in cache keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->