### PR TITLE
fix(followup): stop truncating plus-addressed emails at the plus

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -556,7 +556,13 @@ export function isRetired(cleared, lastFollowupDate) {
 // Emitted shape is `{ name, email, channel }`. `email` stays first-class (and
 // remains non-null for email contacts) so existing consumers keep working;
 // `channel` is additive.
-const EMAIL_RE = /[\w.-]+@[\w.-]+\.\w+/g;
+// `+` must be in the local part. \w is [A-Za-z0-9_], so the previous class silently TRUNCATED a
+// plus-addressed address at the plus — `mayank+6a88…@reply.cutshort.io` was captured as
+// `6a88…@reply.cutshort.io`, a different mailbox that would bounce. Recruiting platforms route
+// replies through exactly this form (CutShort, Greenhouse, Lever, Workable all use
+// `name+token@reply.domain`), so the addresses most worth capturing were the ones being corrupted
+// — and corrupted into something that still looks like a valid address, so nothing notices.
+const EMAIL_RE = /[\w.+%-]+@[\w.-]+\.\w+/g;
 
 // Name-shaped contacts are gated on an explicit outreach verb or role word, so
 // a capitalized company name ("Acme Corp") can never be mistaken for a person.

--- a/tests/contacts-plus-addressing.test.mjs
+++ b/tests/contacts-plus-addressing.test.mjs
@@ -1,0 +1,45 @@
+// tests/contacts-plus-addressing.test.mjs
+//
+// EMAIL_RE used \w for the local part, and \w is [A-Za-z0-9_] — so `+` terminated the match and a
+// plus-addressed address was silently TRUNCATED: `recruiter+a1b2…@reply.cutshort.io` was captured as
+// `a1b2…@reply.cutshort.io`. A different mailbox, it would bounce, and it still looks like a valid
+// address — so nothing downstream could notice that the tracker was showing an unreachable contact.
+//
+// Recruiting platforms route replies through exactly this form (CutShort, Greenhouse, Lever,
+// Workable all use `name+token@reply.domain`), so the addresses being corrupted were the ones that
+// actually reach a human.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nextractContacts — plus-addressed relays (#3283)');
+try {
+  const { extractContacts } = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+  const first = (notes) => extractContacts(notes)[0]?.email;
+
+  const cases = [
+    ['CutShort-style reply relay', 'reply to recruiter+a1b2c3d4e5f60718293a4b5c6d7e8f90@reply.cutshort.io', 'recruiter+a1b2c3d4e5f60718293a4b5c6d7e8f90@reply.cutshort.io'],
+    ['Greenhouse-style token', 'mail jobs+ref123@greenhouse.io', 'jobs+ref123@greenhouse.io'],
+    ['plain address unchanged', 'recruiter dana@acme.example replied', 'dana@acme.example'],
+    ['dots and dashes still fine', 'contact first.last-name@sub.acme.example', 'first.last-name@sub.acme.example'],
+  ];
+  for (const [label, notes, want] of cases) {
+    const got = first(notes);
+    if (got === want) pass(`${label}: ${want}`);
+    else fail(`${label}: expected ${want}, got ${got}`);
+  }
+
+  // Assert the WHOLE expected address, not merely "not the truncated form". A !== check against
+  // the broken value also passes for undefined, for '', and for any other wrong-but-different
+  // address — so it would keep reporting green while the extractor returned nothing at all.
+  const got = first('reply to recruiter+a1b2@reply.cutshort.io');
+  if (got === 'recruiter+a1b2@reply.cutshort.io') {
+    pass('the plus-addressed relay is captured whole');
+  } else if (got === 'a1b2@reply.cutshort.io') {
+    fail('address was truncated at the plus again');
+  } else {
+    fail(`expected recruiter+a1b2@reply.cutshort.io, got ${JSON.stringify(got)}`);
+  }
+} catch (err) {
+  fail(`plus-addressing suite threw: ${err.message}`);
+}


### PR DESCRIPTION
`EMAIL_RE` uses `\w` for the local part, and `\w` is `[A-Za-z0-9_]` — so a `+` terminates the match and the address is silently **truncated**:

```
recruiter+a1b2c3d4e5f60718293a4b5c6d7e8f90@reply.cutshort.io
       ↓ captured as
       a1b2c3d4e5f60718293a4b5c6d7e8f90@reply.cutshort.io
```

That's a different mailbox. It would bounce. And it still looks like a perfectly valid address, so nothing downstream can notice — the tracker displays a contact that can never be reached, and a follow-up sent to it fails silently.

## Why this one matters more than it looks

Recruiting platforms route replies through exactly this form. CutShort, Greenhouse, Lever and Workable all use `name+token@reply.domain`. So **the addresses being corrupted are precisely the ones that reach a human** rather than a `no-reply` box — the follow-up module's whole purpose.

Found live on a real tracker: the highest-scoring row in the pipeline had an open screening questionnaire, its only repliable address was a CutShort relay, and the stored contact was the truncated form. The one contact that mattered most was the one that was wrong.

## Test

`tests/contacts-plus-addressing.test.mjs` asserts the **broken** output specifically, not just the correct one. A regression here produces something email-shaped, so an assertion that only checked "looks like an email" would pass straight through it.

```
node test-all.mjs   5361 passed
```

The 3 failures (`PDF manifest`, `application-artifacts`, `repo path resolved to ""`) are pre-existing on `main` and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Email extraction now preserves addresses containing `+` or `%` in the local part.
  - Prevents truncation of plus-addressed mailboxes, including relay-format and punctuation-based addresses.

- **Tests**
  - Added coverage for plus-addressed emails, ordinary addresses, relay formats, punctuation, and truncation prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
