### PR TITLE
docs: move the offer-verification procedure into the oferta liveness gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,12 +349,7 @@ Two separate axes:
 
 ## Offer Verification -- MANDATORY
 
-**NEVER trust WebSearch/WebFetch to verify if an offer is still active.** ALWAYS use Playwright:
-1. `browser_navigate` to the URL
-2. `browser_snapshot` to read content
-3. Only footer/navbar without JD = closed. Title + description + Apply = active.
-
-**Exception for batch workers (headless mode):** Playwright is unavailable in headless pipe mode. Use WebFetch as fallback and mark the report header `**Verification:** unconfirmed (batch mode)`; the user can verify manually later.
+Neither a WebSearch/WebFetch result nor an aggregator's own page proves a role is open: a filled listing keeps serving title, description and Apply long after the employer closed it. Verify with Playwright, and treat aggregator listings (Wellfound, LinkedIn, Instahyre, Naukri…) as UNCONFIRMED until the employer's own ATS says otherwise. Full procedure -- live/closed classification, employer confirmation, headless-batch fallback -- is the liveness gate in `modes/oferta.md`.
 
 ---
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -14,8 +14,24 @@ When the candidate pastes a **URL** (not JD text), confirm the posting is still 
    - **closed posting evidence:** expired/closed/"no longer accepting applications", missing JD with only nav/footer, hard redirect to a generic careers/search page, or 404/410
 3. If the posting appears closed, **stop before Block A**: tell the candidate the link is dead, and if the entry came from `data/pipeline.md`, mark it `- [x] ~~Company | Role~~ — oferta nieaktywna`. Do not generate an evaluation, report, or CV.
 4. If the candidate pasted JD text (no URL), liveness cannot be verified — note that and proceed; there is no link to check.
+5. **Headless batch exception:** Playwright is unavailable in headless pipe mode. Fall back to WebFetch and mark the report header `**Verification:** unconfirmed (batch mode)`, so the candidate can verify by hand later. This is the one place a search-tool result stands in for a browser, and it is labelled as such in the report rather than passing silently as verified.
 
 Do not continue to Block A until this gate is resolved. The snapshot captured here is reused by Block G's freshness signals.
+
+### Aggregator listings: confirm at the employer
+
+Job aggregators keep stale, filled and ghost listings live long after the employer closed the req. A closed role's aggregator page still renders a title, a description and an Apply button, so step 2 above reads it as **active** and `check-liveness.mjs` agrees: the aggregator page itself proves nothing. **A listing sourced from an aggregator is UNCONFIRMED by default: it is not a real opening until the employer says so.** This covers Wellfound / LinkedIn / Instahyre / Cutshort / Internshala / Naukri and similar, however the listing arrived — pasted, scanned, or found via WebSearch.
+
+Measured on 9 Wellfound listings checked one by one against the employer's own page (#2572): 5 were dead — two returned HTTP 410 Gone, one mirror said "Position Closed", one company had 7 openings posted and none was this one — 1 was live, and 3 were unverifiable. **All 9 passed the liveness check above.** In one case the careers link pointed back at the aggregator, making the verification circular.
+
+**Before an aggregator listing is evaluated, applied to, or presented to the candidate as live:**
+
+1. Identify the employer, then locate the same role on the **employer's own careers page / ATS** (Greenhouse, Lever, Ashby, Workday, or the company's `/careers`). Same Playwright discipline as step 1 above.
+2. **Found at the employer → the employer URL is canonical.** Use it as the report `**URL:**` and apply direct, never through the aggregator.
+3. **Not found at the employer → treat as stale.** Do not apply and do not present it as live. Mark it in `data/scan-history.tsv` or on the tracker row — never silently delete the record, since that is what stops it being re-added as new on the next scan.
+4. **Employer unidentifiable** (some aggregator and agency posts hide the company) → that is a **Block G posting-legitimacy signal**, not a research gap. Report it and stop. NEVER infer, guess, or invent the employer.
+
+This is a confirmation step, not a replacement for `check-liveness.mjs`: run the liveness checker against the **employer** URL once you have it. The headless-batch exception in step 5 still applies.
 
 ## Blacklist gate (#1742)
 


### PR DESCRIPTION
`AGENTS.md` loads on **every message of every session** — 455 lines, roughly 10K tokens, paid by every user on every turn. The Agent Skills guidance draws the line at fact versus procedure:

> Create a skill when [...] a section of CLAUDE.md has grown into a procedure rather than a fact. Unlike CLAUDE.md content, a skill's body loads only when it's used.

`## Offer Verification -- MANDATORY` had grown into a three-step procedure. And it was a **second copy** of one that already lives in `modes/oferta.md`, which loads only when a posting is being evaluated.

### The two copies had drifted

| | `AGENTS.md` (always loaded) | `modes/oferta.md` (loads with the mode) |
|---|---|---|
| "active" means | title + description + Apply | title/role + a real JD **or** an application path |
| Reuses the `auto-pipeline` snapshot | no | yes |
| Opt-in `browser-extract.mjs` | no | yes |
| What to do when it IS dead | unspecified | stop before Block A, mark `pipeline.md` |

Only the second governs an actual evaluation.

### And the always-loaded rule was wrong

#2572 by @gitraun measured it. Nine Wellfound listings checked one by one against the employer's own careers page:

- **5 dead** — two returned HTTP 410 Gone, one mirror said "Position Closed", one company had 7 openings posted and none was this one, another is down to a single employee and "rebuilding"
- 1 live, 3 unverifiable
- **All 9 passed the liveness check**, because on an aggregator a filled role keeps serving title, description and an Apply button
- In one case the employer link pointed back at the aggregator, making the verification circular

So `title + description + Apply = active` is not a rule needing an exception. It is false for aggregators, and it was false in the copy that doesn't govern evaluations.

### What this does

- The live/closed classification and the headless-batch fallback move into the liveness gate, where the surrounding steps already are (now step 5).
- **New**, from @gitraun's measurement: an `### Aggregator listings: confirm at the employer` subsection inside the gate, with the nine-listing result quoted so the rule carries its evidence.
- `AGENTS.md` keeps the **fact** — neither a search result nor an aggregator's page proves a role is open, verify with Playwright — and points at the gate.

His wording is intact; two references were re-anchored ("same Playwright discipline as above" → step 1 of the gate, "the headless-batch exception above" → step 5, which moved there with it).

### Size

```
main today                     455 lines / 41,710 chars
merging #2572 as filed         468 lines / ~43,000
this PR                        454 lines / 41,940
```

Honest reading: `AGENTS.md` does **not** shrink in bytes. It absorbs the aggregator fact without absorbing the procedure — 14 lines less than the alternative, with the rule corrected where it runs.

Local suite green except `live archive`, which fetches a real URL and timed out offline; the same suite ran 5311/0 on this machine earlier today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated offer verification guidance to require employer-side confirmation of job listings.
  * Aggregator listings are now treated as unconfirmed until matched with the employer’s careers page or applicant tracking system.
  * Listings without a verifiable employer are marked stale or blocked from further evaluation.
  * Batch verification can use an alternate web-check method when browser automation is unavailable, with results clearly labeled unconfirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->