### PR TITLE
fix(doctor): surface tracked .bak backup files as a warning

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -6,6 +6,7 @@
  */
 
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -150,6 +151,42 @@ function checkDependencies() {
     pass: false,
     label: 'Dependencies not installed',
     fix: 'Run: npm install',
+  };
+}
+
+// update-system.mjs versions before #2857 could commit cascading .bak backups
+// when a checkout write failed. #2857 stops that for NEW installs, but an
+// install that already `git add`ed one is stuck: nothing in the update path
+// untracks a path git already has, so the .bak files persist forever and the
+// next update looks like it silently did nothing (career-ops#2881) — nothing
+// points at .bak unless something checks for it. Kept to a single cheap
+// `git ls-files` call so it costs nothing on the common case of zero matches.
+function checkTrackedBakFiles(root) {
+  let raw;
+  try {
+    raw = execFileSync('git', ['ls-files', '-z', '--', '*.bak*'], {
+      cwd: root, encoding: 'utf-8', timeout: 5000,
+    });
+  } catch {
+    // Not a git checkout (or git unavailable) — nothing to check.
+    return { pass: true, label: 'Tracked .bak files: skipped (not a git checkout)' };
+  }
+  const paths = raw.split('\0').filter(Boolean);
+  if (paths.length === 0) {
+    return { pass: true, label: 'No tracked .bak backup files' };
+  }
+  const preview = paths.slice(0, 8);
+  const rest = paths.length - preview.length;
+  return {
+    warn: true,
+    label: `${paths.length} tracked .bak backup file${paths.length === 1 ? '' : 's'} found — an old update-system.mjs bug committed these, and no update untracks them on its own`,
+    fix: [
+      ...preview,
+      ...(rest > 0 ? [`...and ${rest} more`] : []),
+      "git ls-files '*.bak*'            # find them",
+      'git rm --cached <each path>      # untrack, leaving the file on disk',
+      'git commit -m "chore: untrack .bak backups"',
+    ],
   };
 }
 
@@ -543,6 +580,7 @@ async function main() {
     geminiNodeFloor(activeCli, process.versions.node),
     checkBillingSource(),
     checkDependencies(),
+    checkTrackedBakFiles(projectRoot),
     await checkPlaywright(),
     checkPlaywrightMcp(projectRoot, activeCli),
     checkScanExtractor(projectRoot),
@@ -633,9 +671,11 @@ function onboardingState(root) {
   const { cli: activeCli, source: cliSource, warning: cliWarning } = resolveActiveCli();
 
   const mcpCheck = checkPlaywrightMcp(root, activeCli);
+  const bakCheck = checkTrackedBakFiles(root);
   const warnings = [
     ...(cliWarning ? [cliWarning] : []),
     ...(mcpCheck?.warn ? [`${mcpCheck.label}\n→ ${[].concat(mcpCheck.fix || []).join('\n  ')}`] : []),
+    ...(bakCheck.warn ? [`${bakCheck.label}\n→ ${[].concat(bakCheck.fix || []).join('\n  ')}`] : []),
   ];
 
   const playwrightMcp = activeCli !== 'unknown' && MCP_CONFIGS.find((c) => c.cli === activeCli)

--- a/tests/doctor-tracked-bak-files.test.mjs
+++ b/tests/doctor-tracked-bak-files.test.mjs
@@ -1,0 +1,112 @@
+// tests/doctor-tracked-bak-files.test.mjs — doctor.mjs's tracked-.bak warning.
+//
+// update-system.mjs versions before #2857 could commit cascading .bak backups
+// when a checkout write failed. #2857 stops that for NEW installs, but an
+// install that already `git add`ed one is stuck: nothing in the update path
+// untracks a path git already has, so the update looks like it silently did
+// nothing (career-ops#2881) with no signal pointing at .bak. This pins the
+// doctor check that surfaces it instead of letting it stay silent.
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+console.log('\ndoctor.mjs — tracked .bak files');
+
+const DOCTOR = join(ROOT, 'doctor.mjs');
+
+function runDoctor(cwd) {
+  try {
+    const out = execFileSync(NODE, [DOCTOR, '--json', '--target', cwd], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return JSON.parse(out);
+  } catch (e) {
+    return { _error: e.message, _stderr: e.stderr ? String(e.stderr) : '' };
+  }
+}
+
+function git(cwd, ...args) {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+function initRepo(dir) {
+  git(dir, 'init', '-q');
+  git(dir, 'config', 'user.email', 'test@example.com');
+  git(dir, 'config', 'user.name', 'Test');
+}
+
+// 1. A tracked .bak file is reported as a warning naming the remedy.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-bak-2-'));
+  try {
+    initRepo(dir);
+    writeFileSync(join(dir, 'notes.md.bak'), 'stale backup\n', 'utf-8');
+    git(dir, 'add', 'notes.md.bak');
+    git(dir, 'commit', '-q', '-m', 'accidentally tracked backup');
+
+    const state = runDoctor(dir);
+    if (state._error) {
+      fail(`tracked .bak run: doctor crashed: ${state._error}`);
+    } else {
+      const warningText = (state.warnings || []).join('\n');
+      if (/tracked \.bak/.test(warningText) && /notes\.md\.bak/.test(warningText)) {
+        pass('a tracked .bak file is surfaced in doctor --json warnings, naming the path');
+      } else {
+        fail(`tracked .bak file was not surfaced: ${JSON.stringify(state.warnings)}`);
+      }
+      if (/git rm --cached/.test(warningText) && /git commit/.test(warningText)) {
+        pass('the warning includes the untrack-and-commit remedy');
+      } else {
+        fail(`remedy commands missing from warning: ${JSON.stringify(state.warnings)}`);
+      }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 2. A clean repo (no tracked .bak files) stays silent on this check.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-bak-3-'));
+  try {
+    initRepo(dir);
+    writeFileSync(join(dir, 'cv.md'), '# CV\n', 'utf-8');
+    git(dir, 'add', 'cv.md');
+    git(dir, 'commit', '-q', '-m', 'add cv');
+
+    const state = runDoctor(dir);
+    if (state._error) {
+      fail(`clean-repo run: doctor crashed: ${state._error}`);
+    } else {
+      const warningText = (state.warnings || []).join('\n');
+      if (!/tracked \.bak/.test(warningText)) {
+        pass('a repo with no tracked .bak files produces no .bak warning');
+      } else {
+        fail(`unexpected .bak warning on a clean repo: ${JSON.stringify(state.warnings)}`);
+      }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 3. A directory that is not a git checkout at all does not crash doctor.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-bak-4-'));
+  try {
+    writeFileSync(join(dir, 'cv.md'), '# CV\n', 'utf-8');
+
+    const state = runDoctor(dir);
+    if (state._error) {
+      fail(`non-git run: doctor crashed: ${state._error}`);
+    } else {
+      pass('a non-git target directory does not crash the .bak check');
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2881. `update-system.mjs` versions before #2857 could commit cascading `.bak` backups when a checkout write failed. #2857 stops that for new installs, but an install that already `git add`ed one is stuck: nothing in the update path untracks a path git already has, so the file persists forever and the next update looks like it silently did nothing.

@santifer already worked out the fix in the #2881 thread — this implements what he specified there:

> the updater should say this itself... doctor (or update-system.mjs check) can notice tracked .bak paths and print the three lines above, rather than letting the update quietly preserve-and-skip.

`doctor.mjs` now runs a single `git ls-files -- '*.bak*'` and, if any tracked `.bak` paths are found, warns with the exact untrack-and-commit remedy from that thread:

```
git ls-files '*.bak*'            # find them
git rm --cached <each path>      # untrack, leaving the file on disk
git commit -m "chore: untrack .bak backups"
```

Folded into both the human CLI output and `--json`'s `warnings` array. No-ops gracefully outside a git checkout. A clean repo stays silent.

4 new test assertions in `tests/doctor-tracked-bak-files.test.mjs`: a tracked `.bak` file is surfaced with the remedy, a clean repo produces no warning, and a non-git target doesn't crash the check.

## Related issue

Fixes #2881 (the `.bak` cascade half — the CRLF false-positive half was already fixed by #2820).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue-first requirement (exempt per template)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs --quick` and all tests pass (5309 passed, 0 failed, 3 pre-existing/unrelated warnings)
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

---
_Generated by [Claude Code](https://claude.ai/code/session_018rpXhKuhxC2fs9GZBBRnVH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics that detect tracked backup files and provide commands to resolve them.
  * Added warnings to both human-readable and JSON diagnostic reports.
  * Diagnostics now handle non-Git directories without failing.

* **Tests**
  * Added coverage for detected backup files, clean repositories, remediation guidance, and non-Git environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->