### PR TITLE
fix(verify): a check that could not run is a failure, not a warning

### DIFF
--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -443,7 +443,12 @@ let syncResult;
 try {
   syncResult = checkTrackerSync({ appsFile: APPS_FILE });
 } catch (err) {
-  warn(`Sync check could not run: ${err.message}`);
+  // A check that could not RUN is a failed check, not a warning. warn() does not affect the exit
+  // code, so a throw here made verify-pipeline print a notice and still exit 0 — and to anything
+  // reading the exit status (CI, a cron wrapper, a pre-push hook) that is indistinguishable from
+  // the invariant holding. We do not know whether the tracker is in sync; we know we failed to
+  // look. The honest report is failure.
+  error(`Sync check could not run — the tracker was NOT verified: ${err.message}`);
 }
 
 if (syncResult) {


### PR DESCRIPTION
The tracker-sync check is wrapped in `try/catch` and reports a throw via `warn()`:

```js
try {
  syncResult = checkTrackerSync({ appsFile: APPS_FILE });
} catch (err) {
  warn(`Sync check could not run: ${err.message}`);
}
```

`warn()` increments `warnings`, and the script ends with `process.exit(errors > 0 ? 1 : 0)` — so warnings never affect the exit code.

**When that check throws, `verify-pipeline` prints a notice and still exits 0.** To anything reading the exit status — CI, a cron wrapper, a pre-push hook — that is indistinguishable from the invariant holding. We don't know whether the tracker is in sync; we know we *failed to look*, and those aren't the same result.

## How I found it

A fork was calling `checkTrackerSync` **with no import at all**. `verify-pipeline` printed `Sync check could not run: checkTrackerSync is not defined` on every single run and exited green, so nothing surfaced it — the check sat dead for an unknown period while the pipeline reported healthy. The bug was only caught by reading the output by eye, which is exactly what an exit code exists to make unnecessary.

## The change

One line: `warn()` → `error()` on that catch path, with a message naming what was *not* verified.

## Worth flagging before merging

This **does** change exit-code behaviour for anyone currently throwing there. That's the point — but it means a pipeline that was silently passing may start failing. I think that's the correct direction (a dead check reporting green is the worse failure), and the message names the cause so it isn't mysterious.

## No test, deliberately

Upstream has no `verify-pipeline` suite to extend, and I couldn't write an honest one: every fixture malformed enough to make `checkTrackerSync` throw also trips an earlier check, so the process would exit 1 for the wrong reason and the test would pass whether or not the fix were present. I verified that empirically rather than assuming it — both patched and unpatched runs exited 1 on each fixture I tried.

Manual repro: make `checkTrackerSync` throw (e.g. temporarily `throw new Error('x')` at the top of it) and run `node verify-pipeline.mjs` on an otherwise clean tracker. Before: `⚠️`, exit 0. After: `❌`, exit 1.

```
node test-all.mjs   5310 passed
```

The 3 failures (`PDF manifest`, `application-artifacts`, `repo path resolved to ""`) are pre-existing on `main` and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline verification now correctly reports synchronization failures as errors.
  * Verification exits with a failure status when synchronization cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->