### PR TITLE
fix(browser-extract): read Workday JDs from the CXS API, and fail loudly on an empty JD

### DIFF
--- a/browser-extract.mjs
+++ b/browser-extract.mjs
@@ -25,9 +25,20 @@
  *                  anchors that look like individual postings, deduped. For scan
  *                  Level 1 (reading a company's open roles).
  *
+ * Workday (`*.myworkdayjobs.com`) is read through its public CXS JSON endpoint
+ * instead of the rendered page: Workday hydrates the JD into a virtualized DOM
+ * that readDom() below cannot see, so scraping it returned a well-formed result
+ * with an EMPTY `text` — indistinguishable, to a caller, from a posting that
+ * genuinely has no content. Same API family scan.mjs already uses for Workday
+ * boards (providers/workday.mjs); the per-job URL derivation is reused from
+ * liveness-api.mjs so the two cannot drift.
+ *
  * Output: compact JSON to stdout. Exit 0 on success; exit 1 on a hard error,
  * printing `{ "error": "...", "code": "..." }` (so a caller/mode can fall back
- * to the MCP path silently). Reuses liveness-browser.mjs's SSRF host guard and
+ * to the MCP path silently). An empty/near-empty jd-mode extraction is one of
+ * those hard errors (`code: "empty_text"`) rather than a successful-looking
+ * empty JD — the documented silent fallback only fires if the tool actually
+ * reports failure. Reuses liveness-browser.mjs's SSRF host guard and
  * realistic-UA context so it isn't instantly bot-walled.
  */
 
@@ -36,6 +47,9 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 import { LIVENESS_CONTEXT_OPTIONS, rejectPrivateOrInvalid } from './liveness-browser.mjs';
+import { resolveAtsApi } from './liveness-api.mjs';
+import { decodeEntities } from './providers/_html-entities.mjs';
+import { DEFAULT_USER_AGENT } from './user-agent.mjs';
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -44,6 +58,16 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const HYDRATION_WAIT_MS = 2_000;
 const JD_TEXT_CAP = 12_000;     // plenty for a JD; a fraction of a full snapshot
 const DEFAULT_LISTING_MAX = 200;
+const WORKDAY_TIMEOUT_MS = 10_000;
+
+// Floor below which a jd-mode extraction is treated as failure, not content.
+// A posting page whose main text is a couple of sentences is a render we
+// missed (SPA shell, consent wall, bot interstitial), never a real JD; the
+// cost of being wrong is one silent fallback to the MCP path, whereas the
+// cost of NOT failing is an empty JD evaluated as if it were the posting.
+// Only jd mode gets this guard: an empty `listing` result is legitimate — a
+// company with no open roles.
+const MIN_JD_TEXT_CHARS = 200;
 
 // Anchor labels that are navigation chrome, not job postings. Kept small and
 // lowercase; matched against the trimmed label.
@@ -90,6 +114,166 @@ export function normalizeJd(raw, finalUrl, textCap = JD_TEXT_CAP) {
     title: compactText(raw?.title || '', 300),
     text: compactText(raw?.text || '', textCap),
   };
+}
+
+/**
+ * Map a `*.myworkdayjobs.com` posting URL to its public per-job CXS endpoint,
+ * or null for any other URL.
+ *
+ * Derivation (tenant/shard/site/jobPath -> `/wday/cxs/{tenant}/{site}/job/{path}`)
+ * is delegated to liveness-api.mjs's Workday provider so there is exactly one
+ * copy of it, including its SSRF guard: every path segment taken from the input
+ * URL is charset-validated and ".." -rejected before it reaches the fixed
+ * `{tenant}.{shard}.myworkdayjobs.com` host template.
+ *
+ * @param {string} rawUrl
+ * @returns {string|null}
+ */
+export function workdayCxsUrl(rawUrl) {
+  const ats = resolveAtsApi(rawUrl);
+  return ats && ats.ats === 'workday' ? ats.apiUrl : null;
+}
+
+// Tags whose CLOSE ends a block, so it becomes a line break. `li` is absent on
+// purpose: its OPEN tag already emits the break plus a bullet below, and
+// breaking on both ends double-spaces every list.
+const BLOCK_END_RE = /<\/(p|div|ul|ol|h[1-6]|tr|section|article|blockquote)\s*>/gi;
+
+/**
+ * Description markup -> plain text, keeping block structure as newlines. Pure —
+ * exported for tests.
+ *
+ * Not providers/_html-to-text.mjs's htmlToText: that one is tuned for scan
+ * payloads and hard-caps at 4000 chars while collapsing ALL whitespace
+ * (newlines included) into single spaces. A JD read for evaluation wants the
+ * full body up to `--max-chars`, with its paragraph and bullet breaks intact.
+ * The entity decoder itself IS shared, so the two cannot drift on the thing
+ * that has actually drifted historically (#1555/#1639/#2623).
+ *
+ * Double-decode for the same reason htmlToText does: payloads often carry
+ * entity-escaped markup (`&lt;p&gt;`), and text-level entities only become
+ * decodable once the real tags are stripped.
+ *
+ * @param {unknown} html
+ * @returns {string}
+ */
+export function jdHtmlToText(html) {
+  if (typeof html !== 'string' || !html) return '';
+  const stripped = decodeEntities(html)
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '\n- ')
+    .replace(BLOCK_END_RE, '\n')
+    .replace(/<[^>]+>/g, ' ');
+  return decodeEntities(stripped)
+    .replace(/[ \t\u00a0]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Shape a jd-mode result from a Workday CXS job payload, into the SAME
+ * `{ url, title, text }` contract as the scraped path so no caller has to know
+ * which route produced it. Pure — exported for tests.
+ *
+ * Returns null when the payload isn't a job (`jobPostingInfo` missing) or
+ * carries no description, so the caller can fall through to the browser rather
+ * than emit a confidently empty JD.
+ *
+ * `url` is the POSTING url the user passed, not the CXS endpoint: it is what
+ * ends up in reports and the tracker.
+ *
+ * The metadata header is prepended to `text` because each of those fields is
+ * evaluation signal the rendered page shows and the description alone does not
+ * — location for the location filter, `jobReqId` for the tracker's same-title
+ * disambiguation rule, and `canApply: false` as a liveness signal on a posting
+ * still served but no longer accepting applications.
+ *
+ * @param {any} json - parsed CXS response body
+ * @param {string} postingUrl
+ * @param {number} [textCap]
+ */
+export function normalizeWorkdayJob(json, postingUrl, textCap = JD_TEXT_CAP) {
+  const info = json && typeof json === 'object' ? json.jobPostingInfo : null;
+  if (!info || typeof info !== 'object') return null;
+
+  const body = jdHtmlToText(info.jobDescription);
+  if (!body) return null;
+
+  const str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : '');
+  const locations = [
+    str(info.location),
+    ...(Array.isArray(info.additionalLocations) ? info.additionalLocations.map(str) : []),
+  ].filter(Boolean);
+
+  const meta = [];
+  if (locations.length) meta.push(`Location: ${locations.join(' | ')}`);
+  if (str(info.timeType)) meta.push(`Job type: ${str(info.timeType)}`);
+  if (str(info.postedOn)) meta.push(`Posted: ${str(info.postedOn)}`);
+  if (str(info.jobReqId)) meta.push(`Req ID: ${str(info.jobReqId)}`);
+  if (info.canApply === false) meta.push('Applications closed (canApply: false)');
+
+  return {
+    url: postingUrl,
+    title: compactText(str(info.title), 300),
+    text: compactText([meta.join('\n'), body].filter(Boolean).join('\n\n'), textCap),
+  };
+}
+
+/**
+ * Fetch + shape one Workday posting from its CXS endpoint. Returns null for
+ * ANY inconclusive outcome (blocked host, redirect, non-200, unparseable or
+ * unexpected body, timeout) so the caller falls through to the browser path —
+ * where a removed posting still yields the real "this job is no longer
+ * available" page rather than a hard error.
+ *
+ * @param {string} apiUrl
+ * @param {string} postingUrl
+ * @param {number} textCap
+ * @param {number} timeoutMs
+ */
+async function fetchWorkdayJd(apiUrl, postingUrl, textCap, timeoutMs) {
+  // Same host as the already-guarded input, but the guard is cheap and this is
+  // the request that actually leaves the process.
+  if (rejectPrivateOrInvalid(apiUrl)) return null;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(timeoutMs, WORKDAY_TIMEOUT_MS));
+  try {
+    const res = await fetch(apiUrl, {
+      headers: { accept: 'application/json', 'user-agent': DEFAULT_USER_AGENT },
+      redirect: 'error', // a redirect off the derived host is not one to follow
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    return normalizeWorkdayJob(await res.json(), postingUrl, textCap);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Write a jd-mode result to stdout, or fail with `empty_text` when the
+ * extraction came back empty enough to be useless.
+ *
+ * A `--max-chars` below the floor is honored rather than made unsatisfiable: a
+ * caller who asks for 50 chars gets 50, not a guaranteed failure.
+ */
+function emitJd(result, maxChars) {
+  const floor = Math.min(MIN_JD_TEXT_CHARS, maxChars);
+  if (result.text.length < floor) {
+    console.error(JSON.stringify({
+      error: `extracted ${result.text.length} chars of JD text (minimum ${floor}) — the page most likely renders its content client-side`,
+      code: 'empty_text',
+      url: result.url,
+    }));
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(JSON.stringify(result));
 }
 
 /**
@@ -258,6 +442,20 @@ async function main() {
     process.exit(1);
   }
 
+  // Workday first: its JD lives behind a client-side render the DOM read can't
+  // reach, and the CXS endpoint answers with the full body and no browser at
+  // all. Inconclusive -> fall through to Playwright, unchanged.
+  if (mode === 'jd') {
+    const cxs = workdayCxsUrl(url);
+    if (cxs) {
+      const workdayResult = await fetchWorkdayJd(cxs, url, maxChars, timeout);
+      if (workdayResult) {
+        emitJd(workdayResult, maxChars);
+        return;
+      }
+    }
+  }
+
   let chromium;
   try {
     ({ chromium } = await import('playwright'));
@@ -292,10 +490,11 @@ async function main() {
     }
     const raw = await readDom(page);
 
-    const result = mode === 'listing'
-      ? normalizeListing(raw.anchors, finalUrl, max)
-      : normalizeJd(raw, finalUrl, maxChars);
-    process.stdout.write(JSON.stringify(result));
+    if (mode === 'listing') {
+      process.stdout.write(JSON.stringify(normalizeListing(raw.anchors, finalUrl, max)));
+    } else {
+      emitJd(normalizeJd(raw, finalUrl, maxChars), maxChars);
+    }
   } catch (err) {
     console.error(JSON.stringify({ error: `navigation error: ${String(err.message).split('\n')[0]}`, code: 'navigation_error' }));
     process.exitCode = 1;

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -25,7 +25,7 @@ All scripts live in the project root as `.mjs` modules. Most are exposed via
 | `npm run update` | `update-system.mjs apply` | Apply upstream update |
 | `npm run rollback` | `update-system.mjs rollback` | Rollback last update |
 | `npm run liveness` | `check-liveness.mjs` | Test if job URLs are still active |
-| `npm run extract` | `browser-extract.mjs` | Headless read-only page extractor (opt-in `scan.extractor: cli`) — compact JSON for scan/JD |
+| `npm run extract` | `browser-extract.mjs` | Headless read-only page extractor (opt-in `scan.extractor: cli`) — compact JSON for scan/JD; Workday postings are read from their public CXS JSON endpoint instead of the client-rendered page, and an empty jd extraction exits 1 with `code: empty_text` |
 | `npm run scan` | `scan.mjs` | Zero-token portal scanner |
 | `npm run scan:full` | `scan-ats-full.mjs` | Reverse ATS discovery scanner |
 | `npm run company:funded` | `company-funded.mjs` | Review-first discovery of recently funded companies |

--- a/tests/browser-extract.test.mjs
+++ b/tests/browser-extract.test.mjs
@@ -11,7 +11,10 @@ console.log('\nbrowser-extract.mjs (config + normalizers)');
 
 try {
   const mod = await import(pathToFileURL(join(ROOT, 'browser-extract.mjs')).href);
-  const { resolveExtractorMode, compactText, normalizeJd, normalizeListing, parseArgs } = mod;
+  const {
+    resolveExtractorMode, compactText, normalizeJd, normalizeListing, parseArgs,
+    workdayCxsUrl, jdHtmlToText, normalizeWorkdayJob,
+  } = mod;
 
   // resolveExtractorMode — default mcp, explicit cli, garbage → mcp, missing → mcp
   const tmp = mkdtempSync(join(tmpdir(), 'career-ops-extractor-'));
@@ -87,6 +90,114 @@ try {
   } else {
     fail(`normalizeJd textCap => raised=${raised.text.length} default=${defaulted.text.length}`);
   }
+
+  // workdayCxsUrl — Workday posting URLs map to the per-job CXS endpoint;
+  // everything else (including a Workday BOARD url with no /job/ segment) is
+  // left to the browser path.
+  const cxs = workdayCxsUrl('https://spgi.wd5.myworkdayjobs.com/spgi_careers/job/London-UK/Lead-PM_329276-2');
+  if (cxs === 'https://spgi.wd5.myworkdayjobs.com/wday/cxs/spgi/spgi_careers/job/London-UK/Lead-PM_329276-2') {
+    pass('workdayCxsUrl derives the per-job CXS endpoint');
+  } else {
+    fail(`workdayCxsUrl => ${cxs}`);
+  }
+  const cxsLocale = workdayCxsUrl('https://acme.wd1.myworkdayjobs.com/en-US/External/job/Toronto-ON-CAN/Eng_R1');
+  if (cxsLocale === 'https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/job/Toronto-ON-CAN/Eng_R1') {
+    pass('workdayCxsUrl drops the optional locale segment');
+  } else {
+    fail(`workdayCxsUrl locale => ${cxsLocale}`);
+  }
+  const notWorkday = [
+    'https://boards.greenhouse.io/acme/jobs/123',          // another ATS — not our branch
+    'https://acme.wd5.myworkdayjobs.com/External',         // a board, not a posting
+    'not a url',
+  ].map(workdayCxsUrl);
+  if (notWorkday.every((v) => v === null)) pass('workdayCxsUrl returns null for non-Workday-posting URLs');
+  else fail(`workdayCxsUrl non-workday => ${JSON.stringify(notWorkday)}`);
+
+  // Path traversal in the job path must not survive into the fixed-host URL.
+  if (workdayCxsUrl('https://acme.wd5.myworkdayjobs.com/External/job/../../evil') === null) {
+    pass('workdayCxsUrl rejects a traversal segment in the job path');
+  } else {
+    fail('workdayCxsUrl must reject ".." in the job path');
+  }
+
+  // jdHtmlToText — block structure survives as newlines, entities decode
+  // (including entity-escaped markup), script/style bodies are dropped.
+  const html = jdHtmlToText('<h1>About</h1><p>We build&nbsp;things &amp; ship.</p><style>p{color:red}</style><ul><li>Own the roadmap</li><li>Ship</li></ul><p>Line<br/>break</p>');
+  if (html === 'About\nWe build things & ship.\n\n- Own the roadmap\n- Ship\nLine\nbreak') {
+    pass('jdHtmlToText keeps block breaks and bullets, decodes entities, drops <style>');
+  } else {
+    fail(`jdHtmlToText => ${JSON.stringify(html)}`);
+  }
+  if (jdHtmlToText('&lt;p&gt;Escaped &lt;b&gt;markup&lt;/b&gt;&lt;/p&gt;') === 'Escaped markup') {
+    pass('jdHtmlToText double-decodes entity-escaped markup');
+  } else {
+    fail(`jdHtmlToText escaped => ${JSON.stringify(jdHtmlToText('&lt;p&gt;Escaped &lt;b&gt;markup&lt;/b&gt;&lt;/p&gt;'))}`);
+  }
+  if (jdHtmlToText(null) === '' && jdHtmlToText('') === '' && jdHtmlToText(42) === '') {
+    pass('jdHtmlToText returns "" for a non-string / empty body');
+  } else {
+    fail('jdHtmlToText should return "" for non-string input');
+  }
+
+  // normalizeWorkdayJob — same { url, title, text } contract as the scraped path
+  const wdPayload = {
+    jobPostingInfo: {
+      title: '  Lead Product Manager  ',
+      jobDescription: '<p>Build the thing.</p><ul><li>Own it</li></ul>',
+      location: 'London, UK',
+      additionalLocations: ['Gurugram, Haryana'],
+      timeType: 'Full time',
+      postedOn: 'Posted 17 Days Ago',
+      jobReqId: '329276',
+      canApply: true,
+    },
+  };
+  const wd = normalizeWorkdayJob(wdPayload, 'https://spgi.wd5.myworkdayjobs.com/spgi_careers/job/London-UK/Lead-PM_329276-2');
+  if (wd
+      && wd.url === 'https://spgi.wd5.myworkdayjobs.com/spgi_careers/job/London-UK/Lead-PM_329276-2'
+      && wd.title === 'Lead Product Manager'
+      && wd.text.includes('Location: London, UK | Gurugram, Haryana')
+      && wd.text.includes('Job type: Full time')
+      && wd.text.includes('Req ID: 329276')
+      && wd.text.includes('Build the thing.')
+      && wd.text.includes('- Own it')
+      && !wd.text.includes('canApply')) {
+    pass('normalizeWorkdayJob shapes { url, title, text } with a metadata header');
+  } else {
+    fail(`normalizeWorkdayJob => ${JSON.stringify(wd)}`);
+  }
+
+  // canApply:false is a liveness signal and must reach the JD text.
+  const closed = normalizeWorkdayJob(
+    { jobPostingInfo: { title: 'X', jobDescription: '<p>Body</p>', canApply: false } },
+    'https://acme.wd5.myworkdayjobs.com/External/job/Loc/X_1',
+  );
+  if (closed && closed.text.includes('Applications closed (canApply: false)')) {
+    pass('normalizeWorkdayJob surfaces canApply: false');
+  } else {
+    fail(`normalizeWorkdayJob canApply => ${JSON.stringify(closed)}`);
+  }
+
+  // Anything that isn't a job payload, or carries no description, returns null
+  // so the caller falls through to the browser instead of emitting an empty JD.
+  const nulls = [
+    normalizeWorkdayJob(null, 'https://x/1'),
+    normalizeWorkdayJob({}, 'https://x/1'),
+    normalizeWorkdayJob({ jobPostingInfo: { title: 'X' } }, 'https://x/1'),
+    normalizeWorkdayJob({ jobPostingInfo: { title: 'X', jobDescription: '<p> </p>' } }, 'https://x/1'),
+  ];
+  if (nulls.every((v) => v === null)) pass('normalizeWorkdayJob returns null for a non-job / description-less payload');
+  else fail(`normalizeWorkdayJob nulls => ${JSON.stringify(nulls)}`);
+
+  // The text cap applies to the CXS path too.
+  const wdCapped = normalizeWorkdayJob(
+    { jobPostingInfo: { title: 'X', jobDescription: `<p>${'word '.repeat(5000)}</p>` } },
+    'https://x/1',
+    500,
+  );
+  if (wdCapped && wdCapped.text.length <= 501) pass('normalizeWorkdayJob honors the text cap');
+  else fail(`normalizeWorkdayJob cap => ${wdCapped && wdCapped.text.length}`);
 
   // normalizeListing — resolve relatives, drop nav/short labels, dedup, cap
   const anchors = [


### PR DESCRIPTION
Fixes #3256

## The bug

`browser-extract.mjs --mode jd` returns an **empty `text`** for every Workday posting (`*.myworkdayjobs.com`) while exiting **0** with well-formed JSON. Workday hydrates the JD client-side into a virtualized DOM, so `readDom()`'s `main, [role="main"], article` → `innerText` read comes back with nothing.

The exit code is the part that actually hurts. A caller cannot tell "extraction failed" from "this posting has no content", so the fallback `modes/pipeline.md` documents —

> Use its `text` as the JD. **Fall back silently** to `browser_navigate` + `browser_snapshot` if it errors or is missing.

— never fires, and the empty JD goes downstream to be evaluated as if it were the posting.

## Two independent fixes

**1. Workday reads from the CXS API.** jd mode short-circuits `*.myworkdayjobs.com` to Workday's public per-job endpoint (`/wday/cxs/{tenant}/{site}/job/{path}`) — the same API family `providers/workday.mjs` already uses for boards.

The URL derivation is **not** reimplemented. `liveness-api.mjs`'s `workday` provider already builds exactly this URL, so `resolveAtsApi()` is reused, SSRF segment validation included (charset-validated, `..`-rejected path segments before the fixed host template). One copy, no drift.

Every inconclusive outcome — non-200, redirect, unparseable body, missing `jobPostingInfo`, timeout — returns `null` and falls through to Playwright unchanged, so a removed posting still yields the real "no longer available" page rather than a hard error.

The metadata header prepended to `text` carries what the rendered page shows and the description body does not: location(s), time type, posted, `jobReqId` (the tracker's same-title disambiguation key from `AGENTS.md`), and `canApply: false` as a liveness signal on a posting still served but closed to applications.

**2. An empty jd extraction exits non-zero.** Independent of Workday: whatever the host, a posting page yielding under 200 chars of main text is a render we missed (SPA shell, consent wall, bot interstitial), never a real JD. It now exits 1 with `{"error": …, "code": "empty_text", "url": …}`, so the silent-fallback path already documented in the modes actually triggers.

- A `--max-chars` below the floor is honored rather than made unsatisfiable — ask for 50 chars, get 50.
- **`listing` mode is deliberately untouched:** an empty `jobs` array is a legitimate result for a company with no open roles, so the same guard there would be wrong.

## Why a local `jdHtmlToText`

`providers/_html-to-text.mjs`'s `htmlToText` is tuned for scan payloads: it hard-caps at 4000 chars and collapses *all* whitespace including newlines. A JD read for evaluation wants the full body up to `--max-chars` with its paragraph and bullet breaks intact. `decodeEntities` **is** shared, so the two cannot drift on the thing that has actually drifted historically (#1555/#1639/#2623).

## Verification

Against two live tenants, where `main` returns empty:

```bash
node browser-extract.mjs "https://umusic.wd5.myworkdayjobs.com/umguk/job/Kings-Cross-London/AI-Product-Manager_UMG-27187" --max-chars 12000
# {"url":…,"title":"AI Product Manager","text":"Location: Kings Cross, London\nJob type: Full time\n…"}  6461 chars, exit 0

node browser-extract.mjs "https://spgi.wd5.myworkdayjobs.com/spgi_careers/job/London-UK/Lead-Product-Manager-AIOPs_329276-2" --max-chars 12000
# {"url":…,"title":"Lead Product Manager AIOPs","text":"Location: London, UK | Gurugram, Haryana | …\nReq ID: 329276\n…"}  7913 chars, exit 0
```

And the `empty_text` guard on a thin non-Workday page:

```bash
node browser-extract.mjs "https://example.com"
# {"error":"extracted 125 chars of JD text (minimum 200) — the page most likely renders its content client-side","code":"empty_text","url":"https://example.com/"}
# exit 1
```

12 new unit tests in `tests/browser-extract.test.mjs` cover the CXS derivation (optional locale segment, board-vs-posting URLs, `..` traversal rejection), the HTML→text pipeline, and the payload normalizer. `node test-all.mjs --only browser-extract` → 43 passed, 0 failed.

## Relation to #2582

#2582 (`fetch-jd.mjs`) proposes the general version of idea 1 across all ATS providers. This is narrower on purpose: the one provider where the scraped path is not merely expensive but silently *wrong*. If #2582 lands, the Workday half here folds into it; the `empty_text` exit is orthogonal to both.

## Notes

- Behaviour is unchanged for every non-Workday host that extracts a real JD, and for `listing` mode entirely.
- No new HTTP client — plain `fetch` with `redirect: 'error'`, `DEFAULT_USER_AGENT`, and an `AbortController` timeout.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Workday job-description extraction through its public endpoint.
  * Added fallback browser extraction when API responses are inconclusive.
  * Added validation for missing or unusually short job-description text.
  * Preserved existing listing output behavior.

* **Bug Fixes**
  * Improved handling of invalid URLs, timeouts, metadata, application status, and HTML content.

* **Documentation**
  * Updated extraction command documentation, including empty-description error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->