### PR TITLE
fix(dates): weekly-digest defaults to a week that has not started; rejection-latency suggests a blacklist row a day early (#3243)

### DIFF
--- a/rejection-latency.mjs
+++ b/rejection-latency.mjs
@@ -54,6 +54,7 @@ import { parseActiveInterviews } from './process-quality.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
@@ -221,9 +222,16 @@ export function buildBlacklistSuggestion(company, todayStr, reason) {
  * @returns {{ flags: object[], warnings: string[], companiesChecked: number }}
  */
 export function computeRejectionLatency(interviewRows, trackerByCompany, opts = {}) {
+  // The default is the LOCAL calendar day at UTC midnight, not `new Date()`.
+  // daysBetween() reduces both operands to their UTC date, so a bare clock read
+  // west of Greenwich counts one extra day all evening: a company crosses the
+  // courtesy threshold a day early and gets a ready-to-copy blacklist row —
+  // stamped, via isoDay(), with tomorrow's date. The UTC-midnight anchor is
+  // what daysBetween expects and is deliberately preserved; only WHICH day it
+  // anchors on moves (#2765 drew the same line).
   const today = opts.today instanceof Date && !Number.isNaN(opts.today.getTime())
     ? opts.today
-    : new Date();
+    : parseDate(localToday());
   const courtesyDays = Number.isFinite(opts.courtesyDays) && opts.courtesyDays > 0
     ? opts.courtesyDays
     : DEFAULT_COURTESY_DAYS;

--- a/tests/local-today-gates.test.mjs
+++ b/tests/local-today-gates.test.mjs
@@ -53,11 +53,15 @@ const NY_DAY = '2026-08-17';
  * `Date` is replaced before the module under test is imported, and the default
  * parameters being tested read the clock at CALL time, so the freeze reaches
  * them.
+ *
+ * `instant` defaults to INSTANT, the day-boundary pair every gate above needs.
+ * A caller pinning a WEEK boundary passes its own — a day apart is not enough
+ * to move an ISO week.
  */
-function inFrozenTz(tz, expr) {
+function inFrozenTz(tz, expr, instant = INSTANT) {
   const preamble =
     `const RealDate = Date;` +
-    `const FROZEN = new RealDate('${INSTANT}');` +
+    `const FROZEN = new RealDate('${instant}');` +
     `globalThis.Date = class extends RealDate {` +
     `  constructor(...a) { if (a.length === 0) { super(FROZEN.getTime()); } else { super(...a); } }` +
     `  static now() { return FROZEN.getTime(); }` +
@@ -145,4 +149,103 @@ test('check-table-freshness --today still overrides, and reports the date it use
   });
   assert.equal(r.error, undefined);
   assert.ok(r.stdout.includes('2026-08-18'), `--today was not honoured: ${r.stdout.slice(0, 200)}`);
+});
+
+
+// ── Reporting windows: which day it is decides which WEEK, and which
+//    threshold has elapsed ──────────────────────────────────────────────
+//
+// Both of these gate a decision the same way scan's cooldown does, and both
+// were still reading the UTC day.
+
+// A Monday 01:30 UTC. In New York it is still the SUNDAY before — so the two
+// readings fall in different ISO weeks, not merely on different days. INSTANT
+// above is a Tuesday/Monday pair inside one week, which cannot see this.
+const WEEK_INSTANT = '2026-08-17T01:30:00Z';
+
+test('the week premise: this instant is a different ISO week in New York', () => {
+  const fmt = (tz) =>
+    new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' })
+      .format(new Date(WEEK_INSTANT));
+  assert.equal(fmt('UTC'), '2026-08-17', 'UTC: Monday');
+  assert.equal(fmt('America/New_York'), '2026-08-16', 'New York: the Sunday before');
+});
+
+test('weekly-digest: "this week" is the week the caller is actually in', () => {
+  // Reading getUTCDate() here returned the week that had not started yet, so
+  // every session logged Mon-Sun fell outside inRange() and the digest for the
+  // week just ended came back empty — which reads as a quiet week, not as a
+  // wrong window.
+  const out = inFrozenTz('America/New_York',
+    `const {computeDefaultRange} = await import('${spec('weekly-digest.mjs')}');` +
+    `process.stdout.write(JSON.stringify(computeDefaultRange()));`,
+    WEEK_INSTANT);
+  assert.deepEqual(JSON.parse(out), { from: '2026-08-10', to: '2026-08-16' },
+    'the digest defaulted to a week the user is not in yet');
+});
+
+test('weekly-digest: an explicit `now` is resolved locally too', () => {
+  const out = inFrozenTz('America/New_York',
+    `const {computeDefaultRange} = await import('${spec('weekly-digest.mjs')}');` +
+    `process.stdout.write(JSON.stringify(computeDefaultRange(new Date('${WEEK_INSTANT}'))));`,
+    WEEK_INSTANT);
+  assert.deepEqual(JSON.parse(out), { from: '2026-08-10', to: '2026-08-16' });
+});
+
+test('rejection-latency: the courtesy threshold is measured from the local day', () => {
+  // daysBetween() reduces both operands to their UTC date, so a bare `new Date()`
+  // default counted one extra day all evening. This interview is exactly
+  // courtesyDays old on the LOCAL day and one day over it on the UTC day, and
+  // the gate is `daysAll <= courtesyDays` — so the UTC reading crosses it and
+  // emits a ready-to-copy data/blacklist.md row for a company whose courtesy
+  // window has not actually elapsed, stamped with tomorrow's date.
+  const active = [
+    '| Company | Role | Round | Date | Interviewer | Status | Notes |',
+    '|---|---|---|---|---|---|---|',
+    '| Acme Corp | Backend Engineer | Round 1 | 2026-07-18 | Panel | Done | final round |',
+  ].join('\n');
+  const tracker = [
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-06-01 | Acme Corp | Backend Engineer | 4.2/5 | Interview | ❌ | — | waiting |',
+  ].join('\n');
+
+  const out = inFrozenTz('America/New_York',
+    `const q = await import('${spec('process-quality.mjs')}');const m = await import('${spec('rejection-latency.mjs')}');` +
+    `const rows = q.parseActiveInterviews(${JSON.stringify(active)});` +
+    `const tr = m.parseTrackerInterviewRows(${JSON.stringify(tracker)});` +
+    // No `today` — the default is what is under test.
+    `const r = m.computeRejectionLatency(rows, tr, { courtesyDays: 30 });` +
+    `process.stdout.write(JSON.stringify(r.flags.map(f => [f.company, f.daysSinceLastInterview])));`);
+
+  assert.deepEqual(JSON.parse(out), [],
+    'flagged a company 30 local days after its last round, one day before the courtesy window elapses');
+});
+
+test('rejection-latency still flags once the local window HAS elapsed', () => {
+  // The other side of the same boundary — without it, "never flag at all" would
+  // satisfy the test above just as well.
+  const active = [
+    '| Company | Role | Round | Date | Interviewer | Status | Notes |',
+    '|---|---|---|---|---|---|---|',
+    '| Acme Corp | Backend Engineer | Round 1 | 2026-07-16 | Panel | Done | final round |',
+  ].join('\n');
+  const tracker = [
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-06-01 | Acme Corp | Backend Engineer | 4.2/5 | Interview | ❌ | — | waiting |',
+  ].join('\n');
+
+  const out = inFrozenTz('America/New_York',
+    `const q = await import('${spec('process-quality.mjs')}');const m = await import('${spec('rejection-latency.mjs')}');` +
+    `const rows = q.parseActiveInterviews(${JSON.stringify(active)});` +
+    `const tr = m.parseTrackerInterviewRows(${JSON.stringify(tracker)});` +
+    `const r = m.computeRejectionLatency(rows, tr, { courtesyDays: 30 });` +
+    `process.stdout.write(JSON.stringify(r.flags.map(f => [f.daysSinceLastInterview, f.blacklistSuggestion])));`);
+
+  const flags = JSON.parse(out);
+  assert.equal(flags.length, 1, 'a genuinely elapsed window must still flag');
+  assert.equal(flags[0][0], 32, 'elapsed days counted from the local day');
+  assert.ok(flags[0][1].includes(`| ${NY_DAY} |`),
+    `the blacklist suggestion is dated with the UTC day: ${flags[0][1]}`);
 });

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -45,6 +45,7 @@ import * as yaml from 'js-yaml';
 // Only validateFlags: this module keeps its own flagValue (see below), so
 // importing the shared one too would shadow it.
 import { validateFlags } from './lib/cli-flags.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SESSIONS_DIR = join(CAREER_OPS, 'interview-prep', 'sessions');
@@ -64,9 +65,17 @@ function isValidDateStr(s) {
  * Current ISO week (Monday–Sunday) containing `now`, as {from, to} strings.
  * `now` is injectable so callers (and tests) never depend on wall-clock time
  * implicitly.
+ *
+ * WHICH day `now` falls on is read from the LOCAL calendar; the arithmetic that
+ * follows stays anchored at UTC midnight. That is the split lib/local-today.mjs
+ * documents, and both halves matter here. Reading getUTCDate() made a Sunday
+ * evening in the Americas resolve to Monday, so "this week" was the week that
+ * had not started yet: every session the user logged Mon–Sun fell outside
+ * inRange() and the digest for the week just ended came back empty — which
+ * reads as "a quiet week", not as a wrong window.
  */
 export function computeDefaultRange(now = new Date()) {
-  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const d = new Date(`${localToday(now)}T00:00:00Z`);
   const dayIdx = (d.getUTCDay() + 6) % 7; // Mon=0 .. Sun=6
   d.setUTCDate(d.getUTCDate() - dayIdx); // roll back to Monday
   const from = d.toISOString().slice(0, 10);
@@ -409,12 +418,33 @@ async function runSelfTest() {
 
   // computeDefaultRange: a known Wednesday (2026-07-22) should yield Mon
   // 2026-07-20 .. Sun 2026-07-26.
-  const wed = computeDefaultRange(new Date('2026-07-22T12:00:00Z'));
+  //
+  // Built with the LOCAL Date constructor, not a Z instant. The range is the
+  // week containing the caller's own calendar day, so `new Date('...T00:00:00Z')`
+  // names a different day depending on where the suite runs and these three
+  // assertions would pass or fail by timezone rather than by behaviour. Local
+  // noon on a named date is that date everywhere.
+  const localNoon = (y, m, d) => new Date(y, m - 1, d, 12, 0, 0);
+  const wed = computeDefaultRange(localNoon(2026, 7, 22));
   check(wed.from === '2026-07-20' && wed.to === '2026-07-26', 'computeDefaultRange resolves the containing Mon-Sun week');
-  const mon = computeDefaultRange(new Date('2026-07-20T00:00:00Z'));
+  const mon = computeDefaultRange(localNoon(2026, 7, 20));
   check(mon.from === '2026-07-20' && mon.to === '2026-07-26', 'computeDefaultRange handles Monday itself as the range start');
-  const sun = computeDefaultRange(new Date('2026-07-26T23:00:00Z'));
+  const sun = computeDefaultRange(localNoon(2026, 7, 26));
   check(sun.from === '2026-07-20' && sun.to === '2026-07-26', 'computeDefaultRange handles Sunday itself as the range end');
+  // The two instants where reading getUTCDate() moves the answer a whole WEEK,
+  // rather than just a day: late on the local Sunday (west of Greenwich the UTC
+  // day is already Monday) and early on the local Monday (east of Greenwich it
+  // is still Sunday). One of the two fires in every non-UTC zone; in UTC both
+  // are no-ops, which is why tests/local-today-gates.test.mjs pins the same
+  // property under an explicit TZ.
+  for (const [now, label] of [
+    [new Date(2026, 6, 26, 23, 30, 0), 'Sunday 23:30 local'],
+    [new Date(2026, 6, 20, 0, 30, 0), 'Monday 00:30 local'],
+  ]) {
+    const r = computeDefaultRange(now);
+    check(r.from <= localToday(now) && localToday(now) <= r.to,
+      `computeDefaultRange contains the caller's own day (${label})`);
+  }
 
   // flagValue: both CLI spellings must reach the same value. The `=` form used
   // to be invisible to indexOf(), so `--from=2020-01-01` silently produced the


### PR DESCRIPTION
Fixes #3243. Two reporting gates that still resolve "now" as the UTC day — the class #2765/#2932/#3070 closed elsewhere. Both *gate a decision*; neither is a display stamp.

## 1. `weekly-digest` — the wrong week, and it looks like a quiet one

`computeDefaultRange` read `now.getUTCDate()`, so at 19:00 Pacific on Sunday 2026-08-23 it returned `2026-08-24 … 2026-08-30` — the week that has not started. Every session logged Mon–Sun falls outside `inRange()` and the digest comes back empty, which reads as a quiet week rather than a wrong window. Sunday evening is a likely time to run a weekly digest.

## 2. `rejection-latency` — a blacklist suggestion a day early

The default `today` was a bare `new Date()`, and `daysBetween()` reduces both operands to their UTC date, so west of Greenwich it counts one extra day all evening. The gate is `daysAll <= courtesyDays` (fires at 31+), so an interview exactly 30 local days old reads as 31 and flags — producing a ready-to-copy `data/blacklist.md` row, stamped with tomorrow's date, for a courtesy window that has not elapsed. For something the user is invited to paste into a do-not-apply list, early-by-a-day is the direction that costs something.

## Change

Read *which* day from the local calendar; keep the arithmetic anchored at UTC midnight. `daysBetween` expects that anchor and it is preserved — only the day it anchors on moves. `--today` and an injected `opts.today` are untouched.

Three commits: each fix, then the tests.

## The weekly-digest self-test needed rebuilding

Its three existing `computeDefaultRange` assertions are built from `Z` instants, which name a different calendar day depending on where the suite runs — once the function reads the local day they pass or fail by timezone rather than by behaviour. Rebuilt on local noon of a named date (that date everywhere), plus the two instants where the reading moves a whole **week** rather than a day: late on the local Sunday, early on the local Monday.

```
UTC                  55 passed, 0 failed
America/Los_Angeles  55 passed, 0 failed
Asia/Tokyo           55 passed, 0 failed
Pacific/Kiritimati   55 passed, 0 failed
```

…and against the pre-fix implementation:

```
UTC                  55 passed, 0 failed          # no-op in UTC by construction
America/Los_Angeles  FAIL: …own day (Sunday 23:30 local)
Asia/Tokyo           FAIL: …own day (Monday 00:30 local)
Pacific/Kiritimati   FAIL: Monday itself as the range start · FAIL: …own day (Monday 00:30 local)
```

Because those are no-ops in UTC, `tests/local-today-gates.test.mjs` pins the same property under an explicit `TZ` for CI. `inFrozenTz` gains an optional instant — the file's `INSTANT` is a day-boundary pair *inside one ISO week*, which cannot see a week move, so `WEEK_INSTANT` is a Monday 01:30 UTC that is still the Sunday before in New York.

`rejection-latency` is pinned on **both** sides of its own boundary: an interview exactly `courtesyDays` old on the local day must not flag, one 32 days old must, and its blacklist suggestion must carry the local date. Without the second, "never flag at all" would satisfy the first.

## Verification

Reverting both fixes and keeping the tests:

```
✖ weekly-digest: "this week" is the week the caller is actually in
✖ weekly-digest: an explicit `now` is resolved locally too
✖ rejection-latency: the courtesy threshold is measured from the local day
✖ rejection-latency still flags once the local window HAS elapsed
ℹ pass 9  ℹ fail 4
```

`node --test tests/local-today-gates.test.mjs` → 13 passed.
`node test-all.mjs --quick` → 5308 passed, 0 failed (3 pre-existing warnings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date-sensitive evaluations now use the local calendar date by default.
  * Weekly digest ranges correctly reflect local Sunday/Monday boundaries.
  * Rejection-latency thresholds and blacklist dates now remain accurate across time zones.
* **Tests**
  * Added coverage for local-time weekly calculations and rejection-latency behavior before and after expiry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->