### PR TITLE
fix(web): a company with no usable slug must not match every tailored CV

### DIFF
--- a/web/src/app/api/cv-pdf/route.ts
+++ b/web/src/app/api/cv-pdf/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
 import { careerOpsRoot } from "@/lib/career-ops";
+import { companySlug } from "@/lib/company-slug.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,9 +13,11 @@ export const dynamic = "force-dynamic";
 export async function GET(req: NextRequest) {
   const company = (req.nextUrl.searchParams.get("company") ?? "").trim();
   if (!company) return new Response("company required", { status: 400 });
-  // Token-extract instead of replace-then-trim: same slug, and no `-+$`-style
-  // pattern that backtracks polynomially on adversarial input (CodeQL).
-  const slug = (company.toLowerCase().match(/[a-z0-9]+/g) ?? []).join("-");
+  // Same invariant as the apply lookup: a company with no usable key serves
+  // nothing rather than the newest unrelated CV (#2352).
+  const key = companySlug(company);
+  if (!key) return new Response("no tailored CV found for this offer", { status: 404 });
+  const { slug } = key;
   const dir = path.join(careerOpsRoot(), "output");
   // Match the slug at a token boundary (delimited by non-alphanumerics) so "Meta"
   // doesn't serve "Metabase"'s tailored CV. The pdf mode names files cv-…-{slug}-….

--- a/web/src/lib/apply/cv.ts
+++ b/web/src/lib/apply/cv.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { careerOpsRoot } from "@/lib/career-ops";
+import { companySlug } from "@/lib/company-slug.mjs";
 
 /**
  * Locate the tailored CV PDF the real `pdf` mode wrote to output/ for a given
@@ -19,10 +20,12 @@ export function resolveTailoredCv(company?: string): string | null {
   } catch {
     return null;
   }
-  // Token-extract instead of replace-then-trim: same slug, and no `-+$`-style
-  // pattern that backtracks polynomially on adversarial input (CodeQL).
-  const slug = (c.toLowerCase().match(/[a-z0-9]+/g) ?? []).join("-");
-  const first = slug.split("-")[0];
+  // No usable key means this company cannot be identified from a filename, so
+  // find nothing. The old empty-string slug was a substring of every name in
+  // output/, which resolved the newest unrelated CV instead (#2352).
+  const key = companySlug(c);
+  if (!key) return null;
+  const { slug, first } = key;
   const matches = files.filter((f) => {
     const l = f.toLowerCase();
     return l.includes(slug) || (first.length > 2 && l.includes(first));

--- a/web/src/lib/company-slug.mjs
+++ b/web/src/lib/company-slug.mjs
@@ -1,0 +1,24 @@
+/**
+ * Derive the key used to find a company's tailored CV in output/, where the pdf
+ * mode names files `cv-{candidate}-{company}-{date}.pdf`.
+ *
+ * Returns null when the company yields no key. Callers must treat that as "this
+ * company cannot be identified" and find nothing, never as "match anything": the
+ * slug is built from ASCII alphanumerics only, so a company that contributes
+ * none of them collapses to the empty string, and an empty needle is contained
+ * in every filename. The result is attached to a real application, so the only
+ * safe answer is no answer.
+ *
+ * Token-extract instead of replace-then-trim: same slug, and no `-+$`-style
+ * pattern that backtracks polynomially on adversarial input (CodeQL).
+ *
+ * @param {string | undefined | null} company
+ * @returns {{ slug: string, first: string } | null}
+ */
+export function companySlug(company) {
+  const c = (company ?? "").trim();
+  if (!c) return null;
+  const slug = (c.toLowerCase().match(/[a-z0-9]+/g) ?? []).join("-");
+  if (!slug) return null;
+  return { slug, first: slug.split("-")[0] };
+}

--- a/web/tests/lib/company-slug.test.mjs
+++ b/web/tests/lib/company-slug.test.mjs
@@ -1,0 +1,85 @@
+// Tests for companySlug(), the filename-matching key derived from a company
+// name, and the decision that a company yields no usable key at all (#2352).
+//
+// Both tailored-CV lookups name files as cv-{candidate}-{company}-{date}.pdf and
+// search output/ for the company segment. When the company contributes no
+// ASCII alphanumerics the segment is empty, and an empty needle matches every
+// file: `l.includes("")` is true for all of them, and the newest wins. A lookup
+// that cannot identify the company has to say so rather than return its best
+// guess, because the caller attaches the result to a real application.
+//
+// Run:  node --test tests/lib/company-slug.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { companySlug } from "../../src/lib/company-slug.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+test("companySlug: derives the slug and its first token", () => {
+  assert.deepEqual(companySlug("Acme"), { slug: "acme", first: "acme" });
+  assert.deepEqual(companySlug("Acme Corp"), { slug: "acme-corp", first: "acme" });
+});
+
+test("companySlug: normalizes punctuation and case the way the pdf mode names files", () => {
+  // Given generate-pdf slugifies on runs of non-alphanumerics, the lookup key
+  // has to collapse the same way or it will never match its own output
+  assert.deepEqual(companySlug("  Jane & Co.  "), { slug: "jane-co", first: "jane" });
+  assert.deepEqual(companySlug("1-800-FLOWERS"), { slug: "1-800-flowers", first: "1" });
+});
+
+test("companySlug: returns null for a company with no usable key", () => {
+  // Given each of these yields an empty slug, and an empty slug is a substring
+  // of every filename in output/
+  for (const c of ["", "   ", "?", "—", "@", "...", "·"]) {
+    assert.equal(companySlug(c), null, `${JSON.stringify(c)} must not produce a key`);
+  }
+});
+
+test("companySlug: returns null for the confidential-employer marker", () => {
+  // Given `?` is the tracker's locale-invariant marker for an unknown end
+  // employer (agency submissions). This is the reported case: the row is real,
+  // the company is deliberately unknown, and the CV lookup must not fall back to
+  // whichever tailored CV happens to be newest.
+  assert.equal(companySlug("?"), null);
+});
+
+test("companySlug: returns null for a company written in a non-Latin script", () => {
+  // Given the slug is built from [a-z0-9] only, every company whose name carries
+  // no ASCII alphanumerics collapses to the same empty key. This is not an edge
+  // case: career-ops ships ja/ar/hi/tr market modes, so these are ordinary
+  // employers for the users those modes exist to serve.
+  for (const c of ["株式会社メルカリ", "楽天", "Яндекс", "مِنّة", "부산은행"]) {
+    assert.equal(companySlug(c), null, `${c} must not produce a key`);
+  }
+});
+
+test("companySlug: keeps a mixed-script name that still has ASCII to match on", () => {
+  // Given a partial key is still a real key. Only a fully empty one is unusable.
+  assert.deepEqual(companySlug("Ωmega"), { slug: "mega", first: "mega" });
+  assert.deepEqual(companySlug("楽天 Rakuten"), { slug: "rakuten", first: "rakuten" });
+});
+
+test("companySlug: tolerates a missing company", () => {
+  assert.equal(companySlug(undefined), null);
+  assert.equal(companySlug(null), null);
+});
+
+test("both tailored-CV lookups derive their key through this module", () => {
+  // Given the guard only holds where it is actually called. Each lookup used to
+  // build the slug inline, and a call site that rebuilds it would pass every
+  // assertion above while still matching every file in output/.
+  const read = (p) => readFileSync(join(HERE, "..", "..", "src", p), "utf8");
+  for (const site of ["lib/apply/cv.ts", "app/api/cv-pdf/route.ts"]) {
+    const src = read(site);
+    assert.match(src, /from "@\/lib\/company-slug\.mjs"/, `${site} must import the key derivation`);
+    assert.match(src, /companySlug\(/, `${site} must call companySlug`);
+    assert.ok(
+      !/\.toLowerCase\(\)\.match\(\/\[a-z0-9\]\+\/g\)/.test(src),
+      `${site} must not rebuild the slug inline`,
+    );
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Makes both tailored-CV lookups fail closed when a company name yields no filename-matching key, instead of keeping every PDF in `output/` and returning the newest one. A shared `companySlug()` derives the key in one place and returns null when there is none.

## Related issue

Closes #2352

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Detail

The slug is built from ASCII alphanumerics only. A company contributing none of them collapses to the empty string, and in `resolveTailoredCv` the search is a substring test, so every filename in `output/` is kept and the newest one wins. The apply flow attaches that file to a real application.

Two ordinary inputs reach it. The tracker writes `?` for an agency submission whose end employer is not disclosed, which is the case reported in the issue. Separately, any employer written in a non-Latin script slugs to empty, which covers Japanese, Chinese, Korean, Russian, Arabic and Greek names. `companyFromTitle()` reaches the same state from an Ashby title ending in such a name.

With three files in `output/`, two CVs and a cover letter, a lookup for `?` or for a Japanese employer keeps all three and resolves to whichever was written last, the cover letter included.

`/api/cv-pdf` already matched at a token boundary rather than by substring, so it was reachable only in narrower cases. It takes the same guard so the invariant holds at both lookup sites rather than at one, and it returns its existing 404 rather than a new status.

Behavior change worth calling out: an application whose company cannot be identified now gets no CV attached where it previously got an arbitrary one. That is the intent, since the caller uploads the result to a real application, but it does mean these users see nothing attached rather than something wrong.

Not addressed here: the display half of #2352, meaning the raw `?` leaking into labels and the split between a stable lookup key and the human-facing label. This PR only stops the lookup matching everything.

A related naming consequence is out of scope. `resolvePdfPaths()` builds filenames from the same slug, so a CV generated for one of these employers is written as `cv-{candidate}--{date}.pdf` with an empty company segment, and every such employer shares that shape.

## Conflict note

#2599 also edits `web/src/lib/apply/cv.ts` and `web/src/app/api/cv-pdf/route.ts` while reworking how a tailored CV is selected. This change is deliberately small and orthogonal to that. If #2599 lands first I am happy to rebase onto it, and the guard should sit inside whatever key derivation that PR settles on.

## Testing

- `npm test --prefix web`: 344 passed, 0 failed
- `npx tsc --noEmit --prefix web`: clean
- `npm run build --prefix web`: compiles
- `node test-all.mjs`: 5311 passed, 0 failed, 2 warnings. Identical to the same command on an unmodified checkout, so the warnings are pre-existing and not from this change.
- `web/tests/lib/company-slug.test.mjs` is new. Each assertion was checked by reverting the behavior it covers and confirming it fails: removing the empty-slug guard, rebuilding the slug inline at each of the two call sites, and loosening the guard to reject only `undefined`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company-name matching when retrieving tailored CV PDFs.
  * Requests with missing, blank, or unusable company names now return a clear “not found” result instead of matching an unrelated document.
  * Company names are consistently normalized across capitalization, punctuation, spacing, and mixed text formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->