### PR TITLE
feat(cv): add optional Interests section to the HTML CV template

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -56,6 +56,7 @@ const DEFAULT_SECTION_TITLES = {
   education: 'Education',
   certifications: 'Certifications',
   awards: 'Awards & Honors',
+  interests: 'Interests',
   skills: 'Skills',
 };
 
@@ -526,6 +527,20 @@ function buildAwards(entries, partial) {
   }).join('\n    ');
 }
 
+// Interests renders as one comma-joined, sentence-cased line rather than a
+// repeating table like certifications/awards, so a partial's entryTemplate
+// (built for one row per entry) doesn't fit — html-only, no partial support,
+// same tradeoff certifications/competencies make for having no LaTeX marker.
+function buildInterests(items) {
+  if (!Array.isArray(items) || items.length === 0) return '';
+  return items
+    .filter(Boolean)
+    .map(String)
+    .map((item, idx) => (idx === 0 ? item : item.charAt(0).toLowerCase() + item.slice(1)))
+    .map(item => escapeHtml(item))
+    .join(', ');
+}
+
 function buildSkills(categories, partial) {
   if (!Array.isArray(categories) || categories.length === 0) return '';
   if (!partial) {
@@ -616,6 +631,8 @@ function renderReport(payload, partials) {
     CERTIFICATIONS: buildCertifications(payload.certifications, partials.get('certifications')),
     SECTION_AWARDS: escapeHtml(sectionTitles.awards),
     AWARDS: buildAwards(payload.awards, partials.get('awards')),
+    SECTION_INTERESTS: escapeHtml(sectionTitles.interests),
+    INTERESTS: buildInterests(payload.interests),
     SECTION_SKILLS: escapeHtml(sectionTitles.skills),
     SKILLS: buildSkills(payload.skills, partials.get('skills')),
   };
@@ -798,6 +815,7 @@ async function runSelfTest() {
       { category: 'Languages', items: 'Python, JavaScript, TypeScript' },
       { category: 'Frameworks', items: ['FastAPI', 'React', 'PyTorch'] },
     ],
+    interests: ['Reading sci-fi & fantasy', 'Hiking', 'Chess'],
   };
 
   if (!existsSync(TEMPLATE_PATH)) {
@@ -823,6 +841,13 @@ async function runSelfTest() {
   }
   if (/Kubernetes & Docker/.test(html)) {
     console.error('Self-test failed: found an unescaped ampersand in output');
+    process.exit(1);
+  }
+
+  // Guard buildInterests(): comma-joined, sentence-cased (only the first item
+  // keeps its capital), and escaped like every other free-text field.
+  if (!html.includes('Reading sci-fi &amp; fantasy, hiking, chess')) {
+    console.error('Self-test failed: Interests did not render as an escaped, comma-joined, sentence-cased line');
     process.exit(1);
   }
 

--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -2,18 +2,19 @@
 // build-cv-latex.mjs).
 //
 // Core competencies, work experience, projects, education, certifications,
-// awards, and skills are the genuinely optional CV sections: a competency tag
-// row is often redundant with the summary and experience bullets that prove
-// the same claims, a student or career-switcher has no professional history
-// to list yet, a candidate's projects are often already covered under Work
-// Experience, not every candidate has a degree, not every application carries
-// a certification worth listing, most candidates have no award to name, and
+// awards, interests, and skills are the genuinely optional CV sections: a
+// competency tag row is often redundant with the summary and experience
+// bullets that prove the same claims, a student or career-switcher has no
+// professional history to list yet, a candidate's projects are often already
+// covered under Work Experience, not every candidate has a degree, not every
+// application carries a certification worth listing, most candidates have no
+// award to name, most candidates don't add a personal-interests line, and
 // plenty of candidates list no skills section at all. The templates wrap all
-// seven unconditionally, so a payload with no entries renders a bare section
+// eight unconditionally, so a payload with no entries renders a bare section
 // header with nothing under it. The builders' buildCompetencies()/
 // buildExperience()/buildProjects()/buildEducation()/buildCertifications()/
-// buildAwards()/buildSkills() correctly return '' — nothing removes the
-// surrounding wrapper, which is what this module does.
+// buildAwards()/buildInterests()/buildSkills() correctly return '' — nothing
+// removes the surrounding wrapper, which is what this module does.
 //
 // Work experience (#2504) is optional for the people this tool is aimed at —
 // new graduates, career changers, and anyone leading with projects or
@@ -23,11 +24,12 @@
 // template, exactly as before. What changed is that an empty `experience` no
 // longer leaves the wrapper behind.
 //
-// Certifications has no marker in the LaTeX template (cv-template.tex has no
-// Certifications section at all), so PATTERNS.tex has no `certifications` key
-// — stripEmptySections skips a section silently when the active format has no
-// pattern for it, rather than trying to match against `undefined`. Awards, by
-// contrast, is defined for both formats.
+// Certifications and Interests have no marker in the LaTeX template
+// (cv-template.tex has neither section at all), so PATTERNS.tex has no
+// `certifications`/`interests` key — stripEmptySections skips a section
+// silently when the active format has no pattern for it, rather than trying
+// to match against `undefined`. Awards, by contrast, is defined for both
+// formats.
 //
 // ── The Skills sentinel: part of the template contract ───────────────────────
 //
@@ -115,6 +117,7 @@ const PATTERNS = {
     certifications: new RegExp(String.raw`<!--\s+CERTIFICATIONS\s+-->[\s\S]*?` + HTML_BOUNDARY),
     awards: new RegExp(String.raw`<!--\s+AWARDS\s+-->[\s\S]*?` + HTML_BOUNDARY),
     skills: new RegExp(String.raw`<!--\s+SKILLS\s+-->[\s\S]*?` + HTML_END_SENTINEL),
+    interests: new RegExp(String.raw`<!--\s+INTERESTS\s+-->[\s\S]*?` + HTML_BOUNDARY),
   },
   tex: {
     // The LaTeX banner is `%%%%  Experience  %%%%` — mixed case, and not the
@@ -127,7 +130,7 @@ const PATTERNS = {
   },
 };
 
-export const OPTIONAL_SECTIONS = ['competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills'];
+export const OPTIONAL_SECTIONS = ['competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'interests', 'skills'];
 
 export function isEmptySection(payload, section) {
   const entries = payload?.[section];

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -260,6 +260,7 @@ const SECTION_ALIASES = new Map([
   ['awards & honours', 'awards'],
   ['skills', 'skills'],
   ['technical skills', 'skills'],
+  ['interests', 'interests'],
   // Polish — the vocabulary documented in modes/pl/README.md, plus the word-order
   // variants that turn up in practice (both "Kompetencje kluczowe" and
   // "Kluczowe kompetencje" are used for the same section).

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -389,6 +389,12 @@
     width: 44px;
   }
 
+  /* === INTERESTS === */
+  .interests-line {
+    font-size: 10.5px;
+    color: #444;
+  }
+
   /* === SKILLS === */
   .skills-grid {
     display: flex;
@@ -692,6 +698,12 @@
   <div class="section">
     <div class="section-title">{{SECTION_AWARDS}}</div>
     <div class="award-table">{{AWARDS}}</div>
+  </div>
+
+  <!-- INTERESTS -->
+  <div class="section">
+    <div class="section-title">{{SECTION_INTERESTS}}</div>
+    <div class="interests-line">{{INTERESTS}}</div>
   </div>
 
   <!-- SKILLS -->

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -46,7 +46,7 @@ import { stripEmptySections } from '../cv-sections-core.mjs';
 
 console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
 
-const EMPTY = { competencies: [], experience: [], projects: [], education: [], certifications: [], awards: [], skills: [] };
+const EMPTY = { competencies: [], experience: [], projects: [], education: [], certifications: [], awards: [], interests: [], skills: [] };
 const FULL = {
   competencies: ['Tag'],
   experience: [{ company: 'E' }],
@@ -54,6 +54,7 @@ const FULL = {
   education: [{ degree: 'D' }],
   certifications: [{ title: 'C' }],
   awards: [{ title: 'A' }],
+  interests: ['Chess'],
   skills: [{ category: 'S', items: 'x' }],
 };
 
@@ -69,15 +70,15 @@ function check(label, actual, expected) {
 // are empty — the `<!-- END -->` / `%%%% END %%%%` marker itself, never the
 // (now-strippable) SKILLS marker or its content.
 const TEMPLATES = [
-  { file: 'templates/cv-template.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/resume-template.html', format: 'html', after: '<!-- END -->', hasCertifications: false, hasCompetencies: true },
-  { file: 'templates/cv-template.zh-minimal.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/cv-template.compact.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/cv-template.executive.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/cv-template.jake.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/cv-template.leadership.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/cv-template.modern.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
-  { file: 'templates/cv-template.tex', format: 'tex', after: '%%%%  END  %%%%', hasCertifications: false, hasCompetencies: false },
+  { file: 'templates/cv-template.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: true },
+  { file: 'templates/resume-template.html', format: 'html', after: '<!-- END -->', hasCertifications: false, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.zh-minimal.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.compact.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.executive.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.jake.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.leadership.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.modern.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true, hasInterests: false },
+  { file: 'templates/cv-template.tex', format: 'tex', after: '%%%%  END  %%%%', hasCertifications: false, hasCompetencies: false, hasInterests: false },
 ];
 
 // --- Coverage guard: no shipped CV template may sit outside the matrix ------
@@ -110,7 +111,7 @@ else fail(`shipped CV templates missing from TEMPLATES — they run zero asserti
 if (phantom.length === 0) pass('every template in the matrix exists on disk');
 else fail(`TEMPLATES names templates that are not on disk: ${phantom.join(', ')}`);
 
-for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLATES) {
+for (const { file, format, after, hasCertifications, hasCompetencies, hasInterests } of TEMPLATES) {
   const template = readFileSync(join(ROOT, file), 'utf-8');
   const name = file.split('/').pop();
   const closingSkeleton = format === 'html' ? '</body>\n</html>' : '\\end{document}';
@@ -121,6 +122,7 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
   const certificationsMarker = '<!-- CERTIFICATIONS -->'; // html-only; no LaTeX Certifications section exists
   const competenciesMarker = '<!-- CORE COMPETENCIES -->'; // html-only; no LaTeX Competencies section exists
   const awardsMarker = format === 'html' ? '<!-- AWARDS -->' : 'AWARDS  %';
+  const interestsMarker = '<!-- INTERESTS -->'; // html-only; no LaTeX Interests section exists
   const skillsMarker = format === 'html' ? '<!-- SKILLS -->' : 'Technical Skills  %';
   // The LaTeX banner reads "Experience" while its \section reads "Work
   // Experience"; the HTML marker is "WORK EXPERIENCE". They are not the same
@@ -137,6 +139,9 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
     check(`${name}: empty payload removes the competencies block`, stripped.includes(competenciesMarker), false);
   }
   check(`${name}: empty payload removes the awards block`, stripped.includes(awardsMarker), false);
+  if (hasInterests) {
+    check(`${name}: empty payload removes the interests block`, stripped.includes(interestsMarker), false);
+  }
   check(`${name}: empty payload removes the skills block`, stripped.includes(skillsMarker), false);
   check(`${name}: empty payload removes the work-experience block`, stripped.includes(experienceMarker), false);
   check(`${name}: the trailing sentinel survives`, stripped.includes(after), true);
@@ -180,6 +185,30 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
   check(`${name}: empty awards alone keeps skills`, onlyAwards.includes(skillsMarker), true);
   if (hasCertifications) {
     check(`${name}: empty awards alone keeps certifications`, onlyAwards.includes(certificationsMarker), true);
+  }
+  if (hasInterests) {
+    check(`${name}: empty awards alone keeps interests`, onlyAwards.includes(interestsMarker), true);
+  }
+
+  // Interests empty on its own: it sits directly between Awards and Skills
+  // (the last section), so a boundary slip here is the one most likely to eat
+  // into Skills or the trailing sentinel — assert both survive.
+  if (hasInterests) {
+    const onlyInterests = stripEmptySections(template, { ...FULL, interests: [] }, format);
+    check(`${name}: empty interests alone keeps awards`, onlyInterests.includes(awardsMarker), true);
+    check(`${name}: empty interests alone drops interests`, onlyInterests.includes(interestsMarker), false);
+    check(`${name}: empty interests alone keeps skills`, onlyInterests.includes(skillsMarker), true);
+    check(`${name}: empty interests alone keeps the closing document skeleton`,
+      onlyInterests.trimEnd().endsWith(closingSkeleton), true);
+
+    // Omitted `interests` key must behave identically to an explicit [].
+    const withoutInterests = { ...FULL };
+    delete withoutInterests.interests;
+    const omittedInterests = stripEmptySections(template, withoutInterests, format);
+    check(`${name}: omitted interests key removes the interests block`, omittedInterests.includes(interestsMarker), false);
+    check(`${name}: omitted interests key keeps skills`, omittedInterests.includes(skillsMarker), true);
+    check(`${name}: omitted interests key keeps the closing document skeleton`,
+      omittedInterests.trimEnd().endsWith(closingSkeleton), true);
   }
 
   // Competencies empty on its own: it is first among the optional sections,
@@ -260,6 +289,19 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
   }
   if (hasCertifications) {
     check(`${name}: empty skills alone keeps certifications`, onlySkills.includes(certificationsMarker), true);
+  }
+  if (hasInterests) {
+    check(`${name}: empty skills alone keeps interests`, onlySkills.includes(interestsMarker), true);
+
+    // Both empty: interests is now the section immediately before the
+    // now-empty (and last) Skills section — the adjacent-empty-sections case
+    // that matters most, since Skills' own boundary is the sentinel-only one.
+    const bothEmpty = stripEmptySections(template, { ...FULL, interests: [], skills: [] }, format);
+    check(`${name}: empty interests+skills drops interests`, bothEmpty.includes(interestsMarker), false);
+    check(`${name}: empty interests+skills drops skills`, bothEmpty.includes(skillsMarker), false);
+    check(`${name}: empty interests+skills keeps awards`, bothEmpty.includes(awardsMarker), true);
+    check(`${name}: empty interests+skills keeps the closing document skeleton`,
+      bothEmpty.trimEnd().endsWith(closingSkeleton), true);
   }
 
   // An omitted `skills` key must behave identically to an explicit empty

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -33,6 +33,7 @@ const RENDERED_TITLES = {
   SECTION_EDUCATION: 'Education',
   SECTION_CERTIFICATIONS: 'Certifications',
   SECTION_AWARDS: 'Awards & Honors',
+  SECTION_INTERESTS: 'Interests',
   SECTION_SKILLS: 'Skills',
 };
 
@@ -245,14 +246,14 @@ try {
   // Asserted against a written-out vocabulary, not against CV_SECTION_KEYS:
   // checking the message with the same list the message is built from would
   // pass however many sections the implementation actually knows about.
-  const EXPECTED_KEYS = ['summary', 'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills'];
+  const EXPECTED_KEYS = ['summary', 'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'interests', 'skills'];
   if (typo.warnings.some(w => EXPECTED_KEYS.every(k => w.includes(k)))) {
-    pass('the unrecognized-name warning lists all eight recognized section keys');
+    pass('the unrecognized-name warning lists all nine recognized section keys');
   } else {
     fail(`the warning should list the recognized keys: ${JSON.stringify(typo.warnings)}`);
   }
   if (EXPECTED_KEYS.every(k => CV_SECTION_KEYS.includes(k)) && CV_SECTION_KEYS.length === EXPECTED_KEYS.length) {
-    pass('CV_SECTION_KEYS is exactly the eight canonical sections the alias table produces');
+    pass('CV_SECTION_KEYS is exactly the nine canonical sections the alias table produces');
   } else {
     fail(`CV_SECTION_KEYS => ${JSON.stringify(CV_SECTION_KEYS)}`);
   }
@@ -655,10 +656,10 @@ try {
   // pass with the other six unreachable.
   const rendered = renderTemplate('cv-template.html');
   const shippedOrder = renderedTitles(rendered);
-  const allKeys = ['summary', 'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills'];
+  const allKeys = ['summary', 'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'interests', 'skills'];
   const reversed = renderedTitles(reorderCvSections(rendered, [...allKeys].reverse()));
-  if (shippedOrder.length === 8 && JSON.stringify(reversed) === JSON.stringify([...shippedOrder].reverse())) {
-    pass('every one of the shipped template\'s eight sections is movable (full reversal)');
+  if (shippedOrder.length === 9 && JSON.stringify(reversed) === JSON.stringify([...shippedOrder].reverse())) {
+    pass('every one of the shipped template\'s nine sections is movable (full reversal)');
   } else {
     fail(`shipped template reversal: before=${JSON.stringify(shippedOrder)} after=${JSON.stringify(reversed)}`);
   }


### PR DESCRIPTION
## Summary

Some candidates want a short, comma-joined "Interests" line (hobbies, volunteering) at the end of the CV. This wires a new optional section through the existing machinery in `cv-sections-core.mjs`: an empty/omitted `payload.interests` drops the whole section header via `OPTIONAL_SECTIONS`, exactly like Certifications/Awards do.

Placed between Awards and Skills (not after Skills) so Skills keeps its "last section" sentinel-boundary treatment untouched — I read the Skills sentinel design note in `cv-sections-core.mjs` carefully and didn't want to touch that logic for a lower-stakes feature.

Registered in `generate-pdf.mjs`'s `SECTION_ALIASES` too, so it's reorderable via `config/profile.yml`'s `cv.sections` like every other section — this is what the `CV_SECTION_KEYS`/shipped-template-reversal test in `tests/cv-section-order.test.mjs` caught when I first added the section without it.

**Scope note:** I only added the section to `templates/cv-template.html`, not the other 8 shipped templates — `hasInterests: false` for the rest in `tests/cv-optional-sections.test.mjs`'s matrix (same asymmetry the matrix already supports for `hasCertifications`/`hasCompetencies`). Happy to extend to the rest if that's the right shape, but wanted to keep the diff reviewable first. I also know new CV sections graduated through issues before (#2220 Awards, #2504 Work Experience) — open to filing one if you'd rather discuss shape/scope before review.

## What changed and why

- `cv-sections-core.mjs`: add an `interests` pattern to `PATTERNS.html` and to `OPTIONAL_SECTIONS`; header comment updated.
- `templates/cv-template.html`: add the `<!-- INTERESTS -->` section (between Awards and Skills) + minimal CSS.
- `build-cv-html.mjs`: add `buildInterests()` (comma-joined, sentence-cased after the first item, matching the existing prose-list convention), section title, and substitution wiring. No partial-template support — Interests renders as one line, not a repeating entry, so the `entryTemplate` partial shape doesn't fit (documented inline, same tradeoff Certifications/Competencies make for having no LaTeX marker).
- `generate-pdf.mjs`: register `interests` in `SECTION_ALIASES` so `cv.sections` reordering recognizes it.
- `tests/cv-optional-sections.test.mjs`: extend `EMPTY`/`FULL` fixtures and the `TEMPLATES` matrix with `hasInterests`, plus assertions for the empty-alone, omitted-key, and adjacent-to-Skills cases.
- `tests/cv-section-order.test.mjs`: add `SECTION_INTERESTS` to `RENDERED_TITLES` and update the canonical-key-count assertions from eight to nine.

## Test plan

- [x] `node build-cv-html.mjs --test` (self-test, includes an Interests escaping/formatting assertion)
- [x] `node tests/cv-optional-sections.test.mjs` — 0 failures
- [x] `node tests/cv-section-order.test.mjs` — 0 failures
- [x] `node test-all.mjs --quick` passes (only pre-existing, network-dependent `ci-gemini-check` failure unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Interests section to HTML CVs.
  * Interests are displayed as a clean, comma-separated, sentence-cased line.
  * Added support for the English “Interests” section label.
  * Updated the CV template with localized titles and styling.

* **Bug Fixes**
  * Improved handling of empty or omitted optional sections to preserve surrounding content correctly.

* **Tests**
  * Added coverage for Interests rendering, section ordering, and empty-section scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->