### PR TITLE
fix(web-apply): extractJsonObject's truncation salvage reused one global pad for every candidate, losing already-drafted fields

### DIFF
--- a/web/src/app/api/apply/prefill/route.ts
+++ b/web/src/app/api/apply/prefill/route.ts
@@ -4,68 +4,11 @@ import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { getSession } from "@/lib/apply/session";
+import { extractJsonObject } from "@/lib/extract-json-object.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 320;
-
-/**
- * Pull a JSON object out of an LLM's text answer, tolerating code fences,
- * trailing prose, and — crucially — TRUNCATION (the planner getting killed
- * mid-output on a big form). When the object is incomplete we salvage the
- * largest valid prefix so the fields that DID finish still come through.
- */
-function extractJsonObject(text: string): { obj: Record<string, unknown> | null; truncated: boolean } {
-  const s = text.replace(/```(?:json)?/gi, "");
-  const start = s.indexOf("{");
-  if (start === -1) return { obj: null, truncated: false };
-
-  let depth = 0;
-  let inStr = false;
-  let esc = false;
-  let end = -1;
-  for (let i = start; i < s.length; i++) {
-    const c = s[i];
-    if (inStr) {
-      if (esc) esc = false;
-      else if (c === "\\") esc = true;
-      else if (c === '"') inStr = false;
-    } else if (c === '"') inStr = true;
-    else if (c === "{") depth++;
-    else if (c === "}") {
-      depth--;
-      if (depth === 0) {
-        end = i;
-        break;
-      }
-    }
-  }
-  if (end !== -1) {
-    try {
-      return { obj: JSON.parse(s.slice(start, end + 1)) as Record<string, unknown>, truncated: false };
-    } catch {
-      /* malformed even though balanced — fall through to salvage */
-    }
-  }
-
-  // Truncated / unbalanced: walk back from successive commas, close the JSON,
-  // and parse the largest prefix that is valid.
-  const frag = s.slice(start);
-  const open = (frag.match(/{/g) || []).length;
-  const close = (frag.match(/}/g) || []).length;
-  const pad = "}".repeat(Math.max(0, open - close));
-  for (let tryEnd = frag.length; tryEnd > 1; ) {
-    const cand = frag.slice(0, tryEnd).replace(/,\s*$/, "") + pad;
-    try {
-      return { obj: JSON.parse(cand) as Record<string, unknown>, truncated: true };
-    } catch {
-      const prevComma = frag.lastIndexOf(",", tryEnd - 1);
-      if (prevComma <= start) break;
-      tryEnd = prevComma;
-    }
-  }
-  return { obj: null, truncated: true };
-}
 
 // AI pre-fill (STREAMING NDJSON). The user's BYO CLI (read-only PLANNER — no
 // browser access) drafts an answer per field from cv.md / profile / the job's

--- a/web/src/lib/extract-json-object.mjs
+++ b/web/src/lib/extract-json-object.mjs
@@ -1,0 +1,84 @@
+/**
+ * extract-json-object.mjs — pull a JSON object out of an LLM's text answer,
+ * tolerating code fences, trailing prose, and — crucially — TRUNCATION (the
+ * planner getting killed mid-output on a big form). When the object is
+ * incomplete we salvage the largest valid prefix so the fields that DID
+ * finish still come through (apply/prefill/route.ts).
+ *
+ * Plain .mjs (same pattern as pdf-paths.mjs / clean-chips.mjs) so this can be
+ * unit-tested with `node --test`, no TypeScript build step — it has no `@/`
+ * dependency, so factoring it out of the route is what makes it testable at
+ * all.
+ */
+
+/**
+ * @typedef {Object} ExtractedJson
+ * @property {Record<string, unknown> | null} obj
+ * @property {boolean} truncated
+ */
+
+/**
+ * @param {string} text
+ * @returns {ExtractedJson}
+ */
+export function extractJsonObject(text) {
+  const s = text.replace(/```(?:json)?/gi, "");
+  const start = s.indexOf("{");
+  if (start === -1) return { obj: null, truncated: false };
+
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  let end = -1;
+  for (let i = start; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === '"') inStr = false;
+    } else if (c === '"') inStr = true;
+    else if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end !== -1) {
+    try {
+      return { obj: JSON.parse(s.slice(start, end + 1)), truncated: false };
+    } catch {
+      /* malformed even though balanced — fall through to salvage */
+    }
+  }
+
+  // Truncated / unbalanced: walk back from successive commas, close the JSON,
+  // and parse the largest prefix that is valid.
+  //
+  // Each candidate prefix gets ITS OWN pad, computed from that prefix's own
+  // open/close count — not the whole fragment's. An earlier field is usually
+  // closed at a shallower depth than whatever the truncated tail was mid-way
+  // through, so a pad sized for the full (broken) fragment almost never
+  // matches what an earlier, complete field needs to close. Reusing one fixed
+  // pad for every backtrack candidate meant a mismatch on any candidate whose
+  // depth didn't happen to equal the full fragment's — i.e. almost always —
+  // so the loop silently exhausted every comma and returned null, discarding
+  // every field that DID finish along with the one that didn't.
+  const frag = s.slice(start);
+  for (let tryEnd = frag.length; tryEnd > 1; ) {
+    const body = frag.slice(0, tryEnd).replace(/,\s*$/, "");
+    const open = (body.match(/{/g) || []).length;
+    const close = (body.match(/}/g) || []).length;
+    const pad = "}".repeat(Math.max(0, open - close));
+    try {
+      return { obj: JSON.parse(body + pad), truncated: true };
+    } catch {
+      const prevComma = frag.lastIndexOf(",", tryEnd - 1);
+      if (prevComma <= start) break;
+      tryEnd = prevComma;
+    }
+  }
+  return { obj: null, truncated: true };
+}

--- a/web/src/lib/extract-json-object.mjs
+++ b/web/src/lib/extract-json-object.mjs
@@ -54,29 +54,67 @@ export function extractJsonObject(text) {
     }
   }
 
-  // Truncated / unbalanced: walk back from successive commas, close the JSON,
-  // and parse the largest prefix that is valid.
+  // Truncated / unbalanced: walk back from successive STRUCTURAL commas
+  // (commas outside any string), closing the JSON at each candidate boundary
+  // and parsing the largest prefix that is valid.
   //
   // Each candidate prefix gets ITS OWN pad, computed from that prefix's own
   // open/close count — not the whole fragment's. An earlier field is usually
   // closed at a shallower depth than whatever the truncated tail was mid-way
   // through, so a pad sized for the full (broken) fragment almost never
-  // matches what an earlier, complete field needs to close. Reusing one fixed
-  // pad for every backtrack candidate meant a mismatch on any candidate whose
-  // depth didn't happen to equal the full fragment's — i.e. almost always —
-  // so the loop silently exhausted every comma and returned null, discarding
-  // every field that DID finish along with the one that didn't.
+  // matches what an earlier, complete field needs to close.
+  //
+  // Both the brace count and the backtrack points must ignore STRING content:
+  // a completed field's own string value can legitimately contain a literal
+  // '{', '}', or ',' (free text, a code snippet, a JSON example in prose), and
+  // counting those as structural corrupts the pad for an otherwise perfectly
+  // valid, already-complete field, or picks a backtrack point that lands
+  // mid-string.
+  //
+  // `start` is an offset into `s`; every index used below (`prevComma`, loop
+  // positions) is relative to `frag = s.slice(start)`, i.e. 0-based from a
+  // DIFFERENT origin. Comparing a frag-relative index against `start` (an
+  // s-relative one) is a unit mismatch: whenever there is enough leading
+  // prose that `start` alone exceeds `frag.length`, EVERY frag-relative
+  // comma index satisfies `<= start` trivially, so backtracking stops on its
+  // first attempt even when a valid earlier candidate exists inside frag.
   const frag = s.slice(start);
-  for (let tryEnd = frag.length; tryEnd > 1; ) {
+  const structural = new Array(frag.length).fill(false);
+  {
+    let inStr2 = false;
+    let esc2 = false;
+    for (let i = 0; i < frag.length; i++) {
+      const c = frag[i];
+      structural[i] = !inStr2;
+      if (inStr2) {
+        if (esc2) esc2 = false;
+        else if (c === "\\") esc2 = true;
+        else if (c === '"') inStr2 = false;
+      } else if (c === '"') inStr2 = true;
+    }
+  }
+  const lastStructuralComma = (before) => {
+    for (let i = before - 1; i >= 0; i--) {
+      if (frag[i] === "," && structural[i]) return i;
+    }
+    return -1;
+  };
+
+  for (let tryEnd = frag.length; tryEnd > 0; ) {
     const body = frag.slice(0, tryEnd).replace(/,\s*$/, "");
-    const open = (body.match(/{/g) || []).length;
-    const close = (body.match(/}/g) || []).length;
+    let open = 0;
+    let close = 0;
+    for (let i = 0; i < body.length; i++) {
+      if (!structural[i]) continue;
+      if (body[i] === "{") open++;
+      else if (body[i] === "}") close++;
+    }
     const pad = "}".repeat(Math.max(0, open - close));
     try {
       return { obj: JSON.parse(body + pad), truncated: true };
     } catch {
-      const prevComma = frag.lastIndexOf(",", tryEnd - 1);
-      if (prevComma <= start) break;
+      const prevComma = lastStructuralComma(tryEnd);
+      if (prevComma < 0) break;
       tryEnd = prevComma;
     }
   }

--- a/web/src/lib/extract-json-object.mjs
+++ b/web/src/lib/extract-json-object.mjs
@@ -78,24 +78,39 @@ export function extractJsonObject(text) {
   // prose that `start` alone exceeds `frag.length`, EVERY frag-relative
   // comma index satisfies `<= start` trivially, so backtracking stops on its
   // first attempt even when a valid earlier candidate exists inside frag.
+  //
+  // A backtrack candidate must also land at ROOT-OBJECT depth (depth 1, i.e.
+  // directly inside the outer `{`) — not at any structural comma regardless
+  // of nesting. A comma one level deeper separates two properties WITHIN one
+  // field's own value object ("value" from "needs_confirmation", say), and
+  // that field is only complete once BOTH have arrived. Accepting a
+  // depth-2+ comma as a boundary can close that field early and hand back a
+  // FABRICATED partial answer that looks complete but silently dropped
+  // content the planner never finished writing — worse than omitting the
+  // field, because the caller has no way to tell the two apart.
   const frag = s.slice(start);
   const structural = new Array(frag.length).fill(false);
+  const depths = new Array(frag.length).fill(0);
   {
     let inStr2 = false;
     let esc2 = false;
+    let depth2 = 0;
     for (let i = 0; i < frag.length; i++) {
       const c = frag[i];
       structural[i] = !inStr2;
+      depths[i] = depth2;
       if (inStr2) {
         if (esc2) esc2 = false;
         else if (c === "\\") esc2 = true;
         else if (c === '"') inStr2 = false;
       } else if (c === '"') inStr2 = true;
+      else if (c === "{") depth2++;
+      else if (c === "}") depth2--;
     }
   }
   const lastStructuralComma = (before) => {
     for (let i = before - 1; i >= 0; i--) {
-      if (frag[i] === "," && structural[i]) return i;
+      if (frag[i] === "," && structural[i] && depths[i] === 1) return i;
     }
     return -1;
   };

--- a/web/tests/lib/extract-json-object.test.mjs
+++ b/web/tests/lib/extract-json-object.test.mjs
@@ -1,0 +1,74 @@
+// extractJsonObject salvages the largest valid prefix of a truncated LLM
+// answer (apply/prefill/route.ts). Factored into its own .mjs specifically so
+// it can be exercised directly here — no @/ alias, no Node-only deps.
+//
+// Covers the bug: the truncation-salvage path used to compute the closing
+// "pad" ONCE from the whole (broken) fragment's brace count, then reuse that
+// same pad for every backtracked candidate. An earlier field almost never
+// needs the same nesting depth as the full truncated tail, so the pad was
+// wrong for every candidate except by coincidence — the loop exhausted every
+// comma and returned null, discarding every field that DID finish along with
+// the one that didn't.
+//
+// Run:  node --test tests/lib/extract-json-object.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractJsonObject } from "../../src/lib/extract-json-object.mjs";
+
+test("a complete, well-formed object parses normally (not the truncation path)", () => {
+  const { obj, truncated } = extractJsonObject('{"a": {"value": "x", "needs_confirmation": false}}');
+  assert.deepEqual(obj, { a: { value: "x", needs_confirmation: false } });
+  assert.equal(truncated, false);
+});
+
+test("strips code fences before locating the object", () => {
+  const { obj } = extractJsonObject('```json\n{"a": {"value": "x"}}\n```');
+  assert.deepEqual(obj, { a: { value: "x" } });
+});
+
+test("the reported bug: an earlier COMPLETE field must survive a later field truncated at a DEEPER nesting level", () => {
+  // "name" is fully closed. "about_you" is a free-text field whose value text
+  // happens to mention brace-heavy content (config examples, code) and gets
+  // killed mid-string at a deeper nesting level than "name" ever reached.
+  const truncated =
+    '{"name": {"value": "Jane Doe", "needs_confirmation": false}, ' +
+    '"about_you": {"value": "I build systems using patterns like {config: {nested: true';
+  const { obj, truncated: wasTruncated } = extractJsonObject(truncated);
+  assert.notEqual(obj, null, "the complete earlier field must not be lost just because a later field was cut deeper");
+  assert.deepEqual(obj, { name: { value: "Jane Doe", needs_confirmation: false } });
+  assert.equal(wasTruncated, true);
+});
+
+test("truncation mid-way through a single field's value: the field itself is unrecoverable, returns null", () => {
+  const { obj, truncated } = extractJsonObject('{"a": {"value": "x');
+  assert.equal(obj, null);
+  assert.equal(truncated, true);
+});
+
+test("multiple recoverable fields at different nesting depths all survive", () => {
+  const truncated =
+    '{"a": {"value": "x", "needs_confirmation": false}, ' +
+    '"b": {"value": "y"}, ' +
+    '"c": {"value": {"deep": {"deeper": "z"}}}, ' +
+    '"d": {"value": "cut off mid';
+  const { obj, truncated: wasTruncated } = extractJsonObject(truncated);
+  assert.deepEqual(obj, {
+    a: { value: "x", needs_confirmation: false },
+    b: { value: "y" },
+    c: { value: { deep: { deeper: "z" } } },
+  });
+  assert.equal(wasTruncated, true);
+});
+
+test("no opening brace at all returns null, not truncated", () => {
+  const { obj, truncated } = extractJsonObject("just some prose, no JSON here");
+  assert.equal(obj, null);
+  assert.equal(truncated, false);
+});
+
+test("an unbalanced fragment with nothing recoverable before the first field returns null cleanly", () => {
+  const { obj, truncated } = extractJsonObject('{"a": {"b"');
+  assert.equal(obj, null);
+  assert.equal(truncated, true);
+});

--- a/web/tests/lib/extract-json-object.test.mjs
+++ b/web/tests/lib/extract-json-object.test.mjs
@@ -72,3 +72,33 @@ test("an unbalanced fragment with nothing recoverable before the first field ret
   assert.equal(obj, null);
   assert.equal(truncated, true);
 });
+
+test("recovery still works when substantial prose precedes the opening brace", () => {
+  // `start` (an offset into the FULL string) used to be compared directly
+  // against a frag-relative backtrack index. With enough leading prose that
+  // start alone exceeds the JSON fragment's own length, every frag-relative
+  // comma satisfied that comparison trivially, so backtracking gave up on its
+  // first attempt even though a valid earlier candidate existed.
+  const longProse = "x".repeat(200) + " Here is the answer:\n\n";
+  const truncated =
+    longProse +
+    '{"name": {"value": "Jane Doe", "needs_confirmation": false}, "about_you": {"value": "cut off mid';
+  const { obj, truncated: wasTruncated } = extractJsonObject(truncated);
+  assert.notEqual(obj, null, "leading prose must not defeat recovery of an otherwise-valid earlier field");
+  assert.deepEqual(obj, { name: { value: "Jane Doe", needs_confirmation: false } });
+  assert.equal(wasTruncated, true);
+});
+
+test("a completed field's own string value may contain a literal unmatched brace", () => {
+  // A free-text answer that mentions code/config syntax is exactly the kind
+  // of content real LLM output contains. The literal '{' inside the STRING
+  // must not be counted as a structural brace when computing the pad, or an
+  // otherwise complete, valid field becomes unparseable.
+  const truncated =
+    '{"about_you": {"value": "I use patterns like {config here", "needs_confirmation": false}, ' +
+    '"other": {"value": "cut off mid';
+  const { obj, truncated: wasTruncated } = extractJsonObject(truncated);
+  assert.notEqual(obj, null, "a literal brace inside a completed field's string value must not block recovery");
+  assert.deepEqual(obj, { about_you: { value: "I use patterns like {config here", needs_confirmation: false } });
+  assert.equal(wasTruncated, true);
+});

--- a/web/tests/lib/extract-json-object.test.mjs
+++ b/web/tests/lib/extract-json-object.test.mjs
@@ -102,3 +102,16 @@ test("a completed field's own string value may contain a literal unmatched brace
   assert.deepEqual(obj, { about_you: { value: "I use patterns like {config here", needs_confirmation: false } });
   assert.equal(wasTruncated, true);
 });
+
+test("an incomplete trailing field must be OMITTED, never fabricated from a partial nested value", () => {
+  // "b"'s own value object only has "value" so far — "needs_confirmation"
+  // never arrived. A backtrack point INSIDE "b" (the comma between its two
+  // properties) is not a field boundary; accepting it would close "b" early
+  // and hand back {"value": "x"} as if that were the planner's complete
+  // answer, when it silently dropped content mid-field. The caller has no
+  // way to distinguish that from a genuinely short but complete answer, so
+  // omitting the field entirely is the only safe outcome.
+  const { obj, truncated } = extractJsonObject('{"a":1,"b":{"value":"x","needs_confirmation":');
+  assert.deepEqual(obj, { a: 1 }, "the incomplete 'b' field must not appear at all, fabricated or otherwise");
+  assert.equal(truncated, true);
+});


### PR DESCRIPTION
`apply/prefill/route.ts`'s `extractJsonObject` is meant to survive the planner CLI getting killed mid-output on a big form — its own docstring: *"we salvage the largest valid prefix so the fields that DID finish still come through."* The truncation-salvage path didn't do that reliably.

```ts
const frag = s.slice(start);
const open = (frag.match(/{/g) || []).length;
const close = (frag.match(/}/g) || []).length;
const pad = "}".repeat(Math.max(0, open - close));   // computed ONCE, from the WHOLE fragment
for (let tryEnd = frag.length; tryEnd > 1; ) {
  const cand = frag.slice(0, tryEnd).replace(/,\s*$/, "") + pad;   // same pad, every candidate
  try {
    return { obj: JSON.parse(cand), truncated: true };
  } catch {
    const prevComma = frag.lastIndexOf(",", tryEnd - 1);
    if (prevComma <= start) break;
    tryEnd = prevComma;
  }
}
```

`pad` is computed once from the brace count of the entire (broken) fragment, then reused unchanged as the loop backtracks through earlier commas trying shorter candidates. Each candidate is a *different, shorter* JSON prefix — it needs however many `}` **it itself** is missing, not however many the full truncated tail was missing. Unless a candidate happens to need exactly the same nesting depth as the whole fragment, appending the wrong number of `}` fails to parse, so the loop exhausts every comma and returns `null` — discarding every field that DID finish along with the one that didn't.

**Verified by execution.** A form with a fully-answered `name` field followed by a free-text field (the kind likely to mention config/code, i.e. contain stray braces) that gets killed mid-string:

```
truncated = {"name": {"value": "Jane Doe", "needs_confirmation": false}, "about_you": {"value": "I build systems using patterns like {config: {nested: true

pre-fix:  extractJsonObject(truncated) -> { obj: null, truncated: true }
post-fix: extractJsonObject(truncated) -> { obj: { name: { value: "Jane Doe", needs_confirmation: false } }, truncated: true }
```

The `name` field is complete and would `JSON.parse` fine entirely on its own — it was lost purely because the global pad (sized for the broken `about_you` tail) didn't fit it.

**Why this isn't an edge case.** Free-text fields — cover letters, "tell us about a project you built," "why us" — are exactly the fields most likely to be both long (more likely to hit a truncation point) and to mention brace-containing content, and exactly the kind of field a planner drafts *last* on a form (identity fields first, free text last). So the failure mode concentrates precisely where truncation is most likely to happen, and it doesn't just lose the broken field — it loses every field that came before it too. The user gets a generic "couldn't parse the planner's answer as JSON" error and re-drafts the whole form, on forms whose planner call can run for minutes (`killMs` scales up to 300s).

## The fix

Moves the `pad` computation inside the loop, scoped to each candidate's own body:

```ts
for (let tryEnd = frag.length; tryEnd > 1; ) {
  const body = frag.slice(0, tryEnd).replace(/,\s*$/, "");
  const open = (body.match(/{/g) || []).length;
  const close = (body.match(/}/g) || []).length;
  const pad = "}".repeat(Math.max(0, open - close));
  try {
    return { obj: JSON.parse(body + pad), truncated: true };
  } catch { ... }
}
```

Also factors `extractJsonObject` out of the route into its own dependency-free `web/src/lib/extract-json-object.mjs` — same pattern as `pdf-paths.mjs`/`clean-chips.mjs`, noted in-file. It has no `@/` alias and no Node-only deps, which is what makes it importable directly by `node --test`; inline inside the route it couldn't be exercised at all, which is very likely why this went uncaught. No behavior change from the move itself, only from the pad fix.

Three-commit shape: the fix (as a new module) → the route now importing it → the tests.

## Test plan
- [x] `node test-all.mjs` — 4990 passed, 0 failed (2 pre-existing unrelated warnings: Go dashboard build skip, PII-heuristic false positive on santifer.io in untouched Go source)
- [x] `cd web && npm test` — 334 passed, 0 failed
- [x] `cd web && npm run typecheck` — clean
- [x] New tests confirm the reported repro (early complete field survives a later, deeper truncation), multiple fields at varying depths all recover, single-field truncation still correctly returns null (unrecoverable), and existing behavior (complete objects, code-fence stripping, no-JSON input) is unchanged
- [x] Confirmed the pre-fix (global-pad) implementation returns `null` on the repro — this test would have caught the regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of JSON responses during application prefilling.
  - Added recovery for incomplete or malformed JSON, including truncated responses.
  - Supports JSON wrapped in code fences and nested objects more reliably.
  - Prevents failures when valid content appears alongside incomplete or unmatched JSON structures.

- **Tests**
  - Added coverage for valid, incomplete, malformed, nested, and unrecoverable JSON inputs.
  - Expanded validation for quoted strings, leading text, and multiple recoverable fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->