### PR TITLE
fix(reconcile-pipeline): validate CLI flags via the shared helper

### DIFF
--- a/reconcile-pipeline.mjs
+++ b/reconcile-pipeline.mjs
@@ -25,20 +25,22 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, copyFileSync, rea
 import { join, dirname, resolve, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { normalizeReportLink } from './tracker-links.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const DRY_RUN = process.argv.includes('--dry-run');
 
-if (process.argv.includes('-h') || process.argv.includes('--help')) {
-  console.log('Usage: node reconcile-pipeline.mjs [--dry-run] [--state <path>] [--pipeline <path>]');
-  console.log('  Moves batch-processed offers out of pipeline.md "Pendientes" into "Procesadas".');
-  process.exit(0);
-}
+const KNOWN_FLAGS = ['--dry-run', '--pipeline', '--state', '--help', '-h'];
+const VALUE_FLAGS = ['--pipeline', '--state'];
+const USAGE = `Usage: node reconcile-pipeline.mjs [--dry-run] [--state <path>] [--pipeline <path>]
+  Moves batch-processed offers out of pipeline.md "Pendientes" into "Procesadas".`;
 
-function argValue(flag) {
-  const i = process.argv.indexOf(flag);
-  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
-}
+// An unrecognized flag (typo'd --dry-run, say) used to be silently ignored
+// and fall through to a LIVE run that writes pipeline.md — the caller
+// believed they were in dry-run mode and were not. Fail fast instead.
+const args = process.argv.slice(2);
+validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
+
+const DRY_RUN = args.includes('--dry-run');
 
 // Constrain user-supplied --state/--pipeline paths to the repository tree, so a
 // crafted path cannot read from or overwrite files outside the project.
@@ -73,8 +75,8 @@ function resolveInsideRepo(inputPath, fallbackPath, flag) {
 const defaultPipeline = existsSync(join(CAREER_OPS, 'data/pipeline.md'))
   ? join(CAREER_OPS, 'data/pipeline.md')
   : join(CAREER_OPS, 'pipeline.md');
-const PIPELINE_FILE = resolveInsideRepo(argValue('--pipeline'), defaultPipeline, '--pipeline');
-const STATE_FILE = resolveInsideRepo(argValue('--state'), join(CAREER_OPS, 'batch/batch-state.tsv'), '--state');
+const PIPELINE_FILE = resolveInsideRepo(flagValue(args, '--pipeline'), defaultPipeline, '--pipeline');
+const STATE_FILE = resolveInsideRepo(flagValue(args, '--state'), join(CAREER_OPS, 'batch/batch-state.tsv'), '--state');
 const REPORTS_DIR = join(CAREER_OPS, 'reports');
 
 // ---- guards ----

--- a/tests/reconcile-pipeline-flags.test.mjs
+++ b/tests/reconcile-pipeline-flags.test.mjs
@@ -1,0 +1,88 @@
+// reconcile-pipeline.mjs must reject a mistyped flag before it can fall
+// through to a LIVE run. Before this fix, a typo'd --dry-run (e.g. --dryrun)
+// was silently ignored and the script proceeded to overwrite pipeline.md for
+// real — the caller believed they were in dry-run mode and were not.
+//
+// Every invocation below passes --dry-run explicitly (even the ones that
+// error before reaching it) so this suite can never write to this repo's own
+// data/pipeline.md, regardless of what batch/batch-state.tsv happens to
+// contain on the machine running it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, 'reconcile-pipeline.mjs');
+
+function runReconcile(...args) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  assert.equal(result.error, undefined, `reconcile-pipeline.mjs failed to spawn: ${result.error?.message}`);
+  assert.equal(result.signal, null, `reconcile-pipeline.mjs was killed by ${result.signal} (timeout?)`);
+  return { ...result, all: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+test('--help prints usage and exits 0', () => {
+  const result = runReconcile('--help');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /node reconcile-pipeline\.mjs/);
+});
+
+test('-h prints usage and exits 0', () => {
+  const result = runReconcile('-h');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+});
+
+test('a typo of --dry-run exits 1 instead of silently running live', () => {
+  const result = runReconcile('--dryrun');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --dryrun/);
+  assert.match(result.stderr, /Valid flags:/);
+});
+
+test('an unknown flag exits 1 and names the flag', () => {
+  const result = runReconcile('--bogus', '--dry-run');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --bogus/);
+});
+
+test('--help plus an unknown flag still fails', () => {
+  const result = runReconcile('--help', '--bogus');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --bogus/);
+  assert.doesNotMatch(result.stdout, /Usage:/);
+});
+
+test('--pipeline without a value is rejected instead of silently using the default', () => {
+  const result = runReconcile('--pipeline', '--dry-run');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--pipeline requires a value/);
+});
+
+test('--state without a value is rejected instead of silently using the default', () => {
+  const result = runReconcile('--state', '--dry-run');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--state requires a value/);
+});
+
+test('--pipeline=<path> (equals form) is recognized, not silently discarded', () => {
+  // A nonexistent target still resolves inside the repo and reports the same
+  // graceful "nothing to reconcile" — the assertion here is that the flag was
+  // accepted at all, not that a specific file was read.
+  const result = runReconcile('--pipeline=data/does-not-exist.md', '--dry-run');
+  assert.doesNotMatch(result.stderr, /unrecognized flag/i);
+  assert.doesNotMatch(result.stderr, /requires a value/);
+});
+
+test('a path escaping the repo is rejected, not silently accepted', () => {
+  const result = runReconcile('--pipeline', '../outside.md', '--dry-run');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /path must stay inside the repository/);
+});


### PR DESCRIPTION
Closes #3216

## Summary

`reconcile-pipeline.mjs` had zero unrecognized-flag validation — a mistyped `--dry-run` (e.g. `--dryrun`) was silently ignored and the script proceeded to a **live run that overwrites `data/pipeline.md`**, with the caller believing they were in dry-run mode. `--pipeline`/`--state` had the value-side defect too: the hand-rolled `argValue()` used `indexOf`, so `--pipeline=path.md` silently fell back to the default file instead of the caller's own path.

Same shape already fixed in `funnel-velocity.mjs` (#3085) and `followup-cadence.mjs` (#3196/#3199).

## Reproduce (before this PR)

```
$ node reconcile-pipeline.mjs --dryrun
# typo silently ignored; if batch-state.tsv has completed entries, this WRITES
# pipeline.md for real, exit 0 — no indication the flag was never applied

$ node reconcile-pipeline.mjs --pipeline=custom-pipeline.md --dry-run
# indexOf('--pipeline') can't see the `=` form; PIPELINE_FILE silently falls
# back to data/pipeline.md instead of the caller's custom-pipeline.md
```

## Changes

- `reconcile-pipeline.mjs`: delegate to `validateFlags`/`flagValue` from `./lib/cli-flags.mjs`. `resolveInsideRepo`'s repo-boundary sandboxing (symlink-safe, rejects paths escaping the repo) is unrelated and untouched — only the flag-parsing layer changes.
- Added `tests/reconcile-pipeline-flags.test.mjs` (9 tests): help, unrecognized flags (including the `--dryrun` typo itself), missing operands for both value flags, the `=`-form fix, and the existing repo-escape guard. Every invocation passes `--dry-run` explicitly so the suite can never write to this repo's own tracker data regardless of what `batch/batch-state.tsv` contains on the machine running it.

## Test plan

- [x] `node test-all.mjs` — 5309 passed, 0 failed
- [x] `node --test tests/reconcile-pipeline-flags.test.mjs` — 9/9 passed
- [x] `node scripts/check-syntax.mjs` — all files pass
- [x] Manually reproduced both bugs above against `main`, confirmed each is now a clear exit 1 / correctly-honored value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line argument handling for pipeline and state paths.
  - Unknown, mistyped, or incomplete options now produce clear errors.
  - Added validation for repository boundaries and required option values.
  - Added support for equals-form pipeline arguments.

- **Documentation**
  - Help and usage information is now centralized for more consistent guidance.

- **Tests**
  - Added coverage for help output, invalid flags, missing values, validation, and exit-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->