### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Spanish _shared.md (#2573)

### DIFF
--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -21,6 +21,8 @@
 
 **REGLA: NUNCA codificar métricas de los proof points en duro.** Leerlas desde `cv.md` y `article-digest.md` en el momento de la evaluación.
 **REGLA: Para métricas de artículos/proyectos, `article-digest.md` tiene prioridad sobre `cv.md`** (`cv.md` puede contener cifras más antiguas).
+**REGLA: NUNCA afirmar que el candidato es autor/creador de un proyecto, repositorio, biblioteca, herramienta, framework o artefacto open-source, salvo que esté explícitamente atribuido a él en `cv.md` o `article-digest.md`.** Confundir "usar una herramienta" con "haberla creado" (usar X no es haber creado X) es el patrón de invención más común, y está prohibido.
+**REGLA: Las palabras clave se reformulan, nunca se inventan.** Reordenar, replantear, enfatizar — pero nunca inventar. Si una afirmación no está respaldada por un archivo dentro del alcance, preguntar al candidato; sin respuesta, omitirla. El silencio sobre un tema es mejor que un detalle inventado.
 
 ---
 


### PR DESCRIPTION
Part of #2573 — Spanish only, per the one-language-per-PR convention.

## What was missing

`modes/es/_shared.md` carried two `**REGLA` blocks, both about metrics. The English source has six, and the two the umbrella targets — authorship and reformulate-never-fabricate — were absent:

```
modes/_shared.md:32   NEVER claim the user authored a project, repo, library…
modes/_shared.md:33   Keywords get reformulated, never fabricated.
```

As the issue puts it: last line of defence intact (`verify-cv-facts.mjs` is language-agnostic and still blocks a fabricated employer at generation time), first line absent. This restores the first line for Spanish.

Placed immediately after the existing metrics rules, which is where the umbrella asks for them and where the English original keeps them.

## Details that decide whether a translation reads as native

**`candidato` is this file's only term for the person** — zero occurrences of `usuario` anywhere in the file, unlike the Portuguese file where `usuário` dominated (#3272). The new rules follow `candidato` exclusively rather than defaulting to the more literal `usuario`.

**`inventar` is the established vocabulary for fabrication** here too — already used in `modes/es/oferta.md:54`: "Si no hay datos, decirlo claramente — no inventar nada." The translation uses `inventar`/`invención`/`inventan`/`inventado` throughout.

**No unicode arrow `→`.** The English rule's parenthetical uses `X → Y` shorthand, and I initially carried that over — but `modes/es/_shared.md` never uses `→` in body prose anywhere; the file's only arrow-shaped notation is ASCII `->`, and only inside HTML comments (`<!-- ... config/profile.yml -> narrative.exit_story -->`), never in rendered text. Introducing a character the file doesn't otherwise use would be a translator's habit bleeding in, not a match to source. Reworded instead: `usar X no es haber creado X`.

**Em dash `—`** matches the file's existing body-prose punctuation (already used multiple times outside headers).

## Scope

Spanish only, deliberately — one language per PR, per the umbrella's rules of engagement.

## Test plan

- [x] `node test-all.mjs` — 5371 passed, 0 failed (2 pre-existing unrelated warnings)
- [x] `npm run lint` (syntax check) — clean
- [x] Diffed against the two reference translations (`modes/nl/_shared.md`, `modes/ja/_shared.md`) for placement and content fidelity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring explicit supporting evidence for authorship claims involving projects, repositories, libraries, tools, frameworks, and open-source artifacts.
  * Clarified that keywords may be rephrased but not invented, and unsupported claims should be omitted or verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->