### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the German _shared.md (#2573)

### DIFF
--- a/modes/de/_shared.md
+++ b/modes/de/_shared.md
@@ -21,6 +21,8 @@
 
 **REGEL: Niemals Kennzahlen aus Proof Points hartcodieren.** Lies sie zur Bewertungszeit aus `cv.md` und `article-digest.md`.
 **REGEL: Bei Kennzahlen zu Artikeln/Projekten hat `article-digest.md` Vorrang vor `cv.md`** (in `cv.md` können ältere Zahlen stehen).
+**REGEL: NIEMALS behaupten, dass der Kandidat Autor/Urheber eines Projekts, Repositories, einer Bibliothek, eines Tools, Frameworks oder Open-Source-Artefakts ist, es sei denn, dies ist ausdrücklich in `cv.md` oder `article-digest.md` belegt.** Die Verwechslung von "ein Tool benutzen" mit "es erschaffen haben" ist das häufigste Erfindungsmuster und ist verboten.
+**REGEL: Keywords werden umformuliert, niemals erfunden.** Umordnen, umformulieren, betonen — aber niemals erfinden. Wenn eine Aussage nicht durch eine Datei im Scope belegt ist, den Kandidaten fragen; ohne Antwort weglassen. Schweigen zu einem Thema ist besser als ein erfundenes Detail.
 
 ---
 


### PR DESCRIPTION
Part of #2573 — German only, per the one-language-per-PR convention.

## What was missing

`modes/de/_shared.md` carried two `**REGEL` blocks, both about metrics. The English source has six, and the two the umbrella targets — authorship and reformulate-never-fabricate — were absent:

```
modes/_shared.md:32   NEVER claim the user authored a project, repo, library…
modes/_shared.md:33   Keywords get reformulated, never fabricated.
```

As the issue puts it: last line of defence intact (`verify-cv-facts.mjs` is language-agnostic and still blocks a fabricated employer at generation time), first line absent. This restores the first line for German.

Placed immediately after the existing metrics rules, which is where the umbrella asks for them and where the English original keeps them.

## Details that decide whether a translation reads as native

**`Kandidat`/`Kandidaten` is this file's established term for the person** (4 occurrences already in the file), so the new rules follow it.

**`erfinden` is the established vocabulary for fabrication** — already used twice in the German modes: `modes/de/_shared.md:166` ("Erfahrung oder Kennzahlen erfinden") and `modes/de/angebot.md:54` ("nichts erfinden"). The translation uses `erfinden`/`Erfindungsmuster`/`erfunden` throughout rather than introducing a synonym.

**`Keywords` stays in English**, matching the file's own established usage (`modes/de/angebot.md:145`: "Extrahierte Keywords") rather than translating to `Schlüsselwörter`.

**No unicode arrow `→` in body prose.** The English rule's parenthetical uses `X → Y` shorthand. `modes/de/_shared.md` does contain `→` three times, but checked each one: all three sit inside HTML comments (`<!-- ... config/profile.yml → narrative.exit_story -->`), never in rendered text. Same situation as the Spanish file (#3312) despite the different ASCII-vs-unicode choice inside comments — the arrow has no rendered-prose precedent here either, so it's reworded instead: `"ein Tool benutzen" mit "es erschaffen haben"`.

**Em dash `—`** matches the file's existing body-prose punctuation.

## Scope

German only, deliberately — one language per PR, per the umbrella's rules of engagement.

## Test plan

- [x] `node test-all.mjs` — 5371 passed, 0 failed (2 pre-existing unrelated warnings)
- [x] `npm run lint` (syntax check) — clean
- [x] Diffed against the two reference translations (`modes/nl/_shared.md`, `modes/ja/_shared.md`) for placement and content fidelity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added German evaluation guidance requiring authorship claims about projects or tools to be supported by approved source documents.
  * Clarified that keywords may be reformulated but not invented; unsupported claims should be clarified or omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->