### PR TITLE
fix(web): tab label spacing and report table word-breaking

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -188,14 +188,30 @@ html {
   color: var(--muted);
 }
 .report-prose hr { border: none; border-top: 1px solid var(--border); margin: 1.75rem 0; }
-.report-prose table { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin: 1rem 0; }
+/* Wide report tables (e.g. the 8-column STAR+R grid in Block F) scroll
+   horizontally instead of being squeezed until words break mid-syllable.
+   width:max-content sizes to the content; max-width keeps it inside the
+   column until it genuinely needs to scroll. */
+.report-prose table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
 .report-prose thead { border-bottom: 1px solid var(--border); }
 .report-prose th { text-align: left; font-weight: 600; color: var(--fg); padding: 0.5rem 0.75rem; vertical-align: top; }
 .report-prose td {
   padding: 0.55rem 0.75rem;
   vertical-align: top;
   border-top: 1px solid var(--border);
-  word-break: break-word;
+  /* overflow-wrap, not word-break: `word-break: break-word` makes every
+     character a soft-wrap opportunity for min-content sizing, so columns
+     collapsed and words split mid-syllable ("consisten/cy"). overflow-wrap
+     still prevents overflow from long unbreakable tokens (URLs). */
+  overflow-wrap: break-word;
 }
 .report-prose tbody tr:hover { background: color-mix(in srgb, var(--fg) 3%, transparent); }
 .report-prose img { border-radius: 0.5rem; }

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -154,7 +154,9 @@ export function PipelineView({
               key={t}
               onClick={() => setParams({ tab: t === "INBOX" ? null : t })}
               className={cn(
-                "-mb-px inline-flex items-center justify-center border-b-2 px-3 py-2 text-xs font-medium transition-colors max-sm:min-h-[44px]",
+                // gap-1, not a whitespace text node: flex containers drop
+                // whitespace-only anonymous items, which rendered "INBOX0".
+                "-mb-px inline-flex items-center justify-center gap-1 border-b-2 px-3 py-2 text-xs font-medium transition-colors max-sm:min-h-[44px]",
                 tab === t
                   ? "border-brand text-foreground"
                   : "border-transparent text-muted hover:text-foreground",


### PR DESCRIPTION
Two small rendering bugs in the web dashboard, found while using career-ops to evaluate a role.

## 1. Status tabs render as `INBOX0` / `APPLIED1`

The pipeline status tabs had no gap between label and count.

The label and count were separated by a JSX whitespace text node:

```jsx
{t} <span className="text-faint tabular-nums">{count}</span>
```

but the button is `inline-flex`, and flex containers discard whitespace-only anonymous items — so "INBOX" and "0" ended up adjacent. Replaced with an explicit `gap-1` on the button.

**Before:** `INBOX0  ALL1  EVALUATED0  APPLIED1`
**After:** `INBOX 0  ALL 1  EVALUATED 0  APPLIED 1`

## 2. Wide report tables break words mid-syllable

The 8-column STAR+R grid in Block F rendered as `Impr/ove`, `consisten/cy`, `Sched/uled`.

`.report-prose td` used `word-break: break-word`, which makes **every character** a soft-wrap opportunity when the browser computes min-content width. Combined with `table { width: 100% }`, the columns collapsed to near-zero and the text shattered.

Changed to `overflow-wrap: break-word` — per spec this still prevents overflow from long unbreakable tokens (URLs) but is *not* considered when calculating min-content intrinsic size, so columns size to whole words. The table is also now a horizontal scroll container (`display: block; width: max-content; max-width: 100%; overflow-x: auto`) so genuinely wide grids scroll instead of being squeezed — matching the pattern already used for the tracker table in `pipeline-view.tsx`.

## Testing

- `npm run typecheck` — clean
- `npm test` — 336/336 pass
- `npm run build` — succeeds
- Verified visually in the dev server: tabs render with spacing, and the STAR+R table shows whole words with the overflow columns reachable by horizontal scroll.

No behaviour changes outside these two styles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report table layouts for better readability across container sizes.
  * Added responsive stacked layouts with repeated column labels for narrow tables.
  * Improved text wrapping and handling of wide tables.
  * Fixed pipeline tab labels and counts appearing concatenated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->