### PR TITLE
fix(update-system): pick the more recent of {updater commit, merge-base} as the local-modification baseline

### DIFF
--- a/tests/updater-baseline-recency.test.mjs
+++ b/tests/updater-baseline-recency.test.mjs
@@ -1,0 +1,156 @@
+/**
+ * updater-baseline-recency.test.mjs — #32 regression coverage.
+ *
+ * locallyModifiedSystemFiles() picks a "baseline" commit to diff against when
+ * deciding whether a system file was edited by THIS install (vs. only by
+ * upstream). It prefers the most recent commit whose message matches
+ * `^chore: auto-update system files` over the plain `merge-base(HEAD,
+ * upstreamRef)` fallback, on the theory that the updater commit is always the
+ * more recent, tighter baseline.
+ *
+ * That assumption broke for cbeaulieu-gt/career-ops#32: the fork's only
+ * matching updater commit was a stale one from a much earlier version, living
+ * on history that has NO ancestor relationship with the merge-base of a
+ * LATER, independently-merged upstream sync (PR #25) — the two candidates sit
+ * on divergent lines from a shared, older root. `merge-base --is-ancestor`
+ * cannot order them (it fails in both directions for genuinely unrelated
+ * commits), so picking "more recent" requires comparing commit time (`%ct`),
+ * not ancestry. Getting this wrong anchored the diff on the ancient commit,
+ * which made ~220 files the fork had never touched — merely re-synced from
+ * upstream via the PR merge — look locally modified, permanently stuck.
+ *
+ * Two properties are pinned here:
+ *   1. (the bug) an updater commit OLDER than a since-superseded merge-base
+ *      must lose to that merge-base, even when neither is an ancestor of the
+ *      other.
+ *   2. (the pre-existing, intended behavior — must not regress) an updater
+ *      commit NEWER than the plain merge-base still wins, which is the
+ *      #2337-adjacent case the updater-commit preference exists for: a file
+ *      the previous `apply` run itself updated must not look user-edited
+ *      just because the old merge-base predates that run.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import { gitIn, locallyModifiedSystemFiles } from '../update-system.mjs';
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-baseline-recency-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
+  g('config', 'core.autocrlf', 'false');
+  g('config', 'core.eol', 'lf');
+  return { dir, g, ctx: { git: g, root: dir } };
+}
+
+/** Commit whatever is staged/dirty with an explicit committer+author time. */
+function commitAt(g, message, isoDate, extraArgs = []) {
+  const savedAuthor = process.env.GIT_AUTHOR_DATE;
+  const savedCommitter = process.env.GIT_COMMITTER_DATE;
+  process.env.GIT_AUTHOR_DATE = isoDate;
+  process.env.GIT_COMMITTER_DATE = isoDate;
+  try {
+    g('add', '-A');
+    g('commit', '-qm', message, ...extraArgs);
+  } finally {
+    if (savedAuthor === undefined) delete process.env.GIT_AUTHOR_DATE; else process.env.GIT_AUTHOR_DATE = savedAuthor;
+    if (savedCommitter === undefined) delete process.env.GIT_COMMITTER_DATE; else process.env.GIT_COMMITTER_DATE = savedCommitter;
+  }
+}
+
+const PATHS = ['x.md'];
+
+// ── 1. #32: a stale, unrelated-branch updater commit must lose to a newer,
+//    independently-merged upstream sync — even with no ancestor relation ──
+{
+  const repo = makeRepo();
+  const { dir, g, ctx } = repo;
+
+  // Shared root, x.md = v1.
+  writeFileSync(join(dir, 'x.md'), 'v1\n');
+  commitAt(g, 'root', '2026-01-01T00:00:00');
+  g('branch', 'upstream');
+
+  // Main's OWN old auto-update commit, early — diverges from the shared root
+  // without ever touching the upstream branch again. This is the stale
+  // updater commit the grep will find.
+  writeFileSync(join(dir, 'x.md'), 'v1-old-apply\n');
+  commitAt(g, 'chore: auto-update system files to v1.3.0', '2026-01-02T00:00:00');
+  // Revert the file back so it doesn't look like a genuine, still-live user
+  // edit later — only the historical existence of this commit matters.
+  writeFileSync(join(dir, 'x.md'), 'v1\n');
+  commitAt(g, 'revert to v1 for the test setup', '2026-01-02T00:05:00');
+
+  // Upstream progresses independently on its own branch, unmerged into main
+  // yet: v1 -> v2 (the content main will later adopt via a real merge).
+  g('checkout', '-q', 'upstream');
+  writeFileSync(join(dir, 'x.md'), 'v2\n');
+  commitAt(g, 'upstream: x.md v2', '2026-06-01T00:00:00');
+  g('checkout', '-q', 'main');
+
+  // Main merges upstream's v2 in — a REAL merge, establishing a genuine
+  // merge-base. main's x.md now matches upstream's v2 exactly.
+  g('merge', '--no-ff', '-m', 'sync: merge upstream (like PR #25)', 'upstream');
+
+  // Upstream keeps moving after the sync: v2 -> v3. This is real, pending
+  // drift main has not adopted yet.
+  g('checkout', '-q', 'upstream');
+  writeFileSync(join(dir, 'x.md'), 'v3\n');
+  commitAt(g, 'upstream: x.md v3', '2026-08-01T00:00:00');
+  g('checkout', '-q', 'main');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', ctx);
+  if (!atRisk.includes('x.md')) {
+    pass('#32: a file only re-synced from a newer, unrelated-branch upstream merge is not flagged as user-edited');
+  } else {
+    fail(`#32 regression: x.md wrongly flagged as locally modified — got ${JSON.stringify(atRisk)}`);
+  }
+
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 2. Pre-existing behavior must not regress: a NEWER updater commit still
+//    beats a stale plain merge-base (the #2337-adjacent case this branch was
+//    added for in the first place) ──
+{
+  const repo = makeRepo();
+  const { dir, g, ctx } = repo;
+
+  // Shared root.
+  writeFileSync(join(dir, 'y.md'), 'v1\n');
+  commitAt(g, 'root', '2026-01-01T00:00:00');
+  g('branch', 'upstream');
+
+  // Upstream advances.
+  g('checkout', '-q', 'upstream');
+  writeFileSync(join(dir, 'y.md'), 'v2\n');
+  commitAt(g, 'upstream: y.md v2', '2026-02-01T00:00:00');
+  g('checkout', '-q', 'main');
+
+  // main runs an "apply": adopts upstream's v2 via a plain checkout+commit
+  // (no merge — this is exactly what update-system.mjs's apply() does, so it
+  // does NOT create ancestry with the upstream branch).
+  g('checkout', 'upstream', '--', 'y.md');
+  commitAt(g, 'chore: auto-update system files to v2.0.0', '2026-02-02T00:00:00');
+
+  // Upstream advances again after that apply.
+  g('checkout', '-q', 'upstream');
+  writeFileSync(join(dir, 'y.md'), 'v3\n');
+  commitAt(g, 'upstream: y.md v3', '2026-03-01T00:00:00');
+  g('checkout', '-q', 'main');
+
+  const atRisk = locallyModifiedSystemFiles(['y.md'], 'upstream', ctx);
+  if (!atRisk.includes('y.md')) {
+    pass('a file the previous apply run itself updated is not flagged just because the plain merge-base predates that run');
+  } else {
+    fail(`#2 regression: y.md wrongly flagged as locally modified — got ${JSON.stringify(atRisk)}`);
+  }
+
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/tests/updater-baseline-recency.test.mjs
+++ b/tests/updater-baseline-recency.test.mjs
@@ -1,33 +1,16 @@
 /**
  * updater-baseline-recency.test.mjs — #32 regression coverage.
  *
- * locallyModifiedSystemFiles() picks a "baseline" commit to diff against when
- * deciding whether a system file was edited by THIS install (vs. only by
- * upstream). It prefers the most recent commit whose message matches
- * `^chore: auto-update system files` over the plain `merge-base(HEAD,
- * upstreamRef)` fallback, on the theory that the updater commit is always the
- * more recent, tighter baseline.
+ * locallyModifiedSystemFiles() baselines its diff on the newer of {updater
+ * commit, merge-base(HEAD, upstreamRef)}: ancestry orders them when it can,
+ * commit time (`%ct`) is the fallback for genuinely unrelated commits. #32:
+ * a stale, unrelated-branch updater commit wrongly anchored the diff and
+ * flagged ~220 merely re-synced files as locally modified.
  *
- * That assumption broke for cbeaulieu-gt/career-ops#32: the fork's only
- * matching updater commit was a stale one from a much earlier version, living
- * on history that has NO ancestor relationship with the merge-base of a
- * LATER, independently-merged upstream sync (PR #25) — the two candidates sit
- * on divergent lines from a shared, older root. `merge-base --is-ancestor`
- * cannot order them (it fails in both directions for genuinely unrelated
- * commits), so picking "more recent" requires comparing commit time (`%ct`),
- * not ancestry. Getting this wrong anchored the diff on the ancient commit,
- * which made ~220 files the fork had never touched — merely re-synced from
- * upstream via the PR merge — look locally modified, permanently stuck.
- *
- * Two properties are pinned here:
- *   1. (the bug) an updater commit OLDER than a since-superseded merge-base
- *      must lose to that merge-base, even when neither is an ancestor of the
- *      other.
- *   2. (the pre-existing, intended behavior — must not regress) an updater
- *      commit NEWER than the plain merge-base still wins, which is the
- *      #2337-adjacent case the updater-commit preference exists for: a file
- *      the previous `apply` run itself updated must not look user-edited
- *      just because the old merge-base predates that run.
+ * Pinned: (1) a stale updater commit must lose to a newer merge-base even
+ * with no ancestor relation; (2) a newer updater commit must still beat a
+ * stale merge-base — the pre-existing #2337-adjacent behavior — must not
+ * regress.
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
@@ -72,34 +55,29 @@ const PATHS = ['x.md'];
   const repo = makeRepo();
   const { dir, g, ctx } = repo;
 
-  // Shared root, x.md = v1.
   writeFileSync(join(dir, 'x.md'), 'v1\n');
   commitAt(g, 'root', '2026-01-01T00:00:00');
   g('branch', 'upstream');
 
-  // Main's OWN old auto-update commit, early — diverges from the shared root
-  // without ever touching the upstream branch again. This is the stale
-  // updater commit the grep will find.
+  // Stale updater commit on its own side branch — never touches upstream
+  // again, so it has no ancestor relation to the later merge-base.
   writeFileSync(join(dir, 'x.md'), 'v1-old-apply\n');
   commitAt(g, 'chore: auto-update system files to v1.3.0', '2026-01-02T00:00:00');
-  // Revert the file back so it doesn't look like a genuine, still-live user
-  // edit later — only the historical existence of this commit matters.
+  // Revert so the content isn't mistaken for a live edit; only the commit's
+  // existence (for the grep) matters.
   writeFileSync(join(dir, 'x.md'), 'v1\n');
   commitAt(g, 'revert to v1 for the test setup', '2026-01-02T00:05:00');
 
-  // Upstream progresses independently on its own branch, unmerged into main
-  // yet: v1 -> v2 (the content main will later adopt via a real merge).
+  // Upstream advances independently, unmerged into main yet.
   g('checkout', '-q', 'upstream');
   writeFileSync(join(dir, 'x.md'), 'v2\n');
   commitAt(g, 'upstream: x.md v2', '2026-06-01T00:00:00');
   g('checkout', '-q', 'main');
 
-  // Main merges upstream's v2 in — a REAL merge, establishing a genuine
-  // merge-base. main's x.md now matches upstream's v2 exactly.
+  // Real merge — establishes the genuine merge-base.
   g('merge', '--no-ff', '-m', 'sync: merge upstream (like PR #25)', 'upstream');
 
-  // Upstream keeps moving after the sync: v2 -> v3. This is real, pending
-  // drift main has not adopted yet.
+  // Upstream keeps moving after the sync: pending drift main hasn't adopted.
   g('checkout', '-q', 'upstream');
   writeFileSync(join(dir, 'x.md'), 'v3\n');
   commitAt(g, 'upstream: x.md v3', '2026-08-01T00:00:00');
@@ -116,30 +94,26 @@ const PATHS = ['x.md'];
 }
 
 // ── 2. Pre-existing behavior must not regress: a NEWER updater commit still
-//    beats a stale plain merge-base (the #2337-adjacent case this branch was
-//    added for in the first place) ──
+//    beats a stale plain merge-base (the #2337-adjacent case this branch
+//    was added for) ──
 {
   const repo = makeRepo();
   const { dir, g, ctx } = repo;
 
-  // Shared root.
   writeFileSync(join(dir, 'y.md'), 'v1\n');
   commitAt(g, 'root', '2026-01-01T00:00:00');
   g('branch', 'upstream');
 
-  // Upstream advances.
   g('checkout', '-q', 'upstream');
   writeFileSync(join(dir, 'y.md'), 'v2\n');
   commitAt(g, 'upstream: y.md v2', '2026-02-01T00:00:00');
   g('checkout', '-q', 'main');
 
-  // main runs an "apply": adopts upstream's v2 via a plain checkout+commit
-  // (no merge — this is exactly what update-system.mjs's apply() does, so it
-  // does NOT create ancestry with the upstream branch).
+  // Plain checkout+commit, not a merge — mirrors update-system.mjs's
+  // apply(), so it creates no ancestry with the upstream branch.
   g('checkout', 'upstream', '--', 'y.md');
   commitAt(g, 'chore: auto-update system files to v2.0.0', '2026-02-02T00:00:00');
 
-  // Upstream advances again after that apply.
   g('checkout', '-q', 'upstream');
   writeFileSync(join(dir, 'y.md'), 'v3\n');
   commitAt(g, 'upstream: y.md v3', '2026-03-01T00:00:00');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1021,24 +1021,88 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
   // using the original merge-base would mistake the previous update's files
   // for user edits. Keep the merge-base fallback for installations without a
   // recorded updater commit.
-  let baseline = null;
+  //
+  // The most-recent matching updater commit is not automatically the correct
+  // (i.e. most recent) baseline, though: an install that received a
+  // legitimate out-of-band sync with upstream AFTER its last `apply` run (a
+  // manually merged PR, e.g. #25 in this fork's own history) has a
+  // merge-base with upstream that is NEWER than that stale updater commit.
+  // Anchoring on the stale commit makes every file the out-of-band sync
+  // touched look "changed locally" — including files the install never
+  // touched — which is exactly what stuck package.json and tracker-utils.mjs
+  // (and ~220 other files) as permanently "diverged" in #32.
+  //
+  // Picking the more recent candidate fixes it. Ancestry is the definitive
+  // signal whenever it applies — deterministic, immune to clock skew and
+  // rewritten history — so try it first. But this fork's own history has the
+  // updater commit and the merge-base sitting on commits with NO ancestor
+  // relation to each other at all (a stale side-branch auto-update commit vs.
+  // a later, independently-merged upstream sync): `merge-base --is-ancestor`
+  // fails in BOTH directions for that pair, and ancestry alone has no way to
+  // order them. Commit time (`%ct`) is the fallback for that genuinely
+  // unrelated case only — it is rewritable (rebase/amend/cherry-pick), so it
+  // is deliberately not the primary signal.
+  let mergeBaseCandidate = null;
   try {
-    const updaterCommit = runGit(
+    mergeBaseCandidate = runGit('merge-base', 'HEAD', upstreamRef) || null;
+  } catch {
+    mergeBaseCandidate = null;
+  }
+
+  let updaterCommit = null;
+  try {
+    const found = runGit(
       'log', '-1', '--format=%H', '--grep=^chore: auto-update system files', 'HEAD',
     ).trim();
-    if (updaterCommit) {
-      runGit('merge-base', '--is-ancestor', updaterCommit, 'HEAD');
-      baseline = updaterCommit;
+    if (found) {
+      runGit('merge-base', '--is-ancestor', found, 'HEAD');
+      updaterCommit = found;
     }
   } catch {
-    baseline = null;
+    updaterCommit = null;
   }
-  if (!baseline) {
+
+  const isAncestor = (maybeAncestor, maybeDescendant) => {
     try {
-      baseline = runGit('merge-base', 'HEAD', upstreamRef) || null;
+      runGit('merge-base', '--is-ancestor', maybeAncestor, maybeDescendant);
+      return true;
     } catch {
-      baseline = null;
+      return false;
     }
+  };
+
+  const commitTimeOf = (sha) => {
+    try {
+      return parseInt(runGit('log', '-1', '--format=%ct', sha).trim(), 10);
+    } catch {
+      return NaN;
+    }
+  };
+
+  let baseline = null;
+  if (updaterCommit && mergeBaseCandidate) {
+    if (updaterCommit === mergeBaseCandidate) {
+      baseline = updaterCommit;
+    } else if (isAncestor(updaterCommit, mergeBaseCandidate)) {
+      // updaterCommit precedes mergeBaseCandidate: an out-of-band sync moved
+      // the true last-synced point forward past the recorded updater commit.
+      baseline = mergeBaseCandidate;
+    } else if (isAncestor(mergeBaseCandidate, updaterCommit)) {
+      // The common, intended case: the updater commit is the later, tighter
+      // baseline.
+      baseline = updaterCommit;
+    } else {
+      // Genuinely unrelated — ancestry cannot order them. Fall back to
+      // commit time; an unreadable timestamp keeps the pre-existing
+      // behavior of preferring the updater commit.
+      const updaterTime = commitTimeOf(updaterCommit);
+      const mergeBaseTime = commitTimeOf(mergeBaseCandidate);
+      baseline = (Number.isFinite(mergeBaseTime) && mergeBaseTime > updaterTime)
+        ? mergeBaseCandidate
+        : updaterCommit;
+    }
+  } else {
+    baseline = updaterCommit || mergeBaseCandidate;
   }
 
   const changedLocally = new Set(diffNames(baseline || 'HEAD'));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1017,31 +1017,12 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
     }
   };
 
-  // An updater commit is the installed system snapshot. On a later update,
-  // using the original merge-base would mistake the previous update's files
-  // for user edits. Keep the merge-base fallback for installations without a
-  // recorded updater commit.
-  //
-  // The most-recent matching updater commit is not automatically the correct
-  // (i.e. most recent) baseline, though: an install that received a
-  // legitimate out-of-band sync with upstream AFTER its last `apply` run (a
-  // manually merged PR, e.g. #25 in this fork's own history) has a
-  // merge-base with upstream that is NEWER than that stale updater commit.
-  // Anchoring on the stale commit makes every file the out-of-band sync
-  // touched look "changed locally" — including files the install never
-  // touched — which is exactly what stuck package.json and tracker-utils.mjs
-  // (and ~220 other files) as permanently "diverged" in #32.
-  //
-  // Picking the more recent candidate fixes it. Ancestry is the definitive
-  // signal whenever it applies — deterministic, immune to clock skew and
-  // rewritten history — so try it first. But this fork's own history has the
-  // updater commit and the merge-base sitting on commits with NO ancestor
-  // relation to each other at all (a stale side-branch auto-update commit vs.
-  // a later, independently-merged upstream sync): `merge-base --is-ancestor`
-  // fails in BOTH directions for that pair, and ancestry alone has no way to
-  // order them. Commit time (`%ct`) is the fallback for that genuinely
-  // unrelated case only — it is rewritable (rebase/amend/cherry-pick), so it
-  // is deliberately not the primary signal.
+  // An updater commit is usually the tighter baseline, but a stale one can
+  // predate a later out-of-band upstream sync (#32) and wrongly flag ~220
+  // merely re-synced files as locally modified. Prefer whichever of {updater
+  // commit, merge-base} is more recent: ancestry decides when it can
+  // (deterministic); commit time (`%ct`, rewritable) is only the fallback
+  // for commits with no ancestor relation either way.
   let mergeBaseCandidate = null;
   try {
     mergeBaseCandidate = runGit('merge-base', 'HEAD', upstreamRef) || null;
@@ -1084,17 +1065,14 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
     if (updaterCommit === mergeBaseCandidate) {
       baseline = updaterCommit;
     } else if (isAncestor(updaterCommit, mergeBaseCandidate)) {
-      // updaterCommit precedes mergeBaseCandidate: an out-of-band sync moved
-      // the true last-synced point forward past the recorded updater commit.
+      // An out-of-band sync moved the true last-synced point past updaterCommit.
       baseline = mergeBaseCandidate;
     } else if (isAncestor(mergeBaseCandidate, updaterCommit)) {
-      // The common, intended case: the updater commit is the later, tighter
-      // baseline.
+      // Common case: the updater commit is the later, tighter baseline.
       baseline = updaterCommit;
     } else {
-      // Genuinely unrelated — ancestry cannot order them. Fall back to
-      // commit time; an unreadable timestamp keeps the pre-existing
-      // behavior of preferring the updater commit.
+      // Unrelated — ancestry can't order them; fall back to commit time.
+      // An unreadable timestamp keeps preferring the updater commit.
       const updaterTime = commitTimeOf(updaterCommit);
       const mergeBaseTime = commitTimeOf(mergeBaseCandidate);
       baseline = (Number.isFinite(mergeBaseTime) && mergeBaseTime > updaterTime)


### PR DESCRIPTION
## Summary

`locallyModifiedSystemFiles()`'s baseline picker preferred a matching `chore: auto-update system files` commit over `merge-base(HEAD, upstreamRef)`, assuming the updater commit is always the more recent baseline. That breaks when a fork's updater commit is stale on unrelated history while a later out-of-band sync produced a newer merge-base — every file the sync touched then looks "changed locally" and gets permanently stranded (observed downstream: ~221 files, including `package.json`). Reported/fixed downstream at cbeaulieu-gt/career-ops#32/#33; opening here since it's an upstream bug, not fork-specific.

## Fix

Order the two candidates by ancestry when it applies (deterministic, immune to clock skew/rewritten history); fall back to commit time (`%ct`) only for the genuinely-unrelated case where ancestry can't order them.

## Tests

New `tests/updater-baseline-recency.test.mjs` against synthetic repos:
1. **The bug**: a stale updater commit on unrelated history must lose to a newer, independently-merged merge-base.
2. **No regression**: a genuinely newer updater commit still wins over a stale plain merge-base.

Verified locally: red against current `update-system.mjs`, green against the fix.

## Note

`apply()`'s self-bootstrap unconditionally overwrites `update-system.mjs` from upstream before any local-modification check runs, so a fork's own fix here (including this one) can get silently reverted on a later `apply`. Filed separately as #3207; not addressed by this PR.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of locally modified system files by selecting the most recent reliable baseline.
  * Prevented stale updater changes from overriding newer repository history.
  * Added regression coverage for updater and merge-base recency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->