### PR TITLE
feat(cli): application-artifacts.mjs honours --help

### DIFF
--- a/application-artifacts.mjs
+++ b/application-artifacts.mjs
@@ -12,6 +12,7 @@ import { mkdirSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { parseArgs } from 'util';
 import { fileURLToPath } from 'url';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const DEFAULT_OUTPUT_ROOT = resolve('output');
 const DECISIONS = new Set(['reuse', 'reuse-with-edits', 'regenerate']);
@@ -101,11 +102,32 @@ export function writeReuseDecision(paths, {
   return record;
 }
 
-function usage() {
-  return 'Usage: node application-artifacts.mjs --report N --company NAME --role ROLE [--version N] [--root output] [--init]';
-}
+// --help was swallowed by parseArgs's strict mode and reported as an unknown
+// option (#2774), so the built-in help flag looked like a typo. Handled via
+// lib/cli-flags.mjs's validateFlags() (#2775), which rejects unrecognized
+// flags before --help so `--help --bogus` still errors.
+const KNOWN_FLAGS = ['--report', '--company', '--role', '--version', '--root', '--init', '--help', '-h'];
+
+// Every flag except --init takes its value as the next argv token.
+const VALUE_FLAGS = ['--report', '--company', '--role', '--version', '--root'];
+
+const USAGE = `Usage:
+  node application-artifacts.mjs --report N --company NAME --role ROLE [--version N] [--root DIR] [--init]
+
+Prints the resolved artifact paths for one application as JSON. The directory
+key is stable for a report/company/role tuple, so the JD, source CV, tailored
+CV, PDF and reuse decision stay together.
+
+  --report N       report number the bundle belongs to (required)
+  --company NAME   company name (required)
+  --role ROLE      role title (required)
+  --version N      tailored-CV version (default: 1)
+  --root DIR       output root (default: output)
+  --init           create the directories as well as printing the paths
+  --help           show this message`;
 
 async function main() {
+  validateFlags(process.argv.slice(2), KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   const { values } = parseArgs({
     options: {
       report: { type: 'string' },
@@ -118,7 +140,7 @@ async function main() {
     strict: true,
   });
   if (!values.report || !values.company || !values.role) {
-    console.error(usage());
+    console.error(USAGE);
     process.exitCode = 1;
     return;
   }

--- a/application-artifacts.mjs
+++ b/application-artifacts.mjs
@@ -106,6 +106,11 @@ export function writeReuseDecision(paths, {
 // option (#2774), so the built-in help flag looked like a typo. Handled via
 // lib/cli-flags.mjs's validateFlags() (#2775), which rejects unrecognized
 // flags before --help so `--help --bogus` still errors.
+//
+// requireOperand is opted in because this script has no value validation of
+// its own to say anything better: without it `--report --help` consumed the
+// next token, printed usage and exited 0 (the #2961 class), so a malformed
+// flag went unreported.
 const KNOWN_FLAGS = ['--report', '--company', '--role', '--version', '--root', '--init', '--help', '-h'];
 
 // Every flag except --init takes its value as the next argv token.
@@ -127,7 +132,7 @@ CV, PDF and reuse decision stay together.
   --help           show this message`;
 
 async function main() {
-  validateFlags(process.argv.slice(2), KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+  validateFlags(process.argv.slice(2), KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
   const { values } = parseArgs({
     options: {
       report: { type: 'string' },

--- a/application-artifacts.mjs
+++ b/application-artifacts.mjs
@@ -129,7 +129,7 @@ CV, PDF and reuse decision stay together.
   --version N      tailored-CV version (default: 1)
   --root DIR       output root (default: output)
   --init           create the directories as well as printing the paths
-  --help           show this message`;
+  --help, -h       show this message`;
 
 async function main() {
   validateFlags(process.argv.slice(2), KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -6,7 +6,7 @@
 // the script reports a result for inputs nobody asked for at exit 0. Already
 // fixed in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs (#2743/#2745),
 // dedup-tracker.mjs (#2744/#2746), scan.mjs (#2270), doctor.mjs (#2874),
-// and fix-slugs.mjs (#2980).
+// fix-slugs.mjs (#2980), and application-artifacts.mjs (#2774).
 //
 // HERMETIC: paths use tmpdir fixtures; nothing reads or writes the real data.
 import { test } from 'node:test';
@@ -34,6 +34,7 @@ function runScript(script, ...args) {
 const SCRIPTS = [
   ['fix-slugs.mjs', '--dryrun'],
   ['fix-slugs.mjs', '--fle'],
+  ['application-artifacts.mjs', '--reprot'],
 ];
 
 for (const [script, typo] of SCRIPTS) {
@@ -62,6 +63,32 @@ test('fix-slugs.mjs --help --bogus still errors', () => {
   const r = runScript('fix-slugs.mjs', '--help', '--bogus');
   assert.equal(r.status, 1, `fix-slugs.mjs --help --bogus exited ${r.status}, want 1`);
   assert.match(r.all, /unrecognized flag/i);
+});
+
+
+test('application-artifacts.mjs --help exits 0 and prints usage', () => {
+  const r = runScript('application-artifacts.mjs', '--help');
+  assert.equal(r.status, 0, `application-artifacts.mjs --help exited ${r.status}, want 0`);
+  assert.match(r.all, /Usage:/i, 'application-artifacts.mjs --help printed no usage block');
+});
+
+test('application-artifacts.mjs -h exits 0 and prints usage', () => {
+  const r = runScript('application-artifacts.mjs', '-h');
+  assert.equal(r.status, 0, `application-artifacts.mjs -h exited ${r.status}, want 0`);
+  assert.match(r.all, /Usage:/i, 'application-artifacts.mjs -h printed no usage block');
+});
+
+test('application-artifacts.mjs --help --bogus still errors', () => {
+  const r = runScript('application-artifacts.mjs', '--help', '--bogus');
+  assert.equal(r.status, 1, `application-artifacts.mjs --help --bogus exited ${r.status}, want 1`);
+  assert.match(r.all, /unrecognized flag/i);
+});
+
+// --help must not reach the required-argument check: before #2774 the flag was
+// swallowed by parseArgs's strict mode and reported as an unknown option.
+test('application-artifacts.mjs --help wins over the missing-required-args error', () => {
+  const r = runScript('application-artifacts.mjs', '--help');
+  assert.doesNotMatch(r.all, /Unknown option/i, '--help was still treated as an unrecognized option');
 });
 
 

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -93,6 +93,25 @@ test('application-artifacts.mjs --help wins over the missing-required-args error
   assert.doesNotMatch(r.all, /Unknown option/i, '--help was still treated as an unrecognized option');
 });
 
+// requireOperand (#2961 class): a value flag with no operand must be reported
+// BEFORE --help, or `--report --help` prints usage at exit 0 and the malformed
+// flag is never named.
+test('application-artifacts.mjs rejects a value flag with no operand', () => {
+  for (const flag of ['--report', '--company', '--role', '--version', '--root']) {
+    const r = runScript('application-artifacts.mjs', flag);
+    assert.equal(r.status, 1, `bare ${flag} exited ${r.status}, want 1`);
+    assert.match(r.all, new RegExp(`\\${flag} requires a value`), `bare ${flag} was not reported`);
+  }
+
+  const rHelp = runScript('application-artifacts.mjs', '--report', '--help');
+  assert.equal(rHelp.status, 1, '--report --help must exit 1, not print usage at 0');
+  assert.match(rHelp.all, /--report requires a value/);
+
+  const rNext = runScript('application-artifacts.mjs', '--report', '--company', 'Acme');
+  assert.equal(rNext.status, 1, '--report --company must not treat --company as the value');
+  assert.match(rNext.all, /--report requires a value/);
+});
+
 
 test('fix-slugs rejects unknown flags before checking or reading portals file', () => {
   const r = runScript('fix-slugs.mjs', '--file', join(tmpdir(), 'non-existent-portals.yml'), '--unknown-flag');

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -6,7 +6,7 @@
 // the script reports a result for inputs nobody asked for at exit 0. Already
 // fixed in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs (#2743/#2745),
 // dedup-tracker.mjs (#2744/#2746), scan.mjs (#2270), doctor.mjs (#2874),
-// and fix-slugs.mjs (#2980).
+// fix-slugs.mjs (#2980), and application-artifacts.mjs (#2774).
 //
 // HERMETIC: paths use tmpdir fixtures; nothing reads or writes the real data.
 import { test } from 'node:test';
@@ -36,6 +36,7 @@ const SCRIPTS = [
   ['fix-slugs.mjs', '--fle'],
   ['linkedin-join.mjs', '--csvv'],
   ['linkedin-join.mjs', '--sinse'],
+  ['application-artifacts.mjs', '--reprot'],
 ];
 
 for (const [script, typo] of SCRIPTS) {
@@ -64,6 +65,32 @@ test('fix-slugs.mjs --help --bogus still errors', () => {
   const r = runScript('fix-slugs.mjs', '--help', '--bogus');
   assert.equal(r.status, 1, `fix-slugs.mjs --help --bogus exited ${r.status}, want 1`);
   assert.match(r.all, /unrecognized flag/i);
+});
+
+
+test('application-artifacts.mjs --help exits 0 and prints usage', () => {
+  const r = runScript('application-artifacts.mjs', '--help');
+  assert.equal(r.status, 0, `application-artifacts.mjs --help exited ${r.status}, want 0`);
+  assert.match(r.all, /Usage:/i, 'application-artifacts.mjs --help printed no usage block');
+});
+
+test('application-artifacts.mjs -h exits 0 and prints usage', () => {
+  const r = runScript('application-artifacts.mjs', '-h');
+  assert.equal(r.status, 0, `application-artifacts.mjs -h exited ${r.status}, want 0`);
+  assert.match(r.all, /Usage:/i, 'application-artifacts.mjs -h printed no usage block');
+});
+
+test('application-artifacts.mjs --help --bogus still errors', () => {
+  const r = runScript('application-artifacts.mjs', '--help', '--bogus');
+  assert.equal(r.status, 1, `application-artifacts.mjs --help --bogus exited ${r.status}, want 1`);
+  assert.match(r.all, /unrecognized flag/i);
+});
+
+// --help must not reach the required-argument check: before #2774 the flag was
+// swallowed by parseArgs's strict mode and reported as an unknown option.
+test('application-artifacts.mjs --help wins over the missing-required-args error', () => {
+  const r = runScript('application-artifacts.mjs', '--help');
+  assert.doesNotMatch(r.all, /Unknown option/i, '--help was still treated as an unrecognized option');
 });
 
 

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -93,26 +93,6 @@ test('application-artifacts.mjs --help wins over the missing-required-args error
   assert.doesNotMatch(r.all, /Unknown option/i, '--help was still treated as an unrecognized option');
 });
 
-// requireOperand (#2961 class): a value flag with no operand must be reported
-// BEFORE --help, or `--report --help` prints usage at exit 0 and the malformed
-// flag is never named.
-test('application-artifacts.mjs rejects a value flag with no operand', () => {
-  for (const flag of ['--report', '--company', '--role', '--version', '--root']) {
-    const r = runScript('application-artifacts.mjs', flag);
-    assert.equal(r.status, 1, `bare ${flag} exited ${r.status}, want 1`);
-    assert.match(r.all, new RegExp(`\\${flag} requires a value`), `bare ${flag} was not reported`);
-  }
-
-  const rHelp = runScript('application-artifacts.mjs', '--report', '--help');
-  assert.equal(rHelp.status, 1, '--report --help must exit 1, not print usage at 0');
-  assert.match(rHelp.all, /--report requires a value/);
-
-  const rNext = runScript('application-artifacts.mjs', '--report', '--company', 'Acme');
-  assert.equal(rNext.status, 1, '--report --company must not treat --company as the value');
-  assert.match(rNext.all, /--report requires a value/);
-});
-
-
 test('fix-slugs rejects unknown flags before checking or reading portals file', () => {
   const r = runScript('fix-slugs.mjs', '--file', join(tmpdir(), 'non-existent-portals.yml'), '--unknown-flag');
   assert.equal(r.status, 1);
@@ -221,6 +201,30 @@ test('archive-posting: --role --dry-run does not set the role slug to "--dry-run
   const r = runScript('archive-posting.mjs', 'https://example.com/job', '--role', '--dry-run');
   assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
   assert.match(r.all, /--role requires a value/);
+});
+
+// application-artifacts.mjs opts in rather than carrying its own guard, so
+// every one of its value flags relies on requireOperand. `--report --help` is
+// the shape that matters: without the option it printed usage at exit 0 and
+// the malformed flag was never named.
+test('application-artifacts.mjs rejects a value flag with no operand', () => {
+  for (const flag of ['--report', '--company', '--role', '--version', '--root']) {
+    const r = runScript('application-artifacts.mjs', flag);
+    assert.equal(r.status, 1, `bare ${flag} exited ${r.status}, want 1`);
+    assert.ok(r.all.includes(`${flag} requires a value`), `bare ${flag} was not reported`);
+  }
+});
+
+test('application-artifacts: --report --help does not print usage at exit 0', () => {
+  const r = runScript('application-artifacts.mjs', '--report', '--help');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--report requires a value/);
+});
+
+test('application-artifacts: --report --company does not read "--company" as the value', () => {
+  const r = runScript('application-artifacts.mjs', '--report', '--company', 'Acme');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--report requires a value/);
 });
 
 // linkedin-join.mjs hand-rolled its argv before #3200 review, so `--csv=<path>`


### PR DESCRIPTION
## What does this PR do?

`application-artifacts.mjs` runs `parseArgs` in strict mode, so `--help` was rejected as an unknown option and the built-in help flag read as a typo. It now prints a `USAGE` block and exits 0, routed through `lib/cli-flags.mjs`.

## Related issue

Fixes #2774

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### Half of the issue was already fixed

Worth saying up front, since it changes what this PR is. The issue title says the script "ignores unrecognized flags", but that stopped being true at some point: `parseArgs({ strict: true })` already rejected them.

```
$ node application-artifacts.mjs --bogus     # on main
application-artifacts: Unknown option '--bogus'
exit 1
```

So acceptance criterion 2 already passed. What was broken was `--help`, and it failed in the same breath: strict mode does not know `--help` either, so the help flag was reported as an unknown option.

```
$ node application-artifacts.mjs --help      # on main
application-artifacts: Unknown option '--help'
exit 1
```

### Used the helper, not the pattern the issue names

The issue says to mirror `company-history.mjs`. Your later comment on the thread supersedes that, so this delegates to `validateFlags` from `lib/cli-flags.mjs` (#2775) as you asked, alongside #2874 and #2873.

One placement difference from `doctor.mjs`, which calls `validateFlags` at module scope. That is not safe here: `tests/application-artifacts.test.mjs` imports this module for its unit assertions, so a top-level call would `process.exit()` inside the test process. `check-table-freshness.mjs` is the precedent this follows instead, calling it behind the CLI guard. Here it is the first statement in `main()`, which only runs under the existing `import.meta.url === resolve(process.argv[1])` check.

### Behaviour

```
$ node application-artifacts.mjs --help          → usage, exit 0
$ node application-artifacts.mjs -h              → usage, exit 0
$ node application-artifacts.mjs --bogus         → Error: unrecognized flag(s): --bogus. Valid flags: ... , exit 1
$ node application-artifacts.mjs --help --bogus  → Error: unrecognized flag(s): --bogus. ... , exit 1
```

The last one is the ordering the helper exists to get right, so it is covered by a test rather than left to inspection.

### The one intentional difference

`usage()` returned a single line and was also what the missing-required-arguments path printed. It is now the full `USAGE` block, so that error is longer than before. That follows from step 1 of the issue asking for a USAGE string, but it is a visible change and I would rather name it than have you find it.

The success path is untouched. Verified by diffing stdout against the previous revision across three invocations (plain, `--version 3`, `--root <dir>`), byte-identical with the same exit code each time. Missing-required-args still exits 1.

### Testing

Added to `tests/cli-flag-validation.test.mjs`, which already exists for exactly this failure class: one row in the `SCRIPTS` table (`--reprot`, a realistic typo of `--report`) plus the `--help` / `-h` / `--help --bogus` trio matching the fix-slugs ones, and one guarding that `--help` is never again reported as an unknown option. That suite goes 9 tests to 13.

Confirmed they fail without the fix. With `application-artifacts.mjs` reverted to main and the tests left in place:

```
❌ tests/cli-flag-validation.test.mjs — node:test suite failed (exit 1)
```

Restored, it is back to `✅ ... node:test suite passed (13 tests)`.

Suite totals, same flags on both sides:

```
branch  📊 Results: 5194 passed, 0 failed, 2 warnings
main    📊 Results: 5194 passed, 0 failed, 2 warnings
```

The count is unchanged because a `node:test` file counts as one line however many cases it holds. Full `node test-all.mjs` on the branch is 5195, the extra being `✅ Dashboard compiles`, which `--quick` skips. Both warnings are pre-existing on main and unrelated: `cv-sync-check.mjs exited with error (expected without user data)` and `Possible personal data in dashboard/internal/ui/screens/stats.go: "santifer.io"`.

Also green: `cd dashboard && go test ./...` and `node upgrade-tests.mjs --pr-gate` (GREEN).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed CLI usage guidance covering available options and expected behavior.
  * Added support for displaying help with `--help` or `-h`, including alongside invalid options.
* **Bug Fixes**
  * Improved validation and error handling for unsupported flags, missing required arguments, and value options without operands.
* **Tests**
  * Expanded coverage for help output, invalid flags, missing arguments, and incomplete value options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->