### PR TITLE
fix(rename-sync): migrate 5 vulnerable call sites to renameSyncWithRetry

### DIFF
--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -31,10 +31,11 @@
  * Issue #1864 — github.com/santifer/career-ops
  */
 
-import { readFileSync, existsSync, writeFileSync, renameSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
+import { renameSyncWithRetry } from './tracker-utils.mjs';
 
 import { makeHttpCtx } from './providers/_http.mjs';
 import greenhouse from './providers/greenhouse.mjs';
@@ -1024,7 +1025,7 @@ async function main() {
     // mid-write can't leave the user's portals.yml truncated.
     const tmpPath = `${PORTALS_PATH}.tmp-${process.pid}`;
     writeFileSync(tmpPath, insertIntoTrackedCompanies(current, snippets), 'utf-8');
-    renameSync(tmpPath, PORTALS_PATH);
+    renameSyncWithRetry(tmpPath, PORTALS_PATH);
     written = true;
   } else if (opts.write && fresh.length && !existsSync(PORTALS_PATH)) {
     warnings.push(`--write given but portals.yml not found at ${PORTALS_PATH} — printing entries instead`);

--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -55,7 +55,7 @@
  *   CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS     stale-lock recovery threshold
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync, realpathSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, statSync, realpathSync } from 'fs';
 import { join, dirname, basename, resolve, isAbsolute, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createHash, randomUUID } from 'crypto';
@@ -68,6 +68,7 @@ import {
   isMkdirContention, isRmContention, rmLockArtifactSync, createLockWaitPolicy,
   sameLockDirectory, lockRecoveryVerdict, RECOVER_STALE,
 } from './pipeline-lock.mjs';
+import { renameSyncWithRetry } from './tracker-utils.mjs';
 import { tmpdir } from 'os';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { localToday } from './lib/local-today.mjs';
@@ -440,7 +441,7 @@ function writeFileAtomic(filePath, content) {
   const tmpPath = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
   try {
     writeFileSync(tmpPath, content);
-    renameSync(tmpPath, filePath);
+    renameSyncWithRetry(tmpPath, filePath);
   } catch (err) {
     rmSync(tmpPath, { force: true });
     throw err;

--- a/paste-reply.mjs
+++ b/paste-reply.mjs
@@ -46,6 +46,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { renameSyncWithRetry } from './tracker-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
@@ -131,7 +132,7 @@ export function appendCandidate(candidate, candidatesPath = CANDIDATES_PATH) {
   // can never leave the real candidates file truncated/corrupted.
   const tmpPath = `${candidatesPath}.tmp`;
   fs.writeFileSync(tmpPath, JSON.stringify(candidates, null, 2), 'utf-8');
-  fs.renameSync(tmpPath, candidatesPath);
+  renameSyncWithRetry(tmpPath, candidatesPath);
   return candidates.length;
 }
 

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -35,11 +35,12 @@
  *   node scan-ats-full.mjs --help               # print this usage block and exit
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, renameSync, unlinkSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, unlinkSync } from 'fs';
 import { pathToFileURL } from 'url';
 import { createHash } from 'crypto';
 import path from 'path';
 import * as yaml from 'js-yaml';
+import { renameSyncWithRetry } from './tracker-utils.mjs';
 
 import { makeHttpCtx, fetchJson } from './providers/_http.mjs';
 import { isResolverFailure, dnsPacingStats } from './providers/_dns-cache.mjs';
@@ -137,7 +138,7 @@ function writeCheckpoint(cp) {
     mkdirSync(CACHE_DIR, { recursive: true });
     const tmp = `${CHECKPOINT_PATH}.tmp`;
     writeFileSync(tmp, JSON.stringify(cp), 'utf-8');
-    renameSync(tmp, CHECKPOINT_PATH); // atomic: a crash mid-write can't corrupt the checkpoint
+    renameSyncWithRetry(tmp, CHECKPOINT_PATH); // atomic: a crash mid-write can't corrupt the checkpoint; retries Windows contention
     return true;
   } catch (err) {
     console.error(`\n⚠ checkpoint write failed (${err.message}) — sweep continues, --resume unavailable`);

--- a/tests/rename-contention-family.test.mjs
+++ b/tests/rename-contention-family.test.mjs
@@ -1,0 +1,75 @@
+// tests/rename-contention-family.test.mjs
+//
+// #3006 fixed the Windows rename-contention class (bare `renameSync` racing a
+// LIVE destination handle, answered with EPERM/EACCES/EBUSY) in
+// `writeFileAtomic`'s closing rename inside tracker-utils.mjs. #3046 is the
+// census of the other files carrying the same shape: write-tmp-then-rename
+// over a destination that already exists and can be held open by a transient
+// reader (AV scanner, Search indexer, a concurrent readFileSync).
+//
+// This is tests/rename-contention.test.mjs §4 repeated per migrated file
+// instead of pinning tracker-utils.mjs alone: renameSyncWithRetry is the only
+// code allowed to call renameSync in each of the five files below. A bare
+// call reintroduced by a future edit reopens the exact class #3006 closed —
+// which is what happened twice already to the mkdir/rm side of this same
+// family (#2777, #2984) before the derived-list test in
+// tests/lock-rm-contention.test.mjs pinned it shut.
+//
+// merge-tracker.mjs and plugin-install.mjs are deliberately NOT in this list:
+// merge-tracker.mjs's renameSync moves a freshly processed TSV into merged/,
+// a destination that does not pre-exist (mkdirSync'd immediately above, one
+// file per run); plugin-install.mjs's renameSync is already wrapped in a
+// tolerant catch with a documented in-place fallback. Neither is the
+// write-tmp-then-rename-over-a-live-file shape this test guards.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\n📝 rename contention: the #3006 fix carries to the other five vulnerable call sites (#3046)');
+
+const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
+
+// The five files #3046 classified as the vulnerable shape — write-tmp then
+// rename over a destination that already exists at write time.
+const MIGRATED_FILES = [
+  'followup-seed.mjs',
+  'scan-ats-full.mjs',
+  'discover-ats.mjs',
+  'paste-reply.mjs',
+  'update-system.mjs',
+];
+
+for (const file of MIGRATED_FILES) {
+  const src = readFileSync(join(ROOT, file), 'utf-8');
+
+  // renameSync must never be INVOKED directly in these files. It may appear
+  // in an import list (paste-reply.mjs never imports it by name at all — it
+  // called fs.renameSync) but never as a call; renameSyncWithRetry is the
+  // only permitted seam.
+  const directCalls = [
+    ...src.matchAll(/(?<![\w.])renameSync\s*\(/g),
+    ...src.matchAll(/(?<![\w])fs\.renameSync\s*\(/g),
+  ].length;
+  ok(directCalls === 0, `${file}: no direct renameSync() call remains (found ${directCalls})`);
+
+  // And the migrated write path actually routes through the shared helper —
+  // a file could pass the check above by deleting the write entirely.
+  const seamCalls = [...src.matchAll(/renameSyncWithRetry\s*\(/g)].length;
+  ok(seamCalls >= 1, `${file}: renames through renameSyncWithRetry (found ${seamCalls} call(s))`);
+
+  // The helper has to come from the one canonical definition, not a local
+  // reimplementation — that drift is exactly what #2984 cost weeks chasing.
+  // update-system.mjs must stay self-loading (#1706, see its top-of-file
+  // note): no static top-level relative import, so it pulls the helper in
+  // via a lazy `await import(...)` instead — both forms count here.
+  const importsFromTrackerUtils = new RegExp(
+    `import\\s*\\{[^}]*\\brenameSyncWithRetry\\b[^}]*\\}\\s*from\\s*['"]\\.\\/tracker-utils\\.mjs['"]`,
+  ).test(src);
+  const lazyImportsFromTrackerUtils = /await\s+import\(\s*['"]\.\/tracker-utils\.mjs['"]\s*\)/.test(src) &&
+    /renameSyncWithRetry/.test(src);
+  ok(
+    importsFromTrackerUtils || lazyImportsFromTrackerUtils,
+    `${file}: renameSyncWithRetry is imported from the canonical tracker-utils.mjs (not reimplemented)`,
+  );
+}

--- a/tests/rename-contention-family.test.mjs
+++ b/tests/rename-contention-family.test.mjs
@@ -66,8 +66,8 @@ for (const file of MIGRATED_FILES) {
   const importsFromTrackerUtils = new RegExp(
     `import\\s*\\{[^}]*\\brenameSyncWithRetry\\b[^}]*\\}\\s*from\\s*['"]\\.\\/tracker-utils\\.mjs['"]`,
   ).test(src);
-  const lazyImportsFromTrackerUtils = /await\s+import\(\s*['"]\.\/tracker-utils\.mjs['"]\s*\)/.test(src) &&
-    /renameSyncWithRetry/.test(src);
+  const lazyImportsFromTrackerUtils =
+    /(?:const|let|var)\s*\{[^}]*\brenameSyncWithRetry\b[^}]*\}\s*=\s*await\s+import\(\s*['"]\.\/tracker-utils\.mjs['"]\s*\)/.test(src);
   ok(
     importsFromTrackerUtils || lazyImportsFromTrackerUtils,
     `${file}: renameSyncWithRetry is imported from the canonical tracker-utils.mjs (not reimplemented)`,

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -20,7 +20,7 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, renameSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
 import { join, dirname, posix as pathPosix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -1459,15 +1459,20 @@ function gitShowRaw(spec) {
  * a failed update into exactly the exposure the file exists to prevent, and
  * doing it silently. Mirrors discover-ats.mjs and followup-seed.mjs.
  *
+ * Lazy-imports `renameSyncWithRetry` (see the top-of-file self-loading note —
+ * a static import of tracker-utils.mjs here would crash a pre-#1245 client's
+ * old→new re-exec the same way a static scaffolder/ import would, #1706).
+ *
  * @param {string} filePath - Absolute path to write.
  * @param {string} content - Full file content.
- * @returns {void}
+ * @returns {Promise<void>}
  */
-function writeGitignoreAtomic(filePath, content) {
+async function writeGitignoreAtomic(filePath, content) {
+  const { renameSyncWithRetry } = await import('./tracker-utils.mjs');
   const tmpPath = `${filePath}.tmp-${process.pid}`;
   try {
     writeFileSync(tmpPath, content);
-    renameSync(tmpPath, filePath);
+    renameSyncWithRetry(tmpPath, filePath);
   } catch (err) {
     // The original is still intact: the rename either happened or it did not.
     try { rmSync(tmpPath, { force: true }); } catch { /* already gone */ }
@@ -1861,13 +1866,13 @@ async function apply() {
         // already carries its own final newline; the guard is only for a blob that
         // somehow lacks one.
         const seed = upstreamGitignore.endsWith('\n') ? upstreamGitignore : `${upstreamGitignore}\n`;
-        writeGitignoreAtomic(gitignorePath, seed);
+        await writeGitignoreAtomic(gitignorePath, seed);
         trackGitignore();
         console.log('Restored .gitignore (it was missing).');
       } else {
         const { text, added } = reconcileGitignore(readFileSync(gitignorePath, 'utf-8'), upstreamGitignore);
         if (added.length > 0) {
-          writeGitignoreAtomic(gitignorePath, text);
+          await writeGitignoreAtomic(gitignorePath, text);
           trackGitignore();
           console.log(`.gitignore: appended ${added.length} missing rule(s): ${added.join(', ')}`);
         }


### PR DESCRIPTION
Closes #3046.

Same write-tmp-then-rename-over-a-live-destination shape #3006 fixed in `tracker-utils.mjs`'s `writeFileAtomic`, present in five more files. Migrated all five (import + swap the call, signature matches `renameSync`):

- `followup-seed.mjs:447` (`data/follow-ups.md`, inside its lock)
- `scan-ats-full.mjs:135` (scan checkpoint)
- `discover-ats.mjs:1027` (`portals.yml`)
- `paste-reply.mjs:134` (candidates file)
- `update-system.mjs:1302` (`.gitignore` reconciliation)

`update-system.mjs` needed extra care: it must stay self-loading (#1706) — a static top-level import of `tracker-utils.mjs` crashes a pre-#1245 client's old→new re-exec. `writeGitignoreAtomic` is now `async` and pulls `renameSyncWithRetry` in lazily via `await import(...)`; both call sites now `await` it.

Left alone, per the issue's own classification, confirmed by reading both:
- `merge-tracker.mjs:1326` — moves a freshly processed TSV into `merged/`, a destination `mkdirSync`'d immediately above and unique per run, not a live file.
- `plugin-install.mjs:66` — already wrapped in a tolerant catch with a documented in-place fallback.

Added `tests/rename-contention-family.test.mjs`, same shape as `tests/rename-contention.test.mjs` §4: no bare `renameSync` may remain in any of the five migrated files' atomic paths, the renames route through `renameSyncWithRetry`, and the helper is imported from the one canonical definition (static, or `update-system.mjs`'s lazy form) rather than reimplemented.

`test-all.mjs`: 4309/20 failing → 4324/5 failing. Confirmed via `git stash` against the same baseline that the remaining 5 are pre-existing/environment (`node:sqlite` unavailable on this Node 20 runtime, plus two unrelated coverage-gap failures) — none touch rename paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when replacing files during concurrent or temporarily locked filesystem operations.
  * Preserved atomic updates for portal files, checkpoints, candidate data, and configuration files.

* **Tests**
  * Added regression coverage to verify retry-enabled file replacement across key workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->