### PR TITLE
test(plugin-symlink): junction on Windows, so the suite runs instead of EPERM

### DIFF
--- a/tests/plugin-symlink-discovery.test.mjs
+++ b/tests/plugin-symlink-discovery.test.mjs
@@ -20,6 +20,21 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
 
+// A directory SYMLINK needs SeCreateSymbolicLinkPrivilege on Windows, which a
+// non-elevated shell lacks unless Developer Mode is on. All three links below
+// threw EPERM there, losing every check in this file as one opaque suite
+// failure (#3259). A junction needs no privilege, and it is what test-all.mjs's
+// e2e fixture and generate-pdf-page-budget.test.mjs already use for exactly
+// this reason. The swap is invisible to what this suite asserts: discovery
+// still walks the link, readdirSync still reports isDirectory() === false for
+// it -- the bug #3140 is about -- and stat() through a DANGLING junction throws
+// just as it does through a dangling symlink, which the `gone-away` case
+// depends on. Junctions add two constraints, both already met at all three
+// sites: the target is absolute and on a local volume, since every one is
+// built from mkdtempSync(). The type argument is ignored off Windows.
+const LINK_TYPE = process.platform === 'win32' ? 'junction' : 'dir';
+const linkPlugin = (target, linkPath) => symlinkSync(target, linkPath, LINK_TYPE);
+
 const { discoverPlugins, pluginRoots, loadPlugins } = await import(pathToFileURL(join(ROOT, 'plugins/_engine.mjs')).href);
 
 console.log('\nplugins/_engine.mjs — symlinked plugin discovery (#3140)');
@@ -65,7 +80,7 @@ try {
   // directory name, which is what a developer linking `career-ops-plugin-demo`
   // in as `demo` actually gets.
   const externalCheckout = writePlugin(join(tmp, 'checkouts', 'career-ops-plugin-demo'), 'demo');
-  symlinkSync(externalCheckout, join(local, 'demo'));
+  linkPlugin(externalCheckout, join(local, 'demo'));
 
   // A plain directory plugin alongside it — the sibling that must keep working.
   writePlugin(join(local, 'regular'), 'regular');
@@ -91,7 +106,7 @@ try {
   // A dangling symlink (the checkout was moved or deleted) must be skipped
   // quietly. Resolving it throws, and an unguarded resolve takes down
   // discovery for every other plugin in the root, not just the dead link.
-  symlinkSync(join(tmp, 'checkouts', 'gone-away'), join(local, 'dangling'));
+  linkPlugin(join(tmp, 'checkouts', 'gone-away'), join(local, 'dangling'));
 
   let afterDangling;
   let threw = null;
@@ -127,7 +142,7 @@ try {
     'linked',
     'export default { ingest: async (ctx) => ({ ran: true, dryRun: ctx.dryRun }) };\n',
   );
-  symlinkSync(linkedCheckout, join(loadLocal, 'linked'));
+  linkPlugin(linkedCheckout, join(loadLocal, 'linked'));
   writePluginConfig(tmpEnabled, 'linked', true);
 
   const firstLoad = await loadPlugins('ingest', { root: tmpEnabled, dryRun: true });


### PR DESCRIPTION
Closes #3259.

I have the machine this reproduces on — Windows 11, non-elevated shell, Developer Mode off — so I measured rather than reasoned, and ended up **not** applying the fix the issue suggests. The argument for the difference is below.

## What was happening

On a clean `origin/main`, that suite does not fail a check; it dies at the first of its three `symlinkSync` calls:

```
Error: EPERM: operation not permitted, symlink '...\checkouts\career-ops-plugin-demo' -> '...\plugins.local\demo'
```

All twelve checks are lost as one opaque contained failure, exactly as @jaybee2184 describes.

## Why a junction rather than a skip

The issue proposes the `intake.test.mjs` pattern from #2828: probe, print a skip, return early. That is the right fix **there** — `tests/intake.test.mjs:206` links a *file* (`real-cv.md`), and a junction cannot express a file link, so nothing else was available.

Every link in this file is a *directory*, and for those the repo already has a second, better-established pattern:

| | |
|---|---|
| `test-all.mjs:8253` | e2e `node_modules` fixture, `win32 ? 'junction' : 'dir'`, with the reasoning in a comment |
| `tests/generate-pdf-page-budget.test.mjs:281` | same expression |
| `contacts.test.mjs:446` | `'junction'` with `// works dir-only on Windows w/o privilege` |

So this file did not pick up *either* convention. Taking the junction one costs the same three lines and keeps the coverage a skip throws away.

## What I checked before believing it

**The swap must not make any assertion vacuous.** The bug #3140 fixes is that `readdirSync` reports a linked plugin as a non-directory. If a junction reported `isDirectory() === true`, this suite would pass on Windows *without exercising the bug* — a false pass, strictly worse than the skip. It does not:

```
linked   isDirectory=false  isSymbolicLink=true
plain    isDirectory=true   isSymbolicLink=false

pre-#3140 filter (isDirectory only) sees: ["plain"]
```

**And the suite still fails when the feature is reverted.** Restoring the pre-#3140 discovery filter, with junctions in place:

```
8 of 12 red — including "a symlinked plugin directory is discovered"
              (discovered: ["regular"]) and "an enabled symlinked plugin
              is returned by loadPlugins" (loaded: [])
```

That is the check that separates coverage from a decorative green.

**The dangling case survives.** `gone-away` depends on the resolve throwing. A junction to an absent path is created without complaint and `stat()` through it throws just as through a dangling symlink, so all three `dangling` checks keep their meaning.

**Both junction constraints hold at all three sites** — absolute target, local volume — because every target is built from `mkdtempSync()`.

## Before / after, same branch, same box

```
before   EPERM at the first link, 0 of 12 checks reached
after    12 of 12 pass, 0 skipped
full     node test-all.mjs -> 5301 passed, 0 failed, 4 warnings
```

## Not in scope here

The three existing junction sites above are three hand-rolled copies of one platform expression, and this PR adds a fourth. That is the shape #3050 and #2983 both argue against, but pulling it into `tests/helpers.mjs` touches files this issue is not about, so I have left it alone. Happy to open a follow-up if you want it.

One thing I did not verify: whether junctions behave the same on a Windows filesystem without reparse points (a temp dir on FAT32). I have no such volume to test on. If that case matters, the containment #2867 added still reports it as one named failed suite rather than taking down the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform coverage for plugin discovery through directory links.
  * Added platform-aware handling for Windows junctions and directory symlinks.
  * Preserved existing validation for valid, dangling, and end-to-end plugin loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->