### PR TITLE
fix(pdf): derive the workspace root at use time, not at import (#3162)

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -51,7 +51,33 @@ const PDF_PAGE_MARGIN = '0.6in';
 // /var -> /private/var) is compared like-for-like by assertInsideWorkspace.
 // When CAREER_OPS_TRACKER points at another workspace, that workspace—not the
 // installed script directory—is the safe boundary for input and output.
-const __workspaceRoot = realpathSync(workspaceRoot);
+//
+// Derived at USE time, not frozen at import (#3162, root-caused occurrence 6):
+// the root reads CAREER_OPS_TRACKER, and a sibling test that legitimately sets
+// that variable for its own fixture — and correctly restores it afterwards —
+// still poisoned this module for the whole process if the import happened to
+// land inside that window. A `const` cannot un-read an env var, so the guard
+// then compared perfectly valid repo paths against another test's temp dir and
+// refused to write, intermittently and only under the full suite. Memoized on
+// the variable's own value: same cost as the const while nothing changes, and
+// self-correcting the moment it does. Same defect class as #3159.
+let __rootCache = { key: null, root: null, canonical: null };
+function refreshRootCache() {
+  const key = process.env.CAREER_OPS_TRACKER || '';
+  if (__rootCache.key !== key) {
+    // Always re-derive: falling back to the import-time const when the variable
+    // is unset would hand back the very value the poisoned import froze.
+    const root = resolveWorkspaceRoot(resolveTrackerPath(__dirname));
+    __rootCache = { key, root, canonical: realpathSync(root) };
+  }
+  return __rootCache;
+}
+// Two accessors on purpose, so each call site keeps the exact semantics it had:
+// the containment guard compares canonical forms (a symlinked ancestor must not
+// read as an escape), while the manifest/output helpers work in the lexical form
+// the rest of the module and its callers use.
+function currentWorkspaceRoot() { return refreshRootCache().root; }
+function canonicalWorkspaceRoot() { return refreshRootCache().canonical; }
 
 /**
  * Assert that an already-resolved absolute path stays inside the tracker workspace,
@@ -93,7 +119,8 @@ function assertInsideWorkspace(absPath, label) {
       + ` (${/** @type {any} */ (err)?.code || 'realpath failed'} on ${probe}): ${absPath}`,
     );
   }
-  const rel = relative(__workspaceRoot, canonical);
+  const workspace = canonicalWorkspaceRoot();
+  const rel = relative(workspace, canonical);
   if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
     // #3162: an intermittent macOS-CI-only hit of this branch happens on paths
     // that are lexically inside the sandbox, and canonicalization SUCCEEDS
@@ -101,7 +128,7 @@ function assertInsideWorkspace(absPath, label) {
     // ancestor outright instead of asking a reader to reconstruct it.
     throw new Error(
       `${label} escapes the tracker workspace: ${absPath}`
-      + ` (workspaceRoot=${__workspaceRoot} canonical=${canonical} rel=${rel})`,
+      + ` (workspaceRoot=${workspace} canonical=${canonical} rel=${rel})`,
     );
   }
   return absPath;
@@ -930,7 +957,7 @@ function countRenderedPdfPages(pdfBuffer) {
  * @param {string} [rootDir] - Workspace root used as the manifest base.
  * @returns {string} Workspace-relative path using forward slashes, or an empty string.
  */
-export function workspaceRelativeManifestPath(pathValue, rootDir = workspaceRoot) {
+export function workspaceRelativeManifestPath(pathValue, rootDir = currentWorkspaceRoot()) {
   if (!pathValue) return '';
   const rel = relative(rootDir, resolve(pathValue));
   if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return '';
@@ -938,7 +965,7 @@ export function workspaceRelativeManifestPath(pathValue, rootDir = workspaceRoot
 }
 
 /** @deprecated Use workspaceRelativeManifestPath. */
-export function repoRelativeManifestPath(pathValue, rootDir = workspaceRoot) {
+export function repoRelativeManifestPath(pathValue, rootDir = currentWorkspaceRoot()) {
   return workspaceRelativeManifestPath(pathValue, rootDir);
 }
 
@@ -962,7 +989,7 @@ function nearestExistingPath(pathValue) {
  * Resolving the nearest existing ancestor catches output directories that are
  * symlinks to another location before Chromium writes through them.
  */
-export function isWorkspaceOutputPath(pathValue, rootDir = workspaceRoot) {
+export function isWorkspaceOutputPath(pathValue, rootDir = currentWorkspaceRoot()) {
   const root = resolve(rootDir);
   const candidate = resolve(pathValue);
   const lexical = relative(root, candidate);

--- a/tests/batch-evaluate.test.mjs
+++ b/tests/batch-evaluate.test.mjs
@@ -142,4 +142,13 @@ async function run() {
   }
 }
 
-run();
+// Top-level await, not a floating `run()`: this suite is imported in-process by
+// test-all.mjs, and it sets CAREER_OPS_TRACKER for its own fixture. Without the
+// await the import resolves immediately, the async work keeps running alongside
+// later sections, and that variable stays pointed at this temp directory for a
+// window whose length depends on how fast the fixture runs — which is exactly
+// how the intermittent macOS-only page-budget failure in #3162 happened: a
+// valid repo path got compared against this fixture's root. The finally below
+// does restore it, but only once the work finishes. Awaiting here means the
+// import does not resolve until the environment is clean again.
+await run();

--- a/tests/generate-pdf-workspace-root.test.mjs
+++ b/tests/generate-pdf-workspace-root.test.mjs
@@ -1,0 +1,47 @@
+// #3162: the workspace root must survive a sibling test that legitimately sets
+// CAREER_OPS_TRACKER for its own fixture. Before the fix, generate-pdf.mjs
+// froze the root at import time, so an import landing inside that window
+// anchored the containment guard to another test's temp directory for the rest
+// of the process — the guard then refused valid repo paths, intermittently and
+// only under the full suite (occurrence 6 of #3162 named the temp dir outright).
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\ngenerate-pdf-workspace-root.test.mjs — the containment root is read at use time (#3162)');
+
+const original = process.env.CAREER_OPS_TRACKER;
+const foreign = mkdtempSync(join(tmpdir(), 'cops-foreign-'));
+mkdirSync(join(foreign, 'output'), { recursive: true });
+writeFileSync(join(foreign, 'applications.md'), '# Applications Tracker\n');
+
+let failures = 0;
+try {
+  // Poison the environment the way a sibling fixture does, THEN import.
+  process.env.CAREER_OPS_TRACKER = join(foreign, 'applications.md');
+  const mod = await import('../generate-pdf.mjs');
+  // Restore exactly as that sibling does in its finally.
+  if (original === undefined) delete process.env.CAREER_OPS_TRACKER;
+  else process.env.CAREER_OPS_TRACKER = original;
+
+  // A path inside the real repo must be accepted now that the variable is back.
+  const repoPath = join(ROOT, 'output', 'workspace-root-probe.html');
+  try {
+    const rel = mod.workspaceRelativeManifestPath(repoPath);
+    if (typeof rel === 'string' && rel.length > 0 && !rel.startsWith('..')) {
+      pass('a repo path resolves against the real workspace after a sibling restored CAREER_OPS_TRACKER');
+    } else {
+      fail(`repo path resolved to "${rel}" — the root is still anchored to the foreign fixture (#3162)`);
+      failures++;
+    }
+  } catch (err) {
+    fail(`repo path rejected after restore: ${err.message}`);
+    failures++;
+  }
+} finally {
+  if (original === undefined) delete process.env.CAREER_OPS_TRACKER;
+  else process.env.CAREER_OPS_TRACKER = original;
+}
+
+if (failures) process.exitCode = 1;


### PR DESCRIPTION
Closes #3162.

**Root cause**, named by the instrumentation from #3184 on occurrence 6 (macOS run of #3195):

```
workspaceRoot=/private/var/folders/df/.../T/cops-batcheval-N5TfQ3
canonical=/Users/runner/work/career-ops/career-ops/output/page-budget-test-7eO0Km/three-pages.html
```

The input was never escaping anything. The guard was comparing a valid repo path against **another test's temp directory**.

`tests/batch-evaluate.test.mjs:23` sets `CAREER_OPS_TRACKER` for its own fixture and **does** restore it in a `finally`. But this module resolved `trackerPath` → `workspaceRoot` → the canonical root as module-level `const`s that read that variable, so an import landing inside that window froze the root to the temp dir for the lifetime of the process. A later `delete` cannot un-read an env var.

Every property of the flake follows: only under the full suite (it needs the sibling to have run first), intermittent (import ordering), macOS-shaped (the `/var` → `/private/var` symlink made the relative path spectacular), and untouched by #3172, which was faithfully canonicalizing a correct input against the wrong root. Same defect class as #3159.

**Fix**: the root is memoized on the env variable's own value, so it costs the same as the const while nothing changes and self-corrects the moment it does. Two accessors keep each call site's existing semantics: canonical for the containment guard (a symlinked ancestor must not read as an escape), lexical for the manifest helpers.

**Verification**
- New `tests/generate-pdf-workspace-root.test.mjs` poisons the env before import and restores it exactly as the sibling does, then asserts a repo path still resolves against the real workspace.
- Discrimination checked: the test **fails on main** (exit 1, `repo path resolved to ""`) and passes here (exit 0).
- Full `test-all.mjs --quick`: **5309 passed, 0 failed**.

Note for reviewers: my first attempt fixed only the containment guard and the new test caught that the manifest helpers were still reading the frozen const, which is why both accessors exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace path validation after temporary environment changes, preventing valid repository paths from being incorrectly rejected.
  * Ensured workspace-related path checks consistently use the current workspace location.

* **Tests**
  * Added regression coverage for workspace resolution and environment restoration scenarios.
  * Improved test cleanup by waiting for asynchronous operations to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->