### PR TITLE
test(readme): the HITL marker check never reads what the marker anchors

### DIFF
--- a/tests/readme-hitl-markers.test.mjs
+++ b/tests/readme-hitl-markers.test.mjs
@@ -59,18 +59,36 @@ for (const file of readmes) {
   // still in place and this suite still green. Checking README.md is what
   // closes that door; the marker check continues to carry the translations.
   if (file === 'README.md') {
-    // Strip the comment before scanning: the marker QUOTES the hedges it
+    // Remove the comment before scanning: the marker QUOTES the hedges it
     // forbids, so a scan of the raw line matches the anchor's own warning
     // text and fails a correctly-worded row.
-    const prose = line.replace(/<!--[\s\S]*?-->/g, '');
-    if (/never submits an application/i.test(prose)) {
+    //
+    // Sliced at the marker's own bounds rather than stripped with
+    // /<!--[\s\S]*?-->/g. CodeQL flags that pattern as incomplete
+    // multi-character sanitization, and the objection holds here: an unclosed
+    // comment leaves a bare `<!--` sitting in `prose`, so a row whose comment
+    // lost its `-->` would be scanned with the anchor text still in it and the
+    // hedge check would fail for a reason that has nothing to do with hedging.
+    // The marker's position is already known, so exact bounds are available —
+    // and an unclosed comment becomes its own named failure instead.
+    const mStart = line.indexOf(MARKER);
+    const mEnd = line.indexOf('-->', mStart);
+    // Not `continue` — that would skip the A-H check further down for this
+    // file, hiding a second problem behind the first.
+    const prose = mEnd === -1 ? null : line.slice(0, mStart) + line.slice(mEnd + '-->'.length);
+    if (prose === null) {
+      fail(`${file}: the HITL marker comment is never closed with -->`);
+    } else if (/never submits an application/i.test(prose)) {
       pass(`${file}: the row states the prohibition in absolute terms`);
     } else {
       fail(`${file}: the HITL row no longer says "never submits an application"`);
     }
     const HEDGES = /\b(usually|generally|normally|typically|by default|unless|without your permission|automatically|by itself)\b/i;
-    const hedge = prose.match(HEDGES);
-    if (hedge) {
+    const hedge = prose === null ? null : prose.match(HEDGES);
+    if (prose === null) {
+      // Already reported above; do not also claim the row is hedge-free, which
+      // would be a green tick on a line that was never successfully read.
+    } else if (hedge) {
       fail(`${file}: the HITL row hedges with "${hedge[0]}" -- the guarantee is absolute, not a default`);
     } else {
       pass(`${file}: no hedge in the guarantee row`);

--- a/tests/readme-hitl-markers.test.mjs
+++ b/tests/readme-hitl-markers.test.mjs
@@ -49,6 +49,34 @@ for (const file of readmes) {
     pass(`${file}: marker present, inside its table row`);
   }
 
+  // The marker is an anchor, and until now nothing read what it anchors: a
+  // README whose row had been hedged still passed, because the comment was
+  // present and inside a table row. That is the wrong half to check on its own.
+  //
+  // The hedge cannot be caught in 17 languages, but it does not have to be.
+  // Every translation is derived from the English source, so a hedge that
+  // enters there propagates to all of them faithfully -- with every marker
+  // still in place and this suite still green. Checking README.md is what
+  // closes that door; the marker check continues to carry the translations.
+  if (file === 'README.md') {
+    // Strip the comment before scanning: the marker QUOTES the hedges it
+    // forbids, so a scan of the raw line matches the anchor's own warning
+    // text and fails a correctly-worded row.
+    const prose = line.replace(/<!--[\s\S]*?-->/g, '');
+    if (/never submits an application/i.test(prose)) {
+      pass(`${file}: the row states the prohibition in absolute terms`);
+    } else {
+      fail(`${file}: the HITL row no longer says "never submits an application"`);
+    }
+    const HEDGES = /\b(usually|generally|normally|typically|by default|unless|without your permission|automatically|by itself)\b/i;
+    const hedge = prose.match(HEDGES);
+    if (hedge) {
+      fail(`${file}: the HITL row hedges with "${hedge[0]}" -- the guarantee is absolute, not a default`);
+    } else {
+      pass(`${file}: no hedge in the guarantee row`);
+    }
+  }
+
   // Wholesale-drift control: every README describes the report as A-H. This
   // deliberately does NOT try to catch phrasing variants (French and Arabic
   // write ranges with a preposition, "de A à F" / "من A إلى F", which is how


### PR DESCRIPTION
`tests/readme-hitl-markers.test.mjs` (added in c9cae10) verifies that the HITL marker is present and that it sits inside its table row. It never checks the row's **text**.

So a README whose guarantee had been hedged passes today: the comment is there, it's in a row, green.

That's the wrong half to check on its own. The marker's own words are an instruction — *do not add "automatically", "by itself", "without your permission"* — and nothing reads the sentence it is attached to.

### Why asserting on the English file is enough

The comment rightly notes the row label is translated ("Humain dans la Boucle", "人机协同"), so English can't be grepped across the family. Agreed — and it doesn't need to be.

Every translation derives from the English source. A hedge entering `README.md` propagates to all 17 faithfully, with **every marker still in place** and this suite still green. That is the gap: the audit that motivated the marker found translations drifting away from a correct source, but the one file that would take all of them down at once is the file nothing asserts on.

Two assertions, `README.md` only. The marker check continues to carry the translations, unchanged.

### One subtlety worth naming

The marker quotes the hedges it forbids, so a scan of the raw line matches the anchor's own warning text and fails a correctly-worded row. The comment is stripped before scanning. I hit this in my own first draft, which is why it's called out in a comment rather than left for the next reader to rediscover.

### Verified

Each failure injected individually into the row, then reverted:

| Injected | Result |
|---|---|
| `never submits an application **by default**` | 1 failure |
| `never submits an application **automatically**` | 1 failure |
| `never submits an application **by itself**` | 1 failure |
| prohibition replaced entirely | 1 failure |

`README.md` restored byte-identical afterwards (`git diff origin/main -- README.md` empty). The diff touches only `tests/`: +28 lines, no new dependencies. 37 assertions pass on a pristine checkout of this branch.

### How this was found

Porting this test downstream. My fork carries one README rather than 17, so the `>= 17` count assertion couldn't port as-is — and reading closely enough to adapt it is what surfaced that the rest of the file never checks the anchored text. (The fork also turned out to have no HITL row in its README at all, which is its own problem and fixed on my side.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation for the English README’s human-in-the-loop statement, including the requirement that it explicitly says the system never submits an application.
  * Added checks for disallowed hedge terms and separately reports unclosed marker comments.
  * Preserved existing validation for marker placement and translated README files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->