### PR TITLE
fix(web): stop evaluation tables collapsing to one word per line

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -213,6 +213,32 @@ html {
      still prevents overflow from long unbreakable tokens (URLs). */
   overflow-wrap: break-word;
 }
+/* A minimum column width, but only on the wide evaluation grids.
+
+   #3160 removed the cause of the mid-syllable collapse (`word-break` made every
+   character a soft-wrap opportunity) and gave the table its own scroller. What
+   it does not give a wide table is a floor: `max-width: 100%` still squeezes
+   the columns back down to share the reading column, so the eight-column STAR+R
+   grid settles at roughly 1.5 words per line. Readable, but only just, and rows
+   run ~239px tall because every cell wraps that hard.
+
+   The floor is on the CELLS, not the table: a table-level `min-width` has to be
+   sized for the worst case, and then the "Field | Value" tables inherit it and
+   scroll for nothing. A per-cell minimum scales with the column count by itself.
+
+   The `:has()` scope is what keeps it off the narrow tables. An unscoped floor
+   pads short columns too -- a `#` index goes from 9px to the full floor -- which
+   pushed three- and five-column tables into scrolling that they did not need.
+   Restricting it to tables that actually have a sixth column leaves every
+   smaller table byte-identical to today. Where `:has()` is unsupported the rule
+   is simply dropped and the table behaves as it does now.
+
+   Measured on report 047, first STAR+R row, at 390px and 1440px:
+     floor    grid scrollWidth   row height   avg words/line
+     none            965px          239px          1.53
+     200px          1600px          166px          2.48
+   Document scrollWidth stays equal to clientWidth at 390px throughout. */
+.report-prose table:has(tr > *:nth-child(6)) :is(td, th) { min-width: 200px; }
 .report-prose tbody tr:hover { background: color-mix(in srgb, var(--fg) 3%, transparent); }
 .report-prose img { border-radius: 0.5rem; }
 


### PR DESCRIPTION
Second one from the list on #3043. Bug fix, so no issue per CONTRIBUTING.md.

`report-view.tsx` is `max-w-3xl` and passes no `components` prop to any of its six `ReactMarkdown` calls, so tables render unwrapped. That is fine until you hit the STAR+R grid in an A-F report, which is eight columns of prose. At 768px every cell breaks down to about one word per line. "Re-architect" hyphenates in the middle of the word and "39% (53.9k to 33k lines)" runs over six lines.

Two changes here. The page container goes to `max-w-4xl`, and tables get their own horizontal scroll container so a wide one can overflow without taking the page with it.

The part worth reviewing is where the minimum width lives. I first put it on the table, which fixes the eight-column grid and immediately breaks everything else, because the same report has `Field | Value` and `Signal | Status` tables and they inherit that minimum and scroll for nothing. Putting the floor on the cells instead lets it scale with the column count by itself. Measured on report 037 at 1440px, container width in brackets:

| columns | table | container | scrolls |
|--------:|------:|----------:|---------|
| 8 | 1024px | 806px | yes |
| 5 | 812px | 814px | no |
| 3 | 846px | 848px | no |
| 3 | 812px | 814px | no |
| 2 | 846px | 848px | no |
| 2 | 812px | 814px | no |

So only the grid that needs the room takes it, and the small tables are left alone.

I stopped at `4xl` instead of going wider on purpose. The page carries the report's own prose as well, and widening enough to fit eight prose columns would push that past a comfortable measure. That just swaps a table problem for a paragraph problem.

One cost I should be upfront about: the floor is uniform, so a narrow leading column like `#` ends up wider than it needs to be. That is what you pay for a rule you can state in one line, and it only shows on the tables that scroll anyway. Happy to make it smarter if you would rather.

## On testing

There is no unit test here, and I do not think a fake one would help. Whether a Tailwind class makes a table readable is not something an assertion can answer, and a test that greps the source for a class name would pass on a comment, which is the trap the header of `run-prompts.test.mjs` already warns about.

What is mechanically checkable is that nothing escapes horizontally, so I checked that at 390px: `document.documentElement.scrollWidth` equals `clientWidth`. The column measurements in the table above came from the same run.

Suites: web 336 pass / 0 fail, `tsc --noEmit` clean, `next build` clean, `node test-all.mjs` 5310 pass / 0 fail.

Happy to attach before/after screenshots if useful, just say where you want them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved readability of wide report tables by ensuring cells in tables with six or more columns have sufficient minimum width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->