### PR TITLE
fix(plugins): scale export hook timeout with tracker size

### DIFF
--- a/plugins.mjs
+++ b/plugins.mjs
@@ -168,7 +168,12 @@ async function cmdRun(args) {
 
   if (hook === 'export') {
     const snapshot = buildSnapshot();
-    const results = await runHook('export', snapshot, { root: ROOT, dryRun });
+    // Export upserts one-by-one over the network (query + create/update per
+    // row), so the default 15s hook timeout only covers a handful of rows.
+    // Scale with tracker size so a growing applications.md doesn't age out.
+    const rowCount = snapshot.applications.length + snapshot.pipeline.length;
+    const timeoutMs = Math.min(120_000, Math.max(15_000, rowCount * 3_000));
+    const results = await runHook('export', snapshot, { root: ROOT, dryRun, timeoutMs });
     for (const r of results) {
       if (r.ok) console.log(`${r.id} export: pushed ${r.result?.pushed ?? 0} record(s).`);
       else console.log(`${r.id} export: failed — ${r.error}`);

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -171,7 +171,12 @@ async function cmdRun(args) {
     // Export upserts one-by-one over the network (query + create/update per
     // row), so the default 15s hook timeout only covers a handful of rows.
     // Scale with tracker size so a growing applications.md doesn't age out.
-    const rowCount = snapshot.applications.length + snapshot.pipeline.length;
+    // applications.length only: the bundled Notion export hook reads
+    // snapshot.applications exclusively, and snapshot.pipeline is parsed from
+    // data/pipeline.md's `- [ ]` checklist format by a table parser that can
+    // never match it (a pre-existing, separate bug in buildSnapshot() — always
+    // reads as empty), so counting it here would silently do nothing anyway.
+    const rowCount = snapshot.applications.length;
     const timeoutMs = Math.min(120_000, Math.max(15_000, rowCount * 3_000));
     const results = await runHook('export', snapshot, { root: ROOT, dryRun, timeoutMs });
     for (const r of results) {


### PR DESCRIPTION
## Summary

Using the Notion export the first time was failing due to the large pipeline on my first run.

`plugins.mjs`'s `export` hook call doesn't pass a `timeoutMs`, so it falls back to `runHook`'s `DEFAULT_HOOK_TIMEOUT_MS` (15s) regardless of tracker size. Export upserts rows one at a time over the network (query + create/update per row), so 15s only covers a handful of rows before a growing `applications.md` ages out mid-push.

This derives the timeout from the snapshot row count (3s/row), clamped to 15s–120s, and passes it through the `timeoutMs` option `runHook` already accepts.

## What changed and why

- `plugins.mjs`: compute `timeoutMs` from `snapshot.applications.length` before calling `runHook('export', ...)`.
- Updated per [CodeRabbit's review](https://github.com/santifer/career-ops/pull/3231#discussion_r3838945880): the original version also counted `snapshot.pipeline.length`, but that count is always 0 (`buildSnapshot()` parses `data/pipeline.md`'s `- [ ]` checklist with a markdown-table parser that can't match it — a pre-existing, unrelated bug) and wouldn't have been the right thing to count anyway, since the only real `export` hook (Notion's) reads `snapshot.applications` exclusively and never touches `snapshot.pipeline`. Scaling on `applications.length` alone matches what `export` actually iterates over.

## Test plan

- [x] `node test-all.mjs --only plugin` passes (13/13)
- [x] `node test-all.mjs --quick` passes (only pre-existing, network-dependent `ci-gemini-check` failure unrelated to this change)
- [x] `node --check plugins.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export reliability by adjusting the hook timeout based on the number of application rows.
  * Timeout is capped between 15 and 120 seconds to better accommodate different export sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->