### PR TITLE
fix(gfi-claims): reply when /assign is used outside claim pool (#3224)

### DIFF
--- a/.github/workflows/gfi-claims.yml
+++ b/.github/workflows/gfi-claims.yml
@@ -46,7 +46,11 @@ jobs:
             const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: num });
             const labels = issue.labels.map(l => (l.name || '').toLowerCase());
             const isFto = labels.includes('first-timers-only');
-            if (!labels.includes('good first issue') && !isFto) return;
+            if (!labels.includes('good first issue') && !isFto) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: num,
+                body: "This one isn't in the good-first-issue pool, so I can't assign it automatically. A maintainer will pick it up from here, and it's yours unless someone says otherwise." });
+              return;
+            }
             const user = context.payload.comment.user.login;
             const say = (body) => github.rest.issues.createComment({ owner, repo, issue_number: num, body });
             const FREE = `https://github.com/${owner}/${repo}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee`;


### PR DESCRIPTION
## What does this PR do?
Updates `.github/workflows/gfi-claims.yml` so that when a contributor uses `/assign` on an issue outside the `good first issue` or `first-timers-only` pool, the bot posts an explanatory comment before exiting instead of returning silently.

## Related issue
Closes #3224

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear explanatory comments when claim commands are used on issues that are not eligible.
  * Prevented non-eligible issues from proceeding through the claim workflow.
  * Preserved the existing claim process for good-first-issue and first-timers-only issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->