### PR TITLE
fix(test): avoid regex comment sanitizer in HITL marker check

### DIFF
--- a/tests/readme-hitl-markers.test.mjs
+++ b/tests/readme-hitl-markers.test.mjs
@@ -59,10 +59,16 @@ for (const file of readmes) {
   // still in place and this suite still green. Checking README.md is what
   // closes that door; the marker check continues to carry the translations.
   if (file === 'README.md') {
-    // Strip the comment before scanning: the marker QUOTES the hedges it
-    // forbids, so a scan of the raw line matches the anchor's own warning
-    // text and fails a correctly-worded row.
-    const prose = line.replace(/<!--[\s\S]*?-->/g, '');
+    // Read only the row prose outside the exact marker comment. The marker
+    // QUOTES the hedges it forbids, so scanning the whole line would match the
+    // anchor's own warning text and fail a correctly-worded row.
+    const markerStart = line.indexOf(MARKER);
+    const markerEnd = line.indexOf('-->', markerStart);
+    if (markerEnd === -1) {
+      fail(`${file}: HITL marker comment is not closed`);
+      continue;
+    }
+    const prose = `${line.slice(0, markerStart)}${line.slice(markerEnd + 3)}`;
     if (/never submits an application/i.test(prose)) {
       pass(`${file}: the row states the prohibition in absolute terms`);
     } else {

--- a/tests/readme-hitl-markers.test.mjs
+++ b/tests/readme-hitl-markers.test.mjs
@@ -49,6 +49,34 @@ for (const file of readmes) {
     pass(`${file}: marker present, inside its table row`);
   }
 
+  // The marker is an anchor, and until now nothing read what it anchors: a
+  // README whose row had been hedged still passed, because the comment was
+  // present and inside a table row. That is the wrong half to check on its own.
+  //
+  // The hedge cannot be caught in 17 languages, but it does not have to be.
+  // Every translation is derived from the English source, so a hedge that
+  // enters there propagates to all of them faithfully -- with every marker
+  // still in place and this suite still green. Checking README.md is what
+  // closes that door; the marker check continues to carry the translations.
+  if (file === 'README.md') {
+    // Strip the comment before scanning: the marker QUOTES the hedges it
+    // forbids, so a scan of the raw line matches the anchor's own warning
+    // text and fails a correctly-worded row.
+    const prose = line.replace(/<!--[\s\S]*?-->/g, '');
+    if (/never submits an application/i.test(prose)) {
+      pass(`${file}: the row states the prohibition in absolute terms`);
+    } else {
+      fail(`${file}: the HITL row no longer says "never submits an application"`);
+    }
+    const HEDGES = /\b(usually|generally|normally|typically|by default|unless|without your permission|automatically|by itself)\b/i;
+    const hedge = prose.match(HEDGES);
+    if (hedge) {
+      fail(`${file}: the HITL row hedges with "${hedge[0]}" -- the guarantee is absolute, not a default`);
+    } else {
+      pass(`${file}: no hedge in the guarantee row`);
+    }
+  }
+
   // Wholesale-drift control: every README describes the report as A-H. This
   // deliberately does NOT try to catch phrasing variants (French and Arabic
   // write ranges with a preposition, "de A à F" / "من A إلى F", which is how


### PR DESCRIPTION
## Summary
- Bridge PR for #3299's failing CodeQL gate.
- Replaces the repeated regex HTML-comment stripper in tests/readme-hitl-markers.test.mjs with a bounded parser that removes complete comment blocks without incomplete multi-character sanitization.
- Preserves the original #3299 assertion intent while avoiding the CodeQL high alert.

## Steward context
- Original PR: https://github.com/santifer/career-ops/pull/3299
- Original head darkpandawarrior:fix/hitl-marker-guards-nothing rejected direct push from chipoto69 despite maintainerCanModify=true.
- This branch is a non-force fork bridge: original #3299 commit 2f1a7ef + steward fix commit 093c8f0.

## Test Plan
- node tests/readme-hitl-markers.test.mjs
- git diff --check origin/main...HEAD

## Merge note
If maintainers prefer not to merge this bridge PR, cherry-pick commit 093c8f0 onto #3299 or apply the equivalent one-file diff, then rerun CodeQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure the English README clearly states that applications are never submitted automatically.
  * Added checks to reject hedging language and detect unclosed HITL markers.
  * Continued validating marker placement in translated README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->