### PR TITLE
feat(title-filter): a `stem:` prefix, for the half a plain keyword gives away

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -297,6 +297,23 @@ title_filter:
   # add the suffix forms you still want gone, the way the negative list below
   # pairs `word:Intern` with `word:Interns` and a plain `Internship`.
   #
+  # Prefix an entry with `stem:` for the half in between. A plain keyword is
+  # loose on BOTH sides, and usually only one of them was meant:
+  #
+  #   agent         Agentforce yes   Agents yes   Reagents yes   <- the default
+  #   stem:agent    Agentforce yes   Agents yes   Reagents NO    <- must START a word
+  #   word:agent    Agentforce NO    Agents NO    Reagents NO    <- the whole word
+  #
+  # So `stem:` is for a keyword that begins a longer word you also want — "Crypto"
+  # reaching "Cryptocurrency", "Fellows" reaching "Fellowship" — without it also
+  # landing in the middle of an unrelated one. It is what separates "Rust
+  # Engineer" from "Zero Trust Engineer" while keeping "Rust Engineering".
+  #
+  # It does NOT cover a keyword that ENDS a longer word instead of starting it:
+  # "Automation" inside the German compound "Gebäudeautomation" still needs the
+  # plain form. That side has no prefix, deliberately — the plain default already
+  # serves it, and nothing has been measured that the pair cannot express.
+  #
   # Use " + " (with spaces) to require SEVERAL terms in any order:
   #
   #   - "director + engineering"   matches "Director of Engineering",

--- a/tests/title-stem-prefix.test.mjs
+++ b/tests/title-stem-prefix.test.mjs
@@ -1,0 +1,135 @@
+// tests/title-stem-prefix.test.mjs — `stem:` demands that a keyword START a
+// word, leaving the rest of the word free.
+//
+// A plain keyword is loose on BOTH sides and usually only one was meant. The
+// three settings differ on exactly one axis each:
+//
+//   agent        Agentforce yes   Reagents yes    both sides open (the default)
+//   stem:agent   Agentforce yes   Reagents NO     left boundary only
+//   word:agent   Agentforce NO    Reagents NO     both boundaries
+//
+// Every assertion below is a TRIPLE rather than a pair, because the interesting
+// property is not "stem: matches" — a plain substring matches everything stem:
+// does — it is that stem: sits strictly between the other two. A pair against
+// the default alone would pass on an implementation that simply anchored both
+// sides, which is `word:` under another name.
+
+import { pass, fail, ROOT } from './helpers.mjs';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as yaml from 'js-yaml';
+import { compileKeyword, buildTitleFilter } from '../scan.mjs';
+
+console.log('\ntitle filter — `stem:` prefix');
+
+// ── 1. The three settings, on one title each ─────────────────────────
+const TRIPLES = [
+  // keyword, title, plain, stem, word
+  ['agent', 'Agentforce Developer', true, true, false],
+  ['agent', 'AI Agents Manager', true, true, false],
+  ['agent', 'Account Manager Instrumentation & Reagents', true, false, false],
+  ['crypto', 'Cryptocurrency Analyst', true, true, false],
+  ['crypto', 'Encrypto Systems Lead', true, false, false],
+  ['fellows', 'Fellowship Programme Lead', true, true, false],
+  ['rust engineer', 'Rust Engineering Lead', true, true, false],
+  ['rust engineer', 'Sr. Zero Trust Engineer III (6794)', true, false, false],
+];
+const wrong = [];
+for (const [kw, title, wantPlain, wantStem, wantWord] of TRIPLES) {
+  const l = title.toLowerCase();
+  const got = [compileKeyword(kw)(l), compileKeyword(`stem:${kw}`)(l), compileKeyword(`word:${kw}`)(l)];
+  const want = [wantPlain, wantStem, wantWord];
+  if (String(got) !== String(want)) wrong.push(`"${kw}" vs "${title}": got ${got}, want ${want}`);
+}
+if (wrong.length === 0) {
+  pass('stem: sits strictly between a plain keyword and word: on every case');
+} else {
+  fail(`stem: semantics wrong: ${JSON.stringify(wrong)}`);
+}
+
+// The distinguishing property stated on its own, so a regression cannot hide in
+// the table above: there is at least one title stem: accepts and word: does not,
+// and at least one the default accepts and stem: does not.
+const loosenedByStem = TRIPLES.some(([, , , s, w]) => s && !w);
+const tightenedByStem = TRIPLES.some(([, , p, s]) => p && !s);
+if (loosenedByStem && tightenedByStem) {
+  pass('stem: is neither word: nor the default — it differs from both, in the right directions');
+} else {
+  fail(`stem: collapsed into a neighbour: looser-than-word=${loosenedByStem} tighter-than-default=${tightenedByStem}`);
+}
+
+// ── 2. The side stem: deliberately does not cover ────────────────────
+// A keyword that ENDS a longer word rather than starting it. The docs say the
+// plain default serves this and stem: does not; assert that rather than leave a
+// reader to discover it.
+const compound = 'Gebäudeautomation Ingenieur (m/w/d)'.toLowerCase();
+if (compileKeyword('automation')(compound) && !compileKeyword('stem:automation')(compound)) {
+  pass('stem: does not reach a keyword that ends a compound — the plain form still does');
+} else {
+  fail('the compound case behaves differently from what the template documents');
+}
+
+// ── 3. Shared plumbing: a bare prefix, escaping, AND-groups ──────────
+if (compileKeyword('stem:')('customer success manager') === false) {
+  pass('a bare `stem:` matches nothing rather than everything');
+} else {
+  fail('a bare `stem:` matched a title — one stray colon would flood or veto a scan');
+}
+// Metacharacters are literal, exactly as under `word:`.
+const dotnet = compileKeyword('stem:.net');
+if (dotnet('safety .netting specialist') && !dotnet('anet developer')) {
+  pass('`stem:` escapes regex metacharacters (".net" is not "any char + net")');
+} else {
+  fail('`stem:` leaked regex metacharacters into the pattern');
+}
+// A term inside an AND-group keeps its own prefix.
+const group = buildTitleFilter({ positive: ['stem:crypto + engineer'] });
+if (group('Cryptocurrency Engineer') === true && group('Encrypto Engineer') === false) {
+  pass('a `stem:` term inside an AND-group keeps its boundary');
+} else {
+  fail('a `stem:` term lost its boundary inside an AND-group');
+}
+
+// ── 4. The negative side, which the recall corpus cannot reach ───────
+// #3103: none of the corpus's 675 titles contains Internal, International or
+// Internship, so a corpus diff reports zero for exactly the strings the shipped
+// template names as the reason the default is a substring. These six are that
+// blind spot, pinned directly.
+const NEGATIVE_BLIND_SPOT = [
+  // keyword, title, plain rejects, stem rejects, word rejects
+  ['intern', 'Internal Tools Engineer', true, true, false],
+  ['intern', 'International Sales Manager', true, true, false],
+  ['intern', 'Software Engineering Internship', true, true, false],
+  ['crypto', 'Cryptocurrency Analyst', true, true, false],
+  ['agent', 'Agentforce Developer', true, true, false],
+  ['automation', 'Gebäudeautomation Ingenieur', true, false, false],
+];
+const negWrong = [];
+for (const [kw, title, plain, stemR, wordR] of NEGATIVE_BLIND_SPOT) {
+  const rejects = (entry) => buildTitleFilter({ positive: [], negative: [entry] })(title) === false;
+  const got = [rejects(kw), rejects(`stem:${kw}`), rejects(`word:${kw}`)];
+  const want = [plain, stemR, wordR];
+  if (String(got) !== String(want)) negWrong.push(`"${kw}" vs "${title}": rejects ${got}, want ${want}`);
+}
+if (negWrong.length === 0) {
+  pass('the six negative cases the recall corpus is blind to behave as documented');
+} else {
+  fail(`negative-side behaviour wrong: ${JSON.stringify(negWrong)}`);
+}
+
+// ── 5. The shipped template still parses and behaves ─────────────────
+// Adding a prefix must not change any verdict for a config that does not use it.
+const cfg = yaml.load(readFileSync(join(ROOT, 'templates/portals.example.yml'), 'utf-8'));
+const shipped = buildTitleFilter(cfg.title_filter);
+const unchanged = [
+  ['Internal Tools Engineer', true],
+  ['International AI Program Manager', true],
+  ['Operations Intern', false],
+  ['Machine Learning Internship', false],
+];
+const drifted = unchanged.filter(([t, want]) => shipped(t) !== want);
+if (drifted.length === 0) {
+  pass('the shipped template is unaffected: no entry uses the new prefix yet');
+} else {
+  fail(`shipped-config verdicts moved: ${JSON.stringify(drifted)}`);
+}

--- a/title-keywords.mjs
+++ b/title-keywords.mjs
@@ -22,6 +22,20 @@
 // colon-suffixed "word", and an entry is one keyword, not a sentence.
 export const WORD_PREFIX = 'word:';
 
+// `stem:` is the other half of the same question, and it exists because the two
+// halves are NOT the same setting seen from two sides.
+//
+// `word:agent` says "agent, and nothing longer" — it rejects Agentforce.
+// `stem:agent` says "a word that STARTS with agent" — it keeps Agentforce and
+// Agentic, and drops Reagents, where the keyword lands mid-word.
+// A bare `agent`, today's default, keeps all three.
+//
+// So a plain substring is not "the loose option"; it is two loosenesses at once,
+// and only one of them is usually wanted. `stem:` lets an entry ask for the one
+// it means. Under today's substring default that is already a narrowing rather
+// than a no-op: it is what separates Agentforce from Reagents (#3103).
+export const STEM_PREFIX = 'stem:';
+
 function escapeForRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -36,6 +50,9 @@ function escapeForRegExp(s) {
 // to the literal characters p, {, L, } — no error, and the anchor is simply off.
 const WORD_CHAR = String.raw`[\p{L}\p{M}\p{N}_]`;
 const anchoredPattern = (body) => new RegExp(`(?<!${WORD_CHAR})${body}(?!${WORD_CHAR})`, 'u');
+// Same left boundary, no right one: the keyword must start a word, and the word
+// may continue past it.
+const stemPattern = (body) => new RegExp(`(?<!${WORD_CHAR})${body}`, 'u');
 
 /**
  * Compile a lowercased keyword into a matcher.
@@ -68,6 +85,14 @@ export function compileKeyword(kw) {
     // titles this prefix exists to protect. \p{M} covers combining marks, so a
     // decomposed "é" does not split a word either.
     const re = anchoredPattern(escapeForRegExp(bare));
+    return (lower) => re.test(lower);
+  }
+  if (kw.startsWith(STEM_PREFIX)) {
+    const bare = kw.slice(STEM_PREFIX.length).trim();
+    // Same reading as a bare `word:`: a stray prefix with nothing after it is a
+    // typo, and matching nothing is the safe half of that trade.
+    if (!bare) return () => false;
+    const re = stemPattern(escapeForRegExp(bare));
     return (lower) => re.test(lower);
   }
   if (/^[a-z]{2,3}$/.test(kw)) {


### PR DESCRIPTION
Taking you up on #3103. Additive, default untouched, and it turned out to be worth more than migration plumbing.

## Three settings, not two

The framing that made this land differently from what either of us described: a plain keyword is loose on **both** sides, and usually only one of them was meant. `word:` and a bare keyword are not one setting seen from two directions — there is a third between them, and it is the one every example in this thread actually wanted.

```
agent         Agentforce yes   Agents yes   Reagents yes     both sides open (today)
stem:agent    Agentforce yes   Agents yes   Reagents NO      must START a word
word:agent    Agentforce NO    Agents NO    Reagents NO      the whole word only
```

## It is not a no-op today

I expected a stem marker to do nothing until the default flips, and checked before writing the docs paragraph. It already narrows:

```
stem:rust engineer   vs "Sr. Zero Trust Engineer III (6794)"   ->  NO MATCH
stem:rust engineer   vs "Rust Engineering Lead"                ->  match
```

No existing setting does that: the plain form keeps both, `word:` drops both. So this is usable against the motivating case of #3103 immediately, without touching the default — which is the "usable immediately" you named, though not by the route your sentence took.

On @IaroslavMazur's corpus, reading every positive as a stem changes 4 verdicts of 675, all four false positives (`NASTAR` ×2 for `astar`, `Zero Trust Engineer` ×2 for `rust engineer`) and nothing else.

## What it does not cover, said out loud

A keyword that **ends** a longer word rather than starting it. `automation` inside `Gebäudeautomation` needs the plain form and `stem:` will not reach it:

```
                                   plain   stem:   word:
crypto      -> Cryptocurrency       yes     yes     no
fellows     -> Fellowship           yes     yes     no
automation  -> Gebäudeautomation    yes     NO      no
```

Three of the four loose cases raised in this thread are prefix-shaped; that one is not. I did not add a fourth prefix for it: the plain default already serves it, nobody has measured a config that the pair cannot express, and a suffix marker is easier to add later than to remove. The template says this rather than leaving it to be discovered.

## Tests

`tests/title-stem-prefix.test.mjs`, 8 assertions, and they are **triples rather than pairs**. "`stem:` matches X" is satisfied by a plain substring, which matches everything `stem:` does — the property worth pinning is that it sits strictly between its neighbours. Seen red in both directions, each mutation printing proof it applied:

| reverted to | fails on |
|---|---|
| plain substring | Reagents, Encrypto, Zero Trust Engineer |
| both-side anchor (`word:` under another name) | Agentforce, Agents, Cryptocurrency, Fellowship, Rust Engineering |

Your six negative-side rows are pinned as their own block, with a comment saying why they are hand-written rather than corpus-derived: none of the 675 titles contains `Internal`, `International` or `Internship`, so a corpus diff reports zero for exactly the strings the template names as the reason the default is a substring.

And the shipped template's own verdicts are asserted unchanged, since no entry uses the prefix yet.

## The doc paragraph, and what it settled

You said the spelling is whatever survives writing the docs for it. Writing them is what produced the three-way table above and killed the alternative: `agent*` reads as a glob, which invites `*agent`, and a suffix side nothing has measured a need for. `stem:` mirrors `word:`, parses on the same path, and the paragraph explains itself in six lines.

The `word:`-becomes-a-no-op finding is in that paragraph as you asked — under an anchored default it keeps meaning only for keywords with a non-word edge, which is the `.net` case @IaroslavMazur pinned down.

## On the flip

Nothing here depends on it, and I have not assumed it happens. If it does, this is the prerequisite; if it does not, `stem:` still answers `Zero Trust Engineer` on its own. The `DATA_CONTRACT.md` point you raised — that flipping silently changes behaviour for every existing `portals.yml` and nobody gets a signal — is the part I would not want to see decided by a merge either.

`--only title-stem` 8, `--only title-filter` 30, `--only scan` 95, `--only aggregator` 11, `--only keyword` 20, SYSTEM_PATHS over 1,178 tracked files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `stem:` title-filter keywords to match words beginning with a specified prefix while allowing longer endings.
  - Added Unicode-aware matching to avoid matching prefixes within unrelated words.
  - Empty `stem:` filters match nothing.

- **Documentation**
  - Documented the differences between `stem:`, whole-word, and plain keyword matching.

- **Tests**
  - Added coverage for boundary cases, compound words, escaping, grouped filters, negative filters, and existing template behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->