### PR TITLE
feat(explorer): free banded title-vs-profile fit hint on discovery cards

### DIFF
--- a/tests/title-fit.test.mjs
+++ b/tests/title-fit.test.mjs
@@ -1,0 +1,88 @@
+// tests/title-fit.test.mjs — free banded title-vs-profile fit estimator (#3260).
+// Pure string math: no network, no tokens, no filesystem. The band annotates
+// discovery cards; the assertions pin the CONTRACT (recommendation layer,
+// bands not percentages in the UI) as much as the arithmetic.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\ntitle-fit.mjs — free banded title/profile overlap hint (#3260)');
+try {
+  const m = await import(pathToFileURL(join(ROOT, 'web', 'src', 'lib', 'title-fit.mjs')).href);
+  const { titleFit } = m;
+
+  // Word order + punctuation insensitivity — exactly what firstMatch()'s
+  // substring test misses ("platform engineer" chip vs "Engineer, Platform").
+  const r = titleFit('Staff Engineer, Platform', ['platform engineer']);
+  if (r && r.band === 'strong' && r.score === 1) {
+    pass('word-order/punctuation titles still band strong (substring matching misses these)');
+  } else {
+    fail(`expected strong/1 for 'Staff Engineer, Platform': ${JSON.stringify(r)}`);
+  }
+
+  // Seniority words must not dilute the ratio.
+  const rs = titleFit('Senior Staff Platform Engineer', ['platform engineer']);
+  if (rs && rs.band === 'strong') {
+    pass('seniority words (senior/staff) excluded from the ratio');
+  } else {
+    fail(`seniority dilution: ${JSON.stringify(rs)}`);
+  }
+
+  // Partial overlap → related; unrelated → weak (still returned, never hidden).
+  const rp = titleFit('Data Engineer', ['platform engineer']);
+  const rw = titleFit('Product Designer', ['platform engineer']);
+  if (rp && rp.band === 'related' && rw && rw.band === 'weak') {
+    pass('partial overlap → related, no overlap → weak');
+  } else {
+    fail(`banding wrong: partial=${JSON.stringify(rp)} none=${JSON.stringify(rw)}`);
+  }
+
+  // Multi-target profiles take the BEST role match.
+  const rm = titleFit('Data Engineer', ['product designer', 'data engineer']);
+  if (rm && rm.band === 'strong') {
+    pass('best-matching target role wins across profile targets');
+  } else {
+    fail(`multi-target should pick data engineer: ${JSON.stringify(rm)}`);
+  }
+
+  // Band thresholds pinned: 2/3 hits ≈ 0.67 strong, 1/3 ≈ 0.33 weak, 1/2 related.
+  const t3 = ['alpha beta gamma'];
+  const b67 = titleFit('x alpha beta', t3), b33 = titleFit('x gamma', t3), b50 = titleFit('x alpha', ['alpha beta']);
+  if (b67?.band === 'strong' && b33?.band === 'weak' && b50?.band === 'related'
+      && b67.score === 0.67 && b33.score === 0.33 && b50.score === 0.5) {
+    pass('thresholds: >=0.6 strong, >=0.34 related, else weak (scores rounded to 2dp)');
+  } else {
+    fail(`thresholds drifted: ${JSON.stringify([b67, b50, b33])}`);
+  }
+
+  // Empty/no-profile posture: null (chip omitted entirely), never a throw.
+  if (titleFit('Anything At All', []) === null
+      && titleFit('', ['engineer']) === null
+      && titleFit(null, ['engineer']) === null
+      && titleFit('Engineer', null) === null
+      && titleFit('Engineer', 'not an array') === null) {
+    pass('empty title/targets/non-array targets → null (caller omits the chip)');
+  } else {
+    fail('empty-input posture broken — expected null, got a band or a throw');
+  }
+
+  // A lone generic token still bands (profile said "engineer", title says so too):
+  // honest, since it IS the user's declared target. Pinned so drift is visible.
+  const rg = titleFit('Warranty Engineer', ['engineer']);
+  if (rg && rg.band === 'strong' && rg.score === 1) {
+    pass('single-token target matches fully when present (documented behavior)');
+  } else {
+    fail(`single-token target: ${JSON.stringify(rg)}`);
+  }
+
+  // Determinism — same inputs, same object (scan re-runs must be stable).
+  const d1 = titleFit('Senior Platform Engineer', ['platform engineer', 'data engineer']);
+  const d2 = titleFit('Senior Platform Engineer', ['platform engineer', 'data engineer']);
+  if (JSON.stringify(d1) === JSON.stringify(d2)) {
+    pass('deterministic for identical inputs');
+  } else {
+    fail(`nondeterministic: ${JSON.stringify(d1)} vs ${JSON.stringify(d2)}`);
+  }
+} catch (e) {
+  fail(`title-fit tests crashed: ${e.message}`);
+}

--- a/tests/title-fit.test.mjs
+++ b/tests/title-fit.test.mjs
@@ -20,12 +20,16 @@ try {
     fail(`expected strong/1 for 'Staff Engineer, Platform': ${JSON.stringify(r)}`);
   }
 
-  // Seniority words must not dilute the ratio.
+  // Seniority words must not dilute the ratio — from EITHER side. A broken
+  // filter on the title side would cap 'Senior Staff Platform Engineer' below
+  // 1; a broken filter on the TARGET side ('senior platform engineer' counting
+  // 3 tokens) would do the same from the other direction (CodeRabbit, #3261).
   const rs = titleFit('Senior Staff Platform Engineer', ['platform engineer']);
-  if (rs && rs.band === 'strong') {
-    pass('seniority words (senior/staff) excluded from the ratio');
+  const rs2 = titleFit('Platform Engineer', ['senior platform engineer']);
+  if (rs && rs.band === 'strong' && rs.score === 1 && rs2 && rs2.score === 1) {
+    pass('seniority words excluded on both title and target side');
   } else {
-    fail(`seniority dilution: ${JSON.stringify(rs)}`);
+    fail(`seniority dilution: title-side=${JSON.stringify(rs)} target-side=${JSON.stringify(rs2)}`);
   }
 
   // Partial overlap → related; unrelated → weak (still returned, never hidden).

--- a/tests/title-fit.test.mjs
+++ b/tests/title-fit.test.mjs
@@ -79,6 +79,18 @@ try {
     fail(`single-token target: ${JSON.stringify(rg)}`);
   }
 
+  // Terminal periods are punctuation, not part of the role name — but dotted
+  // names must keep their internal/leading dots (CodeRabbit follow-up, #3261).
+  const rpd = titleFit('Platform Engineer.', ['platform engineer']);
+  const rdot = titleFit('Node.js Engineer', ['node.js engineer']);
+  const rdnet = titleFit('.NET Developer', ['.net developer']);
+  if (rpd && rpd.score === 1 && rpd.band === 'strong'
+      && rdot && rdot.score === 1 && rdnet && rdnet.score === 1) {
+    pass('trailing periods stripped; node.js / .net stay whole');
+  } else {
+    fail(`terminal-period handling: ${JSON.stringify([rpd, rdot, rdnet])}`);
+  }
+
   // Determinism — same inputs, same object (scan re-runs must be stable).
   const d1 = titleFit('Senior Platform Engineer', ['platform engineer', 'data engineer']);
   const d2 = titleFit('Senior Platform Engineer', ['platform engineer', 'data engineer']);

--- a/web/src/components/explore/discovery-card.tsx
+++ b/web/src/components/explore/discovery-card.tsx
@@ -101,6 +101,19 @@ export function DiscoveryCard({ offer, inPipeline, evaluatedN }: { offer: Discov
             · matched <span className="text-brand/80">{offer.matchedKeyword}</span>
           </span>
         )}
+        {offer.fit && (
+          <span
+            className={cn(
+              "rounded border px-1 py-0.5 text-[11px] font-medium",
+              offer.fit.band === "strong"
+                ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                : "text-faint",
+            )}
+            title="Free keyword-level estimate: posting title vs your profile's target roles (config/profile.yml). Not an evaluation — Evaluate still gives the real A–F fit score."
+          >
+            · {offer.fit.band} fit
+          </span>
+        )}
       </div>
 
       {offer.why && (

--- a/web/src/lib/core/scan.ts
+++ b/web/src/lib/core/scan.ts
@@ -1,8 +1,12 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
+import * as yaml from "js-yaml";
 import { careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { writeTempPortals, cleanupTempPortals } from "./portals";
-import { ATS_SOURCES, type DiscoveredOffer, type ExploreFilters, type ScanEvent } from "@/lib/explore";
+import { profileTargetKeywords } from "@/lib/profile-keywords.mjs";
+import { titleFit } from "@/lib/title-fit.mjs";
+import { ATS_SOURCES, type DiscoveredOffer, type ExploreFilters, type FitBand, type ScanEvent } from "@/lib/explore";
 
 export type { DiscoveredOffer, ScanEvent, AtsSource } from "@/lib/explore";
 export { ATS_SOURCES } from "@/lib/explore";
@@ -37,6 +41,28 @@ function firstMatch(title: string, positives: string[]): string | undefined {
   const lower = title.toLowerCase();
   for (const k of positives) if (k && lower.includes(k.toLowerCase())) return k;
   return undefined;
+}
+
+/**
+ * Profile target roles for the free fit band (#3260), loaded ONCE per scan run
+ * (tolerantly: missing/unreadable profile.yml just means no chips — same
+ * posture as seedExploreFilters in portals.ts). Annotation only: the result
+ * never feeds filtering, ordering, or the summary counts.
+ */
+function loadProfileTargets(): string[] {
+  try {
+    const doc = yaml.load(fs.readFileSync(path.join(careerOpsRoot(), "config", "profile.yml"), "utf8"));
+    return profileTargetKeywords(doc && typeof doc === "object" ? (doc as Record<string, unknown>) : null);
+  } catch {
+    return [];
+  }
+}
+
+/** Spread-in helper: {} when there is no band (keeps `fit` truly absent rather
+ *  than explicitly undefined, so the offer objects stay JSON-clean). */
+function fitField(title: string, targets: string[]): { fit: { band: FitBand; score: number } } | Record<string, never> {
+  const f = titleFit(title, targets);
+  return f ? { fit: f } : {};
 }
 
 function parseOfferLine(source: string, date: string, rest: string): Omit<DiscoveredOffer, "url"> | null {
@@ -104,6 +130,7 @@ export function runDiscovery(filters: ExploreFilters, onEvent: (e: ScanEvent) =>
 
     const offers: DiscoveredOffer[] = [];
     const seen = new Set<string>();
+    const roleTargets = loadProfileTargets();
     let currentAts: string = ats[0] || "";
     let pending: Omit<DiscoveredOffer, "url"> | null = null;
     let companiesScanned = 0;
@@ -146,7 +173,7 @@ export function runDiscovery(filters: ExploreFilters, onEvent: (e: ScanEvent) =>
         const url = trimmed.split(/\s+/)[0];
         if (!seen.has(url)) {
           seen.add(url);
-          const offer: DiscoveredOffer = { ...pending, url, matchedKeyword: firstMatch(pending.title, filters.positive) };
+          const offer: DiscoveredOffer = { ...pending, url, matchedKeyword: firstMatch(pending.title, filters.positive), ...fitField(pending.title, roleTargets) };
           offers.push(offer);
           onEvent({ kind: "offer", offer });
         }
@@ -245,6 +272,7 @@ export function runDiscovery(filters: ExploreFilters, onEvent: (e: ScanEvent) =>
               source,
               url,
               matchedKeyword: firstMatch(o.title, filters.positive),
+              ...fitField(o.title, roleTargets),
             };
             offers.push(offer);
             onEvent({ kind: "offer", offer });

--- a/web/src/lib/core/scan.ts
+++ b/web/src/lib/core/scan.ts
@@ -59,10 +59,12 @@ function loadProfileTargets(): string[] {
 }
 
 /** Spread-in helper: {} when there is no band (keeps `fit` truly absent rather
- *  than explicitly undefined, so the offer objects stay JSON-clean). */
+ *  than explicitly undefined, so the offer objects stay JSON-clean). titleFit
+ *  is plain JS, so its band arrives typed as string — narrowed here to the
+ *  FitBand union the offer type promises. */
 function fitField(title: string, targets: string[]): { fit: { band: FitBand; score: number } } | Record<string, never> {
   const f = titleFit(title, targets);
-  return f ? { fit: f } : {};
+  return f ? { fit: { band: f.band as FitBand, score: f.score } } : {};
 }
 
 function parseOfferLine(source: string, date: string, rest: string): Omit<DiscoveredOffer, "url"> | null {

--- a/web/src/lib/explore.ts
+++ b/web/src/lib/explore.ts
@@ -40,6 +40,10 @@ export const DEFAULT_FILTERS: ExploreFilters = {
   limitPerAts: 150,
 };
 
+/** Banded title-vs-profile overlap (web/src/lib/title-fit.mjs). Words, not
+ *  numbers, so it can't be mistaken for the evaluation's real 1–5 / A–F. */
+export type FitBand = "strong" | "related" | "weak";
+
 export type DiscoveredOffer = {
   url: string;
   company: string;
@@ -51,6 +55,11 @@ export type DiscoveredOffer = {
   source: string;
   /** which positive keyword matched the title (transparency, e.g. "ai" in "Nail") */
   matchedKeyword?: string;
+  /** free, zero-token triage hint computed at discovery time from the posting
+   *  TITLE vs config/profile.yml target roles (#3260). Recommendation layer
+   *  only — never filters or orders anything; Evaluate gives the real A–F.
+   *  Scan offers only; AI offers already carry why + confidence. */
+  fit?: { band: FitBand; score: number };
   /** optional free-text ranking signal preserved to pipeline.md by the canonical
    *  writer (scan.mjs formatPipelineOffer). Generic and source-agnostic — an
    *  importer can attach a note; the deterministic scan omits it. */

--- a/web/src/lib/title-fit.mjs
+++ b/web/src/lib/title-fit.mjs
@@ -22,6 +22,18 @@
  *       null when either side yields no usable tokens (callers omit the chip).
  */
 
+/**
+ * @typedef {Object} TitleFit
+ * @property {'strong'|'related'|'weak'} band Coarse triage word — never a percentage in the UI.
+ * @property {number} score Rounded overlap ratio (tests/debugging only).
+ */
+
+/**
+ * @param {string|undefined|null} title Posting title as printed by the scanner.
+ * @param {string[]|undefined|null} targets Profile target-role phrases.
+ * @returns {TitleFit|null} Best band across targets, or null when nothing usable.
+ */
+
 // Letters/digits across scripts, plus +#/. so c#, c++, node.js, .net survive.
 const TOKEN_RE = /[\p{L}\p{N}+#.]+/gu;
 

--- a/web/src/lib/title-fit.mjs
+++ b/web/src/lib/title-fit.mjs
@@ -49,7 +49,12 @@ const SENIORITY = new Set([
 
 function tokens(text) {
   const raw = String(text ?? "").toLowerCase().match(TOKEN_RE) ?? [];
-  return raw.filter((t) => t.length > 1 && !SENIORITY.has(t));
+  return raw
+    // TOKEN_RE keeps sentence-ending periods so dotted names survive intact
+    // (node.js, .net); strip only TERMINAL dots afterwards, or "Engineer."
+    // stops equalling "engineer" (CodeRabbit, #3261). Internal/leading dots stay.
+    .map((t) => t.replace(/\.+$/, ""))
+    .filter((t) => t.length > 1 && !SENIORITY.has(t));
 }
 
 export function titleFit(title, targets) {

--- a/web/src/lib/title-fit.mjs
+++ b/web/src/lib/title-fit.mjs
@@ -1,0 +1,65 @@
+/**
+ * title-fit.mjs — banded title-vs-profile-role estimate for discovery cards.
+ *
+ * Deliberately mirrors the tokenizer style of profile-keywords.mjs /
+ * jd-similarity.mjs instead of importing them: the Turbopack root is pinned
+ * to web/, which makes repo-root .mjs imports impossible, and this module must
+ * stay unit-testable under plain Node (tests/title-fit.test.mjs).
+ *
+ * CONTRACT (same posture as jd-similarity.mjs): this is deliberately a
+ * RECOMMENDATION layer. It annotates offers with a coarse band so the user can
+ * decide what to evaluate first. It NEVER gates, filters, orders, or replaces
+ * the holistic evaluation score — the card tooltip says exactly that.
+ *
+ * Why token overlap instead of reusing firstMatch(): the existing `matched`
+ * chip is a case-insensitive SUBSTRING test, so a `platform engineer` chip can
+ * never match the perfectly good title "Staff Engineer, Platform". Comparing
+ * word sets catches those, plus punctuation and word-order differences.
+ *
+ * Exposes:
+ *   titleFit(title, targets): { band: 'strong'|'related'|'weak', score } | null
+ *     — best token-overlap ratio between ONE target role phrase and the title.
+ *       null when either side yields no usable tokens (callers omit the chip).
+ */
+
+// Letters/digits across scripts, plus +#/. so c#, c++, node.js, .net survive.
+const TOKEN_RE = /[\p{L}\p{N}+#.]+/gu;
+
+// Seniority/level words say nothing about WHICH role a title describes: without
+// excluding them, "Senior Platform Engineer" would only ever reach 2/3 against
+// the target "platform engineer" and read as a partial match. Mirrors the
+// spirit of LEVELS / SENIORITY_TOKENS in jd-similarity.mjs.
+const SENIORITY = new Set([
+  "junior", "jr", "mid", "middle", "senior", "sr", "staff", "principal",
+  "lead", "head", "chief", "associate", "assistant", "intern", "internship",
+  "entry", "level", "ii", "iii", "iv",
+]);
+
+function tokens(text) {
+  const raw = String(text ?? "").toLowerCase().match(TOKEN_RE) ?? [];
+  return raw.filter((t) => t.length > 1 && !SENIORITY.has(t));
+}
+
+export function titleFit(title, targets) {
+  const titleTokens = new Set(tokens(title));
+  if (!titleTokens.size || !Array.isArray(targets)) return null;
+
+  let best = -1;
+  for (const target of targets) {
+    const roleTokens = [...new Set(tokens(target))];
+    if (!roleTokens.length) continue;
+    let hits = 0;
+    for (const t of roleTokens) if (titleTokens.has(t)) hits++;
+    best = Math.max(best, hits / roleTokens.length);
+  }
+  if (best < 0) return null;
+
+  // Bands, not numbers: people triage in words, and a pseudo-precise percentage
+  // next to the evaluation's real 1–5/A–F would invite comparing the two. The
+  // score stays on the object for tests/debugging but the UI renders only the
+  // band. Thresholds: a lone shared generic token ("engineer") lands weak,
+  // roughly half the role's tokens lands related, most of them strong.
+  const rounded = Math.round(best * 100) / 100;
+  const band = rounded >= 0.6 ? "strong" : rounded >= 0.34 ? "related" : "weak";
+  return { band, score: rounded };
+}


### PR DESCRIPTION
Closes #3260

## Summary

Adds a free, zero-token triage signal to scan-mode discovery cards, as proposed in #3260: a banded estimate of how well a posting's title overlaps the user's profile target roles, computed at discovery time from data already loaded server-side.

- **New `web/src/lib/title-fit.mjs`** - pure, plain-`.mjs` module (Turbopack pins the root to `web/`, so core helpers are mirrored rather than imported, same as `profile-keywords.mjs`). Token-overlap ratio between the title and each of the user's `config/profile.yml` target roles (seniority words excluded from the ratio), best role wins, banded `strong` / `related` / `weak`.
- **`DiscoveredOffer.fit?`** - optional field only; the stream grammar and AI offers (which already carry `why` + `confidence`) are untouched. Kept truly absent (spread-in) so offer objects stay JSON-clean.
- **`lib/core/scan.ts`** - reads `config/profile.yml` tolerantly ONCE per scan (missing file = no chips, same posture as `seedExploreFilters`) and annotates at both offer-construction sites (`--json` and legacy stdout parse).
- **`discovery-card.tsx`** - small passive chip next to the existing `matched` note; `strong` gets a quiet green tint, others stay faint. Tooltip states exactly what it is and is not: a free keyword-level estimate, NOT an evaluation - Evaluate still gives the real A-F.

## House rules

- Recommendation layer ONLY: nothing is filtered, hidden, reordered, or auto-added; summary counts unchanged (#3260 contract).
- Zero tokens, fully offline: string math on data already read server-side.
- The holistic evaluation (1-5 / A-F) remains the only quality verdict; the chip explicitly points to it.

## Testing

`node test-all.mjs --only title-fit` - 8 assertions, all passing: word-order/punctuation titles (the case substring matching misses), seniority-word exclusion, band thresholds pinned at 0.67/0.5/0.33, multi-target best-match, empty-profile no-op posture (null, chip omitted), single-token target behavior, determinism.

Full suite + web typecheck left to CI (no `node_modules` in this environment). Happy to adjust thresholds, naming, or extend to AI-mode offers if reviewers prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery cards now show an optional title-fit badge for strong, related, or weak matches.
  * Offers can include profile-based title-fit scores when available.
  * Scores are advisory keyword-level estimates and do not replace overall evaluation.

* **Tests**
  * Added coverage for title matching, scoring bands, punctuation and word order, invalid inputs, deterministic results, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->