### PR TITLE
fix(web): the logo resolver deletes accented letters to guess a domain, and caches the miss forever (#3318)

### DIFF
--- a/web/src/app/api/logo/route.ts
+++ b/web/src/app/api/logo/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { companyDomain } from "@/lib/company";
 import { companyCacheKey } from "@/lib/core/logo-cache-key.mjs";
+import { companyDomains } from "@/lib/core/company-domains.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,29 +23,6 @@ const DOMAIN_RE = /^[a-z0-9.-]{1,253}\.[a-z]{2,}$/i;
 
 function cacheDir(): string {
   return path.join(careerOpsRoot(), ".career-ops-web", "logo-cache");
-}
-
-/** Plausible domains for a company name, cheapest/likeliest first.
- *  The curated override map in lib/company wins when it knows the brand (it is
- *  the only source for non-.com marks like notion.so / zoom.us / deepmind.google);
- *  the slug guesses below cover everything else. Keeping both matters because ATS
- *  postings carry legal entity names ("Amazon.com Services LLC") that no single
- *  slug rule resolves — the firstWord stem is what rescues those.
- *  Changing which domains this returns, or their order, means bumping
- *  COMPANY_KEY_VERSION — warm caches would otherwise never see the change. */
-function companyDomains(company: string): string[] {
-  const paren = company.match(/\(([A-Za-z0-9]{2,12})\)/)?.[1]; // "… (5WPR)"
-  // [^()] (not [^)]) keeps the match unambiguous — no polynomial backtracking on
-  // adversarial inputs full of unclosed parens (CodeQL js/polynomial-redos).
-  const base = company.replace(/\([^()]*\)/g, "").trim();
-  const compact = base.toLowerCase().replace(/&/g, "and").replace(/[^a-z0-9]/g, "");
-  const firstWord = base.toLowerCase().split(/\s+/)[0].replace(/[^a-z0-9]/g, "");
-  const stems = [...new Set([compact, paren?.toLowerCase(), firstWord].filter((s): s is string => !!s && s.length >= 2 && s.length <= 30))];
-  const out: string[] = [];
-  const curated = companyDomain(base);
-  if (curated) out.push(curated);
-  for (const t of [".com", ".ai", ".io", ".co"]) for (const s of stems) out.push(s + t);
-  return [...new Set(out)].slice(0, 5);
 }
 
 /** Fetch a real favicon for one domain (Google's tokenless service). Returns the
@@ -82,7 +60,7 @@ export async function GET(req: NextRequest) {
     const companyKey = companyCacheKey(company);
     if (!companyKey) return new Response("bad company", { status: 400 });
     key = companyKey;
-    candidates = companyDomains(company);
+    candidates = companyDomains(company, companyDomain);
     if (candidates.length === 0) return new Response("no logo", { status: 404 });
   } else {
     return new Response("need domain or company", { status: 400 });

--- a/web/src/lib/core/ascii-fold.mjs
+++ b/web/src/lib/core/ascii-fold.mjs
@@ -1,0 +1,73 @@
+/**
+ * ascii-fold.mjs — algorithm mirror of the core's `lib/ascii-fold.mjs`.
+ *
+ * WHY A COPY EXISTS AT ALL: the same reason normalize-text-key.mjs and
+ * url-key.mjs carry one. The core lives in the user's career-ops checkout and
+ * is resolved at runtime via careerOpsRoot(), which the web bundle cannot
+ * import from; and an install predating a given core file would not have it at
+ * all. Keep the body byte-for-byte aligned with `lib/ascii-fold.mjs` — the
+ * parity test in tests/lib/ascii-fold.test.mjs fails the build if they drift.
+ *
+ * WHAT IT IS FOR HERE: turning a company name into a DOMAIN GUESS
+ * (app/api/logo/route.ts). That is the exact case the core module's docstring
+ * describes — the comparison target is ASCII by construction, so folding to the
+ * ASCII base letter is the intent, and DELETING the accented letter is always
+ * wrong. "Telefónica" resolves telefonica.com, never telefnica.com.
+ *
+ * Never reinstate a bare `[^a-z0-9]` strip here. That is the defect this file
+ * exists to end, and it has now been reintroduced independently three times
+ * (#2930 verify-portals, #2924 _trust-validator, and the logo resolver).
+ */
+
+/**
+ * Latin letters that do NOT decompose under NFD, so stripping combining marks
+ * alone still deletes them. Lowercase only; `asciiFold` lowercases first.
+ */
+// A stroke or bar through a letter is part of the GLYPH, not a combining
+// mark, so NFD leaves it and the [^a-z0-9] strip below then deletes the letter
+// outright — the failure this whole module exists to stop, surviving inside
+// it. Unlike the hostname case there is no substring luck here: "Işık" derived
+// "isk" and never "isik", so --add probed a slug no board uses.
+// ŋ is "ng", not "n" — the plausible one-to-one mapping is the wrong one.
+// (CodeRabbit, reviewing #2927.)
+const NON_DECOMPOSING_LATIN = [
+  [/ø/g, 'o'], [/æ/g, 'ae'], [/œ/g, 'oe'], [/ß/g, 'ss'],
+  [/đ/g, 'd'], [/ł/g, 'l'], [/þ/g, 'th'], [/ð/g, 'd'],
+  [/ħ/g, 'h'], [/ı/g, 'i'], [/ŋ/g, 'ng'], [/ŧ/g, 't'],
+  [/ĸ/g, 'k'], [/ſ/g, 's'],
+];
+
+/**
+ * Lowercase and fold a name to ASCII letters, digits and single spaces.
+ *
+ * @param {string} value - Raw display name.
+ * @param {{punctuation?: 'space'|'delete'}} [options] - How residual punctuation
+ *   is treated; see the note in the body. Word-level callers care, slug-style
+ *   callers do not.
+ * @returns {string} Folded name, or '' when nothing Latin survives.
+ */
+export function asciiFold(value, { punctuation = 'space' } = {}) {
+  let out = String(value ?? '').toLowerCase().normalize('NFD').replace(/\p{M}+/gu, '');
+  for (const [re, to] of NON_DECOMPOSING_LATIN) out = out.replace(re, to);
+  // 'space' (default) turns residual punctuation into a separator, so
+  // "Smith&Jones" becomes two words. 'delete' removes it, so it stays one.
+  //
+  // NOT cosmetic, which is why this is an option and not a harmonization
+  // (#3040). A caller that then matches WORDS gains words it never had:
+  //
+  //   Smith&Jones   space  -> "smith jones"  words: [smith, jones]
+  //                 delete -> "smithjones"   words: [smithjones]
+  //
+  // and `smith` substring-matches smithfield.com, so a
+  // company/hostname mismatch that should be flagged silently is not.
+  // Slug-style callers that collapse spaces converge either way; word-level
+  // callers do not, so the caller states which it needs.
+  //
+  // The 'delete' class is `[^a-z0-9 ]` with a LITERAL space, not `\s`: a tab or
+  // newline is removed rather than collapsed, matching the behaviour
+  // _trust-validator.mjs had before it moved here.
+  out = punctuation === 'delete'
+    ? out.replace(/[^a-z0-9 ]/g, '')
+    : out.replace(/[^a-z0-9\s]/g, ' ');
+  return out.replace(/\s+/g, ' ').trim();
+}

--- a/web/src/lib/core/company-domains.mjs
+++ b/web/src/lib/core/company-domains.mjs
@@ -1,0 +1,60 @@
+import { asciiFold } from "./ascii-fold.mjs";
+
+/**
+ * Plausible domains for a company name, cheapest/likeliest first.
+ *
+ * Extracted from app/api/logo/route.ts so it can be exercised directly — a
+ * route handler is not reachable from `node --test`, and this is the half of
+ * the logo resolver that decides whether a company can EVER get a logo. Same
+ * move as funnel-tiles.mjs / clean-chips.mjs / whats-new-suppression.mjs.
+ *
+ * THE FOLD IS THE POINT. The stems used to be built by DELETING every
+ * character outside `[a-z0-9]`, which is the defect lib/ascii-fold.mjs exists
+ * to end — its docstring names verify-portals.mjs (#2930) and
+ * providers/_trust-validator.mjs (#2924) as the two prior instances, and this
+ * was a third. A domain is ASCII by construction, so an accented letter has an
+ * ASCII counterpart the real domain actually uses:
+ *
+ *   Telefónica        deleted -> telefnica.com       folded -> telefonica.com
+ *   Škoda             deleted -> koda.com            folded -> skoda.com
+ *   Ørsted            deleted -> rsted.com           folded -> orsted.com
+ *   Société Générale  deleted -> socitgnrale.com     folded -> societegenerale.com
+ *
+ * It matters more here than in a comparison, because the logo cache never
+ * expires and stores misses as an empty sentinel: a domain that was never going
+ * to resolve is cached as "this company has no logo" permanently.
+ *
+ * A name with no Latin content (CJK, Cyrillic, Greek) folds to '' and yields no
+ * stems — the same real answer the core module documents. The curated override
+ * is still consulted first, so a brand that is in the map resolves regardless.
+ *
+ * `&` becomes "and" BEFORE folding, because the fold would otherwise delete it:
+ * "AT&T" has to stay attandt, which is what the pre-fold resolver produced.
+ * `firstWord` folds the raw first token rather than splitting the &-expanded
+ * string, so it stays "att" as before rather than becoming "atandt".
+ *
+ * @param {string} company - Raw company name, as it appears on a posting.
+ * @param {(name: string) => string|null} curatedDomain - The curated brand-map
+ *   lookup (lib/company.ts). Injected rather than imported: this file is plain
+ *   .mjs so node:test can load it without a TS runner, and the map is TS.
+ * @returns {string[]} Up to 5 domain candidates, curated first.
+ */
+export function companyDomains(company, curatedDomain = () => null) {
+  const paren = String(company ?? "").match(/\(([A-Za-z0-9]{2,12})\)/)?.[1]; // "… (5WPR)"
+  // [^()] (not [^)]) keeps the match unambiguous — no polynomial backtracking on
+  // adversarial inputs full of unclosed parens (CodeQL js/polynomial-redos).
+  const base = String(company ?? "").replace(/\([^()]*\)/g, "").trim();
+
+  const fold = (s) => asciiFold(s, { punctuation: "delete" }).replace(/ /g, "");
+  const compact = fold(base.replace(/&/g, "and"));
+  const firstWord = fold(base.split(/\s+/)[0] ?? "");
+
+  const stems = [...new Set([compact, paren?.toLowerCase(), firstWord]
+    .filter((s) => !!s && s.length >= 2 && s.length <= 30))];
+
+  const out = [];
+  const curated = curatedDomain(base);
+  if (curated) out.push(curated);
+  for (const t of [".com", ".ai", ".io", ".co"]) for (const s of stems) out.push(s + t);
+  return [...new Set(out)].slice(0, 5);
+}

--- a/web/src/lib/core/logo-cache-key.mjs
+++ b/web/src/lib/core/logo-cache-key.mjs
@@ -22,11 +22,16 @@ import { normalizeTextKey } from "./normalize-text-key.mjs";
  *  v2: curated brand domains (notion.so, zoom.us, …) now precede slug guesses.
  *  v3: normalization switched from `[^a-z0-9]` to the Unicode-safe
  *  normalizeTextKey (#2369/#2666's own lesson, reintroduced here independently)
+ *  v4: companyDomains() folds to ASCII instead of deleting non-ASCII letters,
+ *  so "Telefónica" now tries telefonica.com rather than telefnica.com. The bump
+ *  is mandatory per requirement 1 above and not merely tidy: every miss the old
+ *  resolver cached is an EMPTY SENTINEL, so an unchanged version would keep
+ *  serving that permanent "no logo" to exactly the companies the fix is for.
  *  — v2 stripped every non-ASCII letter, so "Škoda" and "Koda" hashed to the
  *  IDENTICAL key and one silently wore the other's logo forever (requirement 2,
  *  violated). Bumping discards any v2 entry poisoned this way rather than
  *  leaving it reachable under an unchanged "koda" key. */
-export const COMPANY_KEY_VERSION = "v3";
+export const COMPANY_KEY_VERSION = "v4";
 
 /** Cache key for a company name, or null if the name carries nothing to key on.
  *

--- a/web/tests/lib/ascii-fold.test.mjs
+++ b/web/tests/lib/ascii-fold.test.mjs
@@ -1,0 +1,53 @@
+// Parity + regression tests for the web's asciiFold mirror.
+// Imports the core and the web copy side-by-side so they can never drift, the
+// same shape normalize-text-key.test.mjs and url-key.test.mjs already use.
+//
+// Run:  node --test tests/lib/ascii-fold.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { asciiFold as webFold } from "../../src/lib/core/ascii-fold.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const { asciiFold: coreFold } = await import(pathToFileURL(join(ROOT, "lib", "ascii-fold.mjs")).href);
+
+const CASES = [
+  "Telefónica", "Škoda", "Ørsted", "Société Générale", "Nestlé",
+  "Peugeot Citroën", "Bâloise", "Sparkasse Köln", "Işık",
+  // The non-decomposing Latin letters the core enumerates by hand — the part a
+  // naive NFD-only mirror would get wrong.
+  "Ørsted", "Æther", "Œuvre", "Straße", "Đorđević", "Łódź", "Þór", "Ðan",
+  "Ħamrun", "Iğdır", "Ŋaro", "Ŧorp", "Kalaallit ĸ", "ſharp",
+  // No Latin content at all.
+  "日本電産", "Яндекс", "Ελλάδα",
+  // Plain ASCII must be untouched.
+  "Acme Inc", "AT&T", "Smith&Jones", "O'Reilly Media", "",
+];
+
+test("the web mirror folds identically to the core, in both punctuation modes", () => {
+  const drift = [];
+  for (const value of CASES) {
+    for (const punctuation of ["space", "delete"]) {
+      const web = webFold(value, { punctuation });
+      const core = coreFold(value, { punctuation });
+      if (web !== core) drift.push(`${JSON.stringify(value)} (${punctuation}): web ${JSON.stringify(web)} vs core ${JSON.stringify(core)}`);
+    }
+  }
+  assert.deepEqual(drift, [], `web/src/lib/core/ascii-fold.mjs has drifted from lib/ascii-fold.mjs:\n  ${drift.join("\n  ")}`);
+});
+
+test("the default punctuation mode matches the core's default", () => {
+  for (const value of CASES) assert.equal(webFold(value), coreFold(value), value);
+});
+
+test("folding transliterates rather than deleting — the whole point", () => {
+  // A guard, not a parity check: if both copies were changed to delete, the
+  // test above would still pass while the defect returned.
+  assert.equal(webFold("Telefónica", { punctuation: "delete" }), "telefonica");
+  assert.equal(webFold("Škoda", { punctuation: "delete" }), "skoda");
+  assert.equal(webFold("Ørsted", { punctuation: "delete" }), "orsted");
+  assert.equal(webFold("Straße", { punctuation: "delete" }), "strasse");
+  assert.equal(webFold("Ŋaro", { punctuation: "delete" }), "ngaro", "ŋ is 'ng', not 'n'");
+});

--- a/web/tests/lib/company-domains.test.mjs
+++ b/web/tests/lib/company-domains.test.mjs
@@ -1,0 +1,98 @@
+// The logo resolver's domain guesser: a company name -> the domains we probe.
+//
+// This decides whether a company can EVER get a logo, because the cache never
+// expires and stores misses as an empty sentinel (see logo-cache-key.mjs). A
+// domain that was never going to resolve is therefore written down as "this
+// company has no logo", permanently — so a stem that is merely *plausible* is
+// not good enough, it has to be the one the real domain uses.
+//
+// The stems used to be built by DELETING every character outside [a-z0-9],
+// which is the defect lib/ascii-fold.mjs exists to end. Its docstring names
+// verify-portals.mjs (#2930) and providers/_trust-validator.mjs (#2924) as the
+// two prior instances; this was a third, in the one place where the result is
+// cached forever.
+//
+// Run:  node --test tests/lib/company-domains.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { companyDomains } from "../../src/lib/core/company-domains.mjs";
+import { COMPANY_KEY_VERSION } from "../../src/lib/core/logo-cache-key.mjs";
+
+const first = (name) => companyDomains(name)[0] ?? null;
+
+test("an accented name resolves the domain it actually has", () => {
+  for (const [name, domain] of [
+    ["Telefónica", "telefonica.com"],
+    ["Škoda", "skoda.com"],
+    ["Ørsted", "orsted.com"],
+    ["Nestlé", "nestle.com"],
+    ["Bâloise", "baloise.com"],
+    ["Sparkasse Köln", "sparkassekoln.com"],
+    ["Peugeot Citroën", "peugeotcitroen.com"],
+  ]) {
+    assert.equal(first(name), domain, `${name} probed the wrong domain first`);
+  }
+});
+
+test("Société Générale gets both its full stem and its first word", () => {
+  const out = companyDomains("Société Générale");
+  assert.ok(out.includes("societegenerale.com"), `missing societegenerale.com: ${out}`);
+  assert.ok(out.includes("societe.com"), `missing the firstWord stem: ${out}`);
+  // The pre-fold resolver produced neither.
+  assert.ok(!out.some((d) => d.includes("socitgnrale")), `a deleted-letter stem survives: ${out}`);
+});
+
+test("plain ASCII names are completely unchanged", () => {
+  // The fold must be invisible to every name that was already resolving. These
+  // are the exact outputs the pre-fold implementation produced.
+  assert.deepEqual(companyDomains("AT&T"), ["atandt.com", "att.com", "atandt.ai", "att.ai", "atandt.io"]);
+  assert.deepEqual(companyDomains("Amazon.com Services LLC").slice(0, 2), ["amazoncomservicesllc.com", "amazoncom.com"]);
+  assert.deepEqual(companyDomains("Acme").slice(0, 2), ["acme.com", "acme.ai"]);
+  assert.deepEqual(companyDomains("O'Reilly Media").slice(0, 2), ["oreillymedia.com", "oreilly.com"]);
+});
+
+test("& becomes 'and' before folding, and firstWord is folded separately", () => {
+  // Two easy ways to get this wrong: fold first (the fold DELETES &, so AT&T
+  // would become "att" and lose the atandt stem), or derive firstWord from the
+  // &-expanded string (AT&T's first word would become "atandt", not "att").
+  const out = companyDomains("AT&T");
+  assert.ok(out.includes("atandt.com"), `& must expand to "and": ${out}`);
+  assert.ok(out.includes("att.com"), `firstWord must fold the raw token: ${out}`);
+});
+
+test("a name with no Latin content yields no stems rather than a bad guess", () => {
+  // Deliberate, and the same answer the core fold documents: no ASCII domain
+  // can contain it, so probing one would only cache a miss. The route turns an
+  // empty list into a 404 and the client falls back to its monogram.
+  for (const name of ["日本電産", "Яндекс", "Ελλάδα"]) {
+    assert.deepEqual(companyDomains(name), [], `${name} produced a guess`);
+  }
+});
+
+test("a curated brand domain still wins, and comes first", () => {
+  const curated = (n) => (n === "Notion" ? "notion.so" : null);
+  const out = companyDomains("Notion", curated);
+  assert.equal(out[0], "notion.so", "the curated map must outrank the slug guesses");
+  assert.ok(out.includes("notion.com"), "the slug guesses are still offered as fallbacks");
+});
+
+test("a parenthesised acronym is still a stem, and parens are stripped from the base", () => {
+  const out = companyDomains("Acme Holdings (5WPR)");
+  assert.ok(out.includes("5wpr.com"), `acronym stem missing: ${out}`);
+  assert.ok(out.includes("acmeholdings.com"), `base stem missing: ${out}`);
+});
+
+test("at most five candidates, deduplicated", () => {
+  const out = companyDomains("Acme");
+  assert.ok(out.length <= 5, `${out.length} candidates`);
+  assert.equal(new Set(out).size, out.length, "duplicates leaked through");
+});
+
+test("the cache key version was bumped for this resolver change", () => {
+  // logo-cache-key.mjs's own docstring makes this mandatory: the cache never
+  // expires and misses are stored as an empty sentinel, so without a bump every
+  // warm install keeps serving the permanent "no logo" this change exists to
+  // fix — to exactly the companies it fixes it for.
+  assert.notEqual(COMPANY_KEY_VERSION, "v3", "companyDomains() changed while COMPANY_KEY_VERSION stayed at v3");
+});

--- a/web/tests/lib/company-domains.test.mjs
+++ b/web/tests/lib/company-domains.test.mjs
@@ -21,6 +21,15 @@ import { COMPANY_KEY_VERSION } from "../../src/lib/core/logo-cache-key.mjs";
 
 const first = (name) => companyDomains(name)[0] ?? null;
 
+// EXACT membership, deliberately not `list.includes(domain)`. CodeQL reads an
+// `includes` whose argument looks like a host as js/incomplete-url-substring-
+// sanitization and flags every one of these (7 alerts on the first push of this
+// PR). It is a false positive here — these are whole domain strings in an
+// array, not a substring test against a URL — but Set.has says what is actually
+// meant, so the query has nothing to misread and the assertion gets stricter
+// rather than merely quieter.
+const offers = (list, domain) => new Set(list).has(domain);
+
 test("an accented name resolves the domain it actually has", () => {
   for (const [name, domain] of [
     ["Telefónica", "telefonica.com"],
@@ -37,10 +46,10 @@ test("an accented name resolves the domain it actually has", () => {
 
 test("Société Générale gets both its full stem and its first word", () => {
   const out = companyDomains("Société Générale");
-  assert.ok(out.includes("societegenerale.com"), `missing societegenerale.com: ${out}`);
-  assert.ok(out.includes("societe.com"), `missing the firstWord stem: ${out}`);
+  assert.ok(offers(out, "societegenerale.com"), `missing societegenerale.com: ${out}`);
+  assert.ok(offers(out, "societe.com"), `missing the firstWord stem: ${out}`);
   // The pre-fold resolver produced neither.
-  assert.ok(!out.some((d) => d.includes("socitgnrale")), `a deleted-letter stem survives: ${out}`);
+  assert.ok(![...out].some((d) => d.startsWith("socitgnrale")), `a deleted-letter stem survives: ${out}`);
 });
 
 test("plain ASCII names are completely unchanged", () => {
@@ -57,8 +66,8 @@ test("& becomes 'and' before folding, and firstWord is folded separately", () =>
   // would become "att" and lose the atandt stem), or derive firstWord from the
   // &-expanded string (AT&T's first word would become "atandt", not "att").
   const out = companyDomains("AT&T");
-  assert.ok(out.includes("atandt.com"), `& must expand to "and": ${out}`);
-  assert.ok(out.includes("att.com"), `firstWord must fold the raw token: ${out}`);
+  assert.ok(offers(out, "atandt.com"), `& must expand to "and": ${out}`);
+  assert.ok(offers(out, "att.com"), `firstWord must fold the raw token: ${out}`);
 });
 
 test("a name with no Latin content yields no stems rather than a bad guess", () => {
@@ -74,13 +83,13 @@ test("a curated brand domain still wins, and comes first", () => {
   const curated = (n) => (n === "Notion" ? "notion.so" : null);
   const out = companyDomains("Notion", curated);
   assert.equal(out[0], "notion.so", "the curated map must outrank the slug guesses");
-  assert.ok(out.includes("notion.com"), "the slug guesses are still offered as fallbacks");
+  assert.ok(offers(out, "notion.com"), "the slug guesses are still offered as fallbacks");
 });
 
 test("a parenthesised acronym is still a stem, and parens are stripped from the base", () => {
   const out = companyDomains("Acme Holdings (5WPR)");
-  assert.ok(out.includes("5wpr.com"), `acronym stem missing: ${out}`);
-  assert.ok(out.includes("acmeholdings.com"), `base stem missing: ${out}`);
+  assert.ok(offers(out, "5wpr.com"), `acronym stem missing: ${out}`);
+  assert.ok(offers(out, "acmeholdings.com"), `base stem missing: ${out}`);
 });
 
 test("at most five candidates, deduplicated", () => {


### PR DESCRIPTION
Fixes #3318.

`companyDomains()` built its stems with `[^a-z0-9]`, which **deletes** an accented letter rather than folding it — so the domain probed is one the company does not have:

| company | before | after |
|---|---|---|
| Telefónica | `telefnica.com` | `telefonica.com` |
| Škoda | `koda.com` | `skoda.com` |
| Ørsted | `rsted.com` | `orsted.com` |
| Nestlé | `nestl.com` | `nestle.com` |
| Société Générale | `socitgnrale.com` | `societegenerale.com` |
| Peugeot Citroën | `peugeotcitron.com` | `peugeotcitroen.com` |
| Sparkasse Köln | `sparkassekln.com` | `sparkassekoln.com` |

This is the third independent instance of the shape `lib/ascii-fold.mjs` exists to end — its docstring names the other two (#2930 `verify-portals`, #2924 `_trust-validator`) and states the rule: deletion is always wrong when the comparison target is ASCII by construction, and a domain is.

**It matters more here than in a comparison.** The logo cache never expires and records misses as an empty sentinel, precisely so a dead company is never refetched. A domain that could not have resolved is written down as *"this company has no logo"* permanently.

**And it is one function away from a fix that just landed.** #3134 made the cache *key* Unicode-aware; `logo-cache-key.mjs`'s v3 note says v2 "stripped every non-ASCII letter, so Škoda and Koda hashed to the same key". The key was fixed, the resolver it versions was not — so Škoda now reliably gets its own permanent miss instead of accidentally sharing Koda's hit.

## Change (two commits)

1. **`web/src/lib/core/ascii-fold.mjs`** — a mirror of `lib/ascii-fold.mjs` with a parity test, alongside the existing `normalize-text-key` / `url-key` mirrors and for the same reason. The parity test also asserts transliteration directly: if *both* copies were changed to delete, parity alone would still pass while the defect returned.
2. **The fix.** `companyDomains()` moves to `web/src/lib/core/company-domains.mjs` so it is testable at all — a route handler is unreachable from `node --test` — with the curated brand map injected rather than imported, since it is TS and this is plain `.mjs` (same shape as `whats-new-suppression.mjs`). `COMPANY_KEY_VERSION` → **v4**, which `logo-cache-key.mjs` makes mandatory: without it every warm install keeps serving the cached "no logo" to exactly the companies this fixes.

## ASCII parity

The fold has to be invisible to every name that already resolved. Checked against the pre-fix implementation over 20 ASCII names — `AT&T`, `Amazon.com Services LLC`, `O'Reilly Media`, `Ben & Jerry's`, `salesforce.com, inc.`, `J.P. Morgan`, `E*TRADE`, `3M`, `Acme (5WPR)`, … — **all 20 byte-identical.**

Two ways to get that wrong, both pinned by a test:

- fold first → the fold deletes `&`, so `AT&T` loses its `atandt` stem. `&` becomes `and` *before* folding.
- derive `firstWord` from the `&`-expanded string → `AT&T`'s first word becomes `atandt`, not `att`. It folds the raw token instead.

## Verification

Reverting the fold to the delete form, with the tests kept:

```
✖ an accented name resolves the domain it actually has
✖ Société Générale gets both its full stem and its first word
ℹ pass 7  ℹ fail 2
```

Reverting only the version bump:

```
✖ the cache key version was bumped for this resolver change
ℹ pass 8  ℹ fail 1
```

`cd web && npm test` → 379 passed, 0 failed.
`node test-all.mjs --quick` → 5377 passed, 0 failed (3 pre-existing warnings).

## Noted, not changed

A name with no Latin content (日本電産, Яндекс) folds to `''`, yields no stems, and the route 404s so the client falls back to its monogram. That is the correct answer — no ASCII domain can contain it — and it is what the core module documents, but it is asserted by a test so it reads as a decision rather than an accident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved logo discovery with more accurate company-domain candidates.
  - Added support for accented and international company names.
  - Expanded suggestions across `.com`, `.ai`, `.io`, and `.co`.
  - Improved handling of ampersands, acronyms, and alternate identifiers.
  - Reduced duplicate and invalid suggestions while preserving curated domains.
  - Updated logo resolution to recognize improved domain matches and refresh affected cached results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->