### PR TITLE
feat(scoring): add interview-process scoring dimension

### DIFF
--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -60,7 +60,7 @@ Every other reference to tier elsewhere in the modes (batch.md, pipeline.md, etc
 
 ## Scoring System
 
-The evaluation scores five dimensions, integrated into one global score of 1-5. (These are the scoring dimensions, not the report's blocks — the report structure is A-H and lives in `modes/oferta.md`.)
+The evaluation scores six dimensions, integrated into one global score of 1-5. (These are the scoring dimensions, not the report's blocks — the report structure is A-H and lives in `modes/oferta.md`.)
 
 | Dimension | What it measures |
 |-----------|-----------------|
@@ -68,8 +68,9 @@ The evaluation scores five dimensions, integrated into one global score of 1-5. 
 | North Star alignment | How well the role fits the user's target archetypes (from _profile.md) |
 | Comp | Salary vs market (5=top quartile, 1=well below) |
 | Cultural signals | Company culture, growth, stability, remote policy |
+| Interview process | Practicality of the hiring process (take-home/pairing/system-design vs. multiple LeetCode-style rounds), scored against `culture_screen.require` |
 | Red flags | Blockers, warnings (negative adjustments) |
-| **Global** | Holistic judgment integrating the five dimensions above (no arithmetic formula) |
+| **Global** | Holistic judgment integrating the six dimensions above (no arithmetic formula) |
 
 **Score interpretation:**
 - 4.5+ → Strong match, recommend applying immediately
@@ -85,6 +86,14 @@ The evaluation scores five dimensions, integrated into one global score of 1-5. 
 5. **If evidence contradicts the `require` criteria** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
 6. **If no evidence exists for any `require` criterion** → score 3 by default, unless `culture_screen.deprioritize_if_absent: true` is set, in which case **cap this dimension at 2/5**.
 7. A role scoring 4.5+ overall but 2 or below on Cultural signals must carry an explicit warning in the report: "High technical fit, unconfirmed/poor culture fit — verify before applying."
+
+**How to score the "Interview process" dimension:**
+1. Find the interview-process line in `culture_screen.require` (e.g., "Practical interview processes (take-home, pair programming, system design) rather than multiple LeetCode rounds"). If `culture_screen` is missing or has no interview-process line, skip the structural capping and score qualitatively from any interview-stage description in the JD.
+2. Look for evidence in the JD's interview-process description and Block D/G company research (counts toward the same Bounded Research Budget — do not spend extra queries beyond that cap solely for this dimension): named stages ("take-home project", "pairing session", "system design interview", "onsite algorithm rounds", "multiple technical rounds").
+3. **Evidence describes take-home/pairing/system-design as the primary technical stage(s)** → score 4-5.
+4. **No interview-process detail is given anywhere** → score 3 by default, unless `culture_screen.deprioritize_if_absent: true` is set, in which case cap this dimension at 2/5.
+5. **Evidence describes multiple LeetCode/algorithm-style rounds as the primary technical stage(s)** → cap this dimension at 2/5, and name the specific stages found in Block A's row for this dimension — do not let a strong CV-match score silently compensate for this.
+6. A role scoring 4.5+ overall but 2 or below on Interview process must carry an explicit warning in the report: "High technical fit, LeetCode-heavy interview process — confirm you want to prep for that before applying."
 
 ## Posting Legitimacy (Block G)
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -56,6 +56,7 @@ Table with:
 - Remote (full/hybrid/onsite)
 - Team size (if mentioned)
 - **Culture screen** (see `_shared.md` § Scoring System): pass / caution / fail, with the specific evidence found or missing — not just a score, name what you saw
+- **Interview process screen** (see `_shared.md` § Scoring System): pass / caution / fail, naming the specific interview stages found (or their absence) — e.g., "take-home + system design" vs. "3 rounds of algorithm interviews"
 - TL;DR in 1 sentence
 
 ### Geo-mismatch check


### PR DESCRIPTION
## Summary

The scoring system doesn't currently capture whether a role's hiring process is practical (take-home / pairing / system design) versus multiple LeetCode-style algorithm rounds — a real cost signal for candidates deciding whether to pursue a role, especially alongside `culture_screen.require`, which already captures similar structural-fit signals.

This adds a sixth "Interview process" dimension to `_shared.md`'s scoring table, following the exact same evidence-based capping pattern already used for "Cultural signals": read the interview-process line from `culture_screen.require` if present, look for evidence in the JD + Block D/G research (within the existing Bounded Research Budget), score 4-5 for practical stages, cap at 2/5 for LeetCode-heavy stages, and default to 3 when no evidence exists either way. A role scoring 4.5+ overall but 2 or below here gets an explicit warning, mirroring the Cultural signals warning.

Wired into `modes/oferta.md`'s Block A report format as an "Interview process screen" row, next to the existing "Culture screen" row.

I know this repo asks for an issue first on new scoring dimensions since I'm sure you have opinions on scope/config-shape here — happy to open one if you'd rather discuss before review, this PR is really just "here's a working implementation to react to."

## What changed and why

- `modes/_shared.md`: add the "Interview process" row to the scoring dimension table (five → six dimensions), and a "How to score" guidance block mirroring Cultural signals.
- `modes/oferta.md`: add the "Interview process screen" row to Block A's report format table.

## Test plan

- [x] `node test-all.mjs --quick` passes (only pre-existing, network-dependent `ci-gemini-check` failure unrelated to this change)
- [x] Manually diffed the new guidance block against the existing Cultural signals block for consistent structure/wording