### PR TITLE
test(harness): jd-similarity.test.mjs ran nowhere, and nothing would have said so

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -318,6 +318,7 @@ const scripts = [
   { name: 'company-funded.mjs --self-test', expectExit: 0 },
   { name: 'invite-match.mjs --self-test', expectExit: 0 },
   { name: 'invite-match.test.mjs', expectExit: 0 },
+  { name: 'jd-similarity.test.mjs', expectExit: 0 },
   { name: 'tracker-sync-check.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },

--- a/tests/root-suite-registration.test.mjs
+++ b/tests/root-suite-registration.test.mjs
@@ -1,0 +1,51 @@
+// tests/root-suite-registration.test.mjs — every root-level *.test.mjs must be
+// registered in test-all.mjs, because nothing discovers them.
+//
+// test-all.mjs auto-discovers tests/**/*.test.mjs (#1440) and the comment on
+// that function is explicit that discovery stops there: "root-level standalone
+// *.test.mjs files are never picked up". Nine such suites live at the repo root
+// and are named one by one in the `scripts` list instead. A list is a thing you
+// can forget, and it was forgotten: jd-similarity.test.mjs was added with 20
+// assertions and appeared in no runner at all — grep found it only in
+// CHANGELOG.md and in the script it tests. It passed the whole time, which is
+// the quiet half of this failure: an unrun suite reports nothing, so the repo
+// looked exactly as green without it as with it.
+//
+// The same shape in the sibling `test/` directory (singular) is #3247 and is
+// deliberately NOT asserted here: which mechanism should cover those five files
+// is an open design question in that thread, and a guard written now would pin
+// whichever answer I happened to prefer.
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\ntest-all.mjs — root-level suite registration');
+
+const harness = readFileSync(join(ROOT, 'test-all.mjs'), 'utf-8');
+const rootSuites = readdirSync(ROOT, { withFileTypes: true })
+  .filter((e) => e.isFile() && e.name.endsWith('.test.mjs'))
+  .map((e) => e.name)
+  .sort();
+
+// 1. A degenerate list would pass assertion 2 forever while guarding nothing.
+if (rootSuites.length > 0) {
+  pass(`${rootSuites.length} root-level suites found to check`);
+} else {
+  fail('no root-level *.test.mjs found — this guard can no longer detect an unregistered suite');
+}
+
+// 2. The registration itself. Substring rather than a parse of the `scripts`
+//    array on purpose: a suite reached by any mechanism at all — the list, an
+//    inline `node --test`, a future glob — names the file somewhere in the
+//    harness, and this guard is about "nothing runs it", not about which
+//    section does.
+const unregistered = rootSuites.filter((name) => !harness.includes(name));
+if (unregistered.length === 0) {
+  pass('every root-level *.test.mjs is named in test-all.mjs');
+} else {
+  fail(
+    `${unregistered.length} root-level suite(s) are never run — nothing in test-all.mjs names them:\n` +
+      unregistered.map((n) => `    ${n}`).join('\n') +
+      "\n  Add an entry to the `scripts` list: { name: '<file>', expectExit: 0 }",
+  );
+}

--- a/tests/root-suite-registration.test.mjs
+++ b/tests/root-suite-registration.test.mjs
@@ -34,14 +34,36 @@ if (rootSuites.length > 0) {
   fail('no root-level *.test.mjs found — this guard can no longer detect an unregistered suite');
 }
 
-// 2. The registration itself. Substring rather than a parse of the `scripts`
-//    array on purpose: a suite reached by any mechanism at all — the list, an
-//    inline `node --test`, a future glob — names the file somewhere in the
-//    harness, and this guard is about "nothing runs it", not about which
-//    section does.
-const unregistered = rootSuites.filter((name) => !harness.includes(name));
+// 2. The registration itself. Deliberately NOT a parse of the `scripts` array:
+//    a suite reached by any mechanism at all — that list, an inline
+//    `node --test`, a future glob — names the file, and the question here is
+//    "does anything run this", not "which section does".
+//
+//    A bare substring is too generous in the other direction, though. This file
+//    names jd-similarity.test.mjs in its own header, and test-all.mjs carries
+//    filenames in prose too, so a suite dropped from `scripts` while its name
+//    survived in a comment would still read as registered. Two narrowings close
+//    that without giving up the mechanism-agnostic part: comments do not count,
+//    and the name must sit inside quotes — which every real registration does
+//    and no prose mention does.
+const code = harness
+  .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+  .replace(/^\s*\/\/.*$/gm, ' '); // whole-line comments
+
+const QUOTES = new Set(["'", '"', '`']);
+/** True when `name` appears quoted in executable code, optionally behind a path. */
+function isRegistered(name) {
+  for (let i = code.indexOf(name); i !== -1; i = code.indexOf(name, i + 1)) {
+    const before = code[i - 1];
+    const after = code[i + name.length];
+    if (QUOTES.has(after) && (QUOTES.has(before) || before === '/')) return true;
+  }
+  return false;
+}
+
+const unregistered = rootSuites.filter((name) => !isRegistered(name));
 if (unregistered.length === 0) {
-  pass('every root-level *.test.mjs is named in test-all.mjs');
+  pass('every root-level *.test.mjs is named in executable code in test-all.mjs');
 } else {
   fail(
     `${unregistered.length} root-level suite(s) are never run — nothing in test-all.mjs names them:\n` +


### PR DESCRIPTION
A sibling of #3247, found while measuring it, and deliberately not a fix for it.

## `jd-similarity.test.mjs` runs nowhere

20 assertions, added alongside the script they cover, named in no runner at all:

```
grep -rn "jd-similarity" --include=*.mjs --include=*.md . | grep -v node_modules
  CHANGELOG.md:204,205,412     history
  jd-similarity.mjs:3,9,143    the script's own usage block
  (nothing in test-all.mjs)
```

`test-all.mjs` discovers `tests/**/*.test.mjs` and stops there on purpose — the comment on `discoverTests` says so — and the nine root-level suites are named one by one in the `scripts` list instead. This one never made the list.

It passes, and always did:

```
node jd-similarity.test.mjs
jd-similarity: 20 passed, 0 failed
```

That is the quiet half of this failure. An unrun suite reports nothing, so the repo read exactly as green without it as with it. No count, no summary line and no CI signal distinguishes "20 assertions passing" from "20 assertions absent" — which is the same observation §5 of the `scripts` list already makes in its own comment about the coverage check: *"which is how five unregistered files shipped."*

## The one-line fix is not the point

Registering it is one entry. The guard is what stops the next one:

`tests/root-suite-registration.test.mjs` asserts that every root-level `*.test.mjs` is named **somewhere** in `test-all.mjs`. It checks for the filename rather than parsing the `scripts` array, because the question is "does anything run this", not "which section does" — a suite reached by a future glob, or by an inline `node --test`, is fine by this guard and should be.

Assertion 1 pins the other edge: an empty root listing would satisfy assertion 2 forever while guarding nothing.

Verified by mutation — removing the registration line I just added:

```
❌ 1 root-level suite(s) are never run — nothing in test-all.mjs names them:
     jd-similarity.test.mjs
   Add an entry to the `scripts` list: { name: '<file>', expectExit: 0 }
```

## What this deliberately does not do

`test/` (singular) has the same disease — that is #3247, and I have left it alone. Which mechanism should cover those five files is an open design question in that thread, its author has said they intend to send the fix, and a guard written now would pin whichever answer I happened to prefer. I have posted a measurement there that bears on the choice, and nothing more.

## Verification

```
node test-all.mjs         5338 passed, 1 failed
                          (5336 before; +2 is this guard's own assertions)
harness section 5:        ✅ jd-similarity.test.mjs runs OK
```

The single failure is `tests/plugin-symlink-discovery.test.mjs` dying with EPERM. That is #3259, fixed in #3267, unrelated to this branch and present on `main` for anyone on a default Windows box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added the similarity test suite to the complete test run.
  - Added automated validation to detect root-level test suites that are not registered with the test harness.
  - Improved safeguards against incomplete test execution and overlooked test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->