### PR TITLE
fix: handle quoted angle brackets while stripping HTML tags

### DIFF
--- a/providers/_html-to-text.mjs
+++ b/providers/_html-to-text.mjs
@@ -10,6 +10,11 @@ import { decodeEntities } from './_html-entities.mjs';
 // normal on these boards, and scan payloads must stay sane.
 export const DESCRIPTION_CAP = 4000;
 
+// A tag ends at an unquoted `>`. Attribute values may contain angle brackets,
+// so the common `<[^>]+>` shortcut can stop midway through a tag and expose
+// the remaining attributes as description text.
+const HTML_TAG_RE = /<(?:[^>"']|"[^"]*"|'[^']*')*>/g;
+
 /**
  * Entity-decoded markup → stripped plain text.
  *
@@ -29,5 +34,5 @@ export function htmlToText(content) {
   if (typeof content !== 'string' || !content) return '';
   const html = decodeEntities(content);
   const noMedia = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ');
-  return decodeEntities(noMedia.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
+  return decodeEntities(noMedia.replace(HTML_TAG_RE, ' ')).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
 }

--- a/providers/_html-to-text.mjs
+++ b/providers/_html-to-text.mjs
@@ -12,8 +12,15 @@ export const DESCRIPTION_CAP = 4000;
 
 // A tag ends at an unquoted `>`. Attribute values may contain angle brackets,
 // so the common `<[^>]+>` shortcut can stop midway through a tag and expose
-// the remaining attributes as description text.
-const HTML_TAG_RE = /<(?:[^>"']|"[^"]*"|'[^']*')*>/g;
+// the remaining attributes as description text. Requiring content between the
+// brackets preserves a literal `<>`, as the old matcher did.
+const HTML_TAG_RE = /<(?:[^>"']|"[^"]*"|'[^']*')+>/g;
+const HTML_MEDIA_RE = /<(script|style)\b(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/\1\s*>/gi;
+
+/** @param {string} content */
+function stripMarkup(content) {
+  return content.replace(HTML_MEDIA_RE, ' ').replace(HTML_TAG_RE, ' ');
+}
 
 /**
  * Entity-decoded markup → stripped plain text.
@@ -32,7 +39,10 @@ const HTML_TAG_RE = /<(?:[^>"']|"[^"]*"|'[^']*')*>/g;
  */
 export function htmlToText(content) {
   if (typeof content !== 'string' || !content) return '';
-  const html = decodeEntities(content);
-  const noMedia = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ');
-  return decodeEntities(noMedia.replace(HTML_TAG_RE, ' ')).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
+  // Strip literal markup before decoding: quote entities inside a quoted
+  // attribute are data, and decoding them first would turn them into false
+  // delimiters. The second strip handles entity-escaped tags revealed by the
+  // first decode; the final decode retains the existing double-decode behavior.
+  const decoded = decodeEntities(stripMarkup(content));
+  return decodeEntities(stripMarkup(decoded)).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
 }

--- a/tests/providers/_html-to-text.test.mjs
+++ b/tests/providers/_html-to-text.test.mjs
@@ -35,6 +35,15 @@ try {
     fail(`tag stripping = ${JSON.stringify(htmlToText('<p>Hello <b>world</b></p>'))}`);
   }
 
+  const quotedAngles = htmlToText(
+    `<p>Requires 5&amp;gt;3 years <a title="x > y" data-note='a > b' href="z">apply here</a> today</p>`
+  );
+  if (quotedAngles === 'Requires 5>3 years apply here today') {
+    pass('htmlToText() keeps quoted angle brackets inside tag attributes');
+  } else {
+    fail(`quoted angle attribute = ${JSON.stringify(quotedAngles)}`);
+  }
+
   if (htmlToText('<style>.x{color:red}</style><script>evil()</script><p>Body</p>') === 'Body') {
     pass("htmlToText() drops <script>/<style> WITH their contents");
   } else {

--- a/tests/providers/_html-to-text.test.mjs
+++ b/tests/providers/_html-to-text.test.mjs
@@ -44,10 +44,34 @@ try {
     fail(`quoted angle attribute = ${JSON.stringify(quotedAngles)}`);
   }
 
+  const encodedQuotes = htmlToText(
+    `<a title="say &quot;hello &#34;there > world&#x22;&quot;" data-note='it&apos;s &#39;still > safe&#x27;&apos;'>apply</a>`
+  );
+  if (encodedQuotes === 'apply') {
+    pass('htmlToText() keeps encoded quotes from becoming attribute delimiters');
+  } else {
+    fail(`encoded quote attribute = ${JSON.stringify(encodedQuotes)}`);
+  }
+
+  if (htmlToText('a <> b') === 'a <> b') {
+    pass('htmlToText() preserves empty angle brackets in plain text');
+  } else {
+    fail(`empty angle brackets = ${JSON.stringify(htmlToText('a <> b'))}`);
+  }
+
   if (htmlToText('<style>.x{color:red}</style><script>evil()</script><p>Body</p>') === 'Body') {
     pass("htmlToText() drops <script>/<style> WITH their contents");
   } else {
     fail(`media strip = ${JSON.stringify(htmlToText('<style>.x{color:red}</style><script>evil()</script><p>Body</p>'))}`);
+  }
+
+  const quotedMedia = htmlToText(
+    `<script data-note="x > </script>">evil()</script><style data-note='x > </style>'>bad{}</style><p>Body</p>`
+  );
+  if (quotedMedia === 'Body') {
+    pass('htmlToText() strips media with quoted angle brackets in attributes');
+  } else {
+    fail(`quoted media attribute = ${JSON.stringify(quotedMedia)}`);
   }
 
   // The double-decode case that motivated greenhouse's pipeline: entity-


### PR DESCRIPTION
## What does this PR do?

Updates the shared HTML-to-text pipeline so a `>` inside a quoted attribute remains part of the tag instead of leaking attributes into job-description text. Raw markup is stripped before entity decoding so encoded quotes stay data, and script/style openers use the same quote-aware matching. Regression coverage includes literal and encoded quote forms.

## Related issue

Fixes #3248

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Testing

- `node tests/providers/_html-to-text.test.mjs`
- `node test-all.mjs` — 5,315 passed, 0 failed