### PR TITLE
fix(story-provenance): the context matcher is ASCII-only, so a non-Latin CV verifies nothing (#3235)

### DIFF
--- a/story-provenance-check.mjs
+++ b/story-provenance-check.mjs
@@ -352,20 +352,36 @@ function buildCvNumberContexts(cvText) {
  * @param {number} windowChars
  * @returns {string[]}
  */
-function contextWords(body, matchIndex, matchLength, windowChars = 90) {
-  const start = Math.max(0, matchIndex - windowChars);
-  const end = Math.min(body.length, matchIndex + matchLength + windowChars);
-  const snippet = body
-    .slice(start, end)
-    // NFKC before the strip so a full-width "４０％" keys like "40%", the same
+/**
+ * NFKC, lowercased, with the combining dot a lowercased Turkish `İ` leaves
+ * behind removed.
+ *
+ * Extracted so the two sides of every comparison below are folded IDENTICALLY.
+ * contextWords() folds the claim window; hasContextOverlap() searches cv.md.
+ * Folding only one of them is a bug that hides: a cv.md written "İstanbul"
+ * lowercases to `i` + U+0307 and stops matching a claim word the strip has
+ * already reduced to plain "istanbul".
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function foldForContext(text) {
+  return String(text ?? '')
+    // NFKC before the strip so a full-width "４０％" folds like "40%", the same
     // normalization order normalizeTextKey uses.
     .normalize('NFKC')
     .toLowerCase()
     // Lowercasing a Turkish dotted capital leaves a bare combining dot
-    // (U+0307) behind, and \p{M} below would keep it — so "İstanbul" and
-    // "Istanbul" would not compare equal. Same one-character strip, and the
-    // same reason, as normalizeTextKey's.
-    .replace(/\u0307/gu, '')
+    // (U+0307) behind, and \p{M} in the strip below keeps it — so "İstanbul"
+    // and "Istanbul" would not compare equal. Same one-character strip, and
+    // the same reason, as normalizeTextKey's.
+    .replace(/\u0307/gu, '');
+}
+
+function contextWords(body, matchIndex, matchLength, windowChars = 90) {
+  const start = Math.max(0, matchIndex - windowChars);
+  const end = Math.min(body.length, matchIndex + matchLength + windowChars);
+  const snippet = foldForContext(body.slice(start, end))
     .replace(/[^\p{L}\p{M}\p{N}\s]/gu, ' ');
   const words = snippet.split(/\s+/).filter(Boolean);
   // `\p{N}` not `\d`: a token of Devanagari or full-width digits is just as
@@ -374,13 +390,36 @@ function contextWords(body, matchIndex, matchLength, windowChars = 90) {
 }
 
 /**
- * Whether any context word appears (word-boundary, case-insensitive) in cv.md prose.
- * @param {string[]} words
- * @param {string} cvTextLower
+ * Whether any context word appears, on a word boundary, in cv.md prose.
+ *
+ * The boundary is a lookaround pair, not `\b`. `\b` is defined against `\w`,
+ * which is `[A-Za-z0-9_]` — so for a Cyrillic, Greek, Hebrew, Arabic or CJK
+ * word BOTH sides of every edge are non-word characters and the assertion is
+ * never satisfied:
+ *
+ *   /\bсократил\b/i.test('сократил расходы')   ->  false
+ *
+ * That made this the second half of the same defect as the ASCII strip in
+ * contextWords: even once the words survive folding, they could never be found
+ * in cv.md, so `supportedByResume` stayed unreachable for a non-Latin CV and
+ * every claim still fell to `derived-unverified`.
+ *
+ * Mirrors the `bounded()` helper scan.mjs already uses for company names, down
+ * to its escape set — `\-` is an invalid identity escape under `u`. Both
+ * operands here are folded output (letters, marks, digits and spaces only), so
+ * the escape is defensive rather than load-bearing.
+ *
+ * @param {string[]} words - Claim context words, already folded.
+ * @param {string} cvText - Raw cv.md; folded here so both sides match.
  * @returns {boolean}
  */
-function hasContextOverlap(words, cvTextLower) {
-  return words.some((w) => new RegExp(`\\b${w}\\b`, 'i').test(cvTextLower));
+function hasContextOverlap(words, cvText) {
+  const haystack = foldForContext(cvText);
+  const bounded = (w) => new RegExp(
+    `(?<![\\p{L}\\p{M}\\p{N}])${w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\p{L}\\p{M}\\p{N}])`,
+    'u',
+  );
+  return words.some((w) => bounded(w).test(haystack));
 }
 
 /**
@@ -409,7 +448,6 @@ const USER_STATED_RE = /^user-stated\s+\d{4}-\d{2}-\d{2}$/;
  */
 function classifyStoryBank(storyBankText, cvText) {
   const cvNumberContexts = buildCvNumberContexts(cvText);
-  const cvTextLower = cvText.toLowerCase();
   const stories = parseStoryBlocks(storyBankText);
 
   const buckets = { existing: [], supportedByResume: [], derivedUnverified: [], userCannotConfirm: [] };
@@ -464,7 +502,7 @@ function classifyStoryBank(storyBankText, cvText) {
         continue;
       }
 
-      if (hasContextOverlap(claimWords, cvTextLower)) {
+      if (hasContextOverlap(claimWords, cvText)) {
         buckets.supportedByResume.push({ ...entry, contextWords: claimWords });
         continue;
       }

--- a/story-provenance-check.mjs
+++ b/story-provenance-check.mjs
@@ -314,6 +314,38 @@ function buildCvNumberContexts(cvText) {
  * Content words (length >= 4, not a stopword, not itself a number) in a
  * window around a claim's position — the signal used for the
  * `supportedByResume` heuristic.
+ *
+ * The strip keeps letters, combining marks and digits of ANY script. It used
+ * to be `[^a-z0-9\s]`, which deletes every non-ASCII letter, and that broke
+ * this checker in both directions on a CV that is not written in ASCII:
+ *
+ *   - Cyrillic, Greek, Hebrew, Arabic, CJK — every character is stripped, the
+ *     window yields NO words at all, and an empty list makes both
+ *     hasScopedNumberMatch (`claimWords.includes`) and hasContextOverlap
+ *     (`words.some`) unconditionally false. So `existing` and
+ *     `supportedByResume` are unreachable and every claim the patterns do
+ *     extract lands in `derived-unverified` — including a figure sitting
+ *     verbatim in cv.md with matching context.
+ *   - Accented Latin — the strip does not just delete, it re-cuts the word:
+ *     "évaluation" becomes " valuation", a DIFFERENT real English word that
+ *     can then overlap cv.md prose that has nothing to do with the claim.
+ *     Shorter words vanish outright ("Größe", "naïve", "señor" all fall under
+ *     the length floor once split).
+ *
+ * That matters more here than in a grouping key. `derived-unverified` is what
+ * AGENTS.md's "Confirmation UX invariant" hands to the user to confirm or
+ * deny, and its stated risk is that a confirmed guess launders a guess into a
+ * verified fact. A checker that reports 100% unverified for a non-ASCII CV
+ * hands over a list where every entry is noise, which is how a user learns to
+ * confirm without reading.
+ *
+ * `\p{L}\p{M}\p{N}` is the alphabet tracker-parse.mjs's normalizeTextKey
+ * settled on for exactly this class of bug (#2393/#2429/#2569/#2666), down to
+ * keeping \p{M} so Indic matras survive. It is mirrored rather than imported:
+ * normalizeTextKey builds a solid identity KEY and this needs word boundaries
+ * preserved, and importing tracker-parse.mjs would make a story-bank check
+ * fail hard on a missing tracker-aliases.json it has no other use for.
+ *
  * @param {string} body
  * @param {number} matchIndex
  * @param {number} matchLength
@@ -323,9 +355,22 @@ function buildCvNumberContexts(cvText) {
 function contextWords(body, matchIndex, matchLength, windowChars = 90) {
   const start = Math.max(0, matchIndex - windowChars);
   const end = Math.min(body.length, matchIndex + matchLength + windowChars);
-  const snippet = body.slice(start, end).toLowerCase().replace(/[^a-z0-9\s]/g, ' ');
+  const snippet = body
+    .slice(start, end)
+    // NFKC before the strip so a full-width "４０％" keys like "40%", the same
+    // normalization order normalizeTextKey uses.
+    .normalize('NFKC')
+    .toLowerCase()
+    // Lowercasing a Turkish dotted capital leaves a bare combining dot
+    // (U+0307) behind, and \p{M} below would keep it — so "İstanbul" and
+    // "Istanbul" would not compare equal. Same one-character strip, and the
+    // same reason, as normalizeTextKey's.
+    .replace(/\u0307/gu, '')
+    .replace(/[^\p{L}\p{M}\p{N}\s]/gu, ' ');
   const words = snippet.split(/\s+/).filter(Boolean);
-  return [...new Set(words.filter((w) => w.length >= 4 && !STOPWORDS.has(w) && !/^\d+$/.test(w)))];
+  // `\p{N}` not `\d`: a token of Devanagari or full-width digits is just as
+  // much "a number, not a content word" as an ASCII one.
+  return [...new Set(words.filter((w) => w.length >= 4 && !STOPWORDS.has(w) && !/^\p{N}+$/u.test(w)))];
 }
 
 /**

--- a/tests/story-provenance-non-ascii.test.mjs
+++ b/tests/story-provenance-non-ascii.test.mjs
@@ -110,12 +110,12 @@ test('a Greek claim cv.md supports but does not quantify is supportedByResume', 
 });
 
 test('the boundary is still a boundary — a substring does not count as overlap', () => {
-  // The replacement must not become a bare `includes`. "расход" sits inside
-  // "расходами" in the story window; cv.md carries only the longer form in an
-  // unrelated sentence, so there is no whole-word overlap and nothing else to
-  // match on.
-  const cv = '# CV\n\n- Разработал внутренние инструменты для отдела продаж.';
-  const story = '### [Impact] Затраты\n\n**Result:** Управлял расходами и снизил их на 40%.';
+  // The replacement must not become a bare `includes`, so the fixture has to
+  // CONTAIN the substring case: the claim word "дизайн" sits inside cv.md's
+  // "редизайн", and nothing else is shared. A whole-word matcher finds no
+  // overlap; `includes` would return supportedByResume.
+  const cv = '# CV\n\n- Выполнил редизайн макета.';
+  const story = '### [Impact] Затраты\n\n**Result:** Создал дизайн и сократил расходы на 40%.';
 
   assert.equal(verdict(story, cv), 'derivedUnverified');
 });

--- a/tests/story-provenance-non-ascii.test.mjs
+++ b/tests/story-provenance-non-ascii.test.mjs
@@ -1,0 +1,107 @@
+// tests/story-provenance-non-ascii.test.mjs — the provenance checker must
+// reach the same verdict whatever script the CV is written in.
+//
+// contextWords() stripped with `[^a-z0-9\s]`, the last surviving instance in
+// the repo of the ASCII-only strip #2393/#2429/#2569/#2666 replaced everywhere
+// else. Both of this checker's context consumers read the result as a list:
+// hasScopedNumberMatch does `claimWords.includes(w)` and hasContextOverlap
+// does `words.some(...)`. An EMPTY list makes both unconditionally false, so
+// on a Cyrillic/Greek/Hebrew/Arabic/CJK CV the `existing` and
+// `supportedByResume` buckets are unreachable and every extracted claim lands
+// in `derived-unverified` — a figure sitting verbatim in cv.md included.
+//
+// That bucket is not a quiet one. AGENTS.md's "Confirmation UX invariant"
+// hands derived-unverified findings to the user to confirm or deny, and names
+// the risk: a confirmed guess launders the guess into a verified fact. A list
+// where 100% of the entries are noise is how a user learns not to read it.
+//
+// The tests below pin the fix in BOTH directions — a real trace must verify,
+// and the scoping guards that keep `existing` honest must still fire — because
+// "keep every letter" would also be satisfied by a change that simply says yes
+// to everything.
+//
+// Run:  node --test tests/story-provenance-non-ascii.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyStoryBank } from '../story-provenance-check.mjs';
+
+/** Bucket name a single-claim classification landed in. */
+function verdict(storyBank, cv) {
+  const b = classifyStoryBank(storyBank, cv);
+  const hits = Object.entries(b).filter(([, v]) => v.length > 0);
+  assert.equal(hits.length, 1, `expected exactly one non-empty bucket, got ${JSON.stringify(b)}`);
+  assert.equal(hits[0][1].length, 1, `expected exactly one claim, got ${hits[0][1].length}`);
+  return hits[0][0];
+}
+
+// ── The number is in cv.md, in context, in a non-Latin script ──────────
+
+test('a Cyrillic CV verifies a claim its own prose supports', () => {
+  const cv = [
+    '# Иван Петров',
+    '',
+    '- Сократил расходы на инфраструктуру на 40% за один год.',
+  ].join('\n');
+  const story = [
+    '### [Leadership] Масштабирование платформы',
+    '',
+    '**Result:** Сократил расходы на инфраструктуру на 40% за год.',
+  ].join('\n');
+
+  assert.equal(verdict(story, cv), 'existing');
+});
+
+test('a Greek CV verifies a claim its own prose supports', () => {
+  const cv = '# Βιογραφικό\n\n- Μείωσε το κόστος υποδομής κατά 40% σε έναν χρόνο.';
+  const story = '### [Impact] Μείωση κόστους\n\n**Result:** Μείωσε το κόστος υποδομής κατά 40%.';
+
+  assert.equal(verdict(story, cv), 'existing');
+});
+
+// ── …and the scoping guards still fire in those scripts ───────────────
+
+test('a bare digit coincidence in a Cyrillic CV is NOT verified', () => {
+  // 40 appears in cv.md, but as a page count in an unrelated sentence. This is
+  // the #2947 CodeRabbit finding (unscoped number matching) expressed in
+  // Cyrillic: keeping the letters must not also drop the context requirement.
+  const cv = '# Иван Петров\n\n- Опубликовал руководство объёмом 40 страниц.';
+  const story = '### [Impact] Снижение затрат\n\n**Result:** Сократил расходы на инфраструктуру на 40%.';
+
+  assert.equal(verdict(story, cv), 'derivedUnverified');
+});
+
+test('an accented word is no longer re-cut into a different real word', () => {
+  // The old strip turned "évaluation" into " valuation" — a DIFFERENT English
+  // word. Against a finance CV that legitimately says "valuation", the claim
+  // then read as supportedByResume on a token the story never contained.
+  const cv = '# Jane Roe\n\n- Built discounted cash flow valuation models for the M&A desk.';
+  const story = '### [Risk] Revue annuelle\n\n**Result:** Réduit les incidents de 40% après une évaluation complète.';
+
+  assert.equal(verdict(story, cv), 'derivedUnverified');
+});
+
+// ── The ASCII path is untouched ───────────────────────────────────────
+
+test('the English behaviour the checker shipped with is unchanged', () => {
+  const cv = '# Ivan Petrov\n\n- Cut infrastructure costs by 40% in one year.';
+  const story = '### [Impact] Cost reduction\n\n**Result:** Cut infrastructure costs by 40% in one year.';
+  assert.equal(verdict(story, cv), 'existing');
+
+  const unrelated = '# Ivan Petrov\n\n- Published a 40 page onboarding guide.';
+  assert.equal(verdict(story, unrelated), 'derivedUnverified');
+});
+
+test('a Turkish dotted capital folds to the same word as its plain i', () => {
+  // `'İ'.toLowerCase()` is `i` + U+0307, and \p{M} in the new strip would have
+  // KEPT that combining dot — so the fix has to drop it explicitly or
+  // "İstanbul" and "Istanbul" stop comparing equal.
+  // (Written `40%` rather than the Turkish `%40`: the percent pattern requires
+  // the sign to FOLLOW the number, so `%40` extracts no claim at all. That is a
+  // real gap for tr/de-style prose and a separate one — this test is about the
+  // fold, so it uses a shape the extractor already sees.)
+  const cv = '# CV\n\n- İstanbul ekibinde maliyetleri 40% azalttı.';
+  const story = '### [Impact] Maliyet\n\n**Result:** Istanbul ekibinde maliyetleri 40% azalttı.';
+
+  assert.equal(verdict(story, cv), 'existing');
+});

--- a/tests/story-provenance-non-ascii.test.mjs
+++ b/tests/story-provenance-non-ascii.test.mjs
@@ -81,6 +81,59 @@ test('an accented word is no longer re-cut into a different real word', () => {
   assert.equal(verdict(story, cv), 'derivedUnverified');
 });
 
+// ── supportedByResume: the second half of the same defect ─────────────
+//
+// hasContextOverlap searched cv.md with `\b${word}\b`, and `\b` is defined
+// against `\w` = [A-Za-z0-9_]. For a Cyrillic or Greek word BOTH sides of every
+// edge are non-word characters, so the assertion is never satisfied:
+//
+//   /\bсократил\b/i.test('сократил расходы')  ->  false
+//
+// Keeping the letters through the strip therefore was not enough on its own —
+// they still could not be FOUND in cv.md, so this bucket stayed unreachable and
+// every claim fell to derived-unverified anyway.
+
+test('a Cyrillic claim cv.md supports but does not quantify is supportedByResume', () => {
+  // The NUMBER is absent from cv.md, so `existing` is correctly out of reach.
+  // The surrounding fact is there, which is exactly what this bucket means.
+  const cv = '# Иван Петров\n\n- Отвечал за сокращение расходов на инфраструктуру платформы.';
+  const story = '### [Impact] Снижение затрат\n\n**Result:** Сократил расходы на инфраструктуру на 40%.';
+
+  assert.equal(verdict(story, cv), 'supportedByResume');
+});
+
+test('a Greek claim cv.md supports but does not quantify is supportedByResume', () => {
+  const cv = '# Βιογραφικό\n\n- Υπεύθυνος για τη μείωση του κόστους υποδομής.';
+  const story = '### [Impact] Μείωση κόστους\n\n**Result:** Μείωσε το κόστος υποδομής κατά 40%.';
+
+  assert.equal(verdict(story, cv), 'supportedByResume');
+});
+
+test('the boundary is still a boundary — a substring does not count as overlap', () => {
+  // The replacement must not become a bare `includes`. "расход" sits inside
+  // "расходами" in the story window; cv.md carries only the longer form in an
+  // unrelated sentence, so there is no whole-word overlap and nothing else to
+  // match on.
+  const cv = '# CV\n\n- Разработал внутренние инструменты для отдела продаж.';
+  const story = '### [Impact] Затраты\n\n**Result:** Управлял расходами и снизил их на 40%.';
+
+  assert.equal(verdict(story, cv), 'derivedUnverified');
+});
+
+test('a Turkish dotted capital in cv.md still matches a claim word', () => {
+  // Both sides have to be folded the SAME way. cv.md lowercases "İstanbul" to
+  // `i` + U+0307, and the claim window has already had that dot stripped — so
+  // folding only the claim side leaves them unequal.
+  //
+  // Every other content word is disjoint on purpose, so "istanbul" is the ONLY
+  // thing that can produce the overlap — otherwise an ASCII word carries the
+  // test and the fold is never exercised.
+  const cv = '# CV\n\n- İstanbul biriminde görev aldı.';
+  const story = '### [Impact] Tasarruf\n\n**Result:** Istanbul genelinde 40% tasarruf sağlandı.';
+
+  assert.equal(verdict(story, cv), 'supportedByResume');
+});
+
 // ── The ASCII path is untouched ───────────────────────────────────────
 
 test('the English behaviour the checker shipped with is unchanged', () => {


### PR DESCRIPTION
Fixes #3235.

`story-provenance-check.mjs:326` was the last `[^a-z0-9]` strip in the repo — the shape #2393/#2429/#2569/#2666 replaced everywhere else.

`contextWords()` is the checker's only context source, and both consumers read its result as a list (`claimWords.includes(w)`, `words.some(...)`), so an **empty** list makes both unconditionally false. On a Cyrillic/Greek/Hebrew/Arabic/CJK CV the strip empties every window, `existing` and `supportedByResume` become unreachable, and every extracted claim lands in `derived-unverified` — including a figure sitting verbatim in `cv.md`.

Accented Latin fails differently and worse: `évaluation` → `" valuation"`, a **different real English word**, so a French story can overlap an English finance CV on a token it never contained.

## Change

Keep letters, marks and digits of any script — `normalizeTextKey`'s alphabet, plus its NFKC and U+0307 steps (`\p{M}` is kept for Indic matras, and lowercasing a Turkish `İ` leaves a bare combining dot that `\p{M}` would otherwise preserve). Mirrored rather than imported: `normalizeTextKey` builds a solid identity key where this needs word boundaries, and importing `tracker-parse.mjs` would make a story-bank check fail hard on a missing `tracker-aliases.json` it never uses.

Two commits: the fix, then the tests.

## Before / after

Same person, same facts, same story:

| | before | after |
|---|---|---|
| English CV, `40%` in cv.md | `existing` | `existing` |
| Russian CV, `40%` in cv.md | **`derived-unverified`** | `existing` |
| Greek CV, `40%` in cv.md | **`derived-unverified`** | `existing` |
| Russian CV, `40` present but unrelated | `derived-unverified` | `derived-unverified` |
| French story `évaluation` vs English CV `valuation` | **`supportedByResume`** | `derived-unverified` |

## Verification

Three of the six new tests fail on the pre-fix implementation; the other three are guards that must hold on both sides. Checked by reverting only the function body:

```
--- new tests against the OLD implementation ---
✖ a Cyrillic CV verifies a claim its own prose supports
✖ a Greek CV verifies a claim its own prose supports
✔ a bare digit coincidence in a Cyrillic CV is NOT verified
✖ an accented word is no longer re-cut into a different real word
✔ the English behaviour the checker shipped with is unchanged
✔ a Turkish dotted capital folds to the same word as its plain i
ℹ pass 3  ℹ fail 3
```

The guards are the point of the pairing: "keep every letter" would also be satisfied by a change that says yes to everything, and a false `existing` is a fabricated fact rather than a noisy one.

`node story-provenance-check.mjs --self-test` → 24 passed, 0 failed.
`node test-all.mjs --quick` → 5309 passed, 0 failed (3 pre-existing warnings).

## Not in scope

`CLAIM_PATTERNS` is keyed on an English noun lexicon, so the Russian run extracts one claim instead of two — the `15 человек` claim is never checked at all. Internationalising the lexicon is a much larger change; the `percent` pattern is already language-neutral, which is what isolates the context bug cleanly here. Same for `%40` (Turkish/German percent-before), which the extractor does not see. Both noted in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provenance classification for Cyrillic, Greek, accented, Turkish, and other non-ASCII characters.
  * Preserved matching evidence across international scripts while avoiding false matches from accented-word normalization.
  * Correctly handled non-ASCII numeric context and retained existing English-text behavior.

* **Tests**
  * Added coverage for international text, numeric matches, normalization, and existing classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->