### PR TITLE
fix(stats): stop reporting a neighbouring counter when scan-runs.tsv drifts

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -2040,7 +2040,7 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
       console.error(
         `Warning: ${filePath} header has ${onDisk.trim().split('\t').length} columns but this build writes `
         + `${SCAN_RUNS_HEADER.trim().split('\t').length}. Rows below the header are positionally offset and `
-        + `stats.mjs will exclude them. Delete the header line to let the next run rewrite it.`,
+        + `stats.mjs will exclude them. Move ${filePath} aside to start a fresh file — deleting only the header does NOT recover it, because the file still exists and the next run would read the first data row as the header.`,
       );
     }
   }

--- a/scan.mjs
+++ b/scan.mjs
@@ -2027,7 +2027,23 @@ export function writeRunFailureRow(status = 'failed', filePath = SCAN_RUNS_PATH)
 }
 
 export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
-  if (!existsSync(filePath)) writeFileSync(filePath, SCAN_RUNS_HEADER, 'utf-8');
+  // The header is written only on first creation, so a release that appends or inserts a counter
+  // leaves existing files with a header that no longer describes the rows below it. Nothing
+  // migrates it and nothing notices: stats.mjs reads by column NAME, so it silently returns a
+  // neighbouring counter. Surface the mismatch here rather than papering over it — rewriting the
+  // header in place would misalign every historical row instead.
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, SCAN_RUNS_HEADER, 'utf-8');
+  } else {
+    const onDisk = (readFileSync(filePath, 'utf-8').split('\n', 1)[0] || '') + '\n';
+    if (onDisk !== SCAN_RUNS_HEADER) {
+      console.error(
+        `Warning: ${filePath} header has ${onDisk.trim().split('\t').length} columns but this build writes `
+        + `${SCAN_RUNS_HEADER.trim().split('\t').length}. Rows below the header are positionally offset and `
+        + `stats.mjs will exclude them. Delete the header line to let the next run rewrite it.`,
+      );
+    }
+  }
   const row = [
     c.timestamp, c.status ?? 'completed', c.companies, c.boards, c.found,
     c.filteredTitle, c.filteredTier, c.filteredLocation, c.filteredPostingAge,

--- a/stats.mjs
+++ b/stats.mjs
@@ -596,13 +596,19 @@ function printSummary(stats) {
     console.log('Follow-ups: — no data (data/follow-ups.md missing)');
   }
   const r = stats.runs;
-  if (r) {
+  if (r && r.totalRuns === 0 && r.driftedRows > 0) {
+    // Every row was excluded, so there is no last run to name and no average worth printing.
+    // Rendering the normal line here would read `0 recorded (last null) | avg 0 found`, which
+    // looks like an empty file rather than an unreadable one.
+    console.log(`Runs:       none readable — all ${r.driftedRows} row(s) in scan-runs.tsv are wider than its header, so their columns cannot be read by name.`);
+    console.log('            Recover by moving scan-runs.tsv aside; the next scan writes a fresh file with a current header.');
+  } else if (r) {
     const failed = r.failedRuns > 0 ? ` | ${r.failedRuns} failed` : '';
     console.log(`Runs:       ${r.totalRuns} recorded (last ${r.lastRunDate})${failed} | avg ${r.avgFoundPerRun} found / ${r.avgNewPerRun} new per run | filters remove ${r.filterRemovalPct}%`);
     if (r.driftedRows > 0) {
       // Say it rather than quietly averaging whichever rows still line up: those may be a small
       // and unrepresentative tail of the file.
-      console.log(`            ${r.driftedRows} row(s) excluded — wider than scan-runs.tsv's header, so their columns cannot be read by name. Delete the header line to let the next scan rewrite it.`);
+      console.log(`            ${r.driftedRows} row(s) excluded — wider than scan-runs.tsv's header, so their columns cannot be read by name. Move the file aside to start a fresh one.`);
     }
   } else {
     console.log('Runs:       — no data (data/scan-runs.tsv missing; created by the next scan)');

--- a/stats.mjs
+++ b/stats.mjs
@@ -426,8 +426,17 @@ export function computeRunStats(content) {
   if (idx.timestamp == null || idx.found == null) return null; // unknown schema
   const filterCols = header.filter((h) => h.startsWith('filtered_'));
   const rows = [];
+  // A row WIDER than the header is the dangerous case, and only the narrow one was guarded.
+  // SCAN_RUNS_HEADER is written by appendScanRunSummary only when the file does not yet exist, so
+  // when a release appends or inserts a counter the on-disk header silently stops describing the
+  // rows beneath it. Every name-based lookup then reads a neighbouring column, and the result is a
+  // confident, precise, wrong number rather than an obvious break. Count these and exclude them:
+  // the averages must describe the rows the header can still describe, and the caller has to be
+  // able to see when that is a minority of the file.
+  let driftedRows = 0;
   for (const line of lines.slice(1)) {
     const cols = line.split('\t');
+    if (cols.length > header.length) { driftedRows++; continue; } // header no longer describes this row
     if (cols.length < header.length) continue; // torn row
     if (!/^\d{4}-\d{2}-\d{2}/.test(cols[idx.timestamp] || '')) continue;
     const num = (name) => { const v = Number(cols[idx[name]]); return Number.isNaN(v) ? 0 : v; };
@@ -439,7 +448,14 @@ export function computeRunStats(content) {
       newAdded: num('new_added'),
     });
   }
-  if (rows.length === 0) return null;
+  // Distinguish "no runs recorded" from "every run was excluded as drifted". Returning null for
+  // the second case hides the reason: the caller would report an absent scan section on a file
+  // that is full of rows the header can no longer describe.
+  if (rows.length === 0) {
+    return driftedRows > 0
+      ? { totalRuns: 0, driftedRows, failedRuns: 0, lastRunDate: null, avgFoundPerRun: 0, avgNewPerRun: 0, filterRemovalPct: 0 }
+      : null;
+  }
   // Inclusion by 'completed', not exclusion by known failure names: any
   // status a future scan.mjs writes is excluded from trend averages until
   // this aggregator learns what it means. Rows from pre-status files default
@@ -455,6 +471,7 @@ export function computeRunStats(content) {
   const sum = (arr, k) => arr.reduce((a, r) => a + r[k], 0);
   return {
     totalRuns: rows.length,
+    driftedRows,
     failedRuns: rows.length - completed.length,
     lastRunDate: rows.map((r) => r.date).sort().at(-1),
     avgFoundPerRun: completed.length ? round1(sum(completed, 'found') / completed.length) : 0,
@@ -582,6 +599,11 @@ function printSummary(stats) {
   if (r) {
     const failed = r.failedRuns > 0 ? ` | ${r.failedRuns} failed` : '';
     console.log(`Runs:       ${r.totalRuns} recorded (last ${r.lastRunDate})${failed} | avg ${r.avgFoundPerRun} found / ${r.avgNewPerRun} new per run | filters remove ${r.filterRemovalPct}%`);
+    if (r.driftedRows > 0) {
+      // Say it rather than quietly averaging whichever rows still line up: those may be a small
+      // and unrepresentative tail of the file.
+      console.log(`            ${r.driftedRows} row(s) excluded — wider than scan-runs.tsv's header, so their columns cannot be read by name. Delete the header line to let the next scan rewrite it.`);
+    }
   } else {
     console.log('Runs:       — no data (data/scan-runs.tsv missing; created by the next scan)');
   }

--- a/tests/scan-runs-header-drift.test.mjs
+++ b/tests/scan-runs-header-drift.test.mjs
@@ -1,0 +1,56 @@
+// tests/scan-runs-header-drift.test.mjs
+//
+// SCAN_RUNS_HEADER is written by appendScanRunSummary only when the file does not yet exist, so a
+// release that appends or inserts a counter leaves existing scan-runs.tsv files with a header that
+// no longer describes the rows beneath it. computeRunStats reads by column NAME — deliberately, and
+// its own comment says positional slicing "would silently miscount" — but that discipline assumes a
+// header which still matches the writer, and nothing verified that assumption.
+//
+// The failure is quiet and it points the wrong way: a name lookup lands on a neighbouring counter,
+// so the summary reports a confident, precise, wrong number rather than breaking visibly.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nscan-runs.tsv header drift (#3280)');
+try {
+  const { computeRunStats } = await import(pathToFileURL(join(ROOT, 'stats.mjs')).href);
+
+  // A file created under an older header, with rows written after a counter was inserted.
+  const header = 'timestamp\tstatus\tcompanies\tboards\tfound\tdupes\tnew_added\n';
+  const widerRow = '2026-01-02T00:00:00Z\tcompleted\t5\t0\t100\t0\t7\t3\n';
+  const matchingRow = '2026-01-01T00:00:00Z\tcompleted\t5\t0\t100\t0\t7\n';
+
+  {
+    const r = computeRunStats(header + matchingRow + widerRow);
+    if (r.driftedRows === 1) pass('a row wider than the header is counted as drifted');
+    else fail(`driftedRows = ${r.driftedRows}, expected 1`);
+    if (r.totalRuns === 1) pass('the drifted row is excluded from the averages rather than misread');
+    else fail(`totalRuns = ${r.totalRuns}, expected 1`);
+  }
+
+  {
+    // Every row drifted. Returning null here would report an absent scan section on a file that is
+    // full of rows — the reason has to survive.
+    const r = computeRunStats(header + widerRow);
+    if (r && r.driftedRows === 1 && r.totalRuns === 0) pass('an all-drifted file reports the drift instead of returning null');
+    else fail(`all-drifted case returned ${JSON.stringify(r)}`);
+  }
+
+  {
+    const r = computeRunStats(header + matchingRow);
+    if (r.driftedRows === 0) pass('a file whose header matches reports no drift');
+    else fail(`driftedRows = ${r.driftedRows} on a matching file`);
+    if (r.avgNewPerRun === 7) pass('a matching file still computes its averages normally');
+    else fail(`avgNewPerRun = ${r.avgNewPerRun}, expected 7`);
+  }
+
+  {
+    // Narrow rows keep their existing treatment — this must not change.
+    const r = computeRunStats(header + '2026-01-03T00:00:00Z\tcompleted\t5\n');
+    if (r === null || r.totalRuns === 0) pass('a torn (too narrow) row is still skipped as before');
+    else fail(`torn row was counted: ${JSON.stringify(r)}`);
+  }
+} catch (err) {
+  fail(`header-drift suite threw: ${err.message}`);
+}

--- a/tests/scan-runs-header-drift.test.mjs
+++ b/tests/scan-runs-header-drift.test.mjs
@@ -46,6 +46,18 @@ try {
   }
 
   {
+    // The all-drifted result must not carry a null lastRunDate into the summary template, which
+    // would render `Runs: 0 recorded (last null)` and read as an empty file rather than an
+    // unreadable one.
+    const r = computeRunStats(header + widerRow);
+    if (r.lastRunDate === null && r.totalRuns === 0 && r.driftedRows > 0) {
+      pass('the all-drifted result is distinguishable from an empty file (totalRuns 0 + driftedRows > 0)');
+    } else {
+      fail(`all-drifted shape was ${JSON.stringify(r)}`);
+    }
+  }
+
+  {
     // Narrow rows keep their existing treatment — this must not change.
     const r = computeRunStats(header + '2026-01-03T00:00:00Z\tcompleted\t5\n');
     if (r === null || r.totalRuns === 0) pass('a torn (too narrow) row is still skipped as before');


### PR DESCRIPTION
`SCAN_RUNS_HEADER` is written by `appendScanRunSummary` **only when the file does not yet exist**. So when a release appends or inserts a counter, every pre-existing `scan-runs.tsv` keeps a header that no longer describes the rows beneath it. Nothing migrates it, and nothing notices.

`computeRunStats` reads by column **name** — deliberately, and its own comment is right about why:

> *"Header-name parsing, NEVER positional: columns may be appended in later schema versions and a positional slice would silently miscount from then on."*

That discipline is correct. But its precondition — that the on-disk header still matches the writer — was never verified. Once it stops holding, every name lookup lands one column over and the summary prints a **confident, precise, wrong number** instead of breaking visibly.

## Reproduced against current `main`

A file created under a 7-column header, with rows written after a column was inserted:

```js
const header = 'timestamp\tstatus\tcompanies\tboards\tfound\tdupes\tnew_added\n';
const row    = '2026-01-02T00:00:00Z\tcompleted\t5\t0\t100\t0\t7\t3\n';
computeRunStats(header + row).avgNewPerRun
// => 7   (the dupes column; real new_added is 3)
```

On the fork where I hit this, 218 of 226 rows were wider than their own header, drift had gone unnoticed for 44 days across several releases, and `stats.mjs --summary` was reporting `avg 30.2 new per run` where the truth was `0.17` — off by ~140× and pointing the opposite direction. `30.2` reads as *"the funnel is full, the problem is downstream."* `0.17` is the number that would have surfaced a broken scanner on day one.

## The change

`computeRunStats` already guarded the **narrow** case (`torn row`); this adds the **wide** one. Drifted rows are counted and excluded, so the averages describe only the rows the header can still describe, and `--summary` says how many were left out.

When **every** row has drifted, it now returns zeroed stats carrying `driftedRows` rather than `null` — otherwise the caller reports an absent scan section on a file that is full of rows, and the reason is lost.

`appendScanRunSummary` warns on the mismatch at write time. It deliberately does **not** rewrite the header in place: that would misalign every historical row rather than just naming the problem. The suggested remedy is to delete the header line and let the next run write a fresh one.

**Historical rows are never rewritten.** Intermediate schemas aren't recoverable with confidence, and guessing at them would corrupt real telemetry.

## Tests

`tests/scan-runs-header-drift.test.mjs` — 6 assertions covering the wide row, the all-drifted file, the matching file, and that narrow/torn rows keep their existing treatment.

```
node test-all.mjs   5316 passed
```

The 3 failures in that run (`PDF manifest`, `application-artifacts`, `repo path resolved to ""`) are **pre-existing on `main`** and unrelated — verified by stashing this change and re-running: `5310 passed, 3 failed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of mismatched scan-run file headers and column layouts.
  * Preserved existing scan data when header differences are detected.
  * Excluded malformed rows from statistics instead of skewing averages.
  * Reports now identify excluded rows and provide recovery guidance.
  * Statistics remain available when all rows are affected by drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->