### PR TITLE
feat(templates): discover template packs by name (#3202)

### DIFF
--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -4,7 +4,7 @@
 // Backward-compatible: with no config and no named files, resolves the base
 // templates/cv-template.html (name "standard"), identical to prior behavior.
 
-import { readdirSync, readFileSync, existsSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
@@ -108,12 +108,28 @@ function entryFor(parsed, path, pack) {
 // must not be mistaken for a nested pack, and an arbitrarily deep walk over a
 // user-writable directory is a cost (and a surface) with no use case behind it.
 //
-// Symlinked directories are skipped. `Dirent.isDirectory()` is false for a
-// symlink, so this falls out of the dirent type rather than needing a check —
-// but it is load-bearing, not incidental: following one would let a link inside
-// templates/ pull a template in from anywhere on the filesystem. Symlinked
-// template *files* still resolve as they always have; only the pack walk is
-// restricted.
+// Symlinked directories are followed, which needs an explicit stat because
+// `Dirent.isDirectory()` is false for a symlink.
+//
+// Refusing them looks like the safer default and isn't. A symlink grants no
+// capability its creator lacked: anyone who can drop `templates/mine` as a link
+// can drop it as a real directory holding the same file, so skipping buys no
+// protection against a hostile template — it only makes a legitimate one
+// vanish. The repo's actual symlink guards are on a different axis, and both
+// stay intact: resolveInsideRepo() in reconcile-pipeline.mjs resolves
+// user-supplied path *arguments* before a boundary check, and contacts.mjs
+// refuses to *write* through a link escaping the project. Discovery does
+// neither — it enumerates a directory the project owns and only ever reads.
+//
+// Cycles are not a concern precisely because this walk is one level and never
+// recurses; a link pointing at its own ancestor is read once as a directory
+// and contributes whatever template files sit at its top level.
+//
+// The deciding cost is silent invisibility. career-ops sanctions a symlinked
+// user layer (#524), so a pack maintained outside the repo is a supported
+// setup, and skipping it would drop the template from the registry with
+// nothing said — the same failure this file refuses to accept for name
+// collisions.
 //
 // Returns Map<name, entry>. A name claimed twice throws — see assertNoCollision.
 function discover(kind, { dir, format }) {
@@ -137,8 +153,16 @@ function discover(kind, { dir, format }) {
 
   // Packs, one level down.
   for (const d of readdirSync(dir, { withFileTypes: true })) {
-    if (!d.isDirectory()) continue;
     const packDir = resolve(dir, d.name);
+    if (!d.isDirectory()) {
+      // statSync follows the link; it throws on a broken one, which is not a pack.
+      if (!d.isSymbolicLink()) continue;
+      try {
+        if (!statSync(packDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+    }
     let inner;
     try {
       inner = readdirSync(packDir);

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -78,26 +78,104 @@ export function parseMeta(path) {
   return meta;
 }
 
+// Build the entry a discovered template file contributes.
+function entryFor(parsed, path, pack) {
+  const meta = parseMeta(path);
+  return {
+    name: parsed.name,
+    displayName: meta.name || prettify(parsed.name),
+    path,
+    format: parsed.format,
+    meta,
+    pack,
+  };
+}
+
+// Discover every template of `kind`/`format` under `dir`: the flat files that
+// have always lived there, plus one level of *template packs* (#3202).
+//
+// A pack is a subdirectory holding its own `<prefix>.<name>.<format>` next to
+// its own `sections/`. That co-location is the whole point: build-cv-html.mjs
+// resolves partials relative to the template file, so a pack gets its own DOM
+// without touching the `sections/` every flat template shares.
+//
+// The template name comes from the *filename*, exactly as it does for a flat
+// template — never from the directory name. `templates/ats/cv-template.ats.html`
+// is template "ats" because of the file, and the directory could be called
+// anything. That keeps one naming rule instead of two.
+//
+// Packs are one level deep only. Nothing here recurses: a pack's `sections/`
+// must not be mistaken for a nested pack, and an arbitrarily deep walk over a
+// user-writable directory is a cost (and a surface) with no use case behind it.
+//
+// Symlinked directories are skipped. `Dirent.isDirectory()` is false for a
+// symlink, so this falls out of the dirent type rather than needing a check —
+// but it is load-bearing, not incidental: following one would let a link inside
+// templates/ pull a template in from anywhere on the filesystem. Symlinked
+// template *files* still resolve as they always have; only the pack walk is
+// restricted.
+//
+// Returns Map<name, entry>. A name claimed twice throws — see assertNoCollision.
+function discover(kind, { dir, format }) {
+  const cfg = KINDS[kind];
+  const found = new Map();
+  if (!existsSync(dir)) return found;
+
+  const claim = (parsed, path, pack) => {
+    if (parsed.format !== format) return;
+    const prior = found.get(parsed.name);
+    if (prior) assertNoCollision(parsed.name, prior.path, path, dir);
+    found.set(parsed.name, entryFor(parsed, path, pack));
+  };
+
+  // Flat templates. Unchanged from before packs existed, including the fact
+  // that a symlinked file is read through like any other.
+  for (const file of readdirSync(dir)) {
+    const parsed = parseFilename(cfg.prefix, file);
+    if (parsed) claim(parsed, resolve(dir, file), null);
+  }
+
+  // Packs, one level down.
+  for (const d of readdirSync(dir, { withFileTypes: true })) {
+    if (!d.isDirectory()) continue;
+    const packDir = resolve(dir, d.name);
+    let inner;
+    try {
+      inner = readdirSync(packDir);
+    } catch {
+      continue; // unreadable directory is not a pack
+    }
+    for (const file of inner) {
+      const parsed = parseFilename(cfg.prefix, file);
+      if (parsed) claim(parsed, resolve(packDir, file), d.name);
+    }
+  }
+
+  return found;
+}
+
+// A template name resolves to exactly one file, enforced when it is discovered
+// rather than settled by a precedence rule.
+//
+// Precedence would have to pick a winner while both files exist and both look
+// correct — during a migration from a flat template to a pack, say — and the
+// loser would simply stop being rendered, silently, with nothing in the output
+// naming the file that won. Failing at discovery costs one clear error and
+// makes the ambiguity impossible to ship past.
+function assertNoCollision(name, a, b, dir) {
+  const rel = (p) => p.slice(dir.length + 1) || p;
+  const [x, y] = [rel(a), rel(b)].sort();
+  throw new Error(
+    `Template name "${name}" is claimed by two files: ${x} and ${y}. `
+      + `A name must resolve to one template — rename one, or remove the one you no longer use.`
+  );
+}
+
 export function listTemplates(kind, { dir = DEFAULT_TEMPLATES_DIR, format = 'html' } = {}) {
   const cfg = KINDS[kind];
   if (!cfg) throw new Error(`Unknown template kind: ${kind}`);
   assertFormat(format);
-  if (!existsSync(dir)) return [];
-  const out = [];
-  for (const file of readdirSync(dir)) {
-    const parsed = parseFilename(cfg.prefix, file);
-    if (!parsed || parsed.format !== format) continue;
-    const path = resolve(dir, file);
-    const meta = parseMeta(path);
-    out.push({
-      name: parsed.name,
-      displayName: meta.name || prettify(parsed.name),
-      path,
-      format: parsed.format,
-      meta,
-    });
-  }
-  return out.sort((a, b) => a.name.localeCompare(b.name));
+  return [...discover(kind, { dir, format }).values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function validateTemplate(path, kind) {
@@ -138,21 +216,30 @@ export function resolveTemplate(kind, name, opts = {}) {
   let chosen = kebab(explicit ? name : loadProfileDefault(kind, { profilePath }) || 'standard');
   const fileFor = (n) => (n === 'standard' ? `${cfg.prefix}.${format}` : `${cfg.prefix}.${n}.${format}`);
 
-  let path = resolve(dir, fileFor(chosen));
-  if (!existsSync(path)) {
-    if (fallback && chosen !== 'standard') {
-      chosen = 'standard';
-      path = resolve(dir, fileFor(chosen));
-    }
-    if (!existsSync(path)) {
-      throw new Error(`Template not found for kind=${kind} name=${chosen} (${fileFor(chosen)})`);
-    }
+  // Resolution goes through the same discovery as listTemplates, so a name that
+  // lists is a name that resolves. Constructing `dir/fileFor(chosen)` directly
+  // would find flat templates only: a pack would list fine and then throw here,
+  // which is the failure mode that passes review because the demo path works.
+  // Every by-name caller lands here — build-cv-latex.mjs, generate-cover-letter.mjs.
+  const found = discover(kind, { dir, format });
+
+  let entry = found.get(chosen);
+  if (!entry && fallback && chosen !== 'standard') {
+    chosen = 'standard';
+    entry = found.get(chosen);
   }
+  if (!entry) {
+    throw new Error(`Template not found for kind=${kind} name=${chosen} (${fileFor(chosen)})`);
+  }
+  const path = entry.path;
   if (format === 'html') {
     const v = validateTemplate(path, kind);
     if (!v.ok) {
+      // Name the file that is actually short, not the flat filename it would
+      // have had. For a pack these differ, and the flat name points at nothing.
+      const where = entry.pack ? `${entry.pack}/${fileFor(chosen)}` : fileFor(chosen);
       throw new Error(
-        `Template ${fileFor(chosen)} missing required placeholders: ${v.missing.map((m) => `{{${m}}}`).join(', ')}`
+        `Template ${where} missing required placeholders: ${v.missing.map((m) => `{{${m}}}`).join(', ')}`
       );
     }
   }

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -144,15 +144,21 @@ function discover(kind, { dir, format }) {
     found.set(parsed.name, entryFor(parsed, path, pack));
   };
 
+  // One listing serves both passes. Reading twice would let the flat pass and
+  // the pack pass see different directory states, and the collision check spans
+  // them: a file present for one read and gone for the other decides whether a
+  // name is ambiguous. A single snapshot makes that verdict reproducible.
+  const top = readdirSync(dir, { withFileTypes: true });
+
   // Flat templates. Unchanged from before packs existed, including the fact
   // that a symlinked file is read through like any other.
-  for (const file of readdirSync(dir)) {
-    const parsed = parseFilename(cfg.prefix, file);
-    if (parsed) claim(parsed, resolve(dir, file), null);
+  for (const d of top) {
+    const parsed = parseFilename(cfg.prefix, d.name);
+    if (parsed) claim(parsed, resolve(dir, d.name), null);
   }
 
   // Packs, one level down.
-  for (const d of readdirSync(dir, { withFileTypes: true })) {
+  for (const d of top) {
     const packDir = resolve(dir, d.name);
     if (!d.isDirectory()) {
       // statSync follows the link; it throws on a broken one, which is not a pack.

--- a/tests/template-packs.test.mjs
+++ b/tests/template-packs.test.mjs
@@ -20,19 +20,38 @@
 // test/ (singular) and is not gated by anything — see the note at the end of
 // this file.
 
-import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { pass, fail } from './helpers.mjs';
+import { pass, fail, warn } from './helpers.mjs';
 import { listTemplates, resolveTemplate } from '../cv-templates.mjs';
 
 console.log('\nCV template packs — discovery, resolution, and name collisions');
 
 const CV_BODY = '{{NAME}}{{EXPERIENCE}}{{EDUCATION}}';
 
+// Every fixture is a fresh mkdtemp; this suite is meant to run constantly, on
+// three platforms, so they are tracked and removed in a finally at the end.
+const fixtures = [];
+
+// Registered on exit rather than wrapped in a try/finally around the whole
+// file: this suite is a sequence of top-level blocks, and an exit hook still
+// runs when one of them throws and test-all.mjs contains it — which is exactly
+// the run that would otherwise leak every fixture created so far.
+process.on('exit', () => {
+  for (const dir of fixtures) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // A fixture that cannot be removed must not change the suite's verdict.
+    }
+  }
+});
+
 /** A templates/ dir with the flat layout that predates packs. */
 function fixtureDir() {
   const dir = mkdtempSync(join(tmpdir(), 'packs-'));
+  fixtures.push(dir);
   writeFileSync(join(dir, 'cv-template.html'), CV_BODY);
   writeFileSync(join(dir, 'cv-template.compact.html'), CV_BODY);
   writeFileSync(join(dir, 'cover-letter-template.html'), '{{NAME}}{{ROLE_TITLE}}{{OPENING}}');
@@ -54,6 +73,26 @@ function addPack(dir, packName, templateName, { body = CV_BODY, sections = {} } 
 }
 
 const names = (dir, opts = {}) => listTemplates('cv', { dir, ...opts }).map((t) => t.name).sort();
+
+/**
+ * Create a directory symlink, tolerating only a missing privilege.
+ *
+ * A blanket catch here would report an unexercised case as a pass: any
+ * symlinkSync failure — not just the Windows-without-Developer-Mode one — would
+ * land in the same branch and turn broken symlink handling into a green line.
+ * Same argument, and the same narrowing, as tests/intake.test.mjs:250.
+ *
+ * @returns {boolean} true if the link was created, false if the host lacks the privilege.
+ */
+function trySymlink(target, linkPath) {
+  try {
+    symlinkSync(target, linkPath, 'dir');
+    return true;
+  } catch (e) {
+    if (e?.code === 'EPERM' && e?.syscall === 'symlink') return false;
+    throw e;
+  }
+}
 
 /** Assert `fn` throws with a message matching every pattern. */
 function throws(label, fn, ...patterns) {
@@ -78,13 +117,16 @@ function throws(label, fn, ...patterns) {
   if (found.includes('ats')) pass('a pack one level down is discovered by name');
   else fail(`pack not discovered — listTemplates returned ${found.join(', ')}`);
 
+  // Optional chaining on both the assertion and its message: `entry` is
+  // undefined exactly when the assertion fails, so dereferencing it to report
+  // the failure throws and takes the rest of the file with it.
   const entry = listTemplates('cv', { dir }).find((t) => t.name === 'ats');
-  if (entry.pack === 'ats') pass('a pack entry reports the directory holding it');
-  else fail(`expected pack "ats", got ${JSON.stringify(entry.pack)}`);
+  if (entry?.pack === 'ats') pass('a pack entry reports the directory holding it');
+  else fail(`expected pack "ats", got ${JSON.stringify(entry?.pack)}`);
 
   const flat = listTemplates('cv', { dir }).find((t) => t.name === 'compact');
-  if (flat.pack === null) pass('a flat template reports pack: null');
-  else fail(`expected pack null for a flat template, got ${JSON.stringify(flat.pack)}`);
+  if (flat?.pack === null) pass('a flat template reports pack: null');
+  else fail(`expected pack null for a flat template, got ${JSON.stringify(flat?.pack)}`);
 }
 
 {
@@ -105,8 +147,15 @@ function throws(label, fn, ...patterns) {
   addPack(dir, 'ats', 'ats', { sections: { experience: '<!--ENTRY--><div></div><!--/ENTRY-->' } });
   mkdirSync(join(dir, 'ats', 'sections', 'deep'), { recursive: true });
   writeFileSync(join(dir, 'ats', 'sections', 'deep', 'cv-template.sneaky.html'), CV_BODY);
-  if (!names(dir).includes('sneaky')) pass('discovery is one level deep — a pack\'s sections/ is not a pack');
-  else fail('discovery recursed past one level into a pack\'s sections/');
+  // The positive half is the point: without it this passes against a module
+  // that discovers no packs at all, and cannot tell "the boundary holds" from
+  // "nothing happened".
+  const found = names(dir);
+  if (found.includes('ats') && !found.includes('sneaky')) {
+    pass('discovery is one level deep — the pack is found, its sections/ is not');
+  } else {
+    fail(`expected the pack and not its sections/ — got ${found.join(', ')}`);
+  }
 }
 
 {
@@ -126,39 +175,46 @@ function throws(label, fn, ...patterns) {
   // either — whoever can create the link can create a real directory instead.
   const dir = fixtureDir();
   const outside = mkdtempSync(join(tmpdir(), 'packs-outside-'));
+  fixtures.push(outside);
   writeFileSync(join(outside, 'cv-template.linked.html'), CV_BODY);
-  let linked = true;
-  try {
-    symlinkSync(outside, join(dir, 'linked-pack'), 'dir');
-  } catch {
-    linked = false; // no symlink privilege (Windows CI)
-  }
+  const linked = trySymlink(outside, join(dir, 'linked-pack'));
   if (!linked) {
-    pass('symlinked-pack case not exercised — no symlink privilege on this host');
+    warn('symlinked-pack case skipped: no symlink privilege on this host');
   } else if (!names(dir).includes('linked')) {
     fail('a symlinked pack directory was skipped — an out-of-repo pack must still be discoverable');
-  } else if (resolveTemplate('cv', 'linked', { dir }).endsWith('cv-template.linked.html')) {
-    pass('a symlinked pack directory is followed, and resolves by name');
   } else {
-    fail('a symlinked pack listed but did not resolve to its template');
+    // resolveTemplate throws by design on a name that does not resolve, so a
+    // bare call here would abort the file rather than fail one check.
+    let resolved = null;
+    try {
+      resolved = resolveTemplate('cv', 'linked', { dir });
+    } catch (e) {
+      resolved = `threw: ${e.message}`;
+    }
+    if (String(resolved).endsWith('cv-template.linked.html')) {
+      pass('a symlinked pack directory is followed, and resolves by name');
+    } else {
+      fail(`a symlinked pack listed but did not resolve to its template (${resolved})`);
+    }
   }
 }
 
 {
   // A link pointing nowhere is not a pack, and must not throw the whole listing.
   const dir = fixtureDir();
-  let linked = true;
-  try {
-    symlinkSync(join(tmpdir(), 'packs-no-such-target-' + Date.now()), join(dir, 'broken'), 'dir');
-  } catch {
-    linked = false;
-  }
+  const linked = trySymlink(join(tmpdir(), 'packs-no-such-target-' + Date.now()), join(dir, 'broken'));
   if (!linked) {
-    pass('broken-symlink case not exercised — no symlink privilege on this host');
+    warn('broken-symlink case skipped: no symlink privilege on this host');
   } else {
     try {
-      names(dir);
-      pass('a broken symlink is skipped without breaking discovery');
+      // Asserting what still lists, not merely that nothing threw: a bare
+      // did-not-throw check is green against a module that finds nothing.
+      const found = names(dir);
+      if (found.includes('standard') && found.includes('compact')) {
+        pass('a broken symlink is skipped and the rest of the directory still lists');
+      } else {
+        fail(`a broken symlink perturbed discovery — got ${found.join(', ')}`);
+      }
     } catch (e) {
       fail(`a broken symlink broke discovery: ${e.message}`);
     }
@@ -200,24 +256,42 @@ function throws(label, fn, ...patterns) {
 {
   const dir = fixtureDir();
   addPack(dir, 'ats', 'ats');
-  const path = resolveTemplate('cv', 'ats', { dir });
-  if (path.endsWith(join('ats', 'cv-template.ats.html'))) pass('a pack template resolves by name to its pack path');
+  let path;
+  try {
+    path = resolveTemplate('cv', 'ats', { dir });
+  } catch (e) {
+    path = `threw: ${e.message}`;
+  }
+  if (String(path).endsWith(join('ats', 'cv-template.ats.html'))) pass('a pack template resolves by name to its pack path');
   else fail(`resolved to the wrong path: ${path}`);
 }
 
 {
   const dir = fixtureDir();
   addPack(dir, 'ats', 'ats');
-  const mismatched = listTemplates('cv', { dir })
-    .filter((t) => resolveTemplate('cv', t.name, { dir }) !== t.path);
+  // resolveTemplate throws by design on a name it cannot resolve, and a name
+  // that lists but does not resolve is precisely the regression this pins — so
+  // the throw has to be caught and counted, not allowed to abort the file.
+  const mismatched = listTemplates('cv', { dir }).filter((t) => {
+    try {
+      return resolveTemplate('cv', t.name, { dir }) !== t.path;
+    } catch {
+      return true;
+    }
+  });
   if (mismatched.length === 0) pass('every name that lists resolves, to the same path it listed');
-  else fail(`${mismatched.length} discovered template(s) do not resolve to their listed path`);
+  else fail(`${mismatched.map((t) => t.name).join(', ')} listed but did not resolve to the listed path`);
 }
 
 {
   const dir = fixtureDir();
-  const path = resolveTemplate('cv', 'nonexistent', { dir, fallback: true });
-  if (path.endsWith('cv-template.html')) pass('fallback still reaches standard from an unknown name');
+  let path;
+  try {
+    path = resolveTemplate('cv', 'nonexistent', { dir, fallback: true });
+  } catch (e) {
+    path = `threw: ${e.message}`;
+  }
+  if (String(path).endsWith('cv-template.html')) pass('fallback still reaches standard from an unknown name');
   else fail(`fallback landed on ${path}`);
 }
 
@@ -290,8 +364,14 @@ function throws(label, fn, ...patterns) {
     pass('no packs shipped yet — mechanism lands ahead of the first template (#3209)');
   } else {
     for (const t of shipped) {
-      if (resolveTemplate('cv', t.name, {}) === t.path) pass(`shipped pack ${t.pack}/ resolves by name "${t.name}"`);
-      else fail(`shipped pack ${t.pack}/ does not resolve by its own name`);
+      let resolved;
+      try {
+        resolved = resolveTemplate('cv', t.name, {});
+      } catch (e) {
+        resolved = `threw: ${e.message}`;
+      }
+      if (resolved === t.path) pass(`shipped pack ${t.pack}/ resolves by name "${t.name}"`);
+      else fail(`shipped pack ${t.pack}/ does not resolve by its own name (${resolved})`);
     }
   }
 }

--- a/tests/template-packs.test.mjs
+++ b/tests/template-packs.test.mjs
@@ -120,20 +120,49 @@ function throws(label, fn, ...patterns) {
 }
 
 {
-  // Following a symlinked directory would let a link dropped in templates/ pull
-  // a template in from anywhere on the filesystem.
+  // A pack kept outside the repo and linked in is a supported setup: career-ops
+  // sanctions a symlinked user layer (#524), and refusing the link would drop
+  // the template from the registry silently. Skipping buys no protection
+  // either — whoever can create the link can create a real directory instead.
   const dir = fixtureDir();
   const outside = mkdtempSync(join(tmpdir(), 'packs-outside-'));
-  writeFileSync(join(outside, 'cv-template.smuggled.html'), CV_BODY);
+  writeFileSync(join(outside, 'cv-template.linked.html'), CV_BODY);
   let linked = true;
   try {
-    symlinkSync(outside, join(dir, 'linked'), 'dir');
+    symlinkSync(outside, join(dir, 'linked-pack'), 'dir');
   } catch {
     linked = false; // no symlink privilege (Windows CI)
   }
-  if (!linked) pass('symlink guard not exercised — no symlink privilege on this host');
-  else if (!names(dir).includes('smuggled')) pass('a symlinked pack directory is skipped');
-  else fail('a symlinked directory pulled a template in from outside templates/');
+  if (!linked) {
+    pass('symlinked-pack case not exercised — no symlink privilege on this host');
+  } else if (!names(dir).includes('linked')) {
+    fail('a symlinked pack directory was skipped — an out-of-repo pack must still be discoverable');
+  } else if (resolveTemplate('cv', 'linked', { dir }).endsWith('cv-template.linked.html')) {
+    pass('a symlinked pack directory is followed, and resolves by name');
+  } else {
+    fail('a symlinked pack listed but did not resolve to its template');
+  }
+}
+
+{
+  // A link pointing nowhere is not a pack, and must not throw the whole listing.
+  const dir = fixtureDir();
+  let linked = true;
+  try {
+    symlinkSync(join(tmpdir(), 'packs-no-such-target-' + Date.now()), join(dir, 'broken'), 'dir');
+  } catch {
+    linked = false;
+  }
+  if (!linked) {
+    pass('broken-symlink case not exercised — no symlink privilege on this host');
+  } else {
+    try {
+      names(dir);
+      pass('a broken symlink is skipped without breaking discovery');
+    } catch (e) {
+      fail(`a broken symlink broke discovery: ${e.message}`);
+    }
+  }
 }
 
 {

--- a/tests/template-packs.test.mjs
+++ b/tests/template-packs.test.mjs
@@ -1,0 +1,273 @@
+// tests/template-packs.test.mjs — a template pack is discoverable, resolvable,
+// and can never be ambiguous (#3202).
+//
+// career-ops ships seven CV templates that all lay out with flex or grid,
+// because they exist to look right as a PDF a human reads. An ATS parser walks
+// the DOM instead: hand Workday a two-column flex row holding a job title on
+// the left and a date range on the right and the autofill comes back with the
+// two strings concatenated or split across the wrong fields. The answer is a
+// variant with a different DOM, not plainer CSS on the existing ones.
+//
+// A different DOM means different section partials, and build-cv-html.mjs
+// resolves partials from the `sections/` co-located with the template file.
+// Co-location is therefore the whole mechanism: a template in its own
+// subdirectory alongside its own `sections/` gets its own DOM without touching
+// the `templates/sections/` every flat template shares. That subdirectory is a
+// *pack*, and this suite pins what the registry must do with one.
+//
+// Lives in tests/ because only tests/**/*.test.mjs is discovered by
+// test-all.mjs, which is what CI runs. The module's older unit suite sits in
+// test/ (singular) and is not gated by anything — see the note at the end of
+// this file.
+
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import { listTemplates, resolveTemplate } from '../cv-templates.mjs';
+
+console.log('\nCV template packs — discovery, resolution, and name collisions');
+
+const CV_BODY = '{{NAME}}{{EXPERIENCE}}{{EDUCATION}}';
+
+/** A templates/ dir with the flat layout that predates packs. */
+function fixtureDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'packs-'));
+  writeFileSync(join(dir, 'cv-template.html'), CV_BODY);
+  writeFileSync(join(dir, 'cv-template.compact.html'), CV_BODY);
+  writeFileSync(join(dir, 'cover-letter-template.html'), '{{NAME}}{{ROLE_TITLE}}{{OPENING}}');
+  return dir;
+}
+
+/** Add a pack: a subdirectory holding `cv-template.<name>.html` and its sections/. */
+function addPack(dir, packName, templateName, { body = CV_BODY, sections = {} } = {}) {
+  const packDir = join(dir, packName);
+  mkdirSync(packDir, { recursive: true });
+  writeFileSync(join(packDir, `cv-template.${templateName}.html`), body);
+  if (Object.keys(sections).length) {
+    mkdirSync(join(packDir, 'sections'), { recursive: true });
+    for (const [name, html] of Object.entries(sections)) {
+      writeFileSync(join(packDir, 'sections', `${name}.html`), html);
+    }
+  }
+  return packDir;
+}
+
+const names = (dir, opts = {}) => listTemplates('cv', { dir, ...opts }).map((t) => t.name).sort();
+
+/** Assert `fn` throws with a message matching every pattern. */
+function throws(label, fn, ...patterns) {
+  let err = null;
+  try {
+    fn();
+  } catch (e) {
+    err = e;
+  }
+  if (!err) return fail(`${label}: expected a throw, got none`);
+  const missed = patterns.filter((p) => !p.test(err.message));
+  if (missed.length) return fail(`${label}: message missed ${missed.join(', ')} — got "${err.message}"`);
+  pass(label);
+}
+
+// ── Discovery ───────────────────────────────────────────────────────────────
+
+{
+  const dir = fixtureDir();
+  addPack(dir, 'ats', 'ats');
+  const found = names(dir);
+  if (found.includes('ats')) pass('a pack one level down is discovered by name');
+  else fail(`pack not discovered — listTemplates returned ${found.join(', ')}`);
+
+  const entry = listTemplates('cv', { dir }).find((t) => t.name === 'ats');
+  if (entry.pack === 'ats') pass('a pack entry reports the directory holding it');
+  else fail(`expected pack "ats", got ${JSON.stringify(entry.pack)}`);
+
+  const flat = listTemplates('cv', { dir }).find((t) => t.name === 'compact');
+  if (flat.pack === null) pass('a flat template reports pack: null');
+  else fail(`expected pack null for a flat template, got ${JSON.stringify(flat.pack)}`);
+}
+
+{
+  // One naming rule, not two: a template is named by its file everywhere.
+  const dir = fixtureDir();
+  addPack(dir, 'whatever-i-called-it', 'ats');
+  const found = names(dir);
+  if (found.includes('ats') && !found.includes('whatever-i-called-it')) {
+    pass('the template name comes from the filename, never the directory name');
+  } else {
+    fail(`expected "ats" from the filename — got ${found.join(', ')}`);
+  }
+}
+
+{
+  // A pack's own sections/ must never be walked as if it were a nested pack.
+  const dir = fixtureDir();
+  addPack(dir, 'ats', 'ats', { sections: { experience: '<!--ENTRY--><div></div><!--/ENTRY-->' } });
+  mkdirSync(join(dir, 'ats', 'sections', 'deep'), { recursive: true });
+  writeFileSync(join(dir, 'ats', 'sections', 'deep', 'cv-template.sneaky.html'), CV_BODY);
+  if (!names(dir).includes('sneaky')) pass('discovery is one level deep — a pack\'s sections/ is not a pack');
+  else fail('discovery recursed past one level into a pack\'s sections/');
+}
+
+{
+  // The shared partial directory sits in templates/ and holds no template file.
+  const dir = fixtureDir();
+  mkdirSync(join(dir, 'sections'), { recursive: true });
+  writeFileSync(join(dir, 'sections', 'experience.html'), '<!--ENTRY--><div></div><!--/ENTRY-->');
+  const found = names(dir);
+  if (found.length === 2) pass('the shared templates/sections/ is not mistaken for a pack');
+  else fail(`shared sections/ perturbed discovery — got ${found.join(', ')}`);
+}
+
+{
+  // Following a symlinked directory would let a link dropped in templates/ pull
+  // a template in from anywhere on the filesystem.
+  const dir = fixtureDir();
+  const outside = mkdtempSync(join(tmpdir(), 'packs-outside-'));
+  writeFileSync(join(outside, 'cv-template.smuggled.html'), CV_BODY);
+  let linked = true;
+  try {
+    symlinkSync(outside, join(dir, 'linked'), 'dir');
+  } catch {
+    linked = false; // no symlink privilege (Windows CI)
+  }
+  if (!linked) pass('symlink guard not exercised — no symlink privilege on this host');
+  else if (!names(dir).includes('smuggled')) pass('a symlinked pack directory is skipped');
+  else fail('a symlinked directory pulled a template in from outside templates/');
+}
+
+{
+  const dir = fixtureDir();
+  const packDir = addPack(dir, 'ats', 'ats');
+  writeFileSync(join(packDir, 'cv-template.atstex.tex'), '{{NAME}}');
+  const html = names(dir);
+  const tex = names(dir, { format: 'tex' });
+  if (html.includes('ats') && !html.includes('atstex') && tex.includes('atstex') && !tex.includes('ats')) {
+    pass('a pack respects the format filter the same way a flat template does');
+  } else {
+    fail(`format filter leaked across packs — html=${html.join(',')} tex=${tex.join(',')}`);
+  }
+}
+
+{
+  // KINDS is generic, so packs are not a CV-only concept.
+  const dir = fixtureDir();
+  mkdirSync(join(dir, 'brief'), { recursive: true });
+  writeFileSync(join(dir, 'brief', 'cover-letter-template.brief.html'), '{{NAME}}{{ROLE_TITLE}}{{OPENING}}');
+  const found = listTemplates('cover', { dir }).map((t) => t.name).sort();
+  if (found.includes('brief')) pass('cover-letter packs are discovered on the same rule');
+  else fail(`cover pack not discovered — got ${found.join(', ')}`);
+}
+
+// ── Resolution ──────────────────────────────────────────────────────────────
+//
+// The gap the issue's own proposal understated. Discovery alone would let a
+// pack list and then throw on resolve: resolveTemplate() built dir/<file>
+// directly and never consulted the listing. Every by-name caller lands there
+// (build-cv-latex.mjs, generate-cover-letter.mjs), so the demo path — handing
+// build-cv-html.mjs an explicit path — would keep working while selecting the
+// same template by name failed.
+
+{
+  const dir = fixtureDir();
+  addPack(dir, 'ats', 'ats');
+  const path = resolveTemplate('cv', 'ats', { dir });
+  if (path.endsWith(join('ats', 'cv-template.ats.html'))) pass('a pack template resolves by name to its pack path');
+  else fail(`resolved to the wrong path: ${path}`);
+}
+
+{
+  const dir = fixtureDir();
+  addPack(dir, 'ats', 'ats');
+  const mismatched = listTemplates('cv', { dir })
+    .filter((t) => resolveTemplate('cv', t.name, { dir }) !== t.path);
+  if (mismatched.length === 0) pass('every name that lists resolves, to the same path it listed');
+  else fail(`${mismatched.length} discovered template(s) do not resolve to their listed path`);
+}
+
+{
+  const dir = fixtureDir();
+  const path = resolveTemplate('cv', 'nonexistent', { dir, fallback: true });
+  if (path.endsWith('cv-template.html')) pass('fallback still reaches standard from an unknown name');
+  else fail(`fallback landed on ${path}`);
+}
+
+{
+  const dir = fixtureDir();
+  addPack(dir, 'ats', 'ats', { body: '{{NAME}}' });
+  throws(
+    'a pack failing validation names its real path, not the flat name it never had',
+    () => resolveTemplate('cv', 'ats', { dir }),
+    /ats[/\\]cv-template\.ats\.html/,
+    /\{\{EXPERIENCE\}\}/
+  );
+}
+
+// ── Collisions ──────────────────────────────────────────────────────────────
+//
+// A name resolves to one file, enforced at discovery rather than by precedence.
+// Precedence has to pick a winner while both files exist and both look correct
+// — during a migration from a flat template to a pack, say — and the loser just
+// stops rendering, with nothing in the output naming the file that won.
+
+{
+  const dir = fixtureDir();
+  writeFileSync(join(dir, 'cv-template.ats.html'), CV_BODY);
+  addPack(dir, 'ats', 'ats');
+  throws(
+    'a flat template and a pack claiming one name is an error from listTemplates',
+    () => listTemplates('cv', { dir }),
+    /claimed by two files/,
+    /cv-template\.ats\.html/,
+    /ats[/\\]cv-template\.ats\.html/
+  );
+  throws(
+    'and the same error from resolveTemplate — neither entry point picks a winner',
+    () => resolveTemplate('cv', 'ats', { dir }),
+    /claimed by two files/
+  );
+}
+
+{
+  const dir = fixtureDir();
+  addPack(dir, 'ats-a', 'ats');
+  addPack(dir, 'ats-b', 'ats');
+  throws('two packs claiming one name is an error', () => listTemplates('cv', { dir }), /claimed by two files/);
+}
+
+{
+  // An unnamed cv-template.html inside a pack claims "standard".
+  const dir = fixtureDir();
+  mkdirSync(join(dir, 'mine'), { recursive: true });
+  writeFileSync(join(dir, 'mine', 'cv-template.html'), CV_BODY);
+  throws('a pack claiming "standard" collides with the base template', () => listTemplates('cv', { dir }), /claimed by two files/);
+}
+
+{
+  // readdir order is not guaranteed; the message must not depend on it.
+  const dir = fixtureDir();
+  writeFileSync(join(dir, 'cv-template.ats.html'), CV_BODY);
+  addPack(dir, 'ats', 'ats');
+  const grab = () => { try { listTemplates('cv', { dir }); return null; } catch (e) { return e.message; } };
+  if (grab() === grab()) pass('the collision message is stable across runs, whatever the read order');
+  else fail('collision message varies between identical runs');
+}
+
+// ── The real pack, if one is checked in ─────────────────────────────────────
+
+{
+  const shipped = listTemplates('cv').filter((t) => t.pack);
+  if (shipped.length === 0) {
+    pass('no packs shipped yet — mechanism lands ahead of the first template (#3209)');
+  } else {
+    for (const t of shipped) {
+      if (resolveTemplate('cv', t.name, {}) === t.path) pass(`shipped pack ${t.pack}/ resolves by name "${t.name}"`);
+      else fail(`shipped pack ${t.pack}/ does not resolve by its own name`);
+    }
+  }
+}
+
+// NOTE: cv-templates.mjs also has a node:test suite at test/cv-templates.test.mjs
+// (singular). Nothing runs it: test-all.mjs discovers tests/**/*.test.mjs only,
+// CI runs `node test-all.mjs --quick`, and root package.json declares no `test`
+// script. Worth its own issue; not fixed here.

--- a/tests/template-page-breaks.test.mjs
+++ b/tests/template-page-breaks.test.mjs
@@ -22,8 +22,8 @@
 // clone with only Node (#1440), and reproducing the orphan needs Chromium plus a
 // payload tuned to one template's exact geometry. The rule is the contract; the
 // render is how the rule was arrived at.
-import { readFileSync } from 'fs';
-import { relative } from 'path';
+import { readFileSync, existsSync } from 'fs';
+import { relative, join, dirname } from 'path';
 import { pass, fail, ROOT } from './helpers.mjs';
 import { listTemplates } from '../cv-templates.mjs';
 
@@ -64,12 +64,53 @@ function declares(parsed, selector, prop, value) {
   return parsed.some((r) => r.selectors.some((s) => exact.test(s)) && decl.test(r.decls));
 }
 
-const templates = listTemplates('cv').filter((t) => t.format === 'html');
+/**
+ * Whether a template emits `.project-tech` markup it did not author.
+ *
+ * The assertions below rest on one premise: the markup is not the template's to
+ * opt out of, because it comes from the shared templates/sections/projects.html
+ * (or, with no partial there, from the built-in builder in build-cv-html.mjs,
+ * which emits the same classes). A template that never styles .project-tech is
+ * still on the hook, because it still renders the div.
+ *
+ * A template pack (#3202) is the one case where that premise can fail. A pack
+ * ships its own sections/ next to its template, and loadSectionPartials()
+ * resolves partials relative to the template file — so a pack that authors its
+ * own projects.html chooses that section's DOM outright, and a pack whose
+ * projects.html has no .project-tech cannot orphan a line it never emits.
+ *
+ * The exemption is deliberately narrow, and follows the premise rather than the
+ * template's name:
+ *   - flat template            → held (shared partial / built-in builder)
+ *   - pack, no projects.html   → held (falls through to the built-in builder,
+ *                                 which emits .project-tech regardless)
+ *   - pack with projects.html  → held only if that partial emits project-tech
+ */
+function emitsProjectTech(t) {
+  if (!t.pack) return true;
+  const partial = join(dirname(t.path), 'sections', 'projects.html');
+  if (!existsSync(partial)) return true; // built-in builder still emits it
+  return /project-tech/.test(readFileSync(partial, 'utf-8'));
+}
 
-if (templates.length === 0) {
+const discovered = listTemplates('cv').filter((t) => t.format === 'html');
+
+if (discovered.length === 0) {
   fail('no HTML CV templates discovered — listTemplates("cv") returned nothing');
 } else {
-  pass(`discovered ${templates.length} HTML CV templates to check`);
+  pass(`discovered ${discovered.length} HTML CV templates to check`);
+}
+
+const templates = [];
+for (const t of discovered) {
+  if (emitsProjectTech(t)) {
+    templates.push(t);
+    continue;
+  }
+  pass(
+    `${relative(ROOT, t.path).replace(/\\/g, '/')}: pack authors its own sections/projects.html `
+      + 'with no .project-tech — nothing to orphan, page-break rules not applicable'
+  );
 }
 
 for (const t of templates) {


### PR DESCRIPTION
## What does this PR do?

Teaches the template registry to discover **template packs**: a subdirectory holding its own `cv-template.<name>.html` next to its own `sections/`. `build-cv-html.mjs` already resolves partials relative to the template file, so co-location is the whole mechanism — a pack gets its own DOM without editing the `templates/sections/` every flat template shares. Mechanism only; no template ships here.

## Related issue

Part of #3202 — option (a) as agreed in the thread. Not `Fixes`: the ATS template itself is @devanupriyj-code's in #3209, and the `pdf` dual-emit question is still open in the issue.

The pack layout #3209 already produces is the layout this discovers, so the two compose. Neither blocks the other — #3209 can land flat or on this, whichever arrives first.

## What's here

**Discovery, and resolution.** Both entry points now go through one `discover()` pass, so a name that lists is a name that resolves. Routing `resolveTemplate()` through it is the half my own issue understated: it built `dir/<file>` directly and never consulted the listing, so discovery alone would have let a pack list and then throw on resolve — taking `build-cv-latex.mjs` and `generate-cover-letter.mjs` with it, while the explicit-path demo kept working.

**A name resolves to one file, enforced at discovery.** Precedence would have to pick a winner while both files exist and both look correct — during a migration from a flat template to a pack — and the loser would simply stop rendering, with nothing naming the file that won. The error names both paths.

**One level, symlinks followed.** A pack's `sections/` is never walked as a pack. Symlinked pack directories *are* followed (second commit reverses my first attempt — see below); a broken link is skipped rather than throwing the listing.

**The page-break contract stays honest.** `tests/template-page-breaks.test.mjs` asserts over every discovered template, so a pack is enrolled the moment discovery lands. Its premise is that the markup is not the template's to opt out of, coming from the shared `sections/projects.html`. A pack authoring its own `projects.html` is where that stops holding, so the exemption follows the premise rather than a template name — a pack with **no** `projects.html` is still held, because it falls through to the built-in builder, which emits `.project-tech` anyway.

## Two commits, deliberately

`843143d` is the mechanism. `8476731` reverses the symlink guard from the first commit: I'd skipped symlinked directories, then couldn't defend it. A symlink grants no capability its creator lacked, the repo's real guards are on a different axis (`resolveInsideRepo()` guards user-supplied path *arguments*; `contacts.mjs` guards *writes* leaving the tree — both untouched), and #524 sanctions a symlinked user layer, so skipping would drop an out-of-repo pack from the registry silently. Kept separate so the reversal is reviewable rather than buried. Discussed in the issue.

## Testing

`node test-all.mjs` → **5330 passed, 0 failed**, 3 warnings, all pre-existing on `main` (cv-sync-check without user data, no Go compiler, a personal-data heuristic hit on `santifer.io` in `dashboard/`). `node scripts/check-syntax.mjs` clean.

New suite `tests/template-packs.test.mjs` (20 assertions) covers discovery, one-level depth, the shared `sections/` not being mistaken for a pack, the format filter, cover-letter packs, resolution parity with listing, fallback, pack-aware validation errors, and four collision cases including message stability across read order.

It's in `tests/` rather than next to the module's suite in `test/`, so it is auto-discovered and itemized rather than registered and aggregated. Unrelated finding while checking that, filed separately as #3247: two `test/` suites are registered nowhere and have not run since July.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no user-layer files touched)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added discovery and resolution for one-level template packs, including cover-letter packs.
  * Template listings now provide pack details and support consistent format filtering.
  * Added support for symlinked template-pack directories.

* **Bug Fixes**
  * Added clear errors for duplicate template names.
  * Improved fallback and resolution consistency.
  * Validation errors now identify the actual packed template file.

* **Tests**
  * Added coverage for packs, symlinks, collisions, validation, fallbacks, and page-break behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->