### PR TITLE
fix(generate-pdf): derive workspace root before canonicalizing the tracker (#3169)

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -40,11 +40,16 @@ import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFile
 import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
 import { readStyleTokens, injectThemeStyle, readCvSectionOrder } from './theme-style.mjs';
-import { resolvePdfIndexPath, resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
+import { resolvePdfIndexPath, resolveTrackerPath, resolveWorkspaceRootFor } from './tracker-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const trackerPath = resolveTrackerPath(__dirname);
-const workspaceRoot = resolveWorkspaceRoot(trackerPath);
+// Derive from the uncanonicalized tracker path so a symlinked data/ (#524) does
+// not realpath the workspace out of the repo, which silently disabled the CV
+// section-order guard (#2533) and dynamic theming (#1837) by reading cv.md and
+// config/profile.yml from the wrong root (#3169). An external CAREER_OPS_TRACKER
+// workspace still moves the whole set together (#2471).
+const workspaceRoot = resolveWorkspaceRootFor(__dirname);
 const PDF_PAGE_MARGIN = '0.6in';
 
 // Canonical tracker workspace: realpath so a symlinked ancestor (e.g. macOS

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -41,12 +41,17 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { readStyleTokens, injectThemeStyle, readCvSectionOrder } from './theme-style.mjs';
-import { resolvePdfIndexPath, resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
+import { resolvePdfIndexPath, resolveTrackerPath, resolveWorkspaceRootFor } from './tracker-utils.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const trackerPath = resolveTrackerPath(getCareerOpsRoot());
-const workspaceRoot = resolveWorkspaceRoot(trackerPath);
+// Derive the workspace root from the uncanonicalized tracker path (#3169): a
+// repo that symlinks only its data/ out (the #524 workaround) must still resolve
+// cv.md, config/ and output/ inside the repo, not follow data/ to the symlink
+// target. resolveWorkspaceRootFor canonicalizes the derived root itself, so the
+// spelling the rest of the module compares against stays canonical as before.
+const workspaceRoot = resolveWorkspaceRootFor(getCareerOpsRoot());
 const PDF_PAGE_MARGIN = '0.6in';
 
 // Canonical tracker workspace: realpath so a symlinked ancestor (e.g. macOS
@@ -69,8 +74,12 @@ function refreshRootCache() {
   if (__rootCache.key !== key) {
     // Always re-derive: falling back to the import-time const when the variable
     // is unset would hand back the very value the poisoned import froze.
-    const root = resolveWorkspaceRoot(resolveTrackerPath(__dirname));
-    __rootCache = { key, root, canonical: realpathSync(root) };
+    // Same #3169 derivation as the import-time const. resolveWorkspaceRootFor
+    // already realpaths the derived root, so reuse it as the canonical form
+    // instead of realpathing again (a no-op on the happy path that would throw
+    // on a missing root).
+    const root = resolveWorkspaceRootFor(__dirname);
+    __rootCache = { key, root, canonical: root };
   }
   return __rootCache;
 }

--- a/path-resolver.mjs
+++ b/path-resolver.mjs
@@ -57,13 +57,26 @@ export function canonicalizeTrackerPath(path) {
  * @returns {string} Canonical absolute path to the tracker file
  */
 export function resolveTrackerPath(rootDir) {
+  return canonicalizeTrackerPath(rawTrackerPath(rootDir));
+}
+
+/**
+ * The tracker path before canonicalization: the lexical location, with no
+ * symlink along the path resolved. resolveTrackerPath() realpaths this for the
+ * lock key, but workspace derivation uses the raw form instead (see
+ * resolveWorkspaceRootFor) so a symlinked `data/` does not realpath the
+ * workspace out of the repo (#3169).
+ *
+ * @param {string} rootDir The career-ops data root directory
+ * @returns {string} Uncanonicalized tracker path
+ */
+export function rawTrackerPath(rootDir) {
   const env = process.env.CAREER_OPS_TRACKER?.trim();
-  const raw = env
+  return env
     ? env
     : existsSync(join(rootDir, 'data/applications.md'))
       ? join(rootDir, 'data/applications.md')
       : join(rootDir, 'applications.md');
-  return canonicalizeTrackerPath(raw);
 }
 
 /**

--- a/tests/tracker-utils.test.mjs
+++ b/tests/tracker-utils.test.mjs
@@ -8,7 +8,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -19,6 +19,7 @@ import {
   cell,
   resolveTrackerPath,
   resolveWorkspaceRoot,
+  resolveWorkspaceRootFor,
   resolvePdfIndexPath,
   loadCanonicalStates,
   foldStatusInput,
@@ -66,6 +67,42 @@ test('tracker paths follow the workspace selected by the tracker', () => {
     if (oldPdfIndex === undefined) delete process.env.CAREER_OPS_PDF_INDEX;
     else process.env.CAREER_OPS_PDF_INDEX = oldPdfIndex;
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveWorkspaceRootFor keeps a symlinked data/ inside the repo (#3169)', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'career-ops-symlinked-data-'));
+  const repo = join(parent, 'repo');
+  const external = join(parent, 'external');
+  const oldTracker = process.env.CAREER_OPS_TRACKER;
+  try {
+    delete process.env.CAREER_OPS_TRACKER;
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(join(external, 'data'), { recursive: true });
+    writeFileSync(join(external, 'data', 'applications.md'), '# tracker\n');
+    // The natural #524 workaround: symlink only data/ out of the repo.
+    symlinkSync(join('..', 'external', 'data'), join(repo, 'data'));
+
+    const canonicalRepo = realpathSync(repo);
+    const canonicalExternal = realpathSync(external);
+
+    // Deriving from the canonical tracker path realpaths through the symlink and
+    // lands outside the repo — the #3169 bug.
+    assert.equal(realpathSync(resolveWorkspaceRoot(resolveTrackerPath(repo))), canonicalExternal);
+
+    // resolveWorkspaceRootFor derives from the uncanonicalized path and stays in
+    // the repo, where cv.md and config/ actually live.
+    assert.equal(realpathSync(resolveWorkspaceRootFor(repo)), canonicalRepo);
+    assert.notEqual(realpathSync(resolveWorkspaceRootFor(repo)), canonicalExternal);
+
+    // #2471: an explicitly external CAREER_OPS_TRACKER still moves the whole set
+    // together, so the workspace follows the env var out of the repo.
+    process.env.CAREER_OPS_TRACKER = join(external, 'data', 'applications.md');
+    assert.equal(realpathSync(resolveWorkspaceRootFor(repo)), canonicalExternal);
+  } finally {
+    if (oldTracker === undefined) delete process.env.CAREER_OPS_TRACKER;
+    else process.env.CAREER_OPS_TRACKER = oldTracker;
+    rmSync(parent, { recursive: true, force: true });
   }
 });
 

--- a/tests/tracker-utils.test.mjs
+++ b/tests/tracker-utils.test.mjs
@@ -8,7 +8,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -19,6 +19,7 @@ import {
   cell,
   resolveTrackerPath,
   resolveWorkspaceRoot,
+  resolveWorkspaceRootFor,
   resolvePdfIndexPath,
   loadCanonicalStates,
   foldStatusInput,
@@ -100,4 +101,46 @@ test('status input resolves through the canonical states file', () => {
   assert.equal(resolveCanonicalState('**aplicado**', states), 'Applied');
   assert.equal(resolveCanonicalState('TEKLİF', states), 'Offer');
   assert.equal(resolveCanonicalState('not-a-state', states), null);
+});
+
+test('resolveWorkspaceRootFor keeps a symlinked data/ inside the repo (#3169)', () => {
+  const parent = mkdtempSync(join(tmpdir(), 'career-ops-symlinked-data-'));
+  const repo = join(parent, 'repo');
+  const external = join(parent, 'external');
+  const oldTracker = process.env.CAREER_OPS_TRACKER;
+  try {
+    delete process.env.CAREER_OPS_TRACKER;
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(join(external, 'data'), { recursive: true });
+    writeFileSync(join(external, 'data', 'applications.md'), '# tracker\n');
+    // The natural #524 workaround: symlink only data/ out of the repo.
+    symlinkSync(join('..', 'external', 'data'), join(repo, 'data'));
+
+    const canonicalRepo = realpathSync(repo);
+    const canonicalExternal = realpathSync(external);
+
+    // Deriving from the canonical tracker path realpaths through the symlink and
+    // lands outside the repo: the #3169 bug.
+    assert.equal(realpathSync(resolveWorkspaceRoot(resolveTrackerPath(repo))), canonicalExternal);
+
+    // resolveWorkspaceRootFor derives from the uncanonicalized path and stays in
+    // the repo, where cv.md and config/ actually live.
+    assert.equal(realpathSync(resolveWorkspaceRootFor(repo)), canonicalRepo);
+    assert.notEqual(realpathSync(resolveWorkspaceRootFor(repo)), canonicalExternal);
+
+    // The derived root is already canonical, so a consumer's realpathSync stays a
+    // no-op and lexical containment checks keep agreeing, even though mkdtemp sits
+    // under a symlinked ancestor on macOS (/var -> /private/var). Guards #3191.
+    const derived = resolveWorkspaceRootFor(repo);
+    assert.equal(derived, realpathSync(derived));
+
+    // #2471: an explicitly external CAREER_OPS_TRACKER still moves the whole set
+    // together, so the workspace follows the env var out of the repo.
+    process.env.CAREER_OPS_TRACKER = join(external, 'data', 'applications.md');
+    assert.equal(realpathSync(resolveWorkspaceRootFor(repo)), canonicalExternal);
+  } finally {
+    if (oldTracker === undefined) delete process.env.CAREER_OPS_TRACKER;
+    else process.env.CAREER_OPS_TRACKER = oldTracker;
+    rmSync(parent, { recursive: true, force: true });
+  }
 });

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -107,12 +107,25 @@ export function cell(v) {
  * @returns {string} Absolute canonical tracker path.
  */
 export function resolveTrackerPath(rootDir) {
-  const raw = process.env.CAREER_OPS_TRACKER
+  return canonicalizeTrackerPath(rawTrackerPath(rootDir));
+}
+
+/**
+ * The tracker path before canonicalization: the lexical location, with no
+ * symlink along the path resolved. resolveTrackerPath() realpaths this for the
+ * lock key; workspace derivation uses the raw form instead (see
+ * resolveWorkspaceRootFor) so a symlinked `data/` does not realpath the
+ * workspace out of the repo (#3169).
+ *
+ * @param {string} rootDir - The career-ops repository root.
+ * @returns {string} Uncanonicalized tracker path.
+ */
+function rawTrackerPath(rootDir) {
+  return process.env.CAREER_OPS_TRACKER
     ? process.env.CAREER_OPS_TRACKER
     : existsSync(join(rootDir, 'data/applications.md'))
       ? join(rootDir, 'data/applications.md')
       : join(rootDir, 'applications.md');
-  return canonicalizeTrackerPath(raw);
 }
 
 /**
@@ -133,6 +146,28 @@ export function resolveTrackerPath(rootDir) {
 export function resolveWorkspaceRoot(trackerPath) {
   const trackerDir = dirname(trackerPath);
   return basename(trackerDir) === 'data' ? dirname(trackerDir) : trackerDir;
+}
+
+/**
+ * Workspace root for a script started from `rootDir`, derived from the
+ * *uncanonicalized* tracker path. Unlike
+ * `resolveWorkspaceRoot(resolveTrackerPath(rootDir))`, this does not realpath the
+ * tracker first, so a workspace that only symlinks its `data/` directory (the
+ * natural workaround for #524) still resolves to the repo rather than the
+ * symlink's target (#3169). Pointing `CAREER_OPS_TRACKER` at a genuinely external
+ * workspace keeps moving the whole set together (#2471), since the raw path is
+ * then the external tracker itself.
+ *
+ * Use this for a workspace's own files — cv.md, config/, output — that live
+ * beside the tracker in the repo. For `data/` siblings that must follow the
+ * symlink (e.g. pdf-index.tsv), keep using resolveWorkspaceRoot() on the
+ * canonical tracker path.
+ *
+ * @param {string} rootDir - The career-ops repository root.
+ * @returns {string} Absolute workspace root directory.
+ */
+export function resolveWorkspaceRootFor(rootDir) {
+  return resolveWorkspaceRoot(resolve(rawTrackerPath(rootDir)));
 }
 
 /**

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -165,6 +165,33 @@ export function resolveWorkspaceRoot(trackerPath) {
 }
 
 /**
+ * Workspace root for a script started from `rootDir`, derived from the
+ * *uncanonicalized* tracker path. Unlike `resolveWorkspaceRoot(resolveTrackerPath(rootDir))`,
+ * this does not realpath the tracker first, so a workspace that only symlinks its
+ * `data/` directory (the natural workaround for #524) still resolves to the repo
+ * rather than the symlink's target (#3169). Pointing `CAREER_OPS_TRACKER` at a
+ * genuinely external workspace keeps moving the whole set together (#2471), since
+ * the raw path is then the external tracker itself.
+ *
+ * The derived ROOT is canonicalized (not the tracker) so it agrees with the
+ * realpathed cwd and the paths the containment checks compare against; a
+ * symlinked ancestor (e.g. /tmp -> /private/tmp) would otherwise leave this root
+ * lexical while those are canonical. Realpathing the root does not re-follow
+ * `data/` (a child of the root), so the symlinked-data fix stands.
+ *
+ * @param {string} rootDir - The career-ops data root directory.
+ * @returns {string} Absolute workspace root directory.
+ */
+export function resolveWorkspaceRootFor(rootDir) {
+  const lexicalRoot = resolveWorkspaceRoot(resolve(rawTrackerPath(rootDir)));
+  try {
+    return realpathSync(lexicalRoot);
+  } catch {
+    return lexicalRoot;
+  }
+}
+
+/**
  * Resolve the PDF manifest (`data/pdf-index.tsv`) for the workspace that owns
  * a tracker. `CAREER_OPS_PDF_INDEX` overrides it explicitly.
  *
@@ -194,7 +221,7 @@ export function resolvePdfIndexPath(trackerPath) {
  * @param {string} path - Raw tracker path from config, env, or the default.
  * @returns {string} Absolute canonical path when the file exists, else resolved path.
  */
-import { canonicalizeTrackerPath } from './path-resolver.mjs';
+import { canonicalizeTrackerPath, rawTrackerPath } from './path-resolver.mjs';
 export { canonicalizeTrackerPath };
 
 /**


### PR DESCRIPTION
Fixes #3169. Thanks @vliggio for the thorough writeup — the diagnosis and the reproduction made this easy to pin down.

## The bug

`resolveTrackerPath()` realpaths the tracker (correctly — the lock key needs one canonical spelling), and `resolveWorkspaceRoot()` then derives the workspace root lexically from that already-canonicalized path. Composed, a workspace that symlinks only its `data/` directory — the natural #524 workaround — has its root resolved through the symlink to the target's parent, outside the repo:

```
data -> ../job-data/data
trackerPath   = <external>/job-data/data/applications.md
workspaceRoot = <external>/job-data          # not the repo
```

`cv.md` and `config/profile.yml` then read from the wrong root and come back empty (the ENOENT is swallowed), so the CV section-order guard (#2533) and dynamic theming (#1837) quietly turn themselves off. The PDF still renders, just without the declared section order or the theme.

## The fix

This is @vliggio's option 1 (their stated preference): add `resolveWorkspaceRootFor(rootDir)`, which derives the workspace from the **uncanonicalized** tracker path, and use it in `generate-pdf.mjs`. The realpathed path stays exactly as-is for the lock key and for `data/` siblings like `pdf-index.tsv` (via `resolvePdfIndexPath` → `resolveWorkspaceRoot` on the canonical path), which must follow the symlink.

The #2471 property holds: an explicitly external `CAREER_OPS_TRACKER` still moves the whole set together, because the raw path is then the external tracker itself.

## Evidence

A workspace with a symlinked `data/`:

```
OLD  resolveWorkspaceRoot(resolveTrackerPath(repo)) = <tmp>/external   (escaped the repo)
NEW  resolveWorkspaceRootFor(repo)                  = <tmp>/repo       (stays in the repo)
env  CAREER_OPS_TRACKER=<ext>/data/... -> workspace = <tmp>/external   (moves together, #2471)
```

New test in `tests/tracker-utils.test.mjs` builds that symlinked layout and asserts all three: the old derivation escapes, the new one stays, and the env-var workspace still follows. The existing `pdf-index-path` test still passes, since data-path resolution is unchanged.

## Scope

I kept this to `generate-pdf.mjs`, the path in the report. `merge-tracker.mjs:87` and `outcome.mjs:206` derive a root from the tracker the same way and would drift under the same symlink — happy to extend `resolveWorkspaceRootFor` to them here or in a follow-up, whichever you prefer.

The warn-backstop (option 3) isn't included; it's a separate, always-worthwhile change and I didn't want to widen this beyond the root-cause fix. Glad to add it if you'd like it in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

* Fixed PDF workspace resolution when only `data/` is symlinked outside the repository.
* Kept `cv.md`, `config/profile.yml`, and output paths inside the repository.
* Preserved support for an explicitly external `CAREER_OPS_TRACKER`.
* Added `rawTrackerPath()` and `resolveWorkspaceRootFor()` to separate workspace derivation from tracker canonicalization.
* Added regression tests for symlinked data, canonical roots, external trackers, and PDF paths.

Touched files: `generate-pdf.mjs`, `path-resolver.mjs`, `tracker-utils.mjs`, and `tests/tracker-utils.test.mjs`.

The requested system files were not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->