### PR TITLE
feat(i18n): add structural drift checker

### DIFF
--- a/.github/workflows/i18n-drift.yml
+++ b/.github/workflows/i18n-drift.yml
@@ -1,0 +1,69 @@
+name: i18n drift check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'modes/**'
+      - 'i18n-drift.mjs'
+
+# Cancel stale runs on force-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Translation drift report
+    runs-on: ubuntu-latest
+    # This job is informational only — it never blocks a merge.
+    # Once the baseline is clean and all language maintainers have been
+    # notified, promote to `fail` by setting --threshold 1.0.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '18'
+
+      # No npm install needed — i18n-drift.mjs uses only Node built-ins.
+
+      - name: Run i18n drift check (warn only)
+        id: drift
+        run: |
+          # Run the full scan and capture output; never fail CI.
+          node i18n-drift.mjs --summary > drift-summary.txt 2>&1 || true
+          cat drift-summary.txt
+
+      - name: Post drift summary as step summary
+        if: always()
+        run: |
+          echo "## i18n drift report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Structural coverage of translated modes vs their canonical sources." >> $GITHUB_STEP_SUMMARY
+          echo "100 % means every heading in the English/canonical file has a" >> $GITHUB_STEP_SUMMARY
+          echo "counterpart in the translation; lower % = drift." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat drift-summary.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_See [i18n-drift.mjs](../blob/${{ github.sha }}/i18n-drift.mjs)" \
+            "and issue [#3168](https://github.com/santifer/career-ops/issues/3168) for details._" \
+            >> $GITHUB_STEP_SUMMARY
+
+      - name: Full drift report (artifact)
+        if: always()
+        run: node i18n-drift.mjs > drift-full.txt 2>&1 || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: i18n-drift-report
+          path: |
+            drift-summary.txt
+            drift-full.txt
+          if-no-files-found: ignore

--- a/i18n-drift.mjs
+++ b/i18n-drift.mjs
@@ -1,0 +1,574 @@
+#!/usr/bin/env node
+/**
+ * i18n-drift.mjs — Structural drift checker for translated modes
+ *
+ * Compares each modes/{lang}/X.md against its canonical modes/X.md by
+ * section-heading presence (not prose quality). Reports per-language,
+ * per-file coverage: sections present / total, and which headings are missing.
+ *
+ * Usage:
+ *   node i18n-drift.mjs                         # full scan, all languages
+ *   node i18n-drift.mjs --lang tr               # single language
+ *   node i18n-drift.mjs --lang tr --lang ru     # multiple languages
+ *   node i18n-drift.mjs --json                  # machine-readable output
+ *   node i18n-drift.mjs --threshold 0.8         # warn when coverage < 80 %
+ *   node i18n-drift.mjs <canonical> <translated> # two-file comparison (legacy)
+ *
+ * Exit codes:
+ *   0  all checked files meet the threshold (default 0 — CI warn mode)
+ *   1  one or more files are below the threshold (only when --threshold is set)
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, basename, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ROOT = fileURLToPath(new URL('.', import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Heading / section extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all ATX headings from markdown text.
+ * Returns `{ level, text, line }[]` in document order.
+ *
+ * @param {string} text
+ * @returns {{ level: number, text: string, line: number }[]}
+ */
+export function extractHeadings(text) {
+  return text
+    .split(/\r?\n/)
+    .map((line, index) => {
+      const match = line.match(/^(#{1,6})\s+(.+)$/);
+      if (!match) return null;
+      return {
+        level: match[1].length,
+        text: match[2].trim(),
+        line: index,
+      };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Extract sections (headings annotated with their line-count span).
+ *
+ * @param {string} text
+ * @returns {{ level: number, text: string, line: number, startLine: number, endLine: number, lineCount: number }[]}
+ */
+export function extractSections(text) {
+  const headings = extractHeadings(text);
+  const totalLines = text.split(/\r?\n/).length;
+
+  return headings.map((heading, index) => {
+    const nextHeading = headings[index + 1];
+    const endLine = nextHeading ? nextHeading.line : totalLines;
+    return {
+      ...heading,
+      startLine: heading.line,
+      endLine,
+      lineCount: endLine - heading.line,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Structural comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare the structure of a translated document against its canonical source.
+ *
+ * Matching strategy:
+ *   - Canonical headings are matched positionally against translated headings
+ *     at the same heading level, in order. A canonical heading is considered
+ *     "covered" if a translated heading exists at the same ordinal position
+ *     within its level group.
+ *   - "Missing" = canonical headings that have no corresponding translated
+ *     heading at the same ordinal + level position.
+ *
+ * This catches trailing drift (sections added to canonical that weren't
+ * back-ported to the translation) — exactly the issue described in #1666.
+ *
+ * @param {string} canonicalText
+ * @param {string} translatedText
+ * @returns {{
+ *   covered: number,
+ *   total: number,
+ *   coverage: number,
+ *   canonicalCount: number,
+ *   translatedCount: number,
+ *   missing: { text: string, level: number }[]
+ * }}
+ */
+export function compareStructure(canonicalText, translatedText) {
+  const canonical = extractSections(canonicalText);
+  const translated = extractSections(translatedText);
+
+  if (canonical.length === 0) {
+    return {
+      covered: 0,
+      total: 0,
+      coverage: 1,
+      canonicalCount: 0,
+      translatedCount: translated.length,
+      missing: [],
+    };
+  }
+
+  // Build per-level ordinal counters for translated headings.
+  // translatedByLevel[level] = array of translated headings at that level (in order).
+  const translatedByLevel = new Map();
+  for (const s of translated) {
+    if (!translatedByLevel.has(s.level)) translatedByLevel.set(s.level, []);
+    translatedByLevel.get(s.level).push(s);
+  }
+
+  // For each canonical heading, consume the corresponding ordinal slot in the
+  // translated document. If no slot exists → missing.
+  const canonicalByLevel = new Map();
+  const missing = [];
+
+  for (const section of canonical) {
+    if (!canonicalByLevel.has(section.level)) {
+      canonicalByLevel.set(section.level, 0);
+    }
+    const idx = canonicalByLevel.get(section.level);
+    canonicalByLevel.set(section.level, idx + 1);
+
+    const translatedAtLevel = translatedByLevel.get(section.level) ?? [];
+    if (idx >= translatedAtLevel.length) {
+      missing.push({ text: section.text, level: section.level });
+    }
+  }
+
+  const total = canonical.length;
+  const covered = total - missing.length;
+
+  return {
+    covered,
+    total,
+    coverage: total === 0 ? 1 : covered / total,
+    canonicalCount: canonical.length,
+    translatedCount: translated.length,
+    missing,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// README-based canonical mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a lang-dir README.md to discover which translated filename maps to
+ * which canonical modes/*.md file.
+ *
+ * READMEs contain a markdown table like:
+ *   | `is-ilani.md` | `modes/oferta.md` (ES) | … |
+ *   | `fursah.md`   | `modes/oferta.md` (ES) | … |
+ *
+ * Returns a Map<translatedBasename, canonicalBasename>.
+ *
+ * @param {string} readmePath  absolute path to the lang README.md
+ * @returns {Map<string, string>}
+ */
+export function parseReadmeMapping(readmePath) {
+  const map = new Map();
+  if (!existsSync(readmePath)) return map;
+
+  const lines = readFileSync(readmePath, 'utf-8').split(/\r?\n/);
+
+  for (const line of lines) {
+    // Match table rows that contain at least two pipe-delimited cells.
+    // Cell 1: translated file (e.g. `is-ilani.md` or is-ilani.md)
+    // Cell 2: canonical reference (e.g. `modes/oferta.md` (ES))
+    const rowMatch = line.match(/^\s*\|([^|]+)\|([^|]+)\|/);
+    if (!rowMatch) continue;
+
+    const cell1 = rowMatch[1].trim().replace(/`/g, '');
+    const cell2 = rowMatch[2].trim().replace(/`/g, '');
+
+    // cell1 must look like a markdown filename
+    if (!cell1.endsWith('.md')) continue;
+
+    // cell2 must contain a modes/ reference
+    const canonicalMatch = cell2.match(/modes\/([^/\s(]+\.md)/);
+    if (!canonicalMatch) continue;
+
+    const translatedBase = basename(cell1);
+    const canonicalBase = canonicalMatch[1];
+
+    // Skip self-referential mappings (e.g. README mapping itself)
+    if (translatedBase === 'README.md') continue;
+
+    map.set(translatedBase, canonicalBase);
+  }
+
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Language-directory scanning
+// ---------------------------------------------------------------------------
+
+/** Directories inside modes/ that are NOT language directories. */
+const MODES_NON_LANG_DIRS = new Set([
+  'heuristics',
+  'interview',
+  'pdf',
+  'regional',
+]);
+
+/**
+ * Discover all language directories under modes/.
+ * Returns string[] of language codes (e.g. ['ar', 'de', 'tr', ...]).
+ *
+ * @returns {string[]}
+ */
+export function discoverLangs() {
+  const modesDir = join(ROOT, 'modes');
+  return readdirSync(modesDir)
+    .filter(entry => {
+      if (MODES_NON_LANG_DIRS.has(entry)) return false;
+      try {
+        return statSync(join(modesDir, entry)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+/**
+ * Resolve the canonical modes/*.md path for a translated file.
+ *
+ * Resolution order:
+ *   1. README-declared mapping for this lang dir.
+ *   2. Identical filename exists in canonical modes/ root.
+ *   3. No mapping found → returns null.
+ *
+ * @param {string} translatedBase  basename of the translated file
+ * @param {Map<string, string>} readmeMap  parsed from README.md
+ * @returns {string|null}  basename of the canonical file, or null
+ */
+export function resolveCanonical(translatedBase, readmeMap) {
+  // Skip non-content files
+  if (translatedBase === 'README.md') return null;
+
+  // README-declared mapping
+  if (readmeMap.has(translatedBase)) {
+    return readmeMap.get(translatedBase);
+  }
+
+  // Same-name file in canonical root
+  const candidatePath = join(ROOT, 'modes', translatedBase);
+  if (existsSync(candidatePath)) {
+    return translatedBase;
+  }
+
+  return null;
+}
+
+/**
+ * Run the drift check for a single language directory.
+ *
+ * @param {string} lang  language code
+ * @returns {{
+ *   lang: string,
+ *   files: Array<{
+ *     translated: string,
+ *     canonical: string|null,
+ *     result: object|null,
+ *     skipped: boolean,
+ *     skipReason?: string
+ *   }>
+ * }}
+ */
+export function checkLang(lang) {
+  const langDir = join(ROOT, 'modes', lang);
+  const readmeMap = parseReadmeMapping(join(langDir, 'README.md'));
+
+  const entries = readdirSync(langDir)
+    .filter(f => {
+      try {
+        return !statSync(join(langDir, f)).isDirectory() && f.endsWith('.md');
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+
+  const files = [];
+
+  for (const translatedBase of entries) {
+    if (translatedBase === 'README.md') continue;
+
+    const canonicalBase = resolveCanonical(translatedBase, readmeMap);
+
+    if (!canonicalBase) {
+      files.push({
+        translated: translatedBase,
+        canonical: null,
+        result: null,
+        skipped: true,
+        skipReason: 'no canonical mapping found',
+      });
+      continue;
+    }
+
+    const canonicalPath = join(ROOT, 'modes', canonicalBase);
+    if (!existsSync(canonicalPath)) {
+      files.push({
+        translated: translatedBase,
+        canonical: canonicalBase,
+        result: null,
+        skipped: true,
+        skipReason: `canonical modes/${canonicalBase} not found`,
+      });
+      continue;
+    }
+
+    const canonicalText = readFileSync(canonicalPath, 'utf-8');
+    const translatedText = readFileSync(join(langDir, translatedBase), 'utf-8');
+    const result = compareStructure(canonicalText, translatedText);
+
+    files.push({
+      translated: translatedBase,
+      canonical: canonicalBase,
+      result,
+      skipped: false,
+    });
+  }
+
+  return { lang, files };
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+const PCT = (n) => `${Math.round(n * 100)}%`;
+
+/**
+ * Render the per-language, per-file coverage table as a human-readable string.
+ *
+ * @param {ReturnType<typeof checkLang>[]} langResults
+ * @param {object} opts
+ * @param {number} [opts.threshold]  coverage threshold (0–1) for marking failures
+ * @returns {string}
+ */
+export function formatReport(langResults, { threshold = 0 } = {}) {
+  const lines = [];
+
+  for (const { lang, files } of langResults) {
+    const checked = files.filter(f => !f.skipped);
+    if (checked.length === 0) {
+      lines.push(`\n── ${lang.toUpperCase()} ──────────────────────────────`);
+      lines.push('  (no files with a known canonical mapping)');
+      continue;
+    }
+
+    const langTotal = checked.reduce((s, f) => s + f.result.total, 0);
+    const langCovered = checked.reduce((s, f) => s + f.result.covered, 0);
+    const langPct = langTotal === 0 ? 1 : langCovered / langTotal;
+
+    lines.push(
+      `\n── ${lang.toUpperCase()} ─────────────────────────────── ` +
+      `${langCovered}/${langTotal} sections (${PCT(langPct)})`
+    );
+
+    for (const f of files) {
+      if (f.skipped) {
+        lines.push(`  ${f.translated.padEnd(25)} [skipped: ${f.skipReason}]`);
+        continue;
+      }
+      const { covered, total, coverage, missing } = f.result;
+      const bar = coverage >= threshold ? '✓' : '✗';
+      lines.push(
+        `  ${bar} ${f.translated.padEnd(25)} → modes/${f.canonical.padEnd(25)} ` +
+        `${covered}/${total} (${PCT(coverage)})`
+      );
+      if (missing.length > 0) {
+        for (const m of missing) {
+          const hashes = '#'.repeat(m.level);
+          lines.push(`      missing: ${hashes} ${m.text}`);
+        }
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+/**
+ * Render coverage results as a JSON-serialisable object.
+ *
+ * @param {ReturnType<typeof checkLang>[]} langResults
+ * @returns {object}
+ */
+export function toJSON(langResults) {
+  return langResults.map(({ lang, files }) => ({
+    lang,
+    files: files.map(f => ({
+      translated: f.translated,
+      canonical: f.canonical,
+      skipped: f.skipped,
+      skipReason: f.skipReason ?? null,
+      covered: f.result?.covered ?? null,
+      total: f.result?.total ?? null,
+      coveragePct: f.result ? Math.round(f.result.coverage * 100) : null,
+      missing: f.result?.missing ?? [],
+    })),
+    summary: (() => {
+      const checked = files.filter(f => !f.skipped);
+      const total = checked.reduce((s, f) => s + f.result.total, 0);
+      const covered = checked.reduce((s, f) => s + f.result.covered, 0);
+      return {
+        filesChecked: checked.length,
+        sectionsTotal: total,
+        sectionsCovered: covered,
+        coveragePct: total === 0 ? 100 : Math.round((covered / total) * 100),
+      };
+    })(),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function printUsage() {
+  console.error([
+    'Usage:',
+    '  node i18n-drift.mjs                     # full scan, all languages',
+    '  node i18n-drift.mjs --lang tr           # single language',
+    '  node i18n-drift.mjs --lang tr --lang ru # multiple languages',
+    '  node i18n-drift.mjs --json              # machine-readable output',
+    '  node i18n-drift.mjs --threshold 0.8     # exit 1 if any file < 80%',
+    '  node i18n-drift.mjs <canonical> <translated>  # two-file comparison',
+  ].join('\n'));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const args = process.argv.slice(2);
+
+  // ── Legacy two-file comparison mode ────────────────────────────────────
+  // Detect when both positional args look like file paths (not flags).
+  const positional = args.filter(a => !a.startsWith('--'));
+  if (positional.length >= 2 && !args.includes('--lang')) {
+    const [canonicalFile, translatedFile] = positional;
+
+    const canonicalPath = resolve(ROOT, canonicalFile);
+    const translatedPath = resolve(ROOT, translatedFile);
+
+    if (!existsSync(canonicalPath)) {
+      console.error(`Error: canonical file not found: ${canonicalFile}`);
+      process.exit(1);
+    }
+    if (!existsSync(translatedPath)) {
+      console.error(`Error: translated file not found: ${translatedFile}`);
+      process.exit(1);
+    }
+
+    const result = compareStructure(
+      readFileSync(canonicalPath, 'utf-8'),
+      readFileSync(translatedPath, 'utf-8')
+    );
+
+    console.log(
+      `${translatedFile}: ${result.covered}/${result.total} sections ` +
+      `(${PCT(result.coverage)})`
+    );
+
+    if (result.missing.length > 0) {
+      console.log('Missing sections:');
+      for (const section of result.missing) {
+        console.log(`  - ${'#'.repeat(section.level)} ${section.text}`);
+      }
+    }
+    process.exit(0);
+  }
+
+  // ── Full / per-lang scan mode ───────────────────────────────────────────
+  const wantsJson = args.includes('--json');
+  const wantsSummary = args.includes('--summary');
+
+  // Collect --lang values
+  const requestedLangs = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--lang' && args[i + 1]) {
+      requestedLangs.push(args[i + 1]);
+      i++;
+    }
+  }
+
+  // --threshold <float>
+  let threshold = 0;
+  const thIdx = args.indexOf('--threshold');
+  if (thIdx !== -1 && args[thIdx + 1]) {
+    const parsed = parseFloat(args[thIdx + 1]);
+    if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
+      threshold = parsed;
+    } else {
+      console.error(`Error: --threshold must be a number between 0 and 1, got: ${args[thIdx + 1]}`);
+      process.exit(1);
+    }
+  }
+
+  const langs = requestedLangs.length > 0 ? requestedLangs : discoverLangs();
+
+  // Validate requested langs
+  const allLangs = new Set(discoverLangs());
+  for (const l of langs) {
+    if (!allLangs.has(l)) {
+      console.error(`Error: language directory not found: modes/${l}/`);
+      process.exit(1);
+    }
+  }
+
+  const results = langs.map(checkLang);
+
+  if (wantsJson) {
+    console.log(JSON.stringify(toJSON(results), null, 2));
+  } else if (wantsSummary) {
+    // One-line-per-lang summary
+    for (const { lang, files } of results) {
+      const checked = files.filter(f => !f.skipped);
+      const total = checked.reduce((s, f) => s + f.result.total, 0);
+      const covered = checked.reduce((s, f) => s + f.result.covered, 0);
+      const pct = total === 0 ? 100 : Math.round((covered / total) * 100);
+      console.log(`${lang.padEnd(6)} ${covered}/${total} (${pct}%)`);
+    }
+  } else {
+    console.log('i18n drift report — career-ops modes/');
+    console.log('======================================');
+    console.log(formatReport(results, { threshold }));
+    console.log('');
+  }
+
+  // Exit non-zero only when a threshold is set and any file is below it
+  if (threshold > 0) {
+    let anyBelow = false;
+    for (const { files } of results) {
+      for (const f of files) {
+        if (!f.skipped && f.result.coverage < threshold) {
+          anyBelow = true;
+          break;
+        }
+      }
+    }
+    if (anyBelow) {
+      if (!wantsJson && !wantsSummary) {
+        console.error(
+          `\nFAIL: one or more files are below the coverage threshold of ${PCT(threshold)}`
+        );
+      }
+      process.exit(1);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "build:dashboard": "node build-dashboard.mjs",
     "serve:dashboard": "cd dashboard && go run . --path ..",
     "postinstall": "npx playwright install chromium --with-deps || npx playwright install chromium --with-deps",
-    "manifesto": "node manifesto.mjs"
+    "manifesto": "node manifesto.mjs",
+    "i18n:drift": "node i18n-drift.mjs",
+    "i18n:drift:summary": "node i18n-drift.mjs --summary"
   },
   "keywords": [
     "ai",

--- a/tests/i18n-drift.test.mjs
+++ b/tests/i18n-drift.test.mjs
@@ -1,0 +1,414 @@
+// tests/i18n-drift.test.mjs — structural drift checker unit tests (#3168)
+//
+// Discovered suites run IN-PROCESS inside test-all.mjs: they must report via
+// the shared pass/fail counters from helpers.mjs and must never terminate the
+// process themselves.
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pass, fail, ROOT } from './helpers.mjs';
+import {
+  extractHeadings,
+  extractSections,
+  compareStructure,
+  parseReadmeMapping,
+  resolveCanonical,
+  discoverLangs,
+  checkLang,
+  toJSON,
+  formatReport,
+} from '../i18n-drift.mjs';
+
+console.log('\ni18n-drift — structural drift checker (#3168)');
+
+function check(condition, message) {
+  if (condition) pass(message);
+  else fail(message);
+}
+
+// ---------------------------------------------------------------------------
+// extractHeadings
+// ---------------------------------------------------------------------------
+
+{
+  const headings = extractHeadings(`
+# Title
+
+Some text.
+
+## First section
+
+### Nested section
+
+## Second section
+`);
+
+  check(headings.length === 4, 'extractHeadings: extracts all 4 headings');
+  check(
+    JSON.stringify(headings.map(h => h.level)) === JSON.stringify([1, 2, 3, 2]),
+    'extractHeadings: preserves heading levels'
+  );
+  check(headings[1].text === 'First section', 'extractHeadings: preserves heading text');
+  check(
+    !headings.some(h => h.text === 'Some text.'),
+    'extractHeadings: ignores normal text'
+  );
+  check(
+    headings.every(h => typeof h.line === 'number'),
+    'extractHeadings: records line numbers'
+  );
+}
+
+// CRLF tolerance
+{
+  const headings = extractHeadings('# Heading\r\n\r\n## Sub\r\n');
+  check(headings.length === 2, 'extractHeadings: handles CRLF line endings');
+}
+
+// ---------------------------------------------------------------------------
+// extractSections
+// ---------------------------------------------------------------------------
+
+{
+  const sections = extractSections(`
+# Title
+
+intro
+
+## First
+
+content
+
+## Second
+
+more content
+`);
+
+  check(sections.length === 3, 'extractSections: extracts sections');
+  check(
+    JSON.stringify(sections.map(s => s.level)) === JSON.stringify([1, 2, 2]),
+    'extractSections: records section levels'
+  );
+  check(
+    sections.every(s => s.lineCount > 0),
+    'extractSections: records positive line counts'
+  );
+  check(
+    sections[0].startLine < sections[1].startLine,
+    'extractSections: sections are in document order'
+  );
+}
+
+// Duplicate headings
+{
+  const sections = extractSections(`
+# Introduction
+
+First intro.
+
+## Details
+
+First details.
+
+## Details
+
+Second details.
+`);
+
+  check(
+    sections[1].startLine !== sections[2].startLine,
+    'extractSections: handles duplicate heading text (distinct startLines)'
+  );
+  check(
+    sections[1].startLine < sections[2].startLine,
+    'extractSections: preserves order for duplicates'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// compareStructure
+// ---------------------------------------------------------------------------
+
+{
+  const comparison = compareStructure(
+    `
+# English
+## One
+## Two
+### Three
+`,
+    `
+# Turkish
+## Bir
+## Iki
+`
+  );
+
+  check(
+    comparison.covered === 3 && comparison.total === 4,
+    'compareStructure: counts covered sections by level-ordinal matching'
+  );
+  check(comparison.coverage === 0.75, 'compareStructure: calculates coverage ratio');
+  check(comparison.missing.length === 1, 'compareStructure: reports missing sections');
+  check(
+    comparison.missing[0].text === 'Three',
+    'compareStructure: names the missing canonical section'
+  );
+  check(
+    comparison.missing[0].level === 3,
+    'compareStructure: reports the missing section level'
+  );
+}
+
+// Empty canonical
+{
+  const r = compareStructure('', '# Translation');
+  check(
+    r.covered === 0 && r.total === 0 && r.coverage === 1,
+    'compareStructure: treats empty canonical as 100% (nothing to cover)'
+  );
+}
+
+// Perfect match
+{
+  const same = `# A\n## B\n## C\n`;
+  const r = compareStructure(same, same);
+  check(r.coverage === 1, 'compareStructure: 100% coverage for identical structure');
+  check(r.missing.length === 0, 'compareStructure: no missing sections for identical structure');
+}
+
+// All missing
+{
+  const r = compareStructure('# A\n## B\n', '');
+  check(r.covered === 0, 'compareStructure: covered=0 when translation is empty');
+  check(r.missing.length === 2, 'compareStructure: reports all sections as missing for empty translation');
+}
+
+// Extra sections in translation don't inflate coverage
+{
+  const r = compareStructure('# A\n## B\n', '# X\n## Y\n## Z\n### Q\n');
+  check(r.covered === 2 && r.total === 2, 'compareStructure: extra translated headings do not inflate covered count');
+}
+
+// ---------------------------------------------------------------------------
+// parseReadmeMapping
+// ---------------------------------------------------------------------------
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), 'i18n-drift-test-'));
+  const readmePath = join(tmp, 'README.md');
+  writeFileSync(readmePath, `# Lang modes
+
+| File | Source | Purpose |
+|------|--------|---------|
+| \`is-ilani.md\` | \`modes/oferta.md\` (ES) | Full evaluation |
+| \`basvuru.md\` | \`modes/apply.md\` (EN) | Application assistant |
+| \`pipeline.md\` | \`modes/pipeline.md\` (ES) | Pipeline |
+| \`_shared.md\` | \`modes/_shared.md\` (EN) | Shared context |
+`);
+
+  const map = parseReadmeMapping(readmePath);
+  check(map.get('is-ilani.md') === 'oferta.md', 'parseReadmeMapping: resolves localized name → canonical');
+  check(map.get('basvuru.md') === 'apply.md', 'parseReadmeMapping: resolves second entry');
+  check(map.get('pipeline.md') === 'pipeline.md', 'parseReadmeMapping: same-name entry is handled');
+  check(map.get('_shared.md') === '_shared.md', 'parseReadmeMapping: _shared.md entry is handled');
+  check(!map.has('README.md'), 'parseReadmeMapping: skips README.md entries');
+}
+
+// Missing README
+{
+  const map = parseReadmeMapping('/nonexistent/path/README.md');
+  check(map.size === 0, 'parseReadmeMapping: returns empty map when README does not exist');
+}
+
+// ---------------------------------------------------------------------------
+// resolveCanonical
+// ---------------------------------------------------------------------------
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), 'i18n-resolve-test-'));
+  // We cannot easily mock the ROOT filesystem in-process, so we test the
+  // README-map branch directly:
+  const fakeMap = new Map([
+    ['is-ilani.md', 'oferta.md'],
+    ['pipeline.md', 'pipeline.md'],
+  ]);
+
+  check(
+    resolveCanonical('is-ilani.md', fakeMap) === 'oferta.md',
+    'resolveCanonical: uses README mapping'
+  );
+  check(
+    resolveCanonical('pipeline.md', fakeMap) === 'pipeline.md',
+    'resolveCanonical: same-name mapping'
+  );
+  check(
+    resolveCanonical('README.md', fakeMap) === null,
+    'resolveCanonical: returns null for README.md'
+  );
+  // File not in map and not in canonical root (fabricated name)
+  check(
+    resolveCanonical('fabricated-XYZ.md', new Map()) === null,
+    'resolveCanonical: returns null when no mapping and no canonical file found'
+  );
+  // File not in map but exists in canonical root
+  check(
+    resolveCanonical('_shared.md', new Map()) === '_shared.md',
+    'resolveCanonical: falls back to filename identity for same-name canonical files'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// discoverLangs
+// ---------------------------------------------------------------------------
+
+{
+  const langs = discoverLangs();
+  check(Array.isArray(langs), 'discoverLangs: returns an array');
+  check(langs.length > 0, 'discoverLangs: finds at least one language directory');
+  check(langs.includes('tr'), 'discoverLangs: includes Turkish (tr)');
+  check(langs.includes('de'), 'discoverLangs: includes German (de)');
+  check(langs.includes('fr'), 'discoverLangs: includes French (fr)');
+  check(!langs.includes('heuristics'), 'discoverLangs: excludes heuristics (non-lang dir)');
+  check(!langs.includes('interview'), 'discoverLangs: excludes interview (non-lang dir)');
+  check(!langs.includes('pdf'), 'discoverLangs: excludes pdf (non-lang dir)');
+  check(!langs.includes('regional'), 'discoverLangs: excludes regional (non-lang dir)');
+  // Result must be sorted
+  const sorted = [...langs].sort();
+  check(
+    JSON.stringify(langs) === JSON.stringify(sorted),
+    'discoverLangs: returns languages in sorted order'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// checkLang (integration — uses real modes/ files)
+// ---------------------------------------------------------------------------
+
+{
+  const result = checkLang('tr');
+  check(result.lang === 'tr', 'checkLang(tr): result.lang is "tr"');
+  check(Array.isArray(result.files), 'checkLang(tr): result.files is an array');
+
+  const checkedFiles = result.files.filter(f => !f.skipped);
+  check(checkedFiles.length > 0, 'checkLang(tr): at least one file is checked (not all skipped)');
+
+  for (const f of checkedFiles) {
+    check(
+      typeof f.result.covered === 'number',
+      `checkLang(tr) ${f.translated}: result.covered is a number`
+    );
+    check(
+      f.result.coverage >= 0 && f.result.coverage <= 1,
+      `checkLang(tr) ${f.translated}: coverage is between 0 and 1`
+    );
+  }
+
+  // _shared.md should map to _shared.md (same filename, exists in canonical root)
+  const sharedEntry = result.files.find(f => f.translated === '_shared.md');
+  if (sharedEntry) {
+    check(
+      sharedEntry.canonical === '_shared.md',
+      'checkLang(tr): _shared.md maps to canonical _shared.md'
+    );
+    check(!sharedEntry.skipped, 'checkLang(tr): _shared.md is not skipped');
+  }
+}
+
+// Verify German too
+{
+  const result = checkLang('de');
+  const checked = result.files.filter(f => !f.skipped);
+  check(checked.length > 0, 'checkLang(de): at least one file is checked');
+  check(
+    checked.every(f => f.result && typeof f.result.coverage === 'number'),
+    'checkLang(de): all checked files have numeric coverage'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// toJSON
+// ---------------------------------------------------------------------------
+
+{
+  const fakeResults = [
+    {
+      lang: 'xx',
+      files: [
+        {
+          translated: 'foo.md',
+          canonical: 'bar.md',
+          skipped: false,
+          result: { covered: 3, total: 4, coverage: 0.75, missing: [{ text: 'M', level: 2 }] },
+        },
+        {
+          translated: 'baz.md',
+          canonical: null,
+          skipped: true,
+          skipReason: 'no canonical mapping found',
+          result: null,
+        },
+      ],
+    },
+  ];
+
+  const json = toJSON(fakeResults);
+  check(Array.isArray(json), 'toJSON: returns array');
+  check(json[0].lang === 'xx', 'toJSON: preserves lang');
+  check(json[0].files[0].coveragePct === 75, 'toJSON: converts coverage to percentage');
+  check(json[0].files[0].missing[0].text === 'M', 'toJSON: includes missing sections');
+  check(json[0].files[1].skipped === true, 'toJSON: marks skipped files');
+  check(json[0].files[1].coveragePct === null, 'toJSON: null coveragePct for skipped files');
+  check(json[0].summary.sectionsTotal === 4, 'toJSON: summary sectionsTotal');
+  check(json[0].summary.sectionsCovered === 3, 'toJSON: summary sectionsCovered');
+  check(json[0].summary.coveragePct === 75, 'toJSON: summary coveragePct');
+  check(json[0].summary.filesChecked === 1, 'toJSON: summary filesChecked counts non-skipped');
+}
+
+// ---------------------------------------------------------------------------
+// formatReport
+// ---------------------------------------------------------------------------
+
+{
+  const fakeResults = [
+    {
+      lang: 'xx',
+      files: [
+        {
+          translated: 'test.md',
+          canonical: 'source.md',
+          skipped: false,
+          result: {
+            covered: 2,
+            total: 4,
+            coverage: 0.5,
+            missing: [{ text: 'Section A', level: 2 }, { text: 'Section B', level: 3 }],
+          },
+        },
+      ],
+    },
+  ];
+
+  const report = formatReport(fakeResults, { threshold: 0.8 });
+  check(typeof report === 'string', 'formatReport: returns a string');
+  check(report.includes('XX'), 'formatReport: includes language code');
+  check(report.includes('2/4'), 'formatReport: shows covered/total');
+  check(report.includes('50%'), 'formatReport: shows percentage');
+  check(report.includes('Section A'), 'formatReport: lists missing section names');
+  check(report.includes('Section B'), 'formatReport: lists all missing sections');
+  check(report.includes('✗'), 'formatReport: marks files below threshold with ✗');
+
+  // Above threshold → ✓
+  const report2 = formatReport([
+    {
+      lang: 'yy',
+      files: [{
+        translated: 'ok.md',
+        canonical: 'ok.md',
+        skipped: false,
+        result: { covered: 4, total: 4, coverage: 1, missing: [] },
+      }],
+    },
+  ], { threshold: 0.8 });
+  check(report2.includes('✓'), 'formatReport: marks files above threshold with ✓');
+}


### PR DESCRIPTION
## Summary

Implements the automated i18n structural drift checker requested in #3168.

Full-set translations can become stale while waiting to merge because canonical mode files continue to change. This makes it difficult to know whether a translated file still contains the same structural sections as its canonical source.

This PR adds a standalone checker that measures that structural drift and reports coverage per language and file.

## What changed

### `i18n-drift.mjs`

Added a standalone Node.js structural drift checker that:

- Extracts Markdown headings and their levels.
- Compares translated files against their canonical files using heading level + ordinal position.
- Reports covered sections vs. total canonical sections.
- Reports missing canonical sections.
- Calculates a structural coverage percentage.
- Handles duplicate headings using their document position.
- Supports localized filenames through each language's `README.md` mapping.
  - For example, a localized file such as `is-ilani.md` can map back to the canonical `oferta.md`.
- Automatically discovers supported language directories.
- Excludes non-language directories such as:
  - `heuristics`
  - `interview`
  - `pdf`
  - `regional`

### CLI

Added support for:

```text
node i18n-drift.mjs
node i18n-drift.mjs --lang tr
node i18n-drift.mjs --lang tr --lang ru
node i18n-drift.mjs --json
node i18n-drift.mjs --summary
node i18n-drift.mjs --threshold 0.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to detect structural differences between canonical mode documents and their translations.
  * Reports now support human-readable, summary, JSON, and legacy output formats, with configurable coverage thresholds.
  * Added automated pull request checks with downloadable drift reports.

* **Tests**
  * Added comprehensive coverage for document comparison, language mapping, reporting, thresholds, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->