### PR TITLE
fix(followup-cadence): validate CLI flags via the shared helper

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -36,7 +36,17 @@ const overdueOnly = args.includes('--overdue-only');
 // can't see the `=` form and used to silently discard it, falling back to the
 // default cadence for a value the caller did supply (#2401/#2402 defect class).
 const appliedDaysRaw = flagValue(args, '--applied-days');
-const appliedDaysOverride = appliedDaysRaw !== undefined ? parseInt(appliedDaysRaw, 10) : null;
+
+// Whole-string match, not a bare parseInt: parseInt('1.5', 10) is 1 and
+// parseInt('10days', 10) is 10 — both truncate a bad value into a plausible
+// one instead of rejecting it, which is the exact silent-wrong-answer shape
+// this file is being fixed to close. Exported so a value's actual numeric
+// effect can be asserted directly, rather than only "the CLI didn't error".
+const APPLIED_DAYS_RE = /^\d+$/;
+export function parseAppliedDaysOverride(raw) {
+  return raw !== undefined && APPLIED_DAYS_RE.test(raw) ? parseInt(raw, 10) : null;
+}
+const appliedDaysOverride = parseAppliedDaysOverride(appliedDaysRaw);
 
 // --- Cadence config ---
 export const DEFAULT_CADENCE = {

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -18,6 +18,7 @@ import * as yaml from 'js-yaml';
 import { loadCanonicalStates, foldStatusInput } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -31,8 +32,11 @@ const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(CAREER_OPS, 'config/
 const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const overdueOnly = args.includes('--overdue-only');
-const appliedDaysIdx = args.indexOf('--applied-days');
-const appliedDaysOverride = appliedDaysIdx !== -1 ? parseInt(args[appliedDaysIdx + 1], 10) : null;
+// flagValue (not indexOf) so `--applied-days=10` is honored too — indexOf()
+// can't see the `=` form and used to silently discard it, falling back to the
+// default cadence for a value the caller did supply (#2401/#2402 defect class).
+const appliedDaysRaw = flagValue(args, '--applied-days');
+const appliedDaysOverride = appliedDaysRaw !== undefined ? parseInt(appliedDaysRaw, 10) : null;
 
 // --- Cadence config ---
 export const DEFAULT_CADENCE = {
@@ -923,6 +927,7 @@ function printSummary(result) {
 // ── CLI flags + help ────────────────────────────────────────────────
 
 const KNOWN_FLAGS = ['--summary', '--overdue-only', '--applied-days', '--help', '-h'];
+const VALUE_FLAGS = ['--applied-days'];
 
 const USAGE = `Usage:
   node followup-cadence.mjs                    # full JSON analysis to stdout
@@ -933,17 +938,29 @@ const USAGE = `Usage:
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-  } else {
-    const result = analyze();
+  // Must run inside this guard, not at module top level: CADENCE (above) is a
+  // module-level singleton built at import time, and test-all.mjs section 12
+  // dynamic-imports this module in-process to read it — validating the host
+  // process's own argv there would false-positive on the test runner's flags.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
 
-    if (summaryMode) {
-      printSummary(result);
-    } else {
-      console.log(JSON.stringify(result, null, 2));
-    }
-
-    if (result.error) process.exit(1);
+  // positiveInteger() (used to build CADENCE above) treats a NaN/negative value
+  // as "absent" and silently keeps the default — exactly the wrong-answer-at-
+  // exit-0 shape this fix exists to close. A value that was actually SUPPLIED
+  // must fail loudly instead of being swallowed the same way a bad flag NAME
+  // used to be.
+  if (appliedDaysRaw !== undefined && !(Number.isFinite(appliedDaysOverride) && appliedDaysOverride >= 0)) {
+    console.error(`Error: --applied-days requires a non-negative integer, got "${appliedDaysRaw}"`);
+    process.exit(1);
   }
+
+  const result = analyze();
+
+  if (summaryMode) {
+    printSummary(result);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+
+  if (result.error) process.exit(1);
 }

--- a/followup-cadence.test.mjs
+++ b/followup-cadence.test.mjs
@@ -35,6 +35,7 @@ const {
   normalizeStatus,
   resolveCadenceConfig,
   loadProfileCadence,
+  parseAppliedDaysOverride,
 } = await import('./followup-cadence.mjs');
 
 let passed = 0;
@@ -217,6 +218,34 @@ eq(
   'the pinned default profile resolves to DEFAULT_CADENCE',
   resolveCadenceConfig({ profilePath: DEFAULT_CADENCE_PROFILE, appliedDays: null }),
   DEFAULT_CADENCE,
+);
+
+// --- parseAppliedDaysOverride (--applied-days value validation) ---
+//
+// A whole-string match, not a bare parseInt: parseInt truncates '1.5' to 1
+// and '10days' to 10 instead of rejecting them, which would silently apply a
+// value the caller never actually supplied — the same wrong-answer-at-exit-0
+// shape #3196 fixed for the flag NAME.
+eq("parseAppliedDaysOverride('10') is 10", parseAppliedDaysOverride('10'), 10);
+eq("parseAppliedDaysOverride('0') is 0", parseAppliedDaysOverride('0'), 0);
+eq("parseAppliedDaysOverride('1.5') is rejected, not truncated to 1", parseAppliedDaysOverride('1.5'), null);
+eq("parseAppliedDaysOverride('10days') is rejected, not truncated to 10", parseAppliedDaysOverride('10days'), null);
+eq("parseAppliedDaysOverride('-5') is rejected (no negative window)", parseAppliedDaysOverride('-5'), null);
+eq("parseAppliedDaysOverride('abc') is rejected", parseAppliedDaysOverride('abc'), null);
+eq('parseAppliedDaysOverride(undefined) is null (flag absent)', parseAppliedDaysOverride(undefined), null);
+
+// End-to-end: the parsed override actually reaches the effective cadence,
+// not just "the CLI didn't error" — CodeRabbit's review on #3199 flagged that
+// a passing flag-validation test alone doesn't prove the value took effect.
+eq(
+  "resolveCadenceConfig honors parseAppliedDaysOverride('10') as applied_first",
+  resolveCadenceConfig({ profilePath: DEFAULT_CADENCE_PROFILE, appliedDays: parseAppliedDaysOverride('10') }).applied_first,
+  10,
+);
+eq(
+  'resolveCadenceConfig falls back to the default when the override is rejected',
+  resolveCadenceConfig({ profilePath: DEFAULT_CADENCE_PROFILE, appliedDays: parseAppliedDaysOverride('10days') }).applied_first,
+  DEFAULT_CADENCE.applied_first,
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8369,6 +8369,9 @@ try {
       // via lib/local-today.mjs (#3070), so the fixture carries that too.
       mkdirSync(join(e2eTmp, 'lib'), { recursive: true });
       copyFileSync(join(ROOT, 'lib', 'local-today.mjs'), join(e2eTmp, 'lib', 'local-today.mjs'));
+      // ...and followup-cadence now delegates flag validation to the shared
+      // lib/cli-flags.mjs helper, so the fixture carries that too.
+      copyFileSync(join(ROOT, 'lib', 'cli-flags.mjs'), join(e2eTmp, 'lib', 'cli-flags.mjs'));
       mkdirSync(join(e2eTmp, 'templates'), { recursive: true });
       copyFileSync(join(ROOT, 'templates', 'states.yml'), join(e2eTmp, 'templates', 'states.yml'));
       // 'junction' on Windows, not 'dir': a directory symlink needs

--- a/tests/followup-cadence-flags.test.mjs
+++ b/tests/followup-cadence-flags.test.mjs
@@ -1,0 +1,85 @@
+// followup-cadence.mjs must handle help and reject unknown flags before it
+// reads report inputs. A typo (or a `--applied-days=N` the old indexOf lookup
+// couldn't see) must never fall through to a plausible JSON report at exit 0.
+//
+// followup-cadence.mjs's tracker/follow-ups paths are fixed to CAREER_OPS's
+// own data/ dir (unlike funnel-velocity.mjs, there is no env override), so
+// these tests only assert on flag validation itself — everything checked here
+// happens before analyze() ever touches disk, except the one test that
+// deliberately stops short of asserting on the (machine-dependent) analysis
+// result.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, 'followup-cadence.mjs');
+
+function runCadence(...args) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  assert.equal(result.error, undefined, `followup-cadence.mjs failed to spawn: ${result.error?.message}`);
+  assert.equal(result.signal, null, `followup-cadence.mjs was killed by ${result.signal} (timeout?)`);
+  return { ...result, all: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+test('--help prints usage and exits 0', () => {
+  const result = runCadence('--help');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /node followup-cadence\.mjs/);
+  assert.match(result.stdout, /--applied-days 10/);
+});
+
+test('-h prints usage and exits 0', () => {
+  const result = runCadence('-h');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+});
+
+test('an unknown flag exits 1 and names the flag', () => {
+  const result = runCadence('--summry');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --summry/);
+  assert.match(result.stderr, /Valid flags:/);
+});
+
+test('--help plus an unknown flag still fails', () => {
+  const result = runCadence('--help', '--bogus');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --bogus/);
+  assert.doesNotMatch(result.stdout, /Usage:/);
+});
+
+test('--applied-days without a value is rejected instead of using the default', () => {
+  const result = runCadence('--applied-days');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--applied-days requires a value/);
+});
+
+test('--applied-days abc is rejected instead of silently falling back to the default', () => {
+  const result = runCadence('--applied-days', 'abc');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--applied-days requires a non-negative integer, got "abc"/);
+});
+
+test('--applied-days -5 is rejected instead of silently accepting a negative window', () => {
+  const result = runCadence('--applied-days', '-5');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--applied-days requires a non-negative integer, got "-5"/);
+});
+
+test('--applied-days=10 (equals form) reaches analysis instead of being silently discarded', () => {
+  // Whether analysis then succeeds depends on this machine's own
+  // data/applications.md (there is no path override for this script), so this
+  // only asserts the flag itself was recognized and accepted — not the result.
+  const result = runCadence('--applied-days=10');
+  assert.doesNotMatch(result.stderr, /unrecognized flag/i);
+  assert.doesNotMatch(result.stderr, /requires a value/);
+  assert.doesNotMatch(result.stderr, /requires a non-negative integer/);
+});

--- a/tests/followup-cadence-flags.test.mjs
+++ b/tests/followup-cadence-flags.test.mjs
@@ -74,6 +74,18 @@ test('--applied-days -5 is rejected instead of silently accepting a negative win
   assert.match(result.stderr, /--applied-days requires a non-negative integer, got "-5"/);
 });
 
+test('--applied-days 1.5 is rejected, not truncated to 1', () => {
+  const result = runCadence('--applied-days', '1.5');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--applied-days requires a non-negative integer, got "1\.5"/);
+});
+
+test('--applied-days 10days is rejected, not truncated to 10', () => {
+  const result = runCadence('--applied-days', '10days');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--applied-days requires a non-negative integer, got "10days"/);
+});
+
 test('--applied-days=10 (equals form) reaches analysis instead of being silently discarded', () => {
   // Whether analysis then succeeds depends on this machine's own
   // data/applications.md (there is no path override for this script), so this


### PR DESCRIPTION
Closes #3196

## Summary

`followup-cadence.mjs` declared `KNOWN_FLAGS` (`--summary`, `--overdue-only`, `--applied-days`, `--help`, `-h`) but never actually validated argv against it — a mistyped flag silently fell through to the default (full JSON) behavior at exit 0 instead of failing fast. `--applied-days` had the value-side defect too: `indexOf()` can't see `--applied-days=10`, so the equals form was silently discarded, and a non-numeric/negative value was swallowed by `positiveInteger()` into the same silent default.

Same shape already fixed in `funnel-velocity.mjs` (#3085), `upskill.mjs`, and others in the `lib/cli-flags.mjs` family (#2919/#2775).

## Reproduce (before this PR)

```
$ node followup-cadence.mjs --summry
# typo ignored; prints full JSON instead of the summary dashboard, exit 0

$ node followup-cadence.mjs --applied-days=10
# the override is silently discarded, default cadence used instead

$ node followup-cadence.mjs --applied-days abc
# NaN swallowed by positiveInteger(), silently falls back to the default
```

## Changes

- `followup-cadence.mjs`: delegate to `validateFlags`/`flagValue` from `./lib/cli-flags.mjs`, called from inside the existing CLI guard (`if (process.argv[1] && import.meta.url === ...)`) rather than at module top level — `CADENCE` is a module-level singleton built at import time, and `test-all.mjs` section 12 dynamic-imports this module in-process to read it, so validating there would false-positive on the test runner's own argv.
- Switched `--applied-days` lookup from `indexOf` to `flagValue` so both `--applied-days 10` and `--applied-days=10` work.
- A supplied-but-invalid `--applied-days` value now exits 1 with a clear message instead of silently defaulting.
- `test-all.mjs`: the section-12 e2e fixture copies `followup-cadence.mjs` plus its exact dependency list into an isolated sandbox and runs it as a real subprocess — added the new `lib/cli-flags.mjs` dependency to that copy list (same pattern as the existing `lib/local-today.mjs` line), otherwise the sandboxed run throws `ERR_MODULE_NOT_FOUND`.
- Added `tests/followup-cadence-flags.test.mjs`, mirroring `tests/funnel-velocity-flags.test.mjs`. Note: unlike `funnel-velocity.mjs`, this script's tracker path has no env-var override, so the tests assert only on flag-validation behavior (all of which happens before `analyze()` ever touches disk), not on analysis output.

## Test plan

- [x] `node test-all.mjs` — 5303 passed, 0 failed (confirmed the fixture fix resolves the one failure this change introduced before the `test-all.mjs` update)
- [x] `node --test tests/followup-cadence-flags.test.mjs` — 8/8 passed
- [x] `node scripts/check-syntax.mjs` — 522 files pass
- [x] Manually reproduced all three bugs above against `main`, confirmed each is now a clear exit 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying applied days with the `--applied-days=10` format.
  * Added clear handling for help requests and unknown command-line options.

* **Bug Fixes**
  * Invalid, negative, fractional, nonnumeric, or suffixed applied-day values are now rejected.
  * Valid non-negative integer values correctly adjust the cadence.
  * Invalid values preserve the default cadence and provide consistent error messages and exit statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->