### PR TITLE
fix(tests): make the suite symlink-aware for externalized user-layer dirs

### DIFF
--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -7,11 +7,11 @@
 // Assertions run against rendered HTML rather than source patterns: the reorder
 // has to survive nested markup, comments, absent optional sections and a second
 // application, and none of that is observable from the source text.
-import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { pass, fail, linkRepoPackage, ROOT, NODE } from './helpers.mjs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 
 console.log('\nCV section order from config/profile.yml (#2533)');
@@ -733,7 +733,10 @@ try {
 {
   const outputRoot = join(ROOT, 'output');
   mkdirSync(outputRoot, { recursive: true });
-  const sandbox = mkdtempSync(join(outputRoot, 'section-order-batch-'));
+  // realpathSync: see tests/generate-pdf-page-budget.test.mjs -- argv[1] keeps the
+  // caller's spelling while import.meta.url is realpathed, so a symlinked
+  // output/ makes generate-pdf.mjs's isMain guard false and the spawn a no-op (#3165).
+  const sandbox = realpathSync(mkdtempSync(join(outputRoot, 'section-order-batch-')));
   try {
     const script = join(sandbox, 'generate-pdf.mjs');
     for (const f of [
@@ -742,6 +745,12 @@ try {
     ]) {
       copyFileSync(join(ROOT, f), join(sandbox, f));
     }
+
+    // theme-style.mjs and tracker-utils.mjs both `import * as yaml from
+    // 'js-yaml'`, resolved by walking up into the repo's node_modules -- from
+    // the sandbox's REALPATH, so a checkout with a symlinked output/ never
+    // reaches it and the spawned generate-pdf dies before parsing argv (#3165).
+    linkRepoPackage(sandbox, 'js-yaml');
     mkdirSync(join(sandbox, 'data'), { recursive: true });
     writeFileSync(join(sandbox, 'data', 'pdf-index.tsv'), '', 'utf-8');
 
@@ -853,7 +862,10 @@ export const chromium = {
 {
   const outputRoot = join(ROOT, 'output');
   mkdirSync(outputRoot, { recursive: true });
-  const sandbox = mkdtempSync(join(outputRoot, 'section-order-anchor-'));
+  // realpathSync: see tests/generate-pdf-page-budget.test.mjs -- argv[1] keeps the
+  // caller's spelling while import.meta.url is realpathed, so a symlinked
+  // output/ makes generate-pdf.mjs's isMain guard false and the spawn a no-op (#3165).
+  const sandbox = realpathSync(mkdtempSync(join(outputRoot, 'section-order-anchor-')));
   try {
     const script = join(sandbox, 'generate-pdf.mjs');
     for (const f of [
@@ -862,6 +874,12 @@ export const chromium = {
     ]) {
       copyFileSync(join(ROOT, f), join(sandbox, f));
     }
+
+    // theme-style.mjs and tracker-utils.mjs both `import * as yaml from
+    // 'js-yaml'`, resolved by walking up into the repo's node_modules -- from
+    // the sandbox's REALPATH, so a checkout with a symlinked output/ never
+    // reaches it and the spawned generate-pdf dies before parsing argv (#3165).
+    linkRepoPackage(sandbox, 'js-yaml');
 
     // The external workspace: tracker, profile, CV and documents all live here,
     // and NOT beside the script. This is the shape CAREER_OPS_TRACKER creates.

--- a/tests/generate-pdf-batch.test.mjs
+++ b/tests/generate-pdf-batch.test.mjs
@@ -18,17 +18,24 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { pass, fail, linkRepoPackage, ROOT, NODE } from './helpers.mjs';
 
 const outputRoot = join(ROOT, 'output');
 mkdirSync(outputRoot, { recursive: true });
-const sandbox = mkdtempSync(join(outputRoot, 'batch-test-'));
+// realpathSync, not the raw mkdtemp path: Node resolves both `import.meta.url`
+// and a module's node_modules walk from a file's REALPATH, while
+// `process.argv[1]` keeps whatever spelling the caller used. On a checkout with
+// a symlinked output/ the two disagree, so generate-pdf.mjs's `isMain` guard is
+// false and the spawned script exits 0 having done nothing at all -- assertions
+// then fail against empty output rather than against behaviour (#3165).
+const sandbox = realpathSync(mkdtempSync(join(outputRoot, 'batch-test-')));
 const script = join(sandbox, 'generate-pdf.mjs');
 const launchesFile = join(sandbox, '.launches');
 const pageClosesFile = join(sandbox, '.pagecloses');
@@ -42,6 +49,13 @@ copyFileSync(join(ROOT, 'tracker-utils.mjs'), join(sandbox, 'tracker-utils.mjs')
 copyFileSync(join(ROOT, 'tracker-parse.mjs'), join(sandbox, 'tracker-parse.mjs'));
 copyFileSync(join(ROOT, 'tracker-aliases.json'), join(sandbox, 'tracker-aliases.json'));
 copyFileSync(join(ROOT, 'pipeline-lock.mjs'), join(sandbox, 'pipeline-lock.mjs'));
+
+// theme-style.mjs and tracker-utils.mjs both `import * as yaml from 'js-yaml'`,
+// which resolves by walking up into the repo's node_modules -- from the
+// sandbox's REALPATH, so a checkout with a symlinked output/ never reaches it
+// and every spawned generate-pdf dies before parsing argv (#3165). Link the
+// package in beside the playwright stub so the sandbox stands on its own.
+linkRepoPackage(sandbox, 'js-yaml');
 
 const playwrightStub = join(sandbox, 'node_modules', 'playwright');
 mkdirSync(playwrightStub, { recursive: true });

--- a/tests/generate-pdf-page-budget.test.mjs
+++ b/tests/generate-pdf-page-budget.test.mjs
@@ -4,18 +4,25 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from 'fs';
 import { join, relative } from 'path';
-import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { pass, fail, linkRepoPackage, ROOT, NODE } from './helpers.mjs';
 
 const outputRoot = join(ROOT, 'output');
 mkdirSync(outputRoot, { recursive: true });
-const sandbox = mkdtempSync(join(outputRoot, 'page-budget-test-'));
-const externalOutput = mkdtempSync(join(outputRoot, 'page-budget-external-'));
+// realpathSync, not the raw mkdtemp path: Node resolves both `import.meta.url`
+// and a module's node_modules walk from a file's REALPATH, while
+// `process.argv[1]` keeps whatever spelling the caller used. On a checkout with
+// a symlinked output/ the two disagree, so generate-pdf.mjs's `isMain` guard is
+// false and the spawned script exits 0 having done nothing at all -- assertions
+// then fail against empty output rather than against behaviour (#3165).
+const sandbox = realpathSync(mkdtempSync(join(outputRoot, 'page-budget-test-')));
+const externalOutput = realpathSync(mkdtempSync(join(outputRoot, 'page-budget-external-')));
 const script = join(sandbox, 'generate-pdf.mjs');
 const input = join(sandbox, 'two-pages.html');
 const defaultOverflowInput = join(sandbox, 'three-pages.html');
@@ -36,6 +43,13 @@ copyFileSync(join(ROOT, 'tracker-utils.mjs'), join(sandbox, 'tracker-utils.mjs')
 copyFileSync(join(ROOT, 'tracker-parse.mjs'), join(sandbox, 'tracker-parse.mjs'));
 copyFileSync(join(ROOT, 'tracker-aliases.json'), join(sandbox, 'tracker-aliases.json'));
 copyFileSync(join(ROOT, 'pipeline-lock.mjs'), join(sandbox, 'pipeline-lock.mjs'));
+
+// theme-style.mjs and tracker-utils.mjs both `import * as yaml from 'js-yaml'`,
+// which resolves by walking up into the repo's node_modules -- from the
+// sandbox's REALPATH, so a checkout with a symlinked output/ never reaches it
+// and every spawned generate-pdf dies before parsing argv (#3165). Link the
+// package in beside the playwright stub so the sandbox stands on its own.
+linkRepoPackage(sandbox, 'js-yaml');
 mkdirSync(playwrightStub, { recursive: true });
 writeFileSync(join(playwrightStub, 'package.json'), JSON.stringify({
   name: 'playwright',

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -2,7 +2,7 @@
 // Moved verbatim from test-all.mjs (issue #1440); no framework by design:
 // the suite must run on a fresh clone with only Node.
 import { execFileSync } from 'child_process';
-import { existsSync, readdirSync, rmSync as _rmSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync as _rmSync, symlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -326,6 +326,51 @@ export function walkFiles(dir, match, skipDirs = new Set()) {
     }
   }
   return out;
+}
+
+/**
+ * Make one of the repo's own dependencies resolvable from a sandbox Node cannot
+ * reach `ROOT/node_modules` from.
+ *
+ * The PDF sandboxes are created under `ROOT/output` and run a copy of
+ * generate-pdf.mjs, whose siblings theme-style.mjs and tracker-utils.mjs both
+ * `import * as yaml from 'js-yaml'`. That specifier resolves by walking parent
+ * directories up into `ROOT/node_modules`, and the walk starts from the
+ * importer's REALPATH, because --preserve-symlinks is off by default. On a
+ * checkout whose `output/` is symlinked out of the repo -- the layout people
+ * adopt as the manual workaround for #524 -- the walk begins outside the repo,
+ * never reaches `ROOT/node_modules`, and every spawned script dies with
+ * ERR_MODULE_NOT_FOUND before parsing a single argument. The suite then reports
+ * 20 behaviour regressions in assertions that never ran (#3165).
+ *
+ * Relocating those sandboxes to `tmpdir()` does NOT fix this: tmpdir is outside
+ * the repo too. They work today only because `ROOT/output` happens to be
+ * physically inside it, which is the assumption worth removing rather than
+ * relocating. Linking the package into the sandbox's own `node_modules` --
+ * beside the `playwright` stub each sandbox already writes there -- makes the
+ * sandbox self-sufficient wherever it physically lives.
+ *
+ * @param {string} sandboxDir - Sandbox root; its `node_modules/` is created if absent.
+ * @param {string} pkgName - Package directory name under `ROOT/node_modules`.
+ * @returns {string} Path to the package as seen from inside the sandbox.
+ */
+export function linkRepoPackage(sandboxDir, pkgName) {
+  const source = join(ROOT, 'node_modules', pkgName);
+  const dest = join(sandboxDir, 'node_modules', pkgName);
+  if (existsSync(dest)) return dest;
+  if (!existsSync(source)) {
+    throw new Error(`linkRepoPackage: ${pkgName} is not installed at ${source} -- run npm install`);
+  }
+  mkdirSync(dirname(dest), { recursive: true });
+  try {
+    // 'junction' is ignored on POSIX, and on Windows it is the one link type
+    // granted without Developer Mode or elevation -- the privilege whose absence
+    // aborted a whole suite in #2828. The copy below is the last resort.
+    symlinkSync(source, dest, 'junction');
+  } catch {
+    cpSync(source, dest, { recursive: true });
+  }
+  return dest;
 }
 
 let bashCache = null;

--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -8,10 +8,52 @@
 // article-digest.md drifted off .gitignore while remaining on the AGENTS.md list.
 // This test compares the two lists directly so they cannot diverge again.
 
-import { execFileSync } from 'child_process';
-import { readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { lstatSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, warn, ROOT } from './helpers.mjs';
+
+/**
+ * Ask git whether one path is ignored, keeping "git said no" and "git could not
+ * answer" apart.
+ *
+ * check-ignore exits 1 for a path that is simply not ignored, and 128 for a
+ * pathspec it refuses outright. The refusal that matters here is
+ * `fatal: pathspec '...' is beyond a symbolic link`, which is every probe
+ * through a user-layer directory symlinked out of the repo -- the layout people
+ * adopt as the manual workaround for #524. A bare `catch` collapses the two, so
+ * this suite reported data/, output/ and reports/ as unignored PII leaks on a
+ * checkout where they are ignored (#3165): a false negative on the one
+ * assertion in the file whose whole point is to be trustworthy.
+ *
+ * `--no-index` does not avoid it. Git will not evaluate a pathspec that crosses
+ * a symlink at all, with or without an index.
+ *
+ * @param {string} probe - Repo-relative path to test.
+ * @returns {{verdict: 'ignored'|'not-ignored'|'unanswerable', stderr: string}}
+ */
+function checkIgnore(probe) {
+  const r = spawnSync('git', ['check-ignore', '-q', '--no-index', probe], { cwd: ROOT, encoding: 'utf-8' });
+  if (r.status === 0) return { verdict: 'ignored', stderr: '' };
+  if (r.status === 1) return { verdict: 'not-ignored', stderr: '' };
+  const stderr = (r.stderr || r.error?.message || `git exited ${r.status}`).trim();
+  return { verdict: 'unanswerable', stderr };
+}
+
+/**
+ * Whether a repo-relative path is itself a symlink (not merely reached through
+ * one). lstat, so the link is described rather than followed.
+ *
+ * @param {string} rel - Repo-relative path.
+ * @returns {boolean}
+ */
+function isSymlink(rel) {
+  try {
+    return lstatSync(join(ROOT, rel)).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
 
 console.log('\n🔒 user-layer files are git-ignored');
 
@@ -33,16 +75,44 @@ if (!line) {
 
   for (const p of paths) {
     // A directory glob is satisfied by a probe file inside it; a bare filename
-    // is checked directly. check-ignore exits 1 when the path is NOT ignored.
+    // is checked directly.
+    const entry = p.endsWith('/') ? p.slice(0, -1) : p;
     const probe = p.endsWith('/') ? `${p}__gitignore_probe__.md` : p;
-    let ignored = true;
-    try {
-      execFileSync('git', ['check-ignore', '-q', '--no-index', probe], { cwd: ROOT });
-    } catch {
-      ignored = false;
+    const first = checkIgnore(probe);
+
+    if (first.verdict === 'ignored') {
+      pass(`${p} is git-ignored`);
+      continue;
     }
-    if (ignored) pass(`${p} is git-ignored`);
-    else fail(`${p} is declared user-layer in AGENTS.md but is NOT git-ignored — personal data could be committed`);
+    if (first.verdict === 'not-ignored') {
+      fail(`${p} is declared user-layer in AGENTS.md but is NOT git-ignored — personal data could be committed`);
+      continue;
+    }
+
+    // Git refused the pathspec. If the declared path is itself a symlink, the
+    // question it CAN answer is whether the link entry is ignored -- and that is
+    // the question that actually governs what `git add .` stages here, since the
+    // contents live outside the repository entirely.
+    if (!isSymlink(entry)) {
+      fail(`${p}: git check-ignore could not answer — ${first.stderr}`);
+      continue;
+    }
+
+    const link = checkIgnore(entry);
+    if (link.verdict === 'ignored') {
+      pass(`${p} is git-ignored (symlinked out of the repo; checked the link entry itself)`);
+    } else if (link.verdict === 'not-ignored') {
+      // A warning, not a failure. The leak is real but far smaller than the one
+      // the failure message above describes: staging a symlink commits its
+      // target path, not the user's CV or tracker. Failing here would just
+      // recreate the permanently-red suite this check was fixed to end, for the
+      // same people. `data/*` does not match `data`, so stock rules land here.
+      warn(`${p} is symlinked out of the repo and the link entry itself is NOT ignored — `
+        + `\`git add .\` would commit the link (its target path, not your data). `
+        + `Add a rule matching the entry itself, e.g. \`/${entry}\` alongside \`${entry}/*\`.`);
+    } else {
+      fail(`${p}: git check-ignore could not answer for the link entry either — ${link.stderr}`);
+    }
   }
 }
 
@@ -57,14 +127,10 @@ const timestampedBackupProbes = [
 ];
 
 for (const path of timestampedBackupProbes) {
-  let ignored = true;
-  try {
-    execFileSync('git', ['check-ignore', '-q', '--no-index', path], { cwd: ROOT });
-  } catch {
-    ignored = false;
-  }
-  if (ignored) pass(`${path} is git-ignored`);
-  else fail(`${path} is NOT git-ignored — a timestamped backup could expose PII`);
+  const { verdict, stderr } = checkIgnore(path);
+  if (verdict === 'ignored') pass(`${path} is git-ignored`);
+  else if (verdict === 'not-ignored') fail(`${path} is NOT git-ignored — a timestamped backup could expose PII`);
+  else fail(`${path}: git check-ignore could not answer — ${stderr}`);
 }
 
 // Not user-layer data, but the same mechanism: this one is about what a
@@ -80,12 +146,8 @@ const scratchProbes = [
 ];
 
 for (const path of scratchProbes) {
-  let ignored = true;
-  try {
-    execFileSync('git', ['check-ignore', '-q', '--no-index', path], { cwd: ROOT });
-  } catch {
-    ignored = false;
-  }
-  if (ignored) pass(`${path} is git-ignored`);
-  else fail(`${path} is NOT git-ignored — an interrupted test run leaves it stageable`);
+  const { verdict, stderr } = checkIgnore(path);
+  if (verdict === 'ignored') pass(`${path} is git-ignored`);
+  else if (verdict === 'not-ignored') fail(`${path} is NOT git-ignored — an interrupted test run leaves it stageable`);
+  else fail(`${path}: git check-ignore could not answer — ${stderr}`);
 }


### PR DESCRIPTION
Closes #3165.

On a checkout whose user-layer directories are symlinked out of the repo — the layout people adopt as the manual workaround for #524 — `test-all.mjs` reported **25 failures**, 23 of them harness artifacts rather than defects in the behaviour under assertion. They are indistinguishable from real failures in the output, so they mask genuine regressions for everyone on that layout.

**Verified both ways:**

| Layout | Before | After |
|---|---|---|
| symlinked user layer | 25 failed / 5050 passed | **2 failed / 5073 passed** |
| stock checkout (this branch, on current `main`) | — | the four affected suites all green |

The 2 that remain are #3169, a runtime bug in `generate-pdf.mjs` rather than a test artifact. Untouched here, and awaiting your call on its fix shape.

---

## 1. PDF sandboxes could not resolve `js-yaml` (20 failures)

The sandboxes are created under `ROOT/output` and run a copy of `generate-pdf.mjs`, whose siblings `theme-style.mjs` and `tracker-utils.mjs` both `import * as yaml from 'js-yaml'`. That specifier resolves by walking up into `ROOT/node_modules`, and the walk starts from the importer's **realpath**, so a symlinked `output/` puts it out of reach. Every spawned script died with `ERR_MODULE_NOT_FOUND` before parsing an argument, failing 20 assertions that never ran.

`tests/helpers.mjs` gains `linkRepoPackage()`, which links the package into the sandbox's own `node_modules` beside the `playwright` stub each sandbox already writes there. The sandbox stops depending on where it physically sits.

Worth noting, since it was my first instinct too: **relocating these to `tmpdir()` would not have worked** — tmpdir is outside the repo as well. They pass today only because `ROOT/output` happens to be physically inside it, and that assumption is the thing worth removing.

The sandbox roots are also realpathed. That is required on top of the above, not belt-and-braces: with only the package linked, the spawned `generate-pdf.mjs` imports cleanly and then **exits 0 having done nothing**, because its main-guard compares a realpathed `import.meta.url` against a lexical `argv[1]`. I filed that separately as #3170 — it affects ~40 entrypoints and deserves its own decision. Realpathing the sandbox root makes these tests agree with themselves whichever way #3170 goes, so this PR does not depend on it.

## 2. `git check-ignore` beyond a symlink was scored as "not ignored" (3 failures)

`tests/user-layer-gitignored.test.mjs` probed each declared user-layer path inside a bare `try`/`catch`. Git refuses any pathspec that crosses a symlink and exits **128, not 1**, so the catch scored "git could not answer" as "not ignored" — a false negative on the one assertion in the file whose entire purpose is to be trustworthy about PII. `--no-index` does not avoid it.

```
$ git check-ignore --no-index data/__gitignore_probe__.md
fatal: pathspec 'data/__gitignore_probe__.md' is beyond a symbolic link
$ echo $?
128
```

`checkIgnore()` now separates exit 0 / exit 1 / anything else. When the declared path is itself a symlink it probes the link entry, which is the question that actually governs what `git add .` stages once the contents live outside the repository. All three probe loops in the file shared the same bare catch, so all three are converted.

**One judgment call worth your attention.** When only the *link entry* is unignored, this `warn()`s rather than `fail()`s. Stock `data/*` does not match `data`, so a symlinked layout genuinely leaves `?? data` stageable — but staging a symlink commits its target path, not the user's CV or tracker, and failing there would hand exactly the affected users a permanently red suite over a much smaller leak. The warning names the fix (`/data` alongside `data/*`). If you would rather it be a hard failure, or would rather close the gap in `.gitignore` instead (possibly alongside #2277), both are small changes and I am happy to make either.

---

No production code is touched; this is `tests/` only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability when running in temporary and symlinked directories.
  * Enhanced dependency setup for isolated test environments.
  * Added fallback handling for environments that do not support directory junctions.
  * Improved Git ignore checks, including clearer handling of symlinks and pathspec errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->