### PR TITLE
feat(apply): recover previous answers through --read --strict at the CLI seam

### DIFF
--- a/application-answers.mjs
+++ b/application-answers.mjs
@@ -340,6 +340,8 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') args.help = true;
+    else if (arg === '--read') args.read = true;
+    else if (arg === '--strict') args.strict = true;
     else if (arg.startsWith('--')) {
       const value = argv[i + 1];
       if (!value || value.startsWith('--')) {
@@ -355,8 +357,12 @@ function parseArgs(argv) {
 function usage() {
   return [
     'Usage: node application-answers.mjs --report <report.md> --input <answers.json> [--state filled|submitted] [--date YYYY-MM-DD]',
+    '       node application-answers.mjs --report <report.md> --read [--strict]',
     '',
     'The input JSON may contain: freeText, selections, fieldValues, files, date, state.',
+    '--read prints the parsed ## Application Answers snapshot as JSON (null when the section is absent).',
+    '--strict makes --read refuse a partially unreadable section, naming every line it could not parse,',
+    'instead of skipping it. Recovery callers (modes/apply.md) want the refusal; the default stays total.',
   ].join('\n');
 }
 
@@ -371,6 +377,30 @@ async function main() {
   }
   if (args.help) {
     console.log(usage());
+    return;
+  }
+  if (args.strict && !args.read) {
+    console.error(`--strict only applies to --read.\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.read) {
+    if (args.input || args.state || args.date) {
+      console.error(`--read is read-only and takes no --input, --state or --date.\n\n${usage()}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!args.report) {
+      console.error(usage());
+      process.exitCode = 1;
+      return;
+    }
+    // strict throws with a message naming every unreadable line; main().catch
+    // prints it to stderr and sets a non-zero exit code, which is the contract
+    // modes/apply.md keys on. A report without the section prints null.
+    const reportText = readFileSync(resolve(args.report), 'utf-8');
+    const snapshot = parseApplicationAnswersSection(reportText, { strict: args.strict === true });
+    console.log(JSON.stringify(snapshot, null, 2));
     return;
   }
   if (!args.report || !args.input) {

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -128,7 +128,15 @@ If a field matches, warn the candidate BEFORE generating or filling an answer fo
 1. Extract company name and role title from the page
 2. Search in `reports/` by company name (case-insensitive grep)
 3. If there is a match → load the full report
-4. If there is a Section H or `## Application Answers` → load previous answers as a base
+4. If there is a `## Application Answers` section → recover it through the strict reader, never by re-reading the rendered markdown as prose:
+
+   ```bash
+   node application-answers.mjs --report reports/NNN-company-role-date.md --read --strict
+   ```
+
+   - **Exit 0** → the JSON on stdout is the base snapshot of previous answers. `null` means the report has no section; treat it as a fresh application.
+   - **Non-zero exit** → the section is partially unreadable and strict mode refused it, naming every unreadable line on stderr. Do NOT fall back to reading the section as prose, and do NOT proceed with a partial base — a silently dropped answer looks like an answer the candidate never gave, and an absorbed one corrupts an answer they did give. Show the candidate the named lines and ask whether to fix the report first or continue without the affected answers.
+   - A legacy **Section H** (reports that predate `## Application Answers`) has no structured reader; use it as prose context only and tell the candidate that is what it is.
 5. If there is NO match → notify and offer to run a quick auto-pipeline
 
 ## Step 3 — Detect changes in the role

--- a/tests/application-answers.test.mjs
+++ b/tests/application-answers.test.mjs
@@ -35,9 +35,11 @@
 // Anti-vacuity: a round-trip suite over an empty corpus passes trivially, so the
 // corpus is asserted to actually produce entries before any equality is checked.
 
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, run, lastRunFailure, ROOT } from './helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 
 console.log('\napplication-answers.mjs — rendered sections parse back into snapshots');
 
@@ -396,6 +398,93 @@ try {
     pass('formatter output is unchanged by the addition of the reader');
   } else {
     fail(`formatter output changed:\n${section}`);
+  }
+
+  // ── 9. the CLI read path — the seam modes/apply.md actually calls ────────
+  // The prompt layer is CI-blind: an agent mode cannot import the library, it
+  // can only run the CLI. So the recovery contract the apply mode depends on
+  // is pinned here, at the executable seam, even though the mode file itself
+  // cannot be. The contract:
+  //
+  //   --read           prints the parsed snapshot as JSON (null when absent),
+  //                    total on mangled input exactly like the library default
+  //   --read --strict  exits non-zero on a partially unreadable section and
+  //                    names every refused line on stderr
+  //   --strict alone   is refused, not silently ignored — a caller who typed
+  //                    it wanted the refusal semantics somewhere
+  const cliTmp = mkdtempSync(join(tmpdir(), 'application-answers-cli-'));
+  try {
+    const cleanPath = join(cliTmp, 'clean.md');
+    const mangledPath = join(cliTmp, 'mangled.md');
+    const noSectionPath = join(cliTmp, 'no-section.md');
+    writeFileSync(cleanPath, clean, 'utf-8');
+    writeFileSync(mangledPath, mangled, 'utf-8');
+    writeFileSync(noSectionPath, '# Report 001\n\n## Evaluation\n\nBody only.\n', 'utf-8');
+
+    // stderr is piped, not inherited: the strict invocation below fails BY
+    // DESIGN, and its refusal message belongs in lastRunFailure(), not
+    // interleaved with the suite's own output.
+    const cli = (...extra) =>
+      run('node', ['application-answers.mjs', ...extra], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const cliChecks = [];
+
+    const cleanOut = cli('--report', cleanPath, '--read');
+    cliChecks.push([
+      cleanOut !== null &&
+        JSON.stringify(JSON.parse(cleanOut)) ===
+        JSON.stringify(parseApplicationAnswersSection(clean)),
+      'clean --read must print exactly what the library parse returns',
+    ]);
+
+    const nullOut = cli('--report', noSectionPath, '--read');
+    cliChecks.push([
+      nullOut === 'null',
+      `--read on a report without the section must print null, got: ${nullOut}`,
+    ]);
+
+    const lenientOut = cli('--report', mangledPath, '--read');
+    cliChecks.push([
+      lenientOut !== null &&
+        JSON.stringify(JSON.parse(lenientOut)) ===
+        JSON.stringify(parseApplicationAnswersSection(mangled)),
+      '--read without --strict must stay total on a mangled section (library default, unchanged)',
+    ]);
+
+    const strictOut = cli('--report', mangledPath, '--read', '--strict');
+    const strictRun = strictOut === null ? lastRunFailure() : null;
+    cliChecks.push([
+      strictOut === null,
+      '--read --strict must exit non-zero on a mangled section',
+    ]);
+    cliChecks.push([
+      strictRun !== null &&
+        /2 unreadable entries/.test(strictRun.stderr) &&
+        strictRun.stderr.includes('Notice period'),
+      `--read --strict stderr must name what it refused, got: ${strictRun && strictRun.stderr}`,
+    ]);
+
+    // The dangerous shape is a full, VALID write invocation with --strict
+    // tacked on: without the guard it would write successfully while silently
+    // ignoring the flag, and the caller who asked for refusal semantics gets
+    // none. Uses a disposable copy so a buggy build cannot dirty the fixtures.
+    const writeVictimPath = join(cliTmp, 'write-victim.md');
+    const writeInputPath = join(cliTmp, 'write-input.json');
+    writeFileSync(writeVictimPath, '# Report 002\n\n## Evaluation\n\nBody only.\n', 'utf-8');
+    writeFileSync(writeInputPath, JSON.stringify({ freeText: [{ question: 'Q', answer: 'A' }] }), 'utf-8');
+    const strictOnWriteOut = cli('--report', writeVictimPath, '--input', writeInputPath, '--state', 'filled', '--strict');
+    cliChecks.push([
+      strictOnWriteOut === null,
+      '--strict on a write invocation must be refused, not silently ignored',
+    ]);
+
+    const cliBroken = cliChecks.filter(([ok]) => !ok).map(([, detail]) => detail);
+    if (cliBroken.length === 0) {
+      pass('CLI --read/--strict expose the parser contract at the seam apply mode calls');
+    } else {
+      fail(`CLI read path broken:\n  ${cliBroken.join('\n  ')}`);
+    }
+  } finally {
+    rmSync(cliTmp, { recursive: true, force: true });
   }
 } catch (e) {
   fail(`application answers round-trip tests crashed: ${e.stack || e.message}`);


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2809, the wiring you invited in the merge message: apply mode now opts into strict. `application-answers.mjs` gets a `--read [--strict]` CLI path that prints the parsed `## Application Answers` snapshot as JSON (strict refuses a partially unreadable section with a non-zero exit and names every unreadable line on stderr), a new test section pins that contract at the CLI seam, and `modes/apply.md` Step 2 recovers previous answers through `--read --strict` instead of re-reading the rendered markdown as prose.

## Related issue

No issue. This is the follow-up invited in the #2809 merge message ("wiring modes/apply.md to opt into strict").

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (this one was invited directly in the #2809 merge message, so I sent it straight in; happy to open an issue retroactively if you'd rather track it)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## Details

**`application-answers.mjs`** grows a read path next to the existing write path. `--report <file> --read` prints the parsed snapshot as JSON on stdout; a report with no section prints `null`. `--read` is read-only by contract, so it rejects `--input`, `--state` and `--date`, and `--strict` without `--read` is refused too (it doesn't apply to the write path).

**`tests/application-answers.test.mjs`** gets a section 9 that pins the contract at the exact seam apply mode calls, the CLI, not the library. It runs the real binary against temp-dir fixtures: a clean report round-trips byte for byte with the library parse, a no-section report prints `null`, lenient read matches the library on a mangled section, `--read --strict` exits non-zero and its stderr names both unreadable entries, and `--strict` on a full valid write invocation is refused with the victim file untouched.

**`modes/apply.md`** Step 2: exit 0 means the JSON is the base snapshot. Non-zero means strict refused, and the agent must not fall back to prose or proceed with a partial base: a silently dropped answer looks like an answer the candidate never gave, and an absorbed one corrupts an answer they did give. The agent shows the candidate the named lines and asks. Legacy Section H reports stay prose context only.

## Verification

- Focused suite: 11/11, including the new CLI seam test.
- Full suite: 3704 passed, 0 failed, 1 pre-existing warning (the Go compiler dashboard skip).
- Mutation checks: reverting each change kills exactly its own new assertion. The guard test for `--strict` without `--read` originally passed for the wrong reason (a missing `--input` also exits non-zero), so it was sharpened to a full valid write invocation plus `--strict`, which the mutant now fails.
- Write path untouched: formatter output stays byte-identical, and the existing sections still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read mode for retrieving Application Answers from existing reports as JSON.
  * Added strict validation to identify unreadable answer lines and report errors.
  * Updated the application workflow to reuse previously recorded answers when available.
  * Added handling for missing sections, which now starts a fresh answer set.
* **Documentation**
  * Updated command usage guidance for the new read and strict options.
* **Bug Fixes**
  * Improved handling of empty or unrecorded answer values when reading reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->