### PR TITLE
fix(portals.example): drop retired EchoJobs block

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1114,11 +1114,6 @@ search_queries:
 #   provider: jobicy
 #   enabled: true
 #
-# - name: EchoJobs                        # tech jobs aggregated from company ATS boards
-#   provider: echojobs
-#   max_pages: 3                          # 100 jobs/page; raise for deeper coverage
-#   enabled: true
-#
 # - name: getManfred                      # Spanish/EU tech roles, salary ranges published
 #   provider: manfred
 #   lang: EN                              # EN or ES; the API rejects the call without it


### PR DESCRIPTION
## Summary
- `templates/portals.example.yml` still carried a commented-out `EchoJobs` example block after #3137 retired the provider (#2976). #3137 only touched `providers/echojobs.mjs`, its tests, and `docs/SUPPORTED_JOB_BOARDS.md` — it never touched this file.
- A user skimming the example template for portal ideas would uncomment a board that's been retired since 2026-08-20, with nothing telling them it's dead until they hit the explanatory throw #3137 added.
- Removed the block outright rather than annotating it — it's a commented-out example, not live config, so there's no reason to keep teaching people to configure a retired provider.

Follow-up to #2976 (closed), flagged in [this comment](https://github.com/santifer/career-ops/issues/2976#issuecomment-5391761340) by @ilyakanevskiy. Opening directly rather than filing a separate issue since the fix is a single already-scoped block deletion and the maintainer's own precedent in that thread was to hand this kind of follow-up straight to a PR.

## Test plan
- [x] `node tests/example-config-support-negatives.test.mjs` — pass
- [x] `node tests/aggregator-companies.test.mjs` — pass
- [x] `node tests/title-filter-word-prefix.test.mjs` — pass
- [x] `node tests/classify-tier-position.test.mjs` — pass
- [x] `node test-all.mjs` on a clean worktree off `upstream/main` — 5311 passed, 0 failed, 2 pre-existing unrelated warnings (missing Go compiler in this environment; a known `santifer.io` string in `dashboard/internal/ui/screens/stats.go` flagged by the personal-data heuristic) — neither touches the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1pEx8vg7XzQgc68MvMbiG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated, commented job-board example from the sample portal configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->