### PR TITLE
docs(title-filter): the side `stem:` cannot close, and what `word:` costs to close it

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -314,6 +314,24 @@ title_filter:
   # plain form. That side has no prefix, deliberately — the plain default already
   # serves it, and nothing has been measured that the pair cannot express.
   #
+  # Nor does it close the MIRROR case, which is worth knowing before reaching for
+  # it: a keyword that genuinely STARTS the unwanted word. "Solana" does begin
+  # "Solanaceae", "Neutron" begins "Neutronics", "DeFi" begins "Defined" — `stem:`
+  # asks for the left boundary only, so it matches all three on purpose, and only
+  # `word:` closes them. Measured over the 675 observed titles in
+  # tests/fixtures/title-recall-corpus.json, that is where the two prefixes divide:
+  #
+  #   stem: closes      Zero Trust Engineer, NASTAR Course Setter        4 titles
+  #   only word: closes Solanaceae, Neutronics, Software Defined (x3),
+  #                     Product Definer, Product Definition              7 titles
+  #
+  # And `word:` is not free on that same corpus: it also drops 4 titles you
+  # probably wanted — "Engineering Manager, Smart Contracts" and "Engineering
+  # Lead - Crypto and DeFi" among them — because it forbids the suffix too. So
+  # reach for `stem:` when a keyword lands MID-word, and for `word:` when it lands
+  # at the START of a word you did not mean, knowing that costs the plural and
+  # compound forms as well.
+  #
   # Use " + " (with spaces) to require SEVERAL terms in any order:
   #
   #   - "director + engineering"   matches "Director of Engineering",

--- a/tests/title-stem-prefix.test.mjs
+++ b/tests/title-stem-prefix.test.mjs
@@ -69,6 +69,26 @@ if (compileKeyword('automation')(compound) && !compileKeyword('stem:automation')
   fail('the compound case behaves differently from what the template documents');
 }
 
+// The MIRROR case, and the one a reader is likelier to hit: a keyword that
+// genuinely STARTS the unwanted word. `stem:` asks for the LEFT boundary only,
+// so it matches these by design and only `word:` closes them. Asserting both
+// halves per title -- stem: still matches, word: does not -- is what makes this
+// discriminating: an implementation that anchored both sides would pass the
+// first half and fail the second. Both titles are observed corpus entries.
+const startsTheWord = [
+  ['solana', 'Genomic Breeder (Solanaceae)'],
+  ['neutron', 'Senior Neutronics Engineer - Isotope Production'],
+];
+const unclosed = startsTheWord.filter(([kw, title]) => {
+  const l = title.toLowerCase();
+  return !(compileKeyword(`stem:${kw}`)(l) && !compileKeyword(`word:${kw}`)(l));
+});
+if (unclosed.length === 0) {
+  pass('stem: does not close a keyword that STARTS the unwanted word — only word: does');
+} else {
+  fail(`the start-of-word case differs from what the template documents: ${JSON.stringify(unclosed)}`);
+}
+
 // ── 3. Shared plumbing: a bare prefix, escaping, AND-groups ──────────
 if (compileKeyword('stem:')('customer success manager') === false) {
   pass('a bare `stem:` matches nothing rather than everything');


### PR DESCRIPTION
Follow-up to #3225, writing down the bound @santifer asked for on #3103:

> `stem:` fixes the Zero Trust half of your eleven and not the Solanaceae half — there the keyword genuinely starts the word, so those need `word:`. Your three-row table already tells a user which case they're in; saying it out loud saves the next person the experiment.

#3225 merged before that landed, so this is the paragraph, plus the assertion that keeps it true.

## What was missing

The template documented **one** side `stem:` does not cover — a keyword that ENDS a compound, `Automation` inside `Gebäudeautomation`, served by the plain form. It did not document the mirror, which is the side a reader is likelier to hit: a keyword that **starts** the unwanted word. `stem:` asks for the left boundary only, so `Solanaceae`, `Neutronics` and `Defined` match on purpose, and only `word:` closes them.

That is derivable from the three-row table — `stem:agent` still matching `Agentforce` says it — but deriving it costs the reader an experiment, which is the thing you asked to spare them.

## Re-measured rather than quoted

Numbers taken again on merged `main` through `buildTitleFilter`, not through a second copy of the rule, over the 675 observed titles in `tests/fixtures/title-recall-corpus.json`:

```
stem: closes        Zero Trust Engineer x2, NASTAR x2                 4 titles
only word: closes   Solanaceae, Neutronics, Software Defined x3,
                    Product Definer, Product Definition               7 titles
word: also drops    Smart Contracts x3, Engineering Lead - Crypto
                    and DeFi                                         4 titles
                    ...real roles, which is why it is not the default
```

4 + 7 is the eleven; the last row is the four the earlier table charged `word:` with, so the two halves reconcile against the fixture rather than against my own notes.

## The assertion

Section 2 of `tests/title-stem-prefix.test.mjs` pinned the compound side rather than leaving a reader to find it. This pins the other side the same way, and asserts **both halves per title** — `stem:` still matches, `word:` does not — so an implementation that anchored both sides fails it instead of passing half of it.

Verified by mutation: making `stemPattern` two-sided turns the new check red and names both titles.

```
❌ the start-of-word case differs from what the template documents:
   [["solana","Genomic Breeder (Solanaceae)"],
    ["neutron","Senior Neutronics Engineer - Isotope Production"]]
```

Both titles are observed corpus entries, so assertion 4's synthetic-marking rule is unaffected.

## Verification

No behaviour change — the shipped filter is untouched and still uses no prefix, which the template's own last check confirms.

```
tests/title-stem-prefix.test.mjs   9/9
templates/portals.example.yml      parses; positive=37 negative=35
node test-all.mjs                  5336 passed, 1 failed
```

That one failure is `tests/plugin-symlink-discovery.test.mjs` dying with EPERM, which is #3259 and is unrelated to this change — it is the default-Windows bug #3267 fixes, and this branch is off `main`, so it carries it. On a machine that can create symlinks the run is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added examples and guidance explaining how `stem:` and `word:` title filters handle mirror-case matching, suffixes, and compound words.

* **Tests**
  * Added coverage for keywords appearing at the start of unwanted words, validating the expected differences between `stem:` and `word:` matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->