### PR TITLE
fix(web): stop killing evaluate runs at 285s and misreporting the kill (#3124)

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -6,7 +6,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveCli } from "@/lib/clis";
-import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr } from "@/lib/run-cli-support.mjs";
+import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr, killMsForKind, timeoutMessage } from "@/lib/run-cli-support.mjs";
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
@@ -205,8 +205,19 @@ export async function POST(req: Request) {
       // generate-pdf.mjs mid-render. 600s agent / ~200s render is ample —
       // a Chromium PDF render normally takes low tens of seconds even with a
       // cold Playwright launch.
-      const killMs = kind === "pdf" ? 600_000 : 285_000;
+      // pdf keeps 600s because its render+mark phase runs AFTER this timer; a
+      // plain evaluate has no such phase, so it can use almost the whole 800s
+      // budget. 285s was cutting real evaluations off mid-run — reading the mode
+      // and profile, fetching the posting, ~25 Bash calls and a few web searches
+      // routinely run past it — and the SIGTERM then surfaced as "didn't save a
+      // report" (see the close handler), blaming the CLI for a limit we imposed
+      // (#3124). 780s leaves ~20s under maxDuration for a graceful shutdown.
+      const killMs = killMsForKind(kind);
+      // Set by the killer so the close handler can tell "we timed it out" apart
+      // from "the CLI exited on its own" — different failures, different message.
+      let killedByTimeout = false;
       killer = setTimeout(() => {
+        killedByTimeout = true;
         try { child.kill("SIGTERM"); } catch { /* ignore */ }
       }, killMs);
       // Declared before send() so send() can clear it the moment it sees the
@@ -380,6 +391,19 @@ export async function POST(req: Request) {
         // run could still start a brand-new render (and re-touch the tracker)
         // after the stream — and its writeToken guard — is already gone.
         if (closed) return;
+        // A timeout is the ROOT cause behind every "no report / not clean"
+        // symptom the gates below test, so classify it FIRST, for any kind.
+        // Otherwise a run we cut off at the time limit reads as "the CLI couldn't
+        // save a report" and sends the user to re-check a CLI that was working
+        // fine (#3124). code is null here (killed by signal), which the gates
+        // would read as a generic non-clean exit.
+        if (killedByTimeout) {
+          send({
+            type: "error",
+            msg: timeoutMessage(killMs, kind),
+          });
+          return close();
+        }
         // A final JSONL line with no trailing newline stays in `buf` forever
         // otherwise — flush it through the same parser so the usage/result event it
         // usually carries (the last one of a run) isn't lost. Ahead of the pdf branch,

--- a/web/src/lib/run-cli-support.mjs
+++ b/web/src/lib/run-cli-support.mjs
@@ -340,3 +340,22 @@ export function hasNewCompletedReport(beforeEntries, afterEntries) {
   }
   return false;
 }
+
+// Graceful-SIGTERM budget (ms) for a run, kept safely under the route's 800s
+// maxDuration. pdf reserves headroom for its post-agent render+mark phase; a
+// plain evaluate has no such phase, so it gets nearly the whole budget. The old
+// 285s evaluate floor killed real evaluations mid-run — ~25 Bash calls plus web
+// searches routinely run longer — and the kill then misreported as "didn't save
+// a report" (#3124).
+export const RUN_MAX_DURATION_S = 800;
+export function killMsForKind(kind) {
+  return kind === "pdf" ? 600_000 : 780_000;
+}
+
+// Message for a run the route stopped at its own time limit. It names the limit,
+// offers a re-run / Claude Code, and DELIBERATELY never says the CLI "didn't save
+// a report": a timeout and a CLI that couldn't write are different failures, and
+// blaming the CLI sends the user to re-check the wrong thing (#3124).
+export function timeoutMessage(killMs, kind) {
+  return `This run passed the ${Math.round(killMs / 1000)}s time limit and was stopped before it could finish — re-run it, or run a very long ${kind} on Claude Code directly. The CLI was working; we cut it off, so it isn't recorded as a result.`;
+}

--- a/web/tests/lib/run-cli-support.test.mjs
+++ b/web/tests/lib/run-cli-support.test.mjs
@@ -483,3 +483,23 @@ test("the fallback still catches every real failure it caught before", () => {
     assert.equal(isFatalGenericStderr(line), true, `real failure no longer detected: ${line}`);
   }
 });
+
+// #3124: evaluate runs were killed at 285s (well under the 800s maxDuration) and
+// the kill was then misreported as "didn't save a report", blaming the CLI for a
+// limit the route imposed. These guard the budget and the honest message.
+import { killMsForKind, timeoutMessage, RUN_MAX_DURATION_S } from "../../src/lib/run-cli-support.mjs";
+
+test("evaluate's kill budget gives real headroom, not the old 285s floor (#3124)", () => {
+  const ms = killMsForKind("evaluate");
+  assert.ok(ms > 285_000, `evaluate must exceed the 285s that killed real runs, got ${ms}ms`);
+  assert.ok(ms < RUN_MAX_DURATION_S * 1000, "must stay under maxDuration so the SIGTERM is graceful, not a hard cutoff");
+  assert.equal(killMsForKind("pdf"), 600_000, "pdf keeps its post-agent render headroom");
+  assert.equal(killMsForKind("fix-portal"), killMsForKind("evaluate"), "non-pdf kinds share the evaluate budget");
+});
+
+test("a timed-out run reads as a timeout, never as 'didn't save a report' (#3124)", () => {
+  const msg = timeoutMessage(780_000, "evaluate");
+  assert.match(msg, /780s time limit/, "the message names the limit it hit");
+  assert.match(msg, /re-run|Claude Code/i, "it offers a next step");
+  assert.doesNotMatch(msg, /didn't save a report/i, "a timeout must not be blamed on the CLI's ability to write");
+});


### PR DESCRIPTION
Closes #3124.

## The bug

An evaluate run does minutes of real work — reading the mode + profile, fetching the posting, ~25 Bash calls, a few web searches — but `web/src/app/api/run/route.ts` fired a SIGTERM **killer at 285s** while the route's `maxDuration` is **800s**. A real evaluation routinely runs past 285s, so it was cut off mid-run: no closing narration, no report.

Then the kill was **misreported**. The child exits on a signal (`code === null`), which the close handler reads as a generic non-clean exit; with no report written, it surfaced *"This evaluation didn't save a report… verified on Claude Code."* — blaming the CLI's ability to write for a limit **we** imposed, and sending the user to re-check something that was working fine. (@nikolaysm's report nailed this.)

## The fix

1. **evaluate's kill budget goes 285s → 780s.** pdf keeps 600s because its render+mark phase runs *after* the timer; a plain evaluate has no such phase, so it can use almost the whole 800s budget (780s leaves ~20s for a graceful SIGTERM under `maxDuration`). There was no local reason for the 285s floor.
2. **A `killedByTimeout` flag, classified FIRST.** A timeout is the root cause behind every "no report / not clean" symptom the later gates test, so the close handler now checks it before anything else, for any kind. Its message names the limit and offers a re-run / Claude Code, and **deliberately never says "didn't save a report"** — a timeout and a CLI that couldn't write are different failures.

`killMsForKind` and `timeoutMessage` are extracted to `run-cli-support.mjs` (beside the other run-route logic) so both are unit-tested: the evaluate budget must exceed 285s and stay under maxDuration, and the timeout message must not read as "didn't save a report".

## Verification
- Full web suite **338/0**, `tsc --noEmit` clean.
- The two guards are red-by-construction against the old values (285s / the old message).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run timeout handling with distinct limits for evaluation and PDF runs.
  * Timeout failures now display clear, run-specific messages and recommended next steps.
  * Prevented timed-out runs from being incorrectly reported as failed to save a report.

* **Tests**
  * Added coverage for timeout limits and user-facing timeout messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->