### PR TITLE
fix(web): "new matches" hides an employer's entire board after one evaluation

### DIFF
--- a/web/src/app/api/whats-new/route.ts
+++ b/web/src/app/api/whats-new/route.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { careerOpsRoot, readApplications } from "@/lib/career-ops";
 import { getNormalizeTextKey } from "@/lib/core/text-key";
+import { evaluatedKeys, isEvaluated } from "@/lib/whats-new-suppression.mjs";
 import type { DiscoveredOffer } from "@/lib/explore";
 import { collectWhatsNew, resolveOfferLimit } from "@/lib/whats-new.mjs";
 
@@ -33,16 +34,17 @@ export async function GET(req: Request) {
     return Response.json({ offers: [], count: 0 });
   }
 
-  // Companies already evaluated → don't resurface as "new".
+  // Roles already evaluated → don't resurface as "new". Keyed on company AND
+  // role, not company alone: suppressing by employer removed that employer's
+  // entire board after one evaluation (#3131). See lib/whats-new-suppression.
   const normalizeTextKey = await getNormalizeTextKey();
-  const norm = (s: string) => normalizeTextKey(s, " ");
-  const evaluated = new Set(readApplications().map((a) => norm(a.company)).filter(Boolean));
+  const evaluated = evaluatedKeys(readApplications(), normalizeTextKey);
 
   const toOffer = (c: string[]): DiscoveredOffer | null => {
     const [url, firstSeen, portal, title, company, status, location] = c;
     if (!url || !/^https?:\/\//i.test(url)) return null;
     if (status && /skipped|expired/i.test(status)) return null;
-    if (company && evaluated.has(norm(company))) return null;
+    if (isEvaluated(evaluated, normalizeTextKey, company, title)) return null;
     return {
       url,
       company: (company || "").trim(),

--- a/web/src/lib/whats-new-suppression.mjs
+++ b/web/src/lib/whats-new-suppression.mjs
@@ -1,0 +1,76 @@
+// Which discovered offers count as "already evaluated" for the Explore /
+// "new matches" supply loop (api/whats-new).
+//
+// Pure JS (no TS types) so it can be imported by the route AND by a
+// `node --test` unit test, matching funnel-tiles.mjs / status-alias.mjs /
+// clean-chips.mjs — web's test script is `node --test tests/**/*.test.mjs`
+// and there is no TS runner.
+//
+// THE KEY IS COMPANY **AND** ROLE (#3131). Suppressing by employer alone meant
+// one evaluated role removed that employer's entire board from Explore,
+// permanently, including postings first seen afterwards. An employer with 20+
+// live roles went completely invisible after evaluating one of them, and the
+// scanner was working throughout — the rows were in scan-history.tsv, only the
+// view hid them. "No new matches" then reads identically to "matches exist but
+// are suppressed", which is what makes it hard to notice.
+//
+// The trade is deliberate and in the safer direction. If the tracker's role
+// text and the scan-history title drift apart ("Staff SWE" vs "Staff Software
+// Engineer"), an already-evaluated role can reappear in Explore once: a
+// VISIBLE false positive the user can dismiss. What it replaces is a silent
+// false negative — a board the user cannot see and gets no signal about.
+//
+// The normalizer is injected rather than imported, because the route resolves
+// the CORE's normalizeTextKey from the user's own checkout (lib/core/text-key)
+// so web dedup always matches CLI dedup. A second key helper here is exactly
+// the local reimplementation #2666 removed.
+
+/**
+ * Suppression key for one company/role pair.
+ *
+ * A tracker row with no role yields "company|", which matches only a scan row
+ * that also has no title — so a backfilled, role-less row (#1799) suppresses
+ * that one shape rather than the whole employer.
+ *
+ * @param {(value: unknown, separator?: string) => string} norm - Core key fn.
+ * @param {string} company
+ * @param {string} role
+ * @returns {string}
+ */
+export function suppressionKey(norm, company, role) {
+  return `${norm(company, " ")}|${norm(role, " ")}`;
+}
+
+/**
+ * Keys for every evaluated application.
+ *
+ * Rows whose company normalizes to nothing are dropped: they cannot identify
+ * an employer, and keeping them would let one blank row suppress every scan
+ * row whose company is also unkeyable.
+ *
+ * @param {{company: string, role: string}[]} applications
+ * @param {(value: unknown, separator?: string) => string} norm
+ * @returns {Set<string>}
+ */
+export function evaluatedKeys(applications, norm) {
+  const keys = new Set();
+  for (const app of applications ?? []) {
+    if (!norm(app?.company, " ")) continue;
+    keys.add(suppressionKey(norm, app?.company ?? "", app?.role ?? ""));
+  }
+  return keys;
+}
+
+/**
+ * Has this discovered offer already been evaluated?
+ *
+ * @param {Set<string>} keys - From evaluatedKeys().
+ * @param {(value: unknown, separator?: string) => string} norm
+ * @param {string} company - Scan-history company cell.
+ * @param {string} title - Scan-history title cell.
+ * @returns {boolean}
+ */
+export function isEvaluated(keys, norm, company, title) {
+  if (!company || !norm(company, " ")) return false;
+  return keys.has(suppressionKey(norm, company, title));
+}

--- a/web/tests/lib/whats-new-suppression.test.mjs
+++ b/web/tests/lib/whats-new-suppression.test.mjs
@@ -1,0 +1,91 @@
+// Suppression for the Explore "new matches" supply loop must be per ROLE, not
+// per employer (#3131).
+//
+// Keying on the company alone meant one evaluated role removed that employer's
+// entire board from Explore, permanently, including postings first seen later.
+// The scanner was working throughout — the rows were in scan-history.tsv, only
+// the view hid them — and "no new matches" reads identically to "matches exist
+// but are suppressed", which is what made it hard to notice.
+//
+// The normalizer is injected in production (the route resolves the CORE's
+// normalizeTextKey from the user's own checkout so web dedup matches CLI
+// dedup), so these tests inject the same Unicode-safe mirror the web ships as
+// its fallback. Using a toy normalizer here would test a key helper that does
+// not exist in production.
+//
+// Run:  node --test tests/lib/whats-new-suppression.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { evaluatedKeys, isEvaluated, suppressionKey } from "../../src/lib/whats-new-suppression.mjs";
+import { normalizeTextKey as norm } from "../../src/lib/core/normalize-text-key.mjs";
+
+const evaluatedAt = (...pairs) => evaluatedKeys(pairs.map(([company, role]) => ({ company, role })), norm);
+
+test("a sibling role at an evaluated employer is NOT suppressed", () => {
+  // The bug: evaluating one Google role hid every Google role forever.
+  const keys = evaluatedAt(["Google", "Staff Software Engineer"]);
+  assert.equal(isEvaluated(keys, norm, "Google", "Staff Software Engineer"), true, "the evaluated role should stay hidden");
+  assert.equal(isEvaluated(keys, norm, "Google", "Senior Product Manager"), false, "a different role at the same employer was hidden");
+  assert.equal(isEvaluated(keys, norm, "Google", "Engineering Manager, Search"), false);
+});
+
+test("the evaluated role itself is still suppressed on a repost", () => {
+  // The guard: this is what the suppression is FOR. A fix that stopped
+  // suppressing would pass the test above and break the feature.
+  const keys = evaluatedAt(["Acme", "Staff Engineer"]);
+  assert.equal(isEvaluated(keys, norm, "Acme", "Staff Engineer"), true);
+  // Same role, cosmetic differences the core key folds away: case and
+  // surrounding/interior whitespace.
+  assert.equal(isEvaluated(keys, norm, "  acme  ", "STAFF   ENGINEER"), true);
+  // NOT folded, and deliberately not asserted as such: the core key keeps
+  // punctuation as a separator, so "Acme, Inc." keys as "acme inc" and does
+  // not match "acme". That is unchanged from the company-only key this
+  // replaces — the legal-suffix question is orthogonal to #3131, and pinning
+  // it either way here would be inventing a contract this key never had.
+  assert.equal(isEvaluated(keys, norm, "Acme, Inc.", "Staff Engineer"), false);
+});
+
+test("an unrelated employer is untouched", () => {
+  const keys = evaluatedAt(["Acme", "Staff Engineer"]);
+  assert.equal(isEvaluated(keys, norm, "Globex", "Staff Engineer"), false);
+});
+
+test("a role-less tracker row suppresses only a title-less scan row", () => {
+  // Backfilled rows (#1799) carry no role. Under the old key they suppressed
+  // the whole employer; they must now suppress just their own shape.
+  const keys = evaluatedAt(["Initech", ""]);
+  assert.equal(isEvaluated(keys, norm, "Initech", ""), true);
+  assert.equal(isEvaluated(keys, norm, "Initech", "Staff Engineer"), false, "a backfilled row hid a real posting");
+});
+
+test("non-Latin companies and roles key distinctly (#2666 stays fixed)", () => {
+  // The core key preserves script; an ASCII-only key would collapse all of
+  // these to the empty string and make every pair collide.
+  const keys = evaluatedAt(["日本電産", "ソフトウェアエンジニア"], ["Škoda", "Konstrukteur"]);
+  assert.equal(isEvaluated(keys, norm, "日本電産", "ソフトウェアエンジニア"), true);
+  assert.equal(isEvaluated(keys, norm, "日本電産", "プロダクトマネージャー"), false, "a sibling role was hidden");
+  assert.equal(isEvaluated(keys, norm, "Škoda", "Konstrukteur"), true);
+  assert.equal(isEvaluated(keys, norm, "Koda", "Konstrukteur"), false, "Škoda and Koda collided");
+});
+
+test("a company that normalizes to nothing suppresses nothing", () => {
+  // Otherwise one unkeyable tracker row would hide every scan row whose
+  // company is also unkeyable — the empty-key collision from #2666, moved.
+  const keys = evaluatedKeys([{ company: "!!!", role: "Staff Engineer" }], norm);
+  assert.equal(keys.size, 0);
+  assert.equal(isEvaluated(keys, norm, "???", "Staff Engineer"), false);
+  assert.equal(isEvaluated(keys, norm, "", "Staff Engineer"), false);
+});
+
+test("the key separates the two fields", () => {
+  // "ab" + "" and "a" + "b" must not produce one key.
+  assert.notEqual(suppressionKey(norm, "ab", ""), suppressionKey(norm, "a", "b"));
+});
+
+test("missing rows and fields do not throw", () => {
+  assert.equal(evaluatedKeys(undefined, norm).size, 0);
+  assert.equal(evaluatedKeys([{}], norm).size, 0);
+  const keys = evaluatedAt(["Acme", "Staff Engineer"]);
+  assert.equal(isEvaluated(keys, norm, undefined, undefined), false);
+});


### PR DESCRIPTION
Fixes #3131. Reported by @KehanLiu, who traced it to the exact line; I commented offering to drop it if they wanted to fix it themselves.

`whats-new/route.ts` keyed suppression on the **company alone**:

```js
const evaluated = new Set(readApplications().map((a) => norm(a.company)).filter(Boolean));
...
if (company && evaluated.has(norm(company))) return null;
```

So evaluating **one** role at an employer removed that employer's entire board from Explore — permanently, including postings first seen afterwards. The reporter had an employer with 20+ live roles go completely invisible after evaluating one of them, and found the rest only by querying the ATS API directly.

The scanner is correct throughout: the roles are in `scan-history.tsv`, only the view hides them. And because the hiding is silent, *"no new matches"* is indistinguishable from *"matches exist but are suppressed"* — which is what makes it hard to notice at all.

Now keyed on **company AND role**, through the same core `normalizeTextKey` the route already resolves, so the pair stays consistent with CLI dedup and no second key helper appears.

## The trade, stated plainly

If the tracker's role text and the scan-history title drift apart (`"Staff SWE"` vs `"Staff Software Engineer"`), an already-evaluated role can reappear in Explore once — a **visible** false positive the user can dismiss. What it replaces is a **silent false negative**: a board the user cannot see and gets no signal about. That's the direction #2544 argues for.

A tracker row with no role keys as `company|`, so a backfilled row (#1799) suppresses only a scan row that also has no title, instead of the whole employer.

## Structure

The decision moved to `web/src/lib/whats-new-suppression.mjs`, because it lived inline in a TypeScript route where no `node --test` unit test can reach it — web's script is `node --test tests/**/*.test.mjs` with no TS runner. Same pattern as `funnel-tiles.mjs` / `status-alias.mjs` / `clean-chips.mjs`.

The normalizer is **injected**, not imported: the route resolves the core's `normalizeTextKey` from the user's own checkout so web dedup matches CLI dedup, and importing a key helper into this file would be exactly the local reimplementation #2666 removed. The tests inject the Unicode-safe mirror the web already ships as its fallback, rather than a toy normalizer that wouldn't exist in production.

## Verification

The decisive pair, because a "fix" that simply stopped suppressing would satisfy the headline assertion and silently break the feature:

- a sibling role at an evaluated employer must **not** be suppressed (the bug);
- the evaluated role itself must **still** be suppressed on a repost.

Also pinned: `日本電産` / `Škoda` key distinctly from a sibling role and from `Koda` (so #2666 stays fixed under the new key), and a company that normalizes to nothing suppresses nothing — otherwise one unkeyable row would hide every scan row whose company is also unkeyable, which would relocate #2666 rather than fix it.

**One assertion records a non-contract deliberately.** I first wrote `"Acme, Inc."` as matching `"acme"`; the test caught me. The core key keeps punctuation as a separator, so it keys as `"acme inc"` and does not match — unchanged from the company-only key this replaces. The legal-suffix question is orthogonal to this issue, so pinning it either way would invent a contract the key never had.

Checked for discrimination: with the key reverted to company-only, **exactly the three assertions whose answers the change alters fail**, and the five pinning unchanged behaviour pass.

`web`: 335 pass / 0 fail. `node test-all.mjs --quick`: 4988 pass / 0 fail (3 warnings pre-existing and environmental).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New match filtering now suppresses only roles that have already been evaluated, rather than hiding all roles from the same company.
  * Reposted roles and variations are handled more consistently.
  * Unrelated employers, distinct roles, and non-Latin names remain correctly visible.

* **Tests**
  * Added coverage for role-level filtering, missing information, reposts, and name collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->