### PR TITLE
feat(community): PR adoption ladder for quiet PRs

### DIFF
--- a/.github/workflows/pr-adoption.yml
+++ b/.github/workflows/pr-adoption.yml
@@ -1,0 +1,117 @@
+name: 'PR adoption ladder'
+
+# Advances the adoption ladder for PRs whose author has gone quiet after a
+# review round. A maintainer opts a PR in by applying `adoption/track` (the
+# clock never starts by itself); from there this workflow handles the two
+# mechanical check-ins, and hands the final step back to a human:
+#
+#   adoption/track   -> post a friendly ping,        add adoption/pinged
+#   +14d of silence  -> post the adoption notice,    add adoption/warned
+#   +14d of silence  -> add adoption/ready           (no comment; a maintainer
+#                       closes with a personal note and opens the companion
+#                       `adoptable` issue - bots never close PRs here)
+#
+# Any activity from the PR author at any step resets the ladder completely
+# (all adoption/* labels removed, nothing posted). The policy is public:
+# CONTRIBUTING.md -> "Adopting an abandoned PR".
+
+on:
+  schedule:
+    - cron: '47 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  ladder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const DAY = 24 * 60 * 60 * 1000;
+            const STEP_DAYS = 14;
+            const { owner, repo } = context.repo;
+
+            const tracked = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'adoption/track', per_page: 100,
+            });
+
+            for (const issue of tracked) {
+              if (!issue.pull_request) continue;
+              const n = issue.number;
+              const author = issue.user.login;
+              const labels = issue.labels.map(l => l.name);
+              const has = (name) => labels.includes(name);
+
+              // Anchor = the most recent adoption/* label event. Author
+              // activity is only meaningful relative to the last ladder step.
+              const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner, repo, issue_number: n, per_page: 100,
+              });
+              const labelEvents = timeline.filter(e =>
+                e.event === 'labeled' && e.label && e.label.name.startsWith('adoption/'));
+              if (labelEvents.length === 0) continue;
+              const anchor = new Date(labelEvents[labelEvents.length - 1].created_at);
+
+              // --- Author activity since the anchor resets the ladder. ---
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: n, since: anchor.toISOString(), per_page: 100,
+              });
+              const authorCommented = comments.some(c => c.user.login === author);
+
+              const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
+                owner, repo, pull_number: n, since: anchor.toISOString(), per_page: 100,
+              });
+              const authorReviewed = reviewComments.some(c => c.user.login === author);
+
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner, repo, pull_number: n, per_page: 100,
+              });
+              const lastCommitAt = commits.length
+                ? new Date(commits[commits.length - 1].commit.committer.date) : null;
+              const authorPushed = lastCommitAt && lastCommitAt > anchor;
+
+              if (authorCommented || authorReviewed || authorPushed) {
+                for (const name of labels.filter(l => l.startsWith('adoption/'))) {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: n, name })
+                    .catch(() => {});
+                }
+                core.info(`#${n}: author active again, ladder reset`);
+                continue;
+              }
+
+              const daysSinceAnchor = (Date.now() - anchor.getTime()) / DAY;
+
+              if (!has('adoption/pinged')) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: n, body:
+                  `👋 Checking in, @${author}: it's been quiet here for a while since the last review round. ` +
+                  `This PR is still yours and there's no rush - this is just a nudge in case it fell off your radar. ` +
+                  `If life got in the way and you'd rather hand it off, say the word and we'll take good care of it. ` +
+                  `If we don't hear back, we'll check in once more in two weeks.` });
+                await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['adoption/pinged'] });
+                core.info(`#${n}: pinged`);
+                continue;
+              }
+
+              if (!has('adoption/warned') && daysSinceAnchor >= STEP_DAYS) {
+                await github.rest.issues.createComment({ owner, repo, issue_number: n, body:
+                  `@${author}, second check-in, and this one comes with a plan attached so nothing here is a surprise. ` +
+                  `If we don't hear from you within **two weeks**, we'll open this work up for adoption: the PR gets closed ` +
+                  `by a maintainer (with thanks, not by a bot), and a companion issue will point another contributor at your ` +
+                  `branch to finish it. **Your commits and your credit travel with the work either way**: the adopter builds ` +
+                  `on your commits or credits you with \`Co-authored-by\`, and you stay the original author. ` +
+                  `And if you come back later, the work is still yours to reclaim - just say so on the issue. ` +
+                  `Details: CONTRIBUTING.md, "Adopting an abandoned PR".` });
+                await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['adoption/warned'] });
+                core.info(`#${n}: warned`);
+                continue;
+              }
+
+              if (has('adoption/warned') && !has('adoption/ready') && daysSinceAnchor >= STEP_DAYS) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: n, labels: ['adoption/ready'] });
+                core.info(`#${n}: ready for maintainer close + adoptable issue`);
+              }
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,5 +30,8 @@ jobs:
           days-before-pr-close: 14
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-issue-labels: 'pinned,security,roadmap'
-          exempt-pr-labels: 'pinned,security'
+          exempt-issue-labels: 'pinned,security,roadmap,adoptable'
+          # adoption/* PRs are governed by the adoption ladder (pr-adoption.yml),
+          # which pings, warns, and hands the close to a human. Two clocks on
+          # one PR would race each other.
+          exempt-pr-labels: 'pinned,security,adoption/track,adoption/pinged,adoption/warned,adoption/ready'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,18 @@ There's a clear path here — we promote people who show up:
 
 We credit contributors publicly and invite high-signal folks up the ladder. Want to help more? Just say so in an issue.
 
+## Adopting an abandoned PR
+
+Life happens: a PR gets a review, the author moves on, and useful work strands at 80% done. We don't let a bot bury it, and we don't let it rot. Instead it goes through a public, predictable ladder:
+
+1. **Two weeks of silence** after a review round, and a maintainer opts the PR into the ladder (`adoption/track`). You get a friendly ping: still yours, no rush.
+2. **Two more weeks**, a second check-in with the plan spelled out: two further weeks of silence and the work opens up for adoption.
+3. **Only then** a maintainer (never a bot) closes the PR with thanks and opens a companion issue labeled **`adoptable`**, pointing at the branch and listing exactly what's left to do.
+
+**Adopting one** is one of the highest-value first contributions you can make: the diff is mostly done, the review is already written, and the remaining work is scoped. Open a *new* PR that carries the original commits (git preserves the author's credit), or add a `Co-authored-by:` trailer for them. Both of you end up credited: the original author for the work, you for landing it.
+
+**If you're the original author coming back**: the work stays yours to reclaim at any point before someone else finishes it. Just say so on the issue. Any comment or push from you at any ladder step resets the clock completely.
+
 ## Scope: the core vs. the shared layer
 
 career-ops core is **local-first and human-in-the-loop** by design — it runs on your machine and drafts applications for *you* to review and submit. Centralized infrastructure — hosted job aggregation, a shared matching service, proxies or Workers the project would operate — is **not part of the core**: it's heavier than a free local tool should carry, and it's where the project is headed as a *separate, opt-in service*. See the direction here: **[Where career-ops is going](https://github.com/santifer/career-ops/discussions/904)**.


### PR DESCRIPTION
Work that strands at 80% done deserves better than a bot close. Research on 20 large OSS projects ([arXiv 2305.18150](https://arxiv.org/abs/2305.18150)) measured what stale bots actually do: clear backlog at first, then a considerable drop in active contributors. This replaces the bot guillotine with a public, predictable ladder for PRs a maintainer opts in:

1. `adoption/track` (maintainer applies after ~2 quiet weeks) → the workflow posts a friendly ping
2. +14 days of silence → adoption notice: two more weeks, then the work opens for adoption, credit preserved either way
3. +14 days → `adoption/ready`: a **maintainer** closes with thanks and opens a companion `adoptable` issue pointing at the branch with what's left

Any comment or push from the author at any step resets the ladder completely and silently.

**What ships:**
- `.github/workflows/pr-adoption.yml`: daily ladder advance via github-script; never closes anything
- `CONTRIBUTING.md`: new "Adopting an abandoned PR" section: the ladder, how to adopt (new PR carrying original commits, or `Co-authored-by`), and the original author's right of return
- `stale.yml`: `adoption/*` PRs exempted so the two clocks never race; `adoptable` issues exempted too
- Labels `adoption/track|pinged|warned|ready` + `adoptable` (already created)

Adoptable PRs become the best kind of first issue: scoped, mostly done, review already written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an adoption process for stalled pull requests, with reminders, warning notices, and a ready-for-adoption status.
  * Automatically resets adoption tracking when the original author resumes activity.
  * Prevented adoption-tracked pull requests and adoptable issues from being marked stale.

* **Documentation**
  * Added guidance for adopting abandoned pull requests, including contributor credit and author reclaim rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->