### PR TITLE
fix(followup): stop reporting the candidate's own address as a contact to chase

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -5,6 +5,10 @@
 candidate:
   full_name: "Jane Smith"
   email: "jane@example.com"
+  # Optional. Any other mailboxes that are also you. Follow-up contact extraction uses these to
+  # avoid reporting your own address as somebody to chase, when a tracker note happens to cite it.
+  # alternate_emails:
+  #   - "jane@previous-employer.example"
   phone: "+1-555-0123"
   # Optional. Used by `/career-ops email` contact blocks in markets where WeChat
   # is an expected recruiting channel. Omit or leave blank if not applicable.

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -601,7 +601,13 @@ export function loadSelfIdentities(profilePath = PROFILE_FILE) {
   const out = new Set();
   const push = (v) => { if (typeof v === 'string' && v.includes('@')) out.add(v.trim().toLowerCase()); };
   push(raw.candidate?.email);
-  for (const alt of raw.candidate?.alternate_emails || []) push(alt);
+  // Only iterate an actual array. A hand-edited profile can reasonably hold a mapping here
+  // (`alternate_emails: { work: me@example.com }`), and `for...of` on an object throws — at module
+  // load, because SELF_IDENTITIES is initialised at import time. That would take followup-cadence
+  // down entirely over a cosmetic config mistake, which is the opposite of the fail-open behaviour
+  // this function promises everywhere else.
+  const alternates = raw.candidate?.alternate_emails;
+  if (Array.isArray(alternates)) for (const alt of alternates) push(alt);
   return out;
 }
 

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -577,7 +577,37 @@ function splitStatements(notes) {
   return String(notes).split(/[;\n]+|\.\s+(?=[A-Z])/).filter(s => s.trim());
 }
 
-export function extractContacts(notes) {
+/**
+ * The candidate's own addresses, so a note that mentions them is not reported as somebody to chase.
+ *
+ * Tracker notes routinely cite your own mailbox while recording where a search ran — e.g. "searched
+ * both accounts (personal + me@work.example) for this thread" written to establish that a reply was
+ * NOT received. extractContacts has no concept of self, so it reads that as a repliable human and
+ * the row advertises a contact that cannot be written to. That is worse than reporting no contact:
+ * it makes an un-chaseable row look actionable.
+ *
+ * Read from config/profile.yml rather than hardcoded, so it stays correct per profile. Fails open —
+ * an absent or unreadable profile yields an empty set, because a missing profile must never start
+ * deleting real contacts.
+ */
+export function loadSelfIdentities(profilePath = PROFILE_FILE) {
+  if (!profilePath || !existsSync(profilePath)) return new Set();
+  let raw;
+  try {
+    raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+  } catch {
+    return new Set();
+  }
+  const out = new Set();
+  const push = (v) => { if (typeof v === 'string' && v.includes('@')) out.add(v.trim().toLowerCase()); };
+  push(raw.candidate?.email);
+  for (const alt of raw.candidate?.alternate_emails || []) push(alt);
+  return out;
+}
+
+const SELF_IDENTITIES = loadSelfIdentities();
+
+export function extractContacts(notes, selfIdentities = SELF_IDENTITIES) {
   if (!notes) return [];
   const byEmail = new Map();  // normalized email -> contact
   const byName = new Map();   // normalized name  -> contact
@@ -648,7 +678,8 @@ export function extractContacts(notes) {
     for (const name of names) add({ name, email: null, channel });
   }
 
-  return contacts;
+  // A note citing your own mailbox is not a person to follow up with.
+  return contacts.filter((c) => !(c.email && selfIdentities.has(c.email.toLowerCase())));
 }
 
 // The channel a single statement names, when it names one. Null rather than a

--- a/tests/contacts-exclude-self.test.mjs
+++ b/tests/contacts-exclude-self.test.mjs
@@ -38,6 +38,30 @@ try {
 
   if (loadSelfIdentities('/nonexistent/profile.yml').size === 0) pass('an absent profile yields no identities rather than throwing');
   else fail('absent profile did not yield an empty set');
+
+  // A hand-edited profile can hold a mapping here instead of a list. `for...of` on an object throws,
+  // and SELF_IDENTITIES is initialised at import time, so that would take the whole module down at
+  // load over a cosmetic config mistake.
+  const { mkdtempSync, writeFileSync } = await import('fs');
+  const { tmpdir } = await import('os');
+  const dir = mkdtempSync(join(tmpdir(), 'self-ids-'));
+  const profile = join(dir, 'profile.yml');
+
+  writeFileSync(profile, 'candidate:\n  email: a@b.c\n  alternate_emails: { work: me@x.y }\n');
+  let mapped;
+  try {
+    mapped = loadSelfIdentities(profile);
+    pass('a mapping under alternate_emails does not throw');
+  } catch (err) {
+    fail(`a mapping under alternate_emails threw: ${err.message}`);
+  }
+  if (mapped && mapped.size === 1 && mapped.has('a@b.c')) pass('the malformed key is ignored and candidate.email still loads');
+  else fail(`mapping case produced ${mapped && [...mapped]}`);
+
+  writeFileSync(profile, 'candidate:\n  email: a@b.c\n  alternate_emails:\n    - me@x.y\n');
+  const listed = loadSelfIdentities(profile);
+  if (listed.size === 2 && listed.has('me@x.y')) pass('a proper list of alternate_emails is read');
+  else fail(`list case produced ${[...listed]}`);
 } catch (err) {
   fail(`self-contact suite threw: ${err.message}`);
 }

--- a/tests/contacts-exclude-self.test.mjs
+++ b/tests/contacts-exclude-self.test.mjs
@@ -1,0 +1,43 @@
+// tests/contacts-exclude-self.test.mjs
+//
+// extractContacts had no concept of "me". Tracker notes routinely cite the candidate's own mailbox
+// while recording where a search ran — "searched both accounts (personal + me@work.example)",
+// written to establish that a reply was NOT received — and that was read as a repliable human.
+// The row then advertises a contact that cannot be written to, which is worse than reporting none:
+// it makes an un-chaseable row look actionable in the follow-up dashboard.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nextractContacts — exclude the candidate\'s own addresses (#3281)');
+try {
+  const { extractContacts, loadSelfIdentities } = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+  const self = new Set(['me@work.example']);
+
+  const mine = extractContacts('searched both accounts (personal + me@work.example) for this thread', self);
+  if (mine.length === 0) pass('a note citing the candidate\'s own address yields no contact');
+  else fail(`self-mention produced ${JSON.stringify(mine)}`);
+
+  const theirs = extractContacts('recruiter Dana (dana@acme.example) said they would call', self);
+  if (theirs.length === 1 && theirs[0].email === 'dana@acme.example') pass('a real counterparty address is still extracted');
+  else fail(`real contact produced ${JSON.stringify(theirs)}`);
+
+  const mixed = extractContacts('mailed dana@acme.example from me@work.example', self);
+  if (mixed.length === 1 && mixed[0].email === 'dana@acme.example') pass('only the counterparty survives when both appear');
+  else fail(`mixed note produced ${JSON.stringify(mixed)}`);
+
+  // Case-insensitive: profiles and notes disagree on casing all the time.
+  const upper = extractContacts('cc ME@Work.Example on the thread', self);
+  if (upper.length === 0) pass('self matching is case-insensitive');
+  else fail(`uppercase self-mention produced ${JSON.stringify(upper)}`);
+
+  // Fails open: with no identities configured, behaviour is exactly as before.
+  const none = extractContacts('mailed dana@acme.example from me@work.example', new Set());
+  if (none.length === 2) pass('with no identities configured, nothing is filtered (unchanged behaviour)');
+  else fail(`empty identity set produced ${JSON.stringify(none)}`);
+
+  if (loadSelfIdentities('/nonexistent/profile.yml').size === 0) pass('an absent profile yields no identities rather than throwing');
+  else fail('absent profile did not yield an empty set');
+} catch (err) {
+  fail(`self-contact suite threw: ${err.message}`);
+}


### PR DESCRIPTION
`extractContacts` has no concept of *"me"*.

Tracker notes routinely cite the candidate's own mailbox while recording **where a search ran** — for example *"searched both accounts (personal + me@work.example) for this thread"*, written specifically to establish that a reply was **not** received. That gets read as a repliable human.

The row then advertises a contact that cannot be written to. That's worse than reporting no contact at all: an un-chaseable row looks actionable in the follow-up dashboard, and the rows that genuinely *do* have somebody to write to become harder to find among them.

On the tracker where I hit this, 47 rows were overdue and only 6 had a real human attached — so a false positive in that set is expensive. The single row flagged most urgent turned out to be flagged on the strength of the candidate's own address.

## The change

Identities come from `config/profile.yml` — `candidate.email` plus a new optional `candidate.alternate_emails` — rather than being hardcoded, so it stays correct per profile. Matching is case-insensitive, because profiles and notes disagree on casing constantly.

**Fails open in both directions.** An absent or unreadable profile yields an empty set, and an empty set filters nothing — so behaviour is exactly as before for anyone who hasn't configured it. A missing profile must never start deleting real contacts.

The new parameter is optional and defaults to the profile-derived set, so the exported contract is unchanged for existing callers.

## Tests

`tests/contacts-exclude-self.test.mjs` — 6 assertions: the self-mention, a real counterparty, a note containing **both** (only the counterparty survives), case-insensitivity, the unconfigured case behaving as before, and an absent profile not throwing.

```
node test-all.mjs   5316 passed
```

The 3 failures in that run (`PDF manifest`, `application-artifacts`, `repo path resolved to ""`) are **pre-existing on `main`** and unrelated — verified by stashing and re-running: `5310 passed, 3 failed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up contact extraction now recognizes the candidate’s primary and alternate email addresses.
  * Candidate-owned email addresses are excluded from extracted contacts, including case-insensitive matches.
  * Added profile guidance for configuring alternate email addresses.

* **Bug Fixes**
  * Prevented self-references from being mistaken for external contacts.
  * Preserved existing behavior when identity information is unavailable or unreadable.
  * Continued extracting valid external contacts from mixed communications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->