### PR TITLE
fix(contacto): stop searching for contacts the mode never uses

### DIFF
--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -20,11 +20,21 @@ short message; otherwise run the LinkedIn power move below.
 
 ## LinkedIn power move (default)
 
-1. **Identify targets** via WebSearch:
-   - Hiring manager of the team
+1. **Find ONE target** via WebSearch -- search in this order and stop at the first
+   one you can actually confirm:
+   - Hiring manager of the team (usually the strongest primary at this stage)
    - Assigned recruiter
-   - 2-3 team peers (people with similar roles)
-   - Interviewer (if the candidate already has a scheduled interview)
+   - A team peer (someone with a similar role)
+   - Interviewer, if the candidate already has a scheduled interview
+
+   **Three WebSearch calls is a hard ceiling, not a suggestion.** Step 3 selects a
+   single primary target and step 4 writes one message, so every search past the
+   first confirmed hit is paid for and thrown away. One confirmed contact is a
+   complete result, not a partial one -- do not keep searching to round out a
+   roster nobody asked for.
+
+   Best-effort and no login: when a target cannot be confirmed, say so plainly and
+   move to the next one in the order. Never guess a name.
 
 2. **Classify contact type** -- ask the candidate or infer from context:
    - **Recruiter** -- person whose role is talent acquisition, sourcing, or recruiting
@@ -62,7 +72,10 @@ short message; otherwise run the LinkedIn power move below.
    - EN (default)
    - ES (if Spanish company)
 
-6. **Alternative targets** with justification for why they are good second choices
+6. **Alternative targets**, if the search happened to confirm any others: one line
+   each (who they are, and the single reason to try them). Omit this section
+   entirely when there is only one target -- it is a note on what you already
+   found, never a reason to go searching again
 
 7. **Offer to save the contact** -- once the candidate picks a target, ask whether
    to save that person to `data/contacts.tsv` (one line:


### PR DESCRIPTION
Third from the #3043 list. You said to send this one if I could lift it out of the mode-surface changes, and it turns out it lifts completely, because the waste is in the mode file rather than in the web prompt. The CLI has been paying for it too.

Step 1 asks the agent to find a hiring manager, a recruiter, two to three peers and an interviewer. Step 3 then picks one primary target and step 4 writes one message. So it is four or five WebSearch calls to use one of them, every run.

Step 1 is now an ordered search that stops at the first target it can confirm, with three calls as a hard ceiling. Same list and same preference order, it just does not go back for contacts that nothing downstream reads. I worded the ceiling as a hard limit rather than guidance, and said outright that one confirmed contact is a complete result, because "identify targets" plural is what invites the extra calls in the first place.

Step 6 needed changing to match. It asked for alternative targets with justification, which only means anything if you went and found several. It is now a note on whatever the search already turned up, and it drops out entirely when there is only one. Otherwise it reads as permission to go searching again and the ceiling does nothing.

I also kept it explicit that a target you cannot confirm gets stated plainly instead of guessed. Stopping early makes it a bit likelier you finish on one you could not pin down, and I would rather that come back as "could not confirm" than as a plausible name.

No web files touched, which is the point.

`node test-all.mjs`: 5310 pass, 0 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the LinkedIn contact workflow to identify and confirm one primary contact.
  - Searches now follow a defined priority order and stop after the first confirmed match.
  - Added safeguards to avoid guessing contact names and to limit web searches.
  - Displays alternative contacts only when they were previously discovered.
  - Preserved the existing greeting style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->