### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Portuguese _shared.md (#2573)

### DIFF
--- a/modes/pt/_shared.md
+++ b/modes/pt/_shared.md
@@ -20,6 +20,8 @@
 **REGRA: NUNCA fazer hardcode de métricas de proof points.** Leia-as de `cv.md` e `article-digest.md` no momento da avaliação.
 **REGRA: Para métricas de artigos/projetos, `article-digest.md` tem prioridade sobre `cv.md`** (`cv.md` pode conter números desatualizados).
 **REGRA: Leia `_profile.md` DEPOIS deste arquivo. As personalizações do usuário em `_profile.md` sobrescrevem os valores padrão aqui.**
+**REGRA: NUNCA afirme que o usuário é autor/criador de um projeto, repositório, biblioteca, ferramenta, framework ou artefato open-source, a menos que isso esteja explicitamente atribuído a ele em `cv.md` ou `article-digest.md`.** Confundir "usar uma ferramenta" com "tê-la criado" (o usuário usa X → o usuário criou X) é o padrão de invenção mais comum, e é proibido.
+**REGRA: Palavras-chave são reformuladas, nunca inventadas.** Reordene, reformule, enfatize — mas nunca invente. Se uma alegação não estiver respaldada por um arquivo dentro do escopo, pergunte ao usuário; sem resposta, omita. Silêncio sobre um tema é melhor do que detalhe inventado.
 
 ---
 


### PR DESCRIPTION
Part of #2573 — Portuguese only, per the one-language-per-PR convention.

## What was missing

`modes/pt/_shared.md` carried three `**REGRA` blocks, all about metrics. The English source has six, and the two the umbrella targets — authorship and reformulate-never-fabricate — were absent:

```
modes/_shared.md:32   NEVER claim the user authored a project, repo, library…
modes/_shared.md:33   Keywords get reformulated, never fabricated.
```

As the issue puts it: last line of defence intact (`verify-cv-facts.mjs` is language-agnostic and still blocks a fabricated employer at generation time), first line absent. This restores the first line for Portuguese.

Placed immediately after the existing metrics rules, which is where the umbrella asks for them and where the English original keeps them.

## Details that decide whether a translation reads as native

**The file is written with full Brazilian Portuguese accentuation** — `avaliação`, `métricas`, `arquétipos`, `vagas-alvo`, zero corners cut. Unlike the French file (unaccented ASCII by its own established convention, per #3009), this one accents everything, so the addition does too: `usuário`, `atribuído`, `é`, `não`, `alegação`, `silêncio`.

**`usuário` is the file's dominant term for the person** (7 occurrences vs. 4 for `candidato`), so the new rules follow the file rather than defaulting to the other option.

**`inventar` is the established vocabulary for fabrication** — already used elsewhere in the Portuguese modes (`modes/pt/oferta.md:54`: "Se não houver dados, dizer isso em vez de inventar"). The translation uses `inventar`/`invenção`/`inventadas`/`inventado` throughout rather than introducing a different word for the same concept.

**Em dash `—` and arrow `→`** match the file's existing body-prose punctuation (both already appear multiple times outside headers), not the ASCII `--` the file reserves for headers/titles.

## Scope

Portuguese only, deliberately — one language per PR, per the umbrella's rules of engagement.

## Test plan

- [x] `node test-all.mjs` — 5311 passed, 0 failed (2 pre-existing unrelated warnings)
- [x] `npm run lint` (syntax check) — clean
- [x] Diffed against the two reference translations (`modes/nl/_shared.md`, `modes/ja/_shared.md`) for placement and content fidelity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that unsupported authorship or creation claims must not be attributed.
  * Prohibited inventing keywords; unsupported claims should be omitted or clarified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->