### PR TITLE
test(title-filter): drop the 12 board-state annotation rows from the recall corpus

### DIFF
--- a/tests/fixtures/title-recall-corpus.json
+++ b/tests/fixtures/title-recall-corpus.json
@@ -1,6 +1,6 @@
 {
   "_why": "Recall regression corpus for the shared title matcher (title-keywords.mjs). Guards the guarantee established in #3103/#3104: a change to keyword matching must not silently stop matching real roles. The failure mode is invisible - a narrowed matcher drops postings and the scan summary reports one lower number, which reads identically to a quiet week. Every entry below is a real title observed on a public ATS board; `matches` is what the CURRENT matcher returns. A diff here is not automatically a bug, but it is always a decision that has to be made deliberately rather than discovered months later.",
-  "_provenance": "675 distinct titles observed by scan.mjs and scan-ats-full.mjs across public Greenhouse, Lever, Ashby, Workday and iCIMS boards, 2026-04-20 to 2026-08-22. Titles only - no company, URL, board, or date. Contributed from the corpus used to measure #3103, #3104 and #2970.",
+  "_provenance": "663 distinct titles observed by scan.mjs and scan-ats-full.mjs across public Greenhouse, Lever, Ashby, Workday and iCIMS boards, 2026-04-20 to 2026-08-22. Titles only - no company, URL, board, or date. Board-state annotation rows carried by the same scan-history column (\"(no openings)\", \"(bot check / blocked)\", and similar) are not titles and are excluded. Contributed from the corpus used to measure #3103, #3104 and #2970.",
   "_filter_note": "The filter is deliberately small and self-contained rather than a copy of any real portals.yml: it holds exactly the keywords whose matching behaviour those issues discussed, so the corpus exercises the documented edge cases without depending on a user config that can change underneath the test.",
   "title_filter": {
     "positive": [
@@ -24,34 +24,6 @@
   },
   "titles": [
     {
-      "title": "(2 listings: PM-Platform + CSM, 0 SC)",
-      "matches": false
-    },
-    {
-      "title": "(31 listings, 0 SC: SRE/Infra/Data/Capital Markets/Sales/PM/Security-IR)",
-      "matches": false
-    },
-    {
-      "title": "(9 Eng listings, 0 SC: Distinguished/Staff/Data/Forward Deployed — all platform/payment infra)",
-      "matches": false
-    },
-    {
-      "title": "(DNS fail, careers_url dead)",
-      "matches": false
-    },
-    {
-      "title": "(Greenhouse board returns 404)",
-      "matches": false
-    },
-    {
-      "title": "(JS-rendered, listings not in a11y tree)",
-      "matches": false
-    },
-    {
-      "title": "(Notion page timeout 60s, careers board unreachable)",
-      "matches": false
-    },
-    {
       "title": "(Senior) Backend Engineer",
       "matches": true
     },
@@ -74,26 +46,6 @@
     {
       "title": "(Senior) Systems Engineer (Solana) - Remote Germany/Europe (m/f/d)",
       "matches": true
-    },
-    {
-      "title": "(board open, 0 engineering roles, only iGaming/Design)",
-      "matches": false
-    },
-    {
-      "title": "(bot check / blocked)",
-      "matches": false
-    },
-    {
-      "title": "(careers index — 12 listings, 0 SC)",
-      "matches": false
-    },
-    {
-      "title": "(no SC roles, all 8 eng titles previously seen)",
-      "matches": false
-    },
-    {
-      "title": "(no openings)",
-      "matches": false
     },
     {
       "title": "AI Backend Product Engineer",


### PR DESCRIPTION

Follow-up to #3193, where you flagged the provenance line as a hair off. It is off by exactly twelve, and the twelve are worth removing rather than counting.

## What they are

`scan-history.tsv` carries board-state annotations in the same column that holds titles - written when a board was reached but had nothing to record. Twelve of them came across into the fixture:

```
(no openings)
(bot check / blocked)
(DNS fail, careers_url dead)
(Greenhouse board returns 404)
(JS-rendered, listings not in a11y tree)
(Notion page timeout 60s, careers board unreachable)
(board open, 0 engineering roles, only iGaming/Design)
(careers index - 12 listings, 0 SC)
(no SC roles, all 8 eng titles previously seen)
(2 listings: PM-Platform + CSM, 0 SC)
(31 listings, 0 SC: SRE/Infra/Data/Capital Markets/Sales/PM/Security-IR)
(9 Eng listings, 0 SC: Distinguished/Staff/Data/Forward Deployed - all platform/payment infra)
```

## Why remove rather than just fix the count

They are inert today - all twelve are `matches:false`, and no positive keyword appears in any of them, so none has ever drifted. The problem is not that they misbehave, it is that they are not what the fixture says they are, on the two lines a reader checking the corpus reads first:

1. **`_provenance`** claimed `675 distinct titles`.
2. **`_why`** claims *"Every entry below is a real title observed on a public ATS board"*.

Correcting the count to 663 would leave the second sentence false. Removing the rows makes both true and needs no wording change to `_why` at all.

They are also inert only by luck. A future matcher change could flip one to `true` - `(31 listings, 0 SC: SRE/Infra/Data/Capital Markets/Sales/PM/Security-IR)` is one keyword away - and the drift report would then name a row that says nothing about recall.

## What the diff does

- Removes the twelve rows **by exact string**, not by a leading-parenthesis pattern. Six genuine titles also start with `(` - `(Senior) Backend Engineer` and its siblings, all `matches:true` - and a pattern would have taken them too. The script asserted it matched exactly twelve and that all twelve were `matches:false` before writing.
- Updates `_provenance` to 663 and names the annotation rows there, so the next extraction from `scan-history.tsv` filters them instead of rediscovering them.
- Touches nothing else. `_why`, `title_filter` and the remaining 663 entries are byte-identical.

## Verification

```
title recall corpus - real titles, checked against the current matcher
  all 663 corpus titles match the recorded verdict
  corpus discriminates: 386 match, 277 do not
  10 documented matching cases from #3103 / #2970 hold
  every pinned case is marked synthetic if and only if it is absent from the corpus
```

The test reads `corpus.titles.length` rather than a literal, so no assertion needed updating, and no pinned case in assertion 4 is among the removed rows. `tests/title-recall-corpus.test.mjs` is the only file in the repo that references the fixture.

## The smaller alternative

A one-line change to `_provenance` alone, 675 to 663, leaving the rows in. It is what you asked for and it is strictly smaller. I went further because it leaves `_why` saying something the data contradicts, and the corpus's whole value is that someone else can check it - but if you would rather keep the fixture's contents frozen and only fix the count, say so and I will cut it back to the one line.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected title corpus metadata to report 663 distinct titles.
  * Removed non-title board-status entries from title results.
  * Clarified that scan-history board-state annotations are excluded.
  * Preserved job-title records and their matching values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->