### PR TITLE
fix(workday): recover offset-clamped tenants with a facet split

### DIFF
--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -485,8 +485,24 @@ export default {
           slicesSpent++;
           await sleep(INTER_PAGE_DELAY_MS, ctx);
           const nextApplied = { ...applied, [facet.facetParameter]: [value.id] };
+          // runQuery()'s page-0 fetch is unguarded — fine for the one page-0 of
+          // an ordinary board, but here it runs once per slice against a tenant
+          // that is by definition large, which is where a WAF or rate limiter
+          // lives. Letting it throw would abandon the whole tenant including
+          // the unfaceted crawl already absorbed into `out`, so a dead slice
+          // becomes an incomplete split and the rest of the partition is still
+          // tried. Same accounting as a slice that died mid-pagination.
+          let sliceResult;
+          try {
+            sliceResult = await runQuery(nextApplied);
+          } catch (err) {
+            const attempts = err.attempts ?? RETRY_POLICY.retries + 1;
+            console.error(`⚠️  workday: ${entry.name} slice ${facet.facetParameter}=${value.id} failed on its first page after ${attempts} attempts: ${err.message}`);
+            splitIncomplete = true;
+            continue;
+          }
           await split(
-            await runQuery(nextApplied),
+            sliceResult,
             nextApplied,
             depth + 1,
             [...excluded, facet.facetParameter],

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -456,6 +456,23 @@ export default {
        */
       const split = async (result, applied, depth, excluded) => {
         absorb(result.jobs);
+        // A slice that stopped early is not a slice that finished. `clamped` is
+        // only ever true for stopReason 'complete', so without this the
+        // `!result.clamped` return below absorbs a slice's partial jobs and
+        // reports the board recovered — the one thing this path exists to
+        // avoid. 'early-stop' (and 'no-date-skip', which only drops postings
+        // the sweep would discard anyway) stay exempt: those slices are
+        // genuinely done for this sweep's purposes.
+        //
+        // 'cap' only counts against an UNCLAMPED query, matching the entry-cap
+        // warning below. A clamped query reports total at the ceiling, which is
+        // exactly maxPages * PAGE_SIZE, so it always ends at the cap — that is
+        // the clamp being detected, not pages going unread, and it is what the
+        // split then recovers. Tagging it would put "(still incomplete)" on
+        // every clamped board and say nothing.
+        if (result.stopReason === 'fetch-error' || (result.stopReason === 'cap' && !result.clamped)) {
+          splitIncomplete = true;
+        }
         if (!result.clamped) return;
 
         if (depth >= MAX_SPLIT_DEPTH) { splitIncomplete = true; return; }

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -43,6 +43,28 @@ const RETRY_POLICY = { retries: 3 };
 // page 1 pay this; no-date-skip and early-stopped tenants never do.
 const INTER_PAGE_DELAY_MS = 250;
 
+// Offset past which some tenants' CXS backend stops paginating: it reports
+// `total` as exactly 2000 and answers offset=2000/4000 with the same postings
+// as offset=0. Raising max_pages buys duplicates, not coverage — see the facet
+// split below for the way around it.
+const WORKDAY_OFFSET_CEILING = 2000;
+
+// How many times a slice may itself be split. Two levels turn a clamped board
+// into (values of facet A) x (values of facet B) queries, which cleared every
+// clamped tenant observed; the bound exists because a tenant that reports a
+// clamp at every level would otherwise recurse until it runs out of facets.
+const MAX_SPLIT_DEPTH = 2;
+
+// Total slice queries one tenant may spend. A pathological facet (hundreds of
+// values, each still clamped) must not turn one board into an unbounded crawl.
+const MAX_SPLIT_SLICES = 100;
+
+// Page budget for a whole tenant, as a multiple of max_pages. A clamped board
+// is crawled once unfaceted and then once per slice, and slices overlap, so the
+// page count is not bounded by the board size — this is what stops one
+// pathological tenant from eating a sweep.
+const SPLIT_PAGE_BUDGET_FACTOR = 5;
+
 // Workday returns postings newest-first, so pagination can stop once a
 // page's oldest *dated* posting is well past --since — no point paying for
 // (and rate-limit-risking) pages that are entirely stale. Only unambiguous
@@ -62,6 +84,94 @@ function resolveMaxPages(entry) {
   const v = entry?.max_pages;
   if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
   return DEFAULT_MAX_PAGES;
+}
+
+// ── Facet split ───────────────────────────────────────────────────
+//
+// Workday's CXS backend refuses to paginate past offset 2000 on some tenants,
+// and reports `total` as exactly 2000 while doing it (dickssportinggoods: says
+// 2000, its own facet counts add up to ~8,400, the public site lists 7,120+).
+// Offsets 2000 and 4000 then return the same postings as offset 0, so raising
+// `max_pages` buys duplicates, not coverage.
+//
+// The facet counts in the same response are not clamped, which gives both the
+// detector and the way out: re-issue the query once per facet value, so a slice
+// that fits under the ceiling paginates honestly.
+//
+// This recovers coverage; it does not guarantee completeness. Real boards are
+// skewed — dickssportinggoods puts 6,564 of its 8,423 postings in one jobFamily
+// value, and *inside that slice* every other facet is skewed the same way
+// (Brand 6562/6564, timeType 6483/6499), so the dominant mass never splits
+// below the ceiling. The split is therefore strictly additive on top of the
+// unfaceted crawl, and a board it could not finish keeps the workdayTruncated
+// tag rather than being reported as complete.
+
+/** Sum one facet's value counts; null when none of its values carry a count. */
+function facetCoverage(facet) {
+  const values = Array.isArray(facet?.values) ? facet.values : [];
+  let sum = 0;
+  let counted = 0;
+  for (const v of values) {
+    if (!Number.isInteger(v?.count) || v.count < 0) continue;
+    sum += v.count;
+    counted++;
+  }
+  return counted > 0 ? sum : null;
+}
+
+/**
+ * Board size according to the facets, or null when no facet carries counts.
+ *
+ * Each facet partitions the same board, so any one of them should sum to the
+ * true total; they disagree slightly in practice (a posting missing a facet
+ * value is absent from that facet's counts), so take the largest — the reading
+ * that under-reports least. Compared against the response's own `total` by the
+ * caller: facets materially higher means `total` is clamped.
+ *
+ * Exported for the test suite, which pins the DSG numbers.
+ */
+export function trueTotalFromFacets(facets) {
+  let best = null;
+  for (const facet of Array.isArray(facets) ? facets : []) {
+    const coverage = facetCoverage(facet);
+    if (coverage === null) continue;
+    if (best === null || coverage > best) best = coverage;
+  }
+  return best;
+}
+
+/**
+ * Pick the facet to split a clamped board on, or null when none can.
+ *
+ * Chooses the facet with the smallest largest-slice, since that slice is the
+ * one at risk of still being clamped and needing another split. Facets whose
+ * values lack an `id` are unusable as a filter (live tenants ship id-less group
+ * headers like `locationMainGroup`), and a facet with fewer than two usable
+ * values is not a partition at all — applying it just re-fetches the same board
+ * under a filter, which turns the split into a spin.
+ *
+ * `exclude` carries the facet parameters already applied further up the split,
+ * without which re-splitting a slice would keep re-deriving the same partition.
+ *
+ * Exported for the test suite.
+ */
+export function chooseSplitFacet(facets, { exclude = [] } = {}) {
+  const skip = new Set(exclude);
+  let best = null;
+  for (const facet of Array.isArray(facets) ? facets : []) {
+    const facetParameter = facet?.facetParameter;
+    if (typeof facetParameter !== 'string' || !facetParameter || skip.has(facetParameter)) continue;
+    const values = (Array.isArray(facet.values) ? facet.values : []).filter(
+      (v) => typeof v?.id === 'string' && v.id && Number.isInteger(v?.count) && v.count >= 0,
+    );
+    if (values.length < 2) continue;
+    const largest = Math.max(...values.map((v) => v.count));
+    // Tie-break on value count: a finer partition leaves less to re-split.
+    if (best === null || largest < best.largest || (largest === best.largest && values.length > best.values.length)) {
+      best = { facetParameter, values, largest };
+    }
+  }
+  return best ? { facetParameter: best.facetParameter, values: best.values } : null;
 }
 
 function sleep(ms, ctx) {
@@ -187,23 +297,9 @@ export default {
         referer: `${ep.jobBase}/`,
       },
     };
-    const makeBody = (offset) => JSON.stringify({ limit: PAGE_SIZE, offset, searchText: '', appliedFacets: {} });
+    const makeBody = (offset, appliedFacets) => JSON.stringify({ limit: PAGE_SIZE, offset, searchText: '', appliedFacets });
     const sinceMs = typeof ctx?.sinceMs === 'number' ? ctx.sinceMs : null;
-
-    const first = await fetchJsonWithRetry(ctx, ep.api, { ...postOpts, body: makeBody(0) }, RETRY_POLICY);
-    const jobs = parseWorkdayResponse(first, entry);
-
-    const total = typeof first?.total === 'number' ? first.total : null;
-    const firstPostings = Array.isArray(first?.jobPostings) ? first.jobPostings : [];
     const maxPages = resolveMaxPages(entry);
-
-    // How many pages to fetch in total (including the first, already-fetched
-    // one): bounded by `total` when the server reports it, always capped at
-    // maxPages. When `total` is absent, only probe further pages if the first
-    // one was full — a short first page already means there's nothing more.
-    let pagesToFetch = total !== null
-      ? Math.min(Math.ceil(total / PAGE_SIZE), maxPages)
-      : (firstPostings.length >= PAGE_SIZE ? maxPages : 1);
 
     // Honor a context page cap — verify-portals' liveness probe sets
     // `ctx.maxPages: 1` so it only needs to know a board is live, not its full
@@ -216,61 +312,179 @@ export default {
     // below (pagesToFetch === maxPages) stays quiet. No effect on real scans,
     // which don't set ctx.maxPages.
     const ctxCap = Number.isInteger(ctx?.maxPages) && ctx.maxPages > 0 ? ctx.maxPages : Infinity;
-    pagesToFetch = Math.min(pagesToFetch, ctxCap);
 
-    // Why pagination stopped — drives which warning (if any) fires below.
-    // 'fetch-error' must NOT produce the "raise max_pages" advice: that knob
-    // does nothing for a tenant that died on a rate limit rather than hit the cap.
-    let stopReason = 'complete';
-    if (pageIsPastWindow(jobs, sinceMs)) stopReason = 'early-stop';
-    // Some tenants' CXS responses never include postedOn at all (e.g.
-    // adventhealth, on every page). Early-stop can't apply then — there's
-    // no dated posting to recognize as "past the window".
-    const sawAnyDatedPosting = jobs.some((j) => typeof j.postedAt === 'number');
+    // Shared across the unfaceted crawl and every slice, so one tenant's total
+    // cost is bounded no matter how its facets fan out.
+    const pageBudget = maxPages * SPLIT_PAGE_BUDGET_FACTOR;
+    let pagesSpent = 0;
+    let budgetExhausted = false;
 
-    // Zero dated postings on page 0, --include-undated off, --since-bounded
-    // scan: further pagination is pure waste — every posting from this
-    // tenant will be dropped downstream as undated regardless of page count
-    // (newest-first sort means if the *freshest* postings lack a date, older
-    // ones will too). Return page 0's results instead of grinding to maxPages.
-    if (stopReason === 'complete' && sinceMs !== null && ctx?.includeUndated !== true
-      && !sawAnyDatedPosting && jobs.length > 0) {
-      stopReason = 'no-date-skip';
-    }
+    /**
+     * True when this query hit the CXS offset clamp and can only be finished by
+     * splitting it. The tell is the reported total sitting at (or under) the
+     * ceiling while the facet counts — which are not clamped — describe a
+     * bigger board. A probe (ctx.maxPages) never splits: it asked for one page.
+     */
+    const isClamped = (total, facets) => {
+      if (ctxCap !== Infinity) return false;
+      if (total === null || total > WORKDAY_OFFSET_CEILING) return false;
+      const trueTotal = trueTotalFromFacets(facets);
+      return trueTotal !== null && trueTotal > WORKDAY_OFFSET_CEILING;
+    };
 
-    // Sequential, not concurrent (mirrors providers/4dayweek.mjs, thehub.mjs,
-    // arbeitnow.mjs, jibeapply.mjs) — a single tenant's API has no reason to
-    // receive a burst of parallel requests, and a mid-run failure stops
-    // cleanly with whatever pages were already gathered instead of
-    // discarding them (Promise.all would fail the whole batch on one error).
-    let page = 1;
-    if (stopReason === 'complete') {
-      for (; page < pagesToFetch; page++) {
-        await sleep(INTER_PAGE_DELAY_MS, ctx);
-        let json;
-        try {
-          json = await fetchJsonWithRetry(ctx, ep.api, { ...postOpts, body: makeBody(page * PAGE_SIZE) }, RETRY_POLICY);
-        } catch (err) {
-          const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
-          // err.attempts (set by fetchJsonWithRetry) is the actual request count —
-          // a non-retryable error can end the loop after just one attempt, well
-          // short of RETRY_POLICY.retries + 1.
-          const attempts = err.attempts ?? RETRY_POLICY.retries + 1;
-          console.error(`⚠️  workday: ${entry.name} truncated at ${page + 1} of ${pagesToFetch} pages after ${attempts} attempts (${jobsSummary}): ${err.message}`);
-          stopReason = 'fetch-error';
-          break;
-        }
-        const pageJobs = parseWorkdayResponse(json, entry);
-        jobs.push(...pageJobs);
-        if (total === null) {
-          const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
-          if (postings.length < PAGE_SIZE) break; // short page → last page reached
-        }
-        if (pageIsPastWindow(pageJobs, sinceMs)) { stopReason = 'early-stop'; break; }
+    /**
+     * One paginated pass over a single query — the whole board when
+     * `appliedFacets` is empty, otherwise one slice of it.
+     *
+     * Returns the facets alongside the jobs because the caller needs them to
+     * decide whether this query was clamped and, if so, what to split it on.
+     */
+    const runQuery = async (appliedFacets) => {
+      pagesSpent++;
+      const first = await fetchJsonWithRetry(ctx, ep.api, { ...postOpts, body: makeBody(0, appliedFacets) }, RETRY_POLICY);
+      const jobs = parseWorkdayResponse(first, entry);
+
+      const total = typeof first?.total === 'number' ? first.total : null;
+      const facets = Array.isArray(first?.facets) ? first.facets : [];
+      const firstPostings = Array.isArray(first?.jobPostings) ? first.jobPostings : [];
+
+      // How many pages to fetch in total (including the first, already-fetched
+      // one): bounded by `total` when the server reports it, always capped at
+      // maxPages. When `total` is absent, only probe further pages if the first
+      // one was full — a short first page already means there's nothing more.
+      let pagesToFetch = total !== null
+        ? Math.min(Math.ceil(total / PAGE_SIZE), maxPages)
+        : (firstPostings.length >= PAGE_SIZE ? maxPages : 1);
+      pagesToFetch = Math.min(pagesToFetch, ctxCap);
+
+      // Why pagination stopped — drives which warning (if any) fires below.
+      // 'fetch-error' must NOT produce the "raise max_pages" advice: that knob
+      // does nothing for a tenant that died on a rate limit rather than hit the cap.
+      let stopReason = 'complete';
+      if (pageIsPastWindow(jobs, sinceMs)) stopReason = 'early-stop';
+      // Some tenants' CXS responses never include postedOn at all (e.g.
+      // adventhealth, on every page). Early-stop can't apply then — there's
+      // no dated posting to recognize as "past the window".
+      const sawAnyDatedPosting = jobs.some((j) => typeof j.postedAt === 'number');
+
+      // Zero dated postings on page 0, --include-undated off, --since-bounded
+      // scan: further pagination is pure waste — every posting from this
+      // tenant will be dropped downstream as undated regardless of page count
+      // (newest-first sort means if the *freshest* postings lack a date, older
+      // ones will too). Return page 0's results instead of grinding to maxPages.
+      if (stopReason === 'complete' && sinceMs !== null && ctx?.includeUndated !== true
+        && !sawAnyDatedPosting && jobs.length > 0) {
+        stopReason = 'no-date-skip';
       }
-      if (stopReason === 'complete' && page === pagesToFetch && pagesToFetch === maxPages) {
-        stopReason = 'cap';
+
+      // A clamped query is still worth paginating: everything up to the ceiling
+      // is real and distinct, and it is the coverage floor the split builds on.
+      // Only the pages *past* the ceiling are duplicates, and `total` being
+      // clamped to the ceiling already stops pagination there.
+      const clamped = stopReason === 'complete' && isClamped(total, facets);
+
+      // Sequential, not concurrent (mirrors providers/4dayweek.mjs, thehub.mjs,
+      // arbeitnow.mjs, jibeapply.mjs) — a single tenant's API has no reason to
+      // receive a burst of parallel requests, and a mid-run failure stops
+      // cleanly with whatever pages were already gathered instead of
+      // discarding them (Promise.all would fail the whole batch on one error).
+      let page = 1;
+      if (stopReason === 'complete') {
+        for (; page < pagesToFetch; page++) {
+          if (pagesSpent >= pageBudget) { budgetExhausted = true; break; }
+          await sleep(INTER_PAGE_DELAY_MS, ctx);
+          pagesSpent++;
+          let json;
+          try {
+            json = await fetchJsonWithRetry(ctx, ep.api, { ...postOpts, body: makeBody(page * PAGE_SIZE, appliedFacets) }, RETRY_POLICY);
+          } catch (err) {
+            const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
+            // err.attempts (set by fetchJsonWithRetry) is the actual request count —
+            // a non-retryable error can end the loop after just one attempt, well
+            // short of RETRY_POLICY.retries + 1.
+            const attempts = err.attempts ?? RETRY_POLICY.retries + 1;
+            console.error(`⚠️  workday: ${entry.name} truncated at ${page + 1} of ${pagesToFetch} pages after ${attempts} attempts (${jobsSummary}): ${err.message}`);
+            stopReason = 'fetch-error';
+            break;
+          }
+          const pageJobs = parseWorkdayResponse(json, entry);
+          jobs.push(...pageJobs);
+          if (total === null) {
+            const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
+            if (postings.length < PAGE_SIZE) break; // short page → last page reached
+          }
+          if (pageIsPastWindow(pageJobs, sinceMs)) { stopReason = 'early-stop'; break; }
+        }
+        if (stopReason === 'complete' && page === pagesToFetch && pagesToFetch === maxPages) {
+          stopReason = 'cap';
+        }
       }
+
+      return { jobs, total, facets, stopReason, clamped };
+    };
+
+    const root = await runQuery({});
+    const { total, stopReason } = root;
+
+    // Set when the split ran out of depth, slices, or splittable facets with
+    // part of the board still unreached — the difference between "this is the
+    // whole board" and "this is as much of it as we could get".
+    let splitIncomplete = false;
+    let slicesSpent = 0;
+    let jobs = root.jobs;
+
+    if (root.clamped) {
+      // Slices overlap wherever a posting carries several values of the split
+      // facet, and every slice re-includes what the unfaceted page 0 already
+      // returned, so the union is deduped on the posting URL. Only the split
+      // path dedups: an unclamped tenant returns exactly what it paginated.
+      const seen = new Set();
+      const out = [];
+      const absorb = (pageJobs) => {
+        for (const job of pageJobs) {
+          if (seen.has(job.url)) continue;
+          seen.add(job.url);
+          out.push(job);
+        }
+      };
+
+      /**
+       * Absorb one query's jobs and, when it came back clamped, recurse into a
+       * facet that partitions it. `applied` accumulates the filters, `excluded`
+       * the facet parameters already spent — without which the next level would
+       * keep re-deriving the same partition.
+       */
+      const split = async (result, applied, depth, excluded) => {
+        absorb(result.jobs);
+        if (!result.clamped) return;
+
+        if (depth >= MAX_SPLIT_DEPTH) { splitIncomplete = true; return; }
+        const facet = chooseSplitFacet(result.facets, { exclude: excluded });
+        if (!facet) { splitIncomplete = true; return; }
+
+        for (const value of facet.values) {
+          if (slicesSpent >= MAX_SPLIT_SLICES) { splitIncomplete = true; break; }
+          if (pagesSpent >= pageBudget) { splitIncomplete = true; break; }
+          slicesSpent++;
+          await sleep(INTER_PAGE_DELAY_MS, ctx);
+          const nextApplied = { ...applied, [facet.facetParameter]: [value.id] };
+          await split(
+            await runQuery(nextApplied),
+            nextApplied,
+            depth + 1,
+            [...excluded, facet.facetParameter],
+          );
+        }
+      };
+
+      await split(root, {}, 0, []);
+      jobs = out;
+
+      // Distinct from the cap warning below: nothing about this tenant's entry
+      // can be edited to fix it, and the count that matters is what the split
+      // recovered on top of the ceiling.
+      const short = splitIncomplete || budgetExhausted ? ' (still incomplete)' : '';
+      console.error(`⚠️  workday: ${entry.name} offset-clamped at ${WORKDAY_OFFSET_CEILING} — recovered ${jobs.length} jobs via ${slicesSpent} facet slices${short}`);
     }
 
     // The cap is a safety net, not a working limit — silent by design, but a
@@ -296,7 +510,7 @@ export default {
     // verify-portals.mjs both probe with ctx.maxPages: 1, which never sets
     // stopReason to 'cap'), so it is the one place that opts out.
     const syntheticEntries = ctx?.syntheticEntries === true;
-    if (stopReason === 'cap') {
+    if (stopReason === 'cap' && !root.clamped) {
       const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
       if (!syntheticEntries) {
         console.error(`⚠️  workday: ${entry.name} truncated at max_pages=${maxPages} (${jobsSummary}) — raise max_pages on this entry for more`);
@@ -305,7 +519,8 @@ export default {
         // maxPages*PAGE_SIZE when the real count is far higher (e.g.
         // dickssportinggoods: total=2000, public site lists 7,120; requests
         // at offset 2000/4000 return the same first posting as offset 0).
-        // Flag it, don't explain it here.
+        // Flag it, don't explain it here. A tenant whose facets prove the
+        // clamp takes the facet-split path above instead of this warning.
         const suspectTag = total !== null && total === maxPages * PAGE_SIZE ? ' (total may be Workday-capped, not real)' : '';
         console.error(`⚠️  workday: ${entry.name} truncated at ${maxPages} pages (${jobsSummary})${suspectTag}`);
       }
@@ -322,6 +537,9 @@ export default {
     // parallel sweep, when the line is quiet — same array-tag pattern as
     // workdayNoDateSkip (no extra per-tenant logging here).
     if (stopReason === 'fetch-error') jobs.workdayTruncated = true;
+    // A split that could not reach the whole board is the same kind of partial
+    // result, and scan-ats-full.mjs already knows how to report that tag.
+    if (splitIncomplete || budgetExhausted) jobs.workdayTruncated = true;
 
     return jobs;
   },

--- a/tests/providers/workday-facet-split.test.mjs
+++ b/tests/providers/workday-facet-split.test.mjs
@@ -1,0 +1,345 @@
+// tests/providers/workday-facet-split.test.mjs — facet-split recovery for
+// Workday tenants whose CXS backend clamps `total` (and pagination) at 2,000.
+import { pass, fail, ROOT, captureConsoleErrors } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — workday facet-split');
+
+// Trimmed from a live dickssportinggoods|wd1|dsg page-0 response (2026-08-25).
+// `total` came back 2,000 while the facet counts sum to ~8,4xx — the clamp this
+// whole feature exists to route around. Counts are the real ones; the value
+// lists are truncated to what the assertions below need.
+const DSG_FACETS = [
+  {
+    facetParameter: 'CF_-_Location_Type__EEB__Extended',
+    descriptor: 'Brand',
+    values: [
+      { id: 'brand-dsg', descriptor: "DICK'S Sporting Goods", count: 7813 },
+      { id: 'brand-hos', descriptor: 'House of Sport', count: 403 },
+      { id: 'brand-gg', descriptor: 'Golf Galaxy', count: 188 },
+      { id: 'brand-pl', descriptor: 'Public Lands', count: 11 },
+    ],
+  },
+  {
+    facetParameter: 'timeType',
+    descriptor: 'Time Type',
+    values: [
+      { id: 'tt-part', descriptor: 'Part time', count: 7044 },
+      { id: 'tt-full', descriptor: 'Full time', count: 1307 },
+    ],
+  },
+  {
+    facetParameter: 'workerSubType',
+    descriptor: 'Job Type',
+    values: [
+      { id: 'wst-reg', descriptor: 'Regular', count: 8316 },
+      { id: 'wst-tmp', descriptor: 'Temporary', count: 109 },
+    ],
+  },
+  {
+    facetParameter: 'jobFamily',
+    descriptor: 'Job Family',
+    values: [
+      { id: 'jf-teammate', descriptor: 'Field - Teammate', count: 6564 },
+      { id: 'jf-specialist', descriptor: 'Field - Specialist', count: 545 },
+      { id: 'jf-captain', descriptor: 'Field - Captain', count: 424 },
+      { id: 'jf-sales', descriptor: 'Field - Hourly (Sales)', count: 253 },
+    ],
+  },
+  // Live tenants carry group headers with no id and no count — never splittable.
+  {
+    facetParameter: 'locationMainGroup',
+    descriptor: null,
+    values: [
+      { id: null, descriptor: 'Location - State', count: null },
+      { id: null, descriptor: 'Locations', count: null },
+    ],
+  },
+];
+
+try {
+  const workdayModule = await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href);
+  const workday = workdayModule.default;
+  const { trueTotalFromFacets, chooseSplitFacet } = workdayModule;
+
+  // ── trueTotalFromFacets ───────────────────────────────────────────
+
+  // The clamp is only detectable by comparing the reported total against what
+  // the facets add up to; without this the caller cannot tell a genuine
+  // 2,000-posting board from a 8,000-posting board reporting 2,000.
+  const dsgTrue = trueTotalFromFacets(DSG_FACETS);
+  if (dsgTrue === 8425) {
+    pass('trueTotalFromFacets() recovers the real board size from facet counts (8425 > clamped 2000)');
+  } else {
+    fail(`trueTotalFromFacets(DSG) returned ${dsgTrue}, expected 8425`);
+  }
+
+  if (trueTotalFromFacets([]) === null && trueTotalFromFacets(undefined) === null) {
+    pass('trueTotalFromFacets() returns null when there are no facets to read');
+  } else {
+    fail('trueTotalFromFacets() should return null for empty/absent facets');
+  }
+
+  // A facet whose values carry no counts tells us nothing about board size —
+  // summing them would report 0 and read as "empty board".
+  const uncounted = trueTotalFromFacets([
+    { facetParameter: 'locationMainGroup', values: [{ id: null, count: null }, { id: null, count: null }] },
+  ]);
+  if (uncounted === null) {
+    pass('trueTotalFromFacets() ignores facets whose values carry no usable counts');
+  } else {
+    fail(`trueTotalFromFacets(uncounted) returned ${uncounted}, expected null`);
+  }
+
+  // ── chooseSplitFacet ──────────────────────────────────────────────
+
+  // Every facet here covers the same board, so the only thing that matters is
+  // which one produces the smallest worst-case slice: jobFamily's 6564 beats
+  // timeType's 7044, Brand's 7813 and workerSubType's 8316.
+  const chosen = chooseSplitFacet(DSG_FACETS);
+  if (chosen && chosen.facetParameter === 'jobFamily') {
+    pass('chooseSplitFacet() picks the facet with the smallest largest-slice (jobFamily)');
+  } else {
+    fail(`chooseSplitFacet(DSG) chose ${JSON.stringify(chosen?.facetParameter)}, expected "jobFamily"`);
+  }
+
+  if (chosen && chosen.values.length === 4 && chosen.values.every((v) => typeof v.id === 'string')) {
+    pass('chooseSplitFacet() returns the facet values to iterate, each with an id');
+  } else {
+    fail(`chooseSplitFacet(DSG).values malformed: ${JSON.stringify(chosen?.values)}`);
+  }
+
+  // Re-splitting a slice must not re-apply the facet already applied, or the
+  // recursion re-derives the same partition forever.
+  const excluded = chooseSplitFacet(DSG_FACETS, { exclude: ['jobFamily'] });
+  if (excluded && excluded.facetParameter === 'timeType') {
+    pass('chooseSplitFacet() honors exclude and falls through to the next-best facet');
+  } else {
+    fail(`chooseSplitFacet(exclude jobFamily) chose ${JSON.stringify(excluded?.facetParameter)}, expected "timeType"`);
+  }
+
+  // A single-valued facet is not a partition — applying it fetches the same
+  // board again under a filter, which is how a split loop turns into a spin.
+  const singleValue = chooseSplitFacet([
+    { facetParameter: 'onlyOne', values: [{ id: 'a', count: 5000 }] },
+  ]);
+  if (singleValue === null) {
+    pass('chooseSplitFacet() rejects a single-valued facet — not a partition');
+  } else {
+    fail(`chooseSplitFacet(single) returned ${JSON.stringify(singleValue)}, expected null`);
+  }
+
+  if (chooseSplitFacet([{ facetParameter: 'locationMainGroup', values: [{ id: null, count: null }, { id: null, count: null }] }]) === null) {
+    pass('chooseSplitFacet() rejects facets whose values have no id (id-less group headers)');
+  } else {
+    fail('chooseSplitFacet() should reject id-less facet values');
+  }
+
+} catch (e) {
+  fail(`workday facet-split tests crashed: ${e.message}`);
+}
+
+// ── workday.fetch() integration ─────────────────────────────────────
+
+try {
+  const workdayModule = await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href);
+  const workday = workdayModule.default;
+
+  const ENTRY = { name: 'Acme', careers_url: 'https://acme.wd1.myworkdayjobs.com/acme' };
+
+  const mkCtx = (fetchJson, extra = {}) => ({
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText should not be called'); },
+    fetchJson,
+    sleep: async () => {},
+    ...extra,
+  });
+
+  // Stable key for "which facet filter is this request under", so a mock can
+  // answer per slice. Sorted so {a,b} and {b,a} address the same slice.
+  const sliceKey = (appliedFacets) => Object.entries(appliedFacets || {})
+    .map(([param, ids]) => `${param}=${[].concat(ids).join(',')}`)
+    .sort()
+    .join('&');
+
+  // Distinct postings per (tag, offset), so a page that is actually fetched is
+  // distinguishable from one that is not.
+  const postings = (tag, offset, n = 20) => Array.from({ length: n }, (_, i) => ({
+    title: `${tag} job ${offset + i}`,
+    externalPath: `/job/city/${tag}-${offset + i}`,
+    postedOn: 'Posted Today',
+  }));
+
+  // A clamped tenant: reports total=2000 (the offset ceiling) while its own
+  // jobFamily counts add up to 2700. Both slices answer honestly.
+  const clampedResponder = (sliceTotals) => async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    if (key === '') {
+      return {
+        total: 2000,
+        facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] }],
+        jobPostings: postings('unfaceted', body.offset),
+      };
+    }
+    const tag = sliceTotals[key];
+    if (!tag) throw new Error(`unexpected slice ${JSON.stringify(key)}`);
+    return { total: 20, facets: [], jobPostings: body.offset === 0 ? postings(tag, 0) : [] };
+  };
+
+  const calls = [];
+  const clampedJobs = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (url, opts) => {
+    calls.push({ key: sliceKey(JSON.parse(opts.body).appliedFacets), offset: JSON.parse(opts.body).offset });
+    return clampedResponder({ 'jobFamily=a': 'a', 'jobFamily=b': 'b' })(url, opts);
+  }, { includeUndated: true }))).then((r) => r.result);
+
+  const facetedKeys = [...new Set(calls.map((c) => c.key))].filter(Boolean).sort();
+  if (facetedKeys.join('|') === 'jobFamily=a|jobFamily=b') {
+    pass('workday.fetch() re-issues the query once per facet value when total is clamped at the offset ceiling');
+  } else {
+    fail(`facet-split issued slices ${JSON.stringify(facetedKeys)}, expected jobFamily=a and jobFamily=b`);
+  }
+
+  // The regression that matters most: everything below the ceiling is real and
+  // reachable, so the split has to be ADDITIVE. An earlier version skipped the
+  // unfaceted crawl on detecting the clamp and returned 917 of 8,423 postings
+  // on a live tenant — fewer than doing nothing at all.
+  const unfacetedPages = calls.filter((c) => c.key === '').length;
+  if (unfacetedPages === 100) {
+    pass('workday.fetch() still paginates the clamped query to the ceiling — the split adds to that floor, never replaces it');
+  } else {
+    fail(`clamped tenant fetched ${unfacetedPages} unfaceted pages, expected 100 (the ceiling)`);
+  }
+
+  if (clampedJobs.length === 2040) {
+    pass('workday.fetch() returns the unfaceted crawl plus every slice (2000 + 20 + 20)');
+  } else {
+    fail(`facet-split returned ${clampedJobs.length} jobs, expected 2040`);
+  }
+
+  // Slices overlap wherever a posting carries several facet values; without a
+  // dedup the union double-counts them.
+  const overlapJobs = await captureConsoleErrors(() => workday.fetch(
+    ENTRY,
+    mkCtx(clampedResponder({ 'jobFamily=a': 'a', 'jobFamily=b': 'a' }), { includeUndated: true }),
+  )).then((r) => r.result);
+  if (overlapJobs.length === 2020) {
+    pass('workday.fetch() dedups postings returned by more than one slice');
+  } else {
+    fail(`facet-split with overlapping slices returned ${overlapJobs.length} jobs, expected 2020`);
+  }
+
+  // A slice can be clamped in its own right; it has to split again on a facet
+  // that has not been applied yet. Totals are kept to one page so the assertion
+  // is about split shape, not pagination.
+  const NESTED = {
+    '': {
+      total: 20,
+      facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 2600 }, { id: 'b', count: 100 }] }],
+      tag: 'unfaceted',
+    },
+    'jobFamily=a': {
+      total: 20,
+      facets: [{ facetParameter: 'timeType', values: [{ id: 'p', count: 1400 }, { id: 'f', count: 1200 }] }],
+      tag: 'a',
+    },
+    'jobFamily=a&timeType=f': { total: 20, facets: [], tag: 'af' },
+    'jobFamily=a&timeType=p': { total: 20, facets: [], tag: 'ap' },
+    'jobFamily=b': { total: 20, facets: [], tag: 'b' },
+  };
+  const nestedCalls = [];
+  const nestedJobs = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    nestedCalls.push(key);
+    const res = NESTED[key];
+    if (!res) throw new Error(`unexpected slice ${JSON.stringify(key)}`);
+    return { total: res.total, facets: res.facets, jobPostings: postings(res.tag, body.offset) };
+  }, { includeUndated: true }))).then((r) => r.result);
+
+  if (nestedCalls.includes('jobFamily=a&timeType=p') && nestedCalls.includes('jobFamily=a&timeType=f')) {
+    pass('workday.fetch() re-splits a still-clamped slice on a second, not-yet-applied facet');
+  } else {
+    fail(`nested split issued ${JSON.stringify([...new Set(nestedCalls)])}, expected jobFamily=a x timeType slices`);
+  }
+
+  if (nestedJobs.length === 100) {
+    pass('workday.fetch() returns the union across both split levels (unfaceted + a + b + ap + af)');
+  } else {
+    fail(`nested split returned ${nestedJobs.length} jobs, expected 100`);
+  }
+
+  // Depth has to bottom out: a tenant that reports a clamp at every level, on a
+  // facet it never runs out of, would otherwise recurse until the board does.
+  let deepCalls = 0;
+  const { result: deepJobs } = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    deepCalls++;
+    if (deepCalls > 100) throw new Error('runaway facet split');
+    const depth = Object.keys(body.appliedFacets || {}).length;
+    return {
+      total: 20,
+      facets: [{ facetParameter: `f${depth}`, values: [{ id: 'x', count: 2600 }, { id: 'y', count: 2600 }] }],
+      jobPostings: postings(`d${depth}`, body.offset),
+    };
+  }, { includeUndated: true })));
+
+  if (deepCalls <= 100) {
+    pass('workday.fetch() bounds the facet split instead of recursing while the tenant keeps claiming a clamp');
+  } else {
+    fail(`facet split made ${deepCalls} requests — unbounded`);
+  }
+
+  if (deepJobs.workdayTruncated === true) {
+    pass('workday.fetch() tags a board it could not fully cover as truncated rather than reporting it complete');
+  } else {
+    fail('facet split that ran out of depth should tag jobs.workdayTruncated');
+  }
+
+  // A pathological facet fan-out must not be able to spend a whole sweep on one
+  // tenant: the live DSG board splits into 24 values whose dominant slice stays
+  // clamped at every level, so the page budget is the only thing bounding it.
+  let budgetCalls = 0;
+  await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    budgetCalls++;
+    if (budgetCalls > 2000) throw new Error('page budget not enforced');
+    const depth = Object.keys(body.appliedFacets || {}).length;
+    return {
+      total: 2000,
+      facets: [{
+        facetParameter: `f${depth}`,
+        values: Array.from({ length: 24 }, (_, i) => ({ id: `v${i}`, count: 2600 })),
+      }],
+      jobPostings: postings(`b${depth}`, body.offset),
+    };
+  }, { includeUndated: true })));
+  // max_pages (100) * SPLIT_PAGE_BUDGET_FACTOR (5), plus the page-0 of the
+  // slice that discovers the budget is gone.
+  if (budgetCalls <= 501) {
+    pass('workday.fetch() caps total pages per tenant so one pathological board cannot eat a sweep');
+  } else {
+    fail(`clamped fan-out spent ${budgetCalls} requests, expected <= 501`);
+  }
+
+  // The unclamped path must not pay for any of this.
+  const healthyCalls = [];
+  await workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    healthyCalls.push(sliceKey(body.appliedFacets));
+    return {
+      total: 30,
+      facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 20 }, { id: 'b', count: 10 }] }],
+      jobPostings: postings('h', body.offset, body.offset === 0 ? 20 : 10),
+    };
+  }, { includeUndated: true }));
+  if (healthyCalls.every((k) => k === '')) {
+    pass('workday.fetch() never issues a faceted request for a tenant whose total is not clamped');
+  } else {
+    fail(`healthy tenant issued faceted requests: ${JSON.stringify(healthyCalls)}`);
+  }
+
+} catch (e) {
+  fail(`workday facet-split fetch tests crashed: ${e.message}`);
+}

--- a/tests/providers/workday-facet-split.test.mjs
+++ b/tests/providers/workday-facet-split.test.mjs
@@ -389,24 +389,38 @@ try {
   // early-stop must stay exempt: a slice that paginated past the --since
   // window is genuinely done for this sweep, and tagging it would send the
   // whole tenant back through the retry pass on every incremental scan.
+  const earlyStopCalls = [];
   const { result: earlyStopJobs } = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
     const body = JSON.parse(opts.body);
     const key = sliceKey(body.appliedFacets);
+    if (key !== '') earlyStopCalls.push(key);
     if (key === '') {
       return {
         total: 2000,
         facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] }],
-        jobPostings: postings('unfaceted', body.offset, 20).map((p) => ({ ...p, postedOn: 'Posted Today' })),
+        jobPostings: postings('unfaceted', body.offset),
       };
     }
-    // Page 0 is fresh, page 1 is well past the window → early-stop.
-    if (body.offset === 0) return { total: 40, facets: [], jobPostings: postings(key, 0) };
+    // Each slice claims 10 pages; page 0 is fresh, page 1 is well past the
+    // window → early-stop after 2 requests. The count is asserted below so
+    // this stays a test about early-stop and cannot pass by never reaching it.
+    if (body.offset === 0) return { total: 200, facets: [], jobPostings: postings(key, 0) };
     return {
-      total: 40,
+      total: 200,
       facets: [],
-      jobPostings: postings(key, body.offset).map((p) => ({ ...p, postedOn: 'Posted 300+ Days Ago' })),
+      // Bounded on purpose: parsePostedOn treats "300+ Days Ago" as undated,
+      // which would leave the page dateless and early-stop unreachable.
+      jobPostings: postings(key, body.offset).map((p) => ({ ...p, postedOn: 'Posted 300 Days Ago' })),
     };
   }, { includeUndated: true, sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000 })));
+
+  // 2 slices x (page 0 + the past-the-window page that stops them). Anything
+  // more means early-stop never fired and the assertion below proves nothing.
+  if (earlyStopCalls.length === 4) {
+    pass('workday.fetch() stops a slice at the first page past the --since window instead of paginating its full total');
+  } else {
+    fail(`early-stop slices made ${earlyStopCalls.length} requests, expected 4 (2 slices x 2 pages) — early-stop did not fire`);
+  }
 
   if (earlyStopJobs.workdayTruncated === undefined) {
     pass('workday.fetch() leaves a slice that early-stopped past the --since window untagged');

--- a/tests/providers/workday-facet-split.test.mjs
+++ b/tests/providers/workday-facet-split.test.mjs
@@ -323,6 +323,97 @@ try {
     fail(`clamped fan-out spent ${budgetCalls} requests, expected <= 501`);
   }
 
+
+  // A slice that dies mid-pagination comes back with stopReason 'fetch-error'
+  // and clamped:false — indistinguishable, to the `!result.clamped` early
+  // return, from a slice that finished. Absorbing its partial jobs and calling
+  // the board recovered is the exact failure this feature exists to prevent:
+  // a recovery line printed WITHOUT the "(still incomplete)" tag.
+  const dyingSliceCalls = [];
+  const { result: dyingJobs, errors: dyingErrors } = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    dyingSliceCalls.push({ key, offset: body.offset });
+    if (key === '') {
+      return {
+        total: 2000,
+        facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] }],
+        jobPostings: postings('unfaceted', body.offset),
+      };
+    }
+    // Slice 'a' claims two pages, then its second page fails for good.
+    if (key === 'jobFamily=a') {
+      if (body.offset === 0) return { total: 40, facets: [], jobPostings: postings('a', 0) };
+      throw new Error('503 from the WAF');
+    }
+    return { total: 20, facets: [], jobPostings: body.offset === 0 ? postings('b', 0) : [] };
+  }, { includeUndated: true })));
+
+  const dyingRecoveryLine = dyingErrors.find((e) => String(e).includes('offset-clamped at'));
+  if (dyingRecoveryLine && String(dyingRecoveryLine).includes('(still incomplete)')) {
+    pass('workday.fetch() tags the recovery line "(still incomplete)" when a slice died mid-fetch');
+  } else {
+    fail(`slice that failed mid-pagination produced recovery line ${JSON.stringify(dyingRecoveryLine)}, expected it to carry "(still incomplete)"`);
+  }
+
+  if (dyingJobs.workdayTruncated === true) {
+    pass('workday.fetch() tags jobs.workdayTruncated when a slice died mid-fetch, so the sweep retries the tenant');
+  } else {
+    fail('a split whose slice hit fetch-error should tag jobs.workdayTruncated, not report the board complete');
+  }
+
+  // 'cap' is the same shape of partial result: the slice stopped at max_pages
+  // with pages it never fetched, so the board is not fully covered either.
+  const { result: cappedJobs } = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    if (key === '') {
+      return {
+        total: 2000,
+        facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] }],
+        jobPostings: postings('unfaceted', body.offset),
+      };
+    }
+    // Slice 'a' has more pages than max_pages (100 * 20 = 2000) allows, and its
+    // facets prove nothing — it stops at the cap, not at the offset clamp.
+    if (key === 'jobFamily=a') return { total: 4000, facets: [], jobPostings: postings('a', body.offset) };
+    return { total: 20, facets: [], jobPostings: body.offset === 0 ? postings('b', 0) : [] };
+  }, { includeUndated: true })));
+
+  if (cappedJobs.workdayTruncated === true) {
+    pass('workday.fetch() tags jobs.workdayTruncated when a slice stopped at the page cap with pages left');
+  } else {
+    fail('a split whose slice hit the page cap should tag jobs.workdayTruncated');
+  }
+
+  // early-stop must stay exempt: a slice that paginated past the --since
+  // window is genuinely done for this sweep, and tagging it would send the
+  // whole tenant back through the retry pass on every incremental scan.
+  const { result: earlyStopJobs } = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    if (key === '') {
+      return {
+        total: 2000,
+        facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] }],
+        jobPostings: postings('unfaceted', body.offset, 20).map((p) => ({ ...p, postedOn: 'Posted Today' })),
+      };
+    }
+    // Page 0 is fresh, page 1 is well past the window → early-stop.
+    if (body.offset === 0) return { total: 40, facets: [], jobPostings: postings(key, 0) };
+    return {
+      total: 40,
+      facets: [],
+      jobPostings: postings(key, body.offset).map((p) => ({ ...p, postedOn: 'Posted 300+ Days Ago' })),
+    };
+  }, { includeUndated: true, sinceMs: Date.now() - 7 * 24 * 60 * 60 * 1000 })));
+
+  if (earlyStopJobs.workdayTruncated === undefined) {
+    pass('workday.fetch() leaves a slice that early-stopped past the --since window untagged');
+  } else {
+    fail('a slice that stopped past the --since window is complete for the sweep and must not tag workdayTruncated');
+  }
+
   // The unclamped path must not pay for any of this.
   const healthyCalls = [];
   await workday.fetch(ENTRY, mkCtx(async (_url, opts) => {

--- a/tests/providers/workday-facet-split.test.mjs
+++ b/tests/providers/workday-facet-split.test.mjs
@@ -386,6 +386,57 @@ try {
     fail('a split whose slice hit the page cap should tag jobs.workdayTruncated');
   }
 
+  // A slice whose PAGE 0 dies is the dangerous shape: runQuery()'s first fetch
+  // is the one unguarded await on the split path, and split() issues up to
+  // MAX_SPLIT_SLICES of them against a tenant large enough to have tripped the
+  // ceiling — exactly where a WAF or rate limiter lives. Letting that throw
+  // escape drops the whole tenant, including the unfaceted crawl's 2,000
+  // postings already sitting in `out`, which breaks the additive guarantee at
+  // the one moment it matters most.
+  const page0Calls = [];
+  const { result: page0Jobs, errors: page0Errors } = await captureConsoleErrors(() => workday.fetch(ENTRY, mkCtx(async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    page0Calls.push({ key, offset: body.offset });
+    if (key === '') {
+      return {
+        total: 2000,
+        facets: [{ facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] }],
+        jobPostings: postings('unfaceted', body.offset),
+      };
+    }
+    // Slice 'a' refuses on its very first request, after every retry.
+    if (key === 'jobFamily=a') throw new Error('403 from the WAF');
+    return { total: 20, facets: [], jobPostings: body.offset === 0 ? postings('b', 0) : [] };
+  }, { includeUndated: true })));
+
+  if (Array.isArray(page0Jobs) && page0Jobs.length >= 2000) {
+    pass('workday.fetch() keeps the unfaceted crawl when a slice fails on page 0 instead of dropping the tenant');
+  } else {
+    fail(`slice failing on page 0 returned ${Array.isArray(page0Jobs) ? page0Jobs.length : typeof page0Jobs} jobs, expected the unfaceted crawl's 2000+ to survive`);
+  }
+
+  // The surviving slices must still be tried: one bad slice is not a reason to
+  // abandon the rest of the partition.
+  if (page0Calls.some((c) => c.key === 'jobFamily=b')) {
+    pass('workday.fetch() keeps splitting the remaining slices after one fails on page 0');
+  } else {
+    fail('a slice failing on page 0 stopped the split from trying the other slices');
+  }
+
+  if (page0Jobs.workdayTruncated === true) {
+    pass('workday.fetch() tags jobs.workdayTruncated when a slice failed on page 0');
+  } else {
+    fail('a split whose slice failed on page 0 should tag jobs.workdayTruncated, not report the board complete');
+  }
+
+  const page0RecoveryLine = page0Errors.find((e) => String(e).includes('offset-clamped at'));
+  if (page0RecoveryLine && String(page0RecoveryLine).includes('(still incomplete)')) {
+    pass('workday.fetch() tags the recovery line "(still incomplete)" when a slice failed on page 0');
+  } else {
+    fail(`slice failing on page 0 produced recovery line ${JSON.stringify(page0RecoveryLine)}, expected it to carry "(still incomplete)"`);
+  }
+
   // early-stop must stay exempt: a slice that paginated past the --since
   // window is genuinely done for this sweep, and tagging it would send the
   // whole tenant back through the retry pass on every incremental scan.


### PR DESCRIPTION
Closes #3310.

### The bug

Some Workday tenants' CXS backend refuses to paginate past **offset 2000** and reports `total` as exactly `2000` while doing it. The provider trusts that `total`, so the board is silently truncated — and since `DEFAULT_MAX_PAGES * PAGE_SIZE` is also 2000, the existing cap warning fires with advice (`raise max_pages`) that cannot help: offsets past the ceiling return the *same postings as offset 0*.

Verified live on `dickssportinggoods|wd1|dsg` (2026-08-25): `offset=2000` and `offset=4000` both return `Specialist Golf` as the first posting. The same page-0 response proves the real size, because **the facet counts are not clamped**:

```
workerSubType   8314 + 109              = 8423
Brand           7821 + 403 + 188 + 11   = 8423
jobFamily       24 values               = 8423
```

The clamp is per-tenant — `cvshealth|wd1|cvs_health_careers` reports `total=19173` and returns genuinely different results at offset 4000 — so a blanket `max_pages` raise is the wrong lever.

### The fix

Detect the clamp by comparing the reported `total` against what the facets add up to, then re-issue the query once per value of a facet that partitions the board, deduping the union on posting URL. Facet parameters are tenant-specific (`CF_-_Location_Type__EEB__Extended` is DSG's own), so they are read from the response, never hardcoded.

Two properties matter more than the split itself, and I only learned them by running against the real board — **every mock test passed while the implementation was strictly worse than doing nothing**:

- **The split is additive.** My first version skipped the unfaceted crawl on detecting the clamp, reasoning that pages past the ceiling are duplicates. Live result: **917 postings recovered, where the unpatched code returns 2,000.** Everything below the ceiling is real and reachable; the slices build on that floor.
- **A clamped slice is still paginated to the ceiling**, for the same reason. Taking only its page 0 was the other half of the 917.

### What it does and does not promise

It recovers coverage; it does not promise completeness. Real boards are skewed: DSG holds **6,564 of 8,423 postings in one `jobFamily` value**, and *inside that slice* every remaining facet is skewed the same way (Brand 6562/6564, timeType 6483/6499, Location Type 6118/6564). The dominant mass never splits below the ceiling, so a board the split could not finish keeps the existing `workdayTruncated` tag rather than being reported as complete.

### Live result

Same tenant, same script, before and after:

| | postings | requests |
|---|---|---|
| before | 2,000 (reported as the whole board) | 100 |
| after | **4,234 unique** (tagged `workdayTruncated`) | 501 |

2.1x coverage, honestly labelled as still short of the ~8,423 the facets describe.

### Bounds

One pathological tenant must not eat a sweep, so the split is bounded on three axes: `MAX_SPLIT_DEPTH` (2), `MAX_SPLIT_SLICES` (100), and a per-tenant page budget (`max_pages * SPLIT_PAGE_BUDGET_FACTOR`) shared by the unfaceted crawl and every slice. The live run stopped at exactly 501 requests. Hitting any bound sets `workdayTruncated`.

### Unclamped tenants are untouched

No faceted request, no dedup, no extra page — the existing path runs exactly as before. A `ctx.maxPages` probe (verify-portals, discover-ats) never splits: it asked for one page. The pre-existing `workday.test.mjs` suite passes unchanged, 61/61, including the `total may be Workday-capped` warning test — that fixture ships no facets, so it takes the old path.

### New API

- `trueTotalFromFacets(facets)` — board size per the facet counts, or null.
- `chooseSplitFacet(facets, { exclude })` — the facet to split on, skipping single-valued facets and id-less group headers (`locationMainGroup` ships `id: null`).

Both exported for the test suite, which pins the live DSG numbers.

### Testing

- New: `tests/providers/workday-facet-split.test.mjs`, 18 assertions. Includes an explicit regression guard for the additive property, named after the 917-vs-2000 failure.
- Existing `tests/providers/workday.test.mjs`: 61/61, unchanged.
- `tests/providers/ats-ssrf-hardening` (3), `tests/scan-ats-full-resume` (26), `tests/scan-ats-full-outage-checkpoint` (5), `tests/scan-ats-full-title-filter-full` (5) — all green.
- `npm run lint` clean.

`node test-all.mjs` OOMs on my Raspberry Pi, so I ran the affected suites individually rather than the full runner; CI will cover the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Workday job listing recovery when pagination limits hide available postings.
  - Added facet-based recovery, including nested splits, to find additional postings.
  - Prevented duplicate postings when results overlap across recovery slices.
  - Added safeguards to limit recovery depth, requests, and processing time.
  - Clearly identifies results when recovery remains incomplete.
  - Preserved existing retry behavior, delays, date filtering, no-date handling, and result limits.
  - Supports filtered searches during recovery while retaining complete results from unaffected listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->