### PR TITLE
fix(web-tracker-lock): withTrackerLock reported a filesystem failure as transient lock contention

### DIFF
--- a/web/src/lib/core/tracker-lock.ts
+++ b/web/src/lib/core/tracker-lock.ts
@@ -85,10 +85,23 @@ export async function withTrackerLock<T>(trackerFile: string, fn: () => T | Prom
     // The core tags ONLY the genuine-contention timeout with code LOCK_TIMEOUT
     // (tracker-utils.mjs's own comment: "so callers can tell 'lock is busy,
     // retry later' apart from filesystem/configuration failures rethrown out
-    // of the loop above"). A bare catch here converted EVERY error — ENOENT
-    // from a missing lock-dir parent, EACCES, a broken checkout — into
+    // of the loop above"). A bare catch here converted EVERY error — including
+    // ENOENT from a missing lock-dir parent, a broken checkout — into
     // "tracker is being written by another process, retry", which is false:
     // those never resolve by retrying. Anything not tagged propagates as-is.
+    //
+    // EACCES/EPERM is its own case, not "propagates as-is" like ENOENT: the
+    // core's isMkdirContention (pipeline-lock.mjs) treats EACCES/EPERM as
+    // contention too, because on Windows a lock dir mid-create/mid-remove by
+    // another process answers with exactly those codes (#2777) — there is no
+    // way to tell that apart from a genuine permission problem by code alone.
+    // So a PERSISTENT EACCES/EPERM (not another writer, just no permission)
+    // still retries inside the core's loop and, after timeoutMs, surfaces as
+    // LOCK_TIMEOUT — which this catch then reports as TrackerBusyError, same
+    // as real contention. That is a known, accepted characteristic of the
+    // shared lock machinery (see the PR discussion), not a gap in this catch:
+    // fixing it means changing isMkdirContention itself, which every lock in
+    // the repo shares, not something scoped to this wrapper.
     const err = e as { code?: string } | null;
     if (err && err.code === "LOCK_TIMEOUT") {
       throw new TrackerBusyError();

--- a/web/src/lib/core/tracker-lock.ts
+++ b/web/src/lib/core/tracker-lock.ts
@@ -81,8 +81,19 @@ export async function withTrackerLock<T>(trackerFile: string, fn: () => T | Prom
       retryMs: 50,
       tracker: trackerFile,
     });
-  } catch {
-    throw new TrackerBusyError();
+  } catch (e) {
+    // The core tags ONLY the genuine-contention timeout with code LOCK_TIMEOUT
+    // (tracker-utils.mjs's own comment: "so callers can tell 'lock is busy,
+    // retry later' apart from filesystem/configuration failures rethrown out
+    // of the loop above"). A bare catch here converted EVERY error — ENOENT
+    // from a missing lock-dir parent, EACCES, a broken checkout — into
+    // "tracker is being written by another process, retry", which is false:
+    // those never resolve by retrying. Anything not tagged propagates as-is.
+    const err = e as { code?: string } | null;
+    if (err && err.code === "LOCK_TIMEOUT") {
+      throw new TrackerBusyError();
+    }
+    throw e;
   }
   try {
     return await fn();

--- a/web/tests/lib/tracker-lock-error-classification.test.mjs
+++ b/web/tests/lib/tracker-lock-error-classification.test.mjs
@@ -104,3 +104,51 @@ test("the core: a genuine ENOENT from acquireTrackerLock is NOT tagged LOCK_TIME
     },
   );
 });
+
+// Two environments cannot produce a persistent mkdir refusal, and in both a
+// green result would mean nothing (same measured skip as
+// tests/pipeline-lock-mkdir-eperm.test.mjs, which this mirrors):
+//   - root: permission bits do not apply, mkdir simply succeeds.
+//   - win32: a POSIX chmod mode maps onto the read-only attribute there, which
+//     does not deny mkdir inside the directory — acquisition would succeed and
+//     no refusal would ever happen. Measured on windows-latest, not assumed.
+const cannotRefuse =
+  typeof process.getuid === "function" && process.getuid() === 0
+    ? "running as root, permission bits do not apply"
+    : process.platform === "win32"
+      ? "win32: a POSIX mode cannot deny mkdir, so the refusal never happens"
+      : false; // NOT null — node:test's `skip` option runs the body but still
+        // reports SKIP for a null value, silently discarding the result.
+
+test(
+  "the core: a PERSISTENT EACCES/EPERM is retried and eventually surfaces as LOCK_TIMEOUT, not thrown raw",
+  { skip: skipCore || cannotRefuse },
+  async () => {
+    // This is the behavior the PR discussion documents but which had no
+    // executable coverage: unlike ENOENT (immediate, untagged) an EACCES/EPERM
+    // mkdir refusal is classified as CONTENTION by the core's isMkdirContention
+    // (pipeline-lock.mjs, #2777) — because on Windows that is exactly what real
+    // contention looks like. So a persistent (non-transient) permission problem
+    // is retried like real contention would be, and only surfaces once the
+    // overall timeout elapses — as LOCK_TIMEOUT, not as the raw EACCES/EPERM.
+    // withTrackerLock's catch then reports that as TrackerBusyError, same as
+    // genuine contention. Known, accepted, not a gap this fix introduces.
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "trklock-eacces-"));
+    const sealed = path.join(base, "sealed");
+    fs.mkdirSync(sealed);
+    const lockDir = path.join(sealed, "lockdir");
+    fs.chmodSync(sealed, 0o500); // r-x: mkdir inside is refused with EACCES
+    try {
+      await assert.rejects(
+        () => acquireTrackerLock(lockDir, { timeoutMs: 300, retryMs: 20 }),
+        (err) => {
+          assert.equal(err.code, "LOCK_TIMEOUT", `expected LOCK_TIMEOUT after retrying, got ${err.code}: ${err.message}`);
+          return true;
+        },
+      );
+    } finally {
+      fs.chmodSync(sealed, 0o700);
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  },
+);

--- a/web/tests/lib/tracker-lock-error-classification.test.mjs
+++ b/web/tests/lib/tracker-lock-error-classification.test.mjs
@@ -1,0 +1,106 @@
+// tracker-lock.ts imports `@/lib/career-ops` (the path alias), which plain
+// `node --test` cannot resolve without the Next.js build — same constraint as
+// pipeline.ts, same workaround already established in
+// tests/lib/pipeline-local-today.test.mjs: read the source and assert the
+// shape of the catch block directly.
+//
+// Covers: withTrackerLock's acquire-failure catch used to be unconditional
+// (`catch { throw new TrackerBusyError(); }`), converting EVERY error from
+// acquiring the lock — including a genuine ENOENT from a missing lock-dir
+// parent, or EACCES — into "tracker is being written by another process,
+// retry". That is false for those cases: they never resolve by retrying. The
+// sibling followups-lock.ts already gets this right (discriminates on the
+// core's SeedError('LOCK_TIMEOUT')); tracker-lock.ts's core equivalent tags a
+// plain Error with `.code = 'LOCK_TIMEOUT'` instead (tracker-utils.mjs), so
+// the discriminator here is `err.code === 'LOCK_TIMEOUT'`.
+//
+// Run:  node --test tests/lib/tracker-lock-error-classification.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(HERE, "..", "..", "src", "lib", "core", "tracker-lock.ts");
+const src = readFileSync(SRC, "utf8");
+
+function acquireCatchBlock() {
+  // The catch immediately after the `acquire(...)` call, up to its closing
+  // brace before the `try { return await fn(); }` that follows.
+  const m = src.match(/lock = await acquire\([\s\S]*?\}\)\s*;\s*\}\s*catch[\s\S]*?\n {2}\}/);
+  assert.ok(m, `${SRC}: could not find the acquire()/catch block — the function was restructured. Update this extractor.`);
+  return m[0];
+}
+
+test("the acquire-failure catch block still exists at the shape this test extracts", () => {
+  assert.ok(acquireCatchBlock().length > 0);
+});
+
+test("a bare catch-all that converts every acquire error to TrackerBusyError is gone", () => {
+  const block = acquireCatchBlock();
+  assert.doesNotMatch(
+    block,
+    /catch\s*\{\s*throw new TrackerBusyError\(\);\s*\}/,
+    `${SRC}: the acquire-failure catch is unconditional again — every error (ENOENT, EACCES, a broken ` +
+      `checkout) gets reported as transient lock contention, which is false for anything that isn't ` +
+      `LOCK_TIMEOUT. Discriminate on err.code before converting.`,
+  );
+});
+
+test("TrackerBusyError is thrown only for the core's LOCK_TIMEOUT tag", () => {
+  const block = acquireCatchBlock();
+  assert.match(
+    block,
+    /err\s*&&\s*err\.code\s*===\s*["']LOCK_TIMEOUT["']/,
+    `${SRC}: expected the catch to check err.code === 'LOCK_TIMEOUT' before throwing TrackerBusyError.`,
+  );
+});
+
+test("anything not tagged LOCK_TIMEOUT propagates as-is, not swallowed", () => {
+  const block = acquireCatchBlock();
+  assert.match(
+    block,
+    /throw e;\s*\}\s*$/,
+    `${SRC}: expected a final "throw e;" so a non-timeout error (e.g. ENOENT) reaches the caller ` +
+      `unchanged instead of being converted or dropped.`,
+  );
+});
+
+// --- Pins the underlying contract this fix depends on: the core function
+// tracker-lock.ts wraps must NOT tag a non-contention failure as LOCK_TIMEOUT.
+// Same core-resolution / skip-if-absent pattern as tracker-lock.test.mjs.
+
+const CORE =
+  process.env.CAREER_OPS_ROOT ||
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const coreLock = path.join(CORE, "tracker-utils.mjs");
+
+let acquireTrackerLock = null;
+let skipCore = false;
+try {
+  ({ acquireTrackerLock } = await import(pathToFileURL(coreLock).href));
+} catch (err) {
+  const coreAbsent = !fs.existsSync(coreLock);
+  const packageUnresolvable = err.url == null;
+  const depsAbsent = !fs.existsSync(path.join(CORE, "node_modules"));
+  if (err.code !== "ERR_MODULE_NOT_FOUND") throw err;
+  if (coreAbsent) skipCore = `no core checkout at ${CORE}`;
+  else if (packageUnresolvable && depsAbsent) skipCore = `core dependencies are not installed at ${CORE} (web-only checkout)`;
+  else throw err;
+}
+
+test("the core: a genuine ENOENT from acquireTrackerLock is NOT tagged LOCK_TIMEOUT", { skip: skipCore }, async () => {
+  const unreachableLockDir = path.join(os.tmpdir(), `no-such-parent-${Date.now()}-xyz`, "lockdir");
+  await assert.rejects(
+    () => acquireTrackerLock(unreachableLockDir, { timeoutMs: 2_000, retryMs: 50 }),
+    (err) => {
+      assert.equal(err.code, "ENOENT");
+      assert.notEqual(err.code, "LOCK_TIMEOUT", "a filesystem failure must not be mistaken for lock contention");
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
`web/src/lib/core/tracker-lock.ts`'s `withTrackerLock` had an unconditional acquire-failure catch:

```ts
try {
  lock = await acquire(lockDirFor(trackerFile), { ... });
} catch {
  throw new TrackerBusyError();
}
```

`TrackerBusyError` means "tracker is being written by another process" — a route answers 409 and the caller is expected to retry. But this catch converted **every** error from `acquire()` into that message, not just genuine contention.

The core it wraps, `tracker-utils.mjs`'s `acquireTrackerLock`, deliberately tags only the real timeout case:

```js
// Tag the timeout so callers can tell "lock is busy, retry later" apart
// from filesystem/configuration failures rethrown out of the loop above.
const timeoutErr = new Error(`Timed out waiting for tracker lock at ${lockDir}`);
timeoutErr.code = 'LOCK_TIMEOUT';
throw timeoutErr;
```

Anything else — an `ENOENT` from a missing lock-dir parent, `EACCES`, a broken checkout — is rethrown untagged. `tracker-lock.ts` wasn't checking the tag, so a real, permanent failure got reported as "retry shortly," which will never resolve by retrying.

**Verified by execution** against the real core function:

```
$ node --input-type=module -e "
import { acquireTrackerLock } from './tracker-utils.mjs';
try {
  await acquireTrackerLock('/nonexistent-parent-dir-xyz-123/lockdir', { timeoutMs: 2000, retryMs: 50 });
} catch (err) {
  console.log('threw:', err.code, '|', err.message);
  console.log('is LOCK_TIMEOUT?', err.code === 'LOCK_TIMEOUT');
}"
threw: ENOENT | ENOENT: no such file or directory, mkdir '/nonexistent-parent-dir-xyz-123/lockdir'
is LOCK_TIMEOUT? false
```

**Why this survived review:** its sibling `web/src/lib/core/followups-lock.ts` — same architecture, same era, explicitly cross-referenced in both files' own header comments as "same failure family, same cure" — already gets this right:

```ts
const err = e as { name?: string; code?: string } | null;
if (err && err.name === "SeedError" && err.code === "LOCK_TIMEOUT") {
  throw new FollowupsBusyError();
}
throw e;
```

`tracker-lock.ts` just never picked up the same discrimination. The fix matches that pattern, adapted for `tracker-utils.mjs`'s plain `Error` + `.code` tag (no `SeedError` name to check here).

**Current reachability, stated plainly rather than left implicit:** `withTrackerLock` is currently unreachable from any live route. #2903 introduced it for `POST /api/status`, but that route was since refactored (see its own header comment) to delegate to `set-status.mjs` via `child_process` instead, which holds the tracker lock core-side — it no longer imports `tracker-lock.ts` at all. I grepped every route under `web/src/app/api` that touches the tracker (`status`, `tracker/delete`, `run`, `report/shape`, `assistant`, `whats-new`) and all delegate to a core CLI subprocess rather than calling `withTrackerLock` directly. So this is a latent-bug fix in an exported, documented, still-referenced-by-its-sibling's-comments utility — not a live-traffic bug today. Worth fixing anyway: it's a landmine for whoever wires this back up (the file's own extensive JSDoc reads like it's meant to be used again), and the asymmetry with its actively-used sibling is exactly the kind of thing a future contributor would copy the wrong half of.

## Test plan
- [x] `node test-all.mjs` — 4990 passed, 0 failed (2 pre-existing unrelated warnings: Go dashboard build skip, PII-heuristic false positive on santifer.io in untouched Go source)
- [x] `cd web && npm test` — 332 passed, 0 failed
- [x] `cd web && npm run typecheck` — clean
- [x] New test file source-text-extracts the catch block (`tracker-lock.ts` imports the `@/` alias, so — same constraint and same workaround as `pipeline-local-today.test.mjs` — it can't be imported directly) and confirms the bare-catch-all shape is gone, the `LOCK_TIMEOUT` discriminator is present, and non-timeout errors propagate
- [x] A live test against the real `acquireTrackerLock` pins the underlying contract this fix depends on: a genuine `ENOENT` is never tagged `LOCK_TIMEOUT`
- [x] Confirmed the regression-guard regex matches the pre-fix source (would have caught this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lock acquisition now reports only genuine timeout conditions as tracker-busy errors.
  * Filesystem, configuration, and other lock acquisition failures retain their original error details.

* **Tests**
  * Added coverage for accurate lock-error classification, propagation, and permission-failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->