### PR TITLE
fix(update-system): never prune a file the update just preserved, or an asset it references

### DIFF
--- a/tests/updater-preserved-file-prune.test.mjs
+++ b/tests/updater-preserved-file-prune.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * updater-preserved-file-prune.test.mjs — a file `apply()` just KEPT because
+ * this install modified it (locallyModifiedSystemFiles → preservedPaths) must
+ * never also be deleted by the separate stale-file prune step, and an asset a
+ * kept file still references (e.g. a custom cv-template's font) must survive
+ * too even when upstream no longer ships it.
+ *
+ * Reproduces the real-world failure: a user's own custom CV template (no
+ * upstream counterpart at all) was backed up to .bak as "kept", then unlinked
+ * by the stale-file prune step in the same `apply()` run, because the two
+ * checks ran independently. The fonts that template's @font-face rules
+ * pointed at were pruned right alongside it, for the same underlying reason.
+ */
+
+import { pass, fail } from './helpers.mjs';
+import { staleSystemFiles, isReferencedByPreservedFile } from '../update-system.mjs';
+
+console.log('\n🧪 Testing preserved-file vs. stale-file prune interaction...');
+
+// ── 1. a preserved (locally-modified) file must not also be pruned as stale ──
+{
+  // Mirrors the real incident: a user's custom template has no upstream
+  // counterpart at all, so a presence-only stale check flags it — exactly
+  // what locallyModifiedSystemFiles already decided to keep and back up.
+  const local = ['templates/cv-template.custom.html', 'templates/cv-template.html', 'fonts/eb-garamond-400.ttf'];
+  const remote = ['templates/cv-template.html'];
+  const system = ['templates/', 'fonts/'];
+  const preserved = ['templates/cv-template.custom.html'];
+
+  const withoutFix = staleSystemFiles(local, remote, system);
+  if (withoutFix.includes('templates/cv-template.custom.html')) {
+    pass('reproduces the bug: an un-widened stale check flags a file that was separately preserved');
+  } else {
+    fail('setup assumption broke: the un-widened stale check no longer flags the preserved file');
+  }
+
+  const withFix = staleSystemFiles(local, remote, system, preserved);
+  if (!withFix.includes('templates/cv-template.custom.html')) {
+    pass('a preserved file is excluded from the stale-file prune candidates');
+  } else {
+    fail('a preserved file was still selected for pruning');
+  }
+  if (withFix.includes('fonts/eb-garamond-400.ttf')) {
+    pass('an unrelated stale file (no preserved counterpart) is still a prune candidate');
+  } else {
+    fail('the fix over-excluded: an unrelated stale file was dropped too');
+  }
+}
+
+// ── 2. an asset referenced by a preserved file is protected even though it, ──
+// ──    itself, was never locally modified (only orphaned by upstream)      ──
+{
+  const preserved = ['templates/cv-template.custom.html'];
+  const fakeTemplateSource = `
+    <style>
+      @font-face { font-family: 'EB Garamond'; src: url('./fonts/eb-garamond-400.ttf') format('truetype'); }
+    </style>
+  `;
+  const readFile = (path) => {
+    if (path.endsWith('cv-template.custom.html')) return fakeTemplateSource;
+    throw new Error(`ENOENT: ${path}`);
+  };
+
+  if (isReferencedByPreservedFile('fonts/eb-garamond-400.ttf', preserved, readFile)) {
+    pass('a font referenced by a preserved template is detected as still needed');
+  } else {
+    fail('a referenced font was not detected — would still be pruned out from under the preserved template');
+  }
+
+  if (!isReferencedByPreservedFile('fonts/eb-garamond-700.ttf', preserved, readFile)) {
+    pass('a font NOT mentioned in the preserved template is correctly reported as unreferenced');
+  } else {
+    fail('an unreferenced font was reported as referenced (false positive)');
+  }
+
+  // Scoping: only html/css preserved files are ever read for references — a
+  // preserved .mjs/.md file with the same substring by coincidence must not
+  // count, since system scripts/docs are not known to reference fonts by path.
+  const preservedScript = ['build-cv-html.mjs'];
+  const readScript = (path) => {
+    if (path.endsWith('build-cv-html.mjs')) return "// mentions eb-garamond-400.ttf in a comment, not a real reference";
+    throw new Error(`ENOENT: ${path}`);
+  };
+  if (!isReferencedByPreservedFile('fonts/eb-garamond-400.ttf', preservedScript, readScript)) {
+    pass('a non-html/css preserved file is never consulted for asset references');
+  } else {
+    fail('a .mjs preserved file was incorrectly treated as an asset-reference source');
+  }
+
+  // A preserved path whose file cannot be read (e.g. already gone) must not
+  // throw — the caller still needs to reach the other prune candidates.
+  const readThrows = () => { throw new Error('EACCES'); };
+  if (isReferencedByPreservedFile('fonts/eb-garamond-400.ttf', preserved, readThrows) === false) {
+    pass('an unreadable preserved file fails closed (treated as no reference) instead of throwing');
+  } else {
+    fail('an unreadable preserved file should fail closed, not throw or report a false reference');
+  }
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -831,6 +831,28 @@ export function staleSystemFiles(localFiles, remoteFiles, systemPaths, userPaths
     .filter((file) => !userPaths.some((entry) => pathMatchesManifest(file, entry)));
 }
 
+// A stale-file prune candidate can still be load-bearing for a file this same
+// run just decided to KEEP because the user modified it (see
+// `locallyModifiedSystemFiles` + the `preservedPaths` handling in `apply()`) —
+// e.g. a user's custom CV template referencing a font file upstream no longer
+// ships. Deleting the referenced asset out from under a preserved file leaves
+// the preserved file silently broken (missing font, broken image) even though
+// the file itself survived. Scoped to preserved HTML/CSS files' on-disk
+// content, since those are the only preserved file types known to reference
+// other system files by relative path.
+export function isReferencedByPreservedFile(candidatePath, preservedPaths, readFile = (path) => readFileSync(path, 'utf-8')) {
+  const basename = normalizeRepoPath(candidatePath).split('/').pop();
+  if (!basename) return false;
+  return preservedPaths.some((preservedPath) => {
+    if (!/\.(html|css)$/i.test(preservedPath)) return false;
+    try {
+      return readFile(join(ROOT, ...preservedPath.split('/'))).includes(basename);
+    } catch {
+      return false;
+    }
+  });
+}
+
 // Files the self-reexec stage must check out so the TARGET update-system.mjs
 // loads without a missing-module crash. Today this is the entry plus its only
 // local import; resolveReexecCheckout derives the real set from the fetched
@@ -1761,7 +1783,17 @@ async function apply() {
       }
       if (remoteFiles.size > 0) {
         const localFiles = git('ls-files').split('\n').filter(Boolean);
-        for (const f of staleSystemFiles(localFiles, remoteFiles, SYSTEM_PATHS)) {
+        // A file just preserved above because THIS install modified it (e.g. a
+        // custom cv-template.*.html no longer shipped upstream) must never also
+        // be deleted here as "stale" — the two checks used to run independently,
+        // so a preserved file with no upstream counterpart was backed up to
+        // .bak by the block above and then unlinked by this one in the same run.
+        const staleCandidates = staleSystemFiles(localFiles, remoteFiles, SYSTEM_PATHS, mergePathLists(USER_PATHS, preservedPaths));
+        for (const f of staleCandidates) {
+          if (isReferencedByPreservedFile(f, preservedPaths)) {
+            console.log(`Kept stale asset still referenced by a preserved file: ${f}`);
+            continue;
+          }
           try {
             unlinkSync(join(ROOT, f));
             updated.push(f);


### PR DESCRIPTION
## Summary

During `node update-system.mjs apply`, two independent checks run over the same file set:

1. **Local-modification detection** (`locallyModifiedSystemFiles`) — flags a system file this install changed, backs it up to `.bak`, and keeps it.
2. **Stale-file pruning** (`staleSystemFiles`) — deletes any local file matching a system path that upstream no longer ships.

A file can be **both**: locally modified *and* absent from the new upstream tree (e.g. a user's own custom `templates/cv-template.*.html`, which was never an upstream file to begin with). Check 1 correctly detects it, backs it up, and prints "Keeping your versions" — then check 2 deletes it a few lines later in the same run, because it only knows "not present upstream," not "was just preserved."

The same run also deleted font files that preserved template's `@font-face` rules pointed at, once upstream stopped shipping those specific fonts. The fonts themselves were never locally modified, so nothing flagged them as at-risk — but they were still load-bearing for the template check 1 had just decided to keep.

Net effect: a locally-customized CV template and its fonts silently vanish on update, with no error — just two unrelated-looking log lines ("Keeping your versions" followed later by "Pruned stale system file").

## Fix

- `staleSystemFiles()`'s call site now passes `preservedPaths` into the existing `userPaths` exclusion parameter — same mechanism that already protects user-layer paths, just widened to also cover this-run's preserved files.
- New `isReferencedByPreservedFile()` skips pruning a stale candidate when any preserved HTML/CSS file's on-disk content still references its basename (e.g. a font `url(...)` in a kept template).

## Testing

- [x] New `tests/updater-preserved-file-prune.test.mjs` reproduces the scenario (a template with no upstream counterpart, plus a font it references) — 7 assertions, all passing
- [x] `node updater-migration-tests.mjs` — 355 passed, 0 failed (no regressions)
- [x] All existing `tests/updater-*.test.mjs` still green
- [x] `node scripts/check-syntax.mjs` — 525 files pass

Found via a real update run that silently deleted a customized CV template plus 4 font files it depended on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of outdated system files while protecting locally preserved files.
  - Retained stale assets referenced by preserved HTML or CSS files.
  - Handled unreadable preserved files safely without interrupting cleanup.
  - Continued pruning unrelated stale files that are not protected or referenced.

- **Tests**
  - Added coverage for preserved-file protection, referenced assets, unsupported file types, and safe handling of unreadable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->