### PR TITLE
ci: skip guestbook webhook when unconfigured

### DIFF
--- a/.github/workflows/manifesto-guestbook.yml
+++ b/.github/workflows/manifesto-guestbook.yml
@@ -21,6 +21,10 @@ jobs:
           WEBHOOK: ${{ secrets.DISCORD_MANIFESTO_WEBHOOK }}
         with:
           script: |
+            if (!process.env.WEBHOOK) {
+              core.info('DISCORD_MANIFESTO_WEBHOOK is not configured — skipping guestbook notification.');
+              return;
+            }
             const before = context.payload.before, after = context.payload.after;
             if (!before || /^0+$/.test(before)) { core.info('primer push — skip'); return; }
             // Diff de la oleada vía compare API (sin checkout)


### PR DESCRIPTION
## Summary
- skip the optional guestbook Discord notification when `DISCORD_MANIFESTO_WEBHOOK` is unset
- preserve normal delivery when the secret is configured

## Validation
- `git diff --check`

This lets forks run the workflow without failing when they have not configured the optional Discord integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary notification attempts when the Discord webhook is not configured.
  * Added a clear skip message when notifications are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->