### PR TITLE
fix(fact-gate): a non-English CV inflating headcount returns 'pass' — say so instead (#3320)

### DIFF
--- a/tests/fact-gate-language-coverage.test.mjs
+++ b/tests/fact-gate-language-coverage.test.mjs
@@ -1,0 +1,108 @@
+// tests/fact-gate-language-coverage.test.mjs — the fabrication gate must not
+// report a confident pass on a document it could not read.
+//
+// verify-cv-facts.mjs is the last check before a generated CV or cover letter
+// goes out (generate-cover-letter.mjs calls assertFacts on every one). Its
+// count extractor is keyed on METRIC_NOUNS, an English word list, and
+// COUNT_CLAIM_RE's modifier window is `[A-Za-z]`. Percentages, currency and
+// multipliers are language-neutral and still checked everywhere — a COUNT is
+// checked only in English.
+//
+// That is not an edge case for this project. AGENTS.md's `language.output`
+// governs "reports, tracker notes, PDFs, cover letters ... any user-visible
+// prose", and the repo ships market modes for de/fr/ar/ja/tr/hi. And counts are
+// the class the file's own METRIC_NOUNS comment singles out:
+//
+//   "Managed 45 staff against a source saying 20 passed the gate silently,
+//    which is the exact fabrication class this script exists to catch."
+//
+// Run:  node --test tests/fact-gate-language-coverage.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { verifyFacts, diagnoseCoverage } from '../verify-cv-facts.mjs';
+
+// No sources and no config: this asks what the gate SEES, not what it allows.
+const BARE = { sourcePaths: [], configPath: 'config/__no_such_config__.json' };
+const verdictOf = (text) => verifyFacts(text, BARE).verdict;
+
+test('an English count inflation is caught, as it always was', () => {
+  const r = verifyFacts('Managed 45 staff across 3 facilities.', BARE);
+  assert.equal(r.verdict, 'block');
+  assert.deepEqual([...r.invented].sort(), ['3 facilities', '45 staff']);
+  assert.equal(r.coverage, null, 'a document the extractor read needs no coverage warning');
+});
+
+test('the same inflation in a space-delimited language is reported as unchecked', () => {
+  for (const [lang, text] of [
+    ['es', 'Gestioné 45 empleados en 3 instalaciones.'],
+    ['de', 'Leitete 45 Mitarbeiter an 3 Standorten.'],
+    ['tr', '3 tesiste 45 çalışanı yönetti.'],
+    ['pt', 'Geri 45 funcionários em 3 unidades.'],
+  ]) {
+    const r = verifyFacts(text, BARE);
+    assert.ok(r.coverage, `${lang}: no coverage signal — this document reads as scanned and clean`);
+    assert.equal(r.coverage.reason, 'no-count-claims-recognized');
+    assert.ok(r.coverage.spans.length >= 2, `${lang}: expected the count spans to be located`);
+    assert.equal(r.verdict, 'warn', `${lang}: a document the gate could not read must not verdict 'pass'`);
+  }
+});
+
+test('a clean English document is untouched — no new noise', () => {
+  // The signal is added to a gate every generated document already runs, so a
+  // false fire is a real cost. These must all stay silent.
+  for (const text of [
+    'Senior Engineer at Acme since 2019. Led the 2024 platform migration.',
+    'Cut p99 latency by 30% and infrastructure spend by $1.2M.',
+    'Mentored 6 engineers and ran 4 hiring loops.',
+    'Managed 20 staff across 2 facilities.',
+    // Currency followed by prose reads as "digits, then a word" to a detector
+    // that has no lexicon — but these ARE checked, in every language, so
+    // reporting them as unread is a false alarm. Caught by the existing suite
+    // (test-all "source-backed currency metrics") before this shipped.
+    'Raised $120k and closed a $90,000 deal.',
+    'Cut spend by $1.2M and latency by 30%.',
+    '',
+  ]) {
+    assert.equal(diagnoseCoverage(text), null, `fired on: ${JSON.stringify(text)}`);
+  }
+});
+
+test('a year is not a count', () => {
+  // Every CV carries several, and "Led the 2024 migration" is the shape of a
+  // count and none of the meaning. Without the year filter this fires on
+  // essentially every document, English included.
+  assert.equal(diagnoseCoverage('Led the 2024 migration and the 2019 rollout.'), null);
+});
+
+test('the signal never creates or masks a block', () => {
+  // A real fabrication still blocks even when the coverage warning also applies,
+  // and a coverage gap alone never escalates to block — that would fail every
+  // non-English document, trading a silent gap for a wall.
+  const both = verifyFacts('Gestioné 45 empleados en 3 instalaciones y aumenté ingresos un 30%.', BARE);
+  assert.equal(both.verdict, 'block', 'the language-neutral 30% claim must still block');
+  assert.ok(both.coverage, 'and the unchecked counts must still be reported');
+
+  assert.equal(verdictOf('Leitete 45 Mitarbeiter an 3 Standorten.'), 'warn');
+});
+
+test('one recognised count silences the warning — the documented under-report', () => {
+  // French "sites" collides with the English noun, so the gate reaches one count
+  // and the rest stay invisible. Asserted so the limitation is a decision on
+  // record rather than an accident, and so a future lexicon change that removes
+  // this coincidence shows up here.
+  const r = verifyFacts('Encadré 45 collaborateurs sur 3 sites.', BARE);
+  assert.equal(r.coverage, null);
+  assert.deepEqual([...r.invented], ['3 sites'], 'only the coincidental noun was read');
+});
+
+test('CJK is NOT covered by this detector, and that is recorded', () => {
+  // Japanese and Chinese put digits flush against the text, so the digit run is
+  // preceded by a letter and the detector does not see it. Relaxing that would
+  // match digits inside Latin identifiers, so it needs script-aware
+  // segmentation rather than a looser regex. Pinned as a known gap: if a later
+  // change makes this fire, that is an improvement and this test should be
+  // updated deliberately, not a regression.
+  assert.equal(diagnoseCoverage('3拠点で45名のスタッフを管理。'), null);
+  assert.equal(diagnoseCoverage('管理3个站点的45名员工。'), null);
+});

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -307,6 +307,121 @@ export function metricClaims(text) {
   return claims;
 }
 
+// A number counting a word, in ANY script — the language-agnostic SHAPE of the
+// claims COUNT_CLAIM_RE recognises only when the noun happens to be English.
+// Used solely to answer "were there count claims this gate could not read?",
+// never to build a claim: it has no lexicon, so it cannot say what was counted.
+const GENERIC_COUNT_RE = new RegExp(
+  String.raw`(?<![\p{L}\p{N}])(\d[\d,.]*)\s*\+?\s*(?:[\p{L}][\p{L}\p{M}-]*[\s]+){0,${MODIFIER_WINDOW}}([\p{L}][\p{L}\p{M}]{2,})`,
+  'giu',
+);
+// A year is not a count. "Led the 2024 migration" is the shape above and none
+// of its meaning, and every CV has several.
+const YEAR_LIKE = /^(?:19|20)\d{2}$/;
+
+/**
+ * Count-shaped spans in `text`, whatever language it is written in.
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+function countShapedSpans(text) {
+  const clean = stripMarkup(String(text ?? ''));
+
+  // Ranges the language-neutral patterns already own. "$120k and closed a
+  // $90,000 deal" is currency followed by prose, and reads as two counts to a
+  // detector that only knows "digits, then a word" — but those amounts ARE
+  // checked, in every language, so reporting them as unread is a false alarm.
+  // Derived from SIMPLE_CLAIM_PATTERNS rather than re-guessed, so the two
+  // cannot drift.
+  const covered = [];
+  for (const pattern of SIMPLE_CLAIM_PATTERNS) {
+    for (const m of clean.matchAll(pattern)) covered.push([m.index, m.index + m[0].length]);
+  }
+  const alreadyChecked = (i) => covered.some(([from, to]) => i >= from && i < to);
+
+  const out = [];
+  for (const m of clean.matchAll(GENERIC_COUNT_RE)) {
+    if (YEAR_LIKE.test(m[1].replace(/[,.]/g, ''))) continue;
+    // The digits are what a simple pattern would have claimed, so test their
+    // position, not the span's — the span starts at the number either way, but
+    // a currency match starts one character earlier, at the symbol.
+    if (alreadyChecked(m.index) || alreadyChecked(m.index + m[0].indexOf(m[1]))) continue;
+    out.push(m[0].trim());
+  }
+  return out;
+}
+
+/**
+ * Whether this document contains count claims the extractor could not read.
+ *
+ * METRIC_NOUNS is an English word list, and COUNT_CLAIM_RE's modifier window is
+ * `[A-Za-z]`. Percentages, currency and multipliers are language-neutral and
+ * still checked everywhere — but a COUNT is checked only in English, and this
+ * file's own METRIC_NOUNS comment names counts as the class that gets inflated:
+ * "Managed 45 staff against a source saying 20 passed the gate silently, which
+ * is the exact fabrication class this script exists to catch."
+ *
+ * For a CV written in one of the market languages the project ships modes for,
+ * that sentence is true of EVERY count, not only the ones outside the list:
+ *
+ *   ES  "Gestioné 45 empleados en 3 instalaciones."  -> 0 count claims, pass
+ *   DE  "Leitete 45 Mitarbeiter an 3 Standorten."    -> 0 count claims, pass
+ *   JA  "3拠点で45名のスタッフを管理。"                   -> 0 count claims, pass
+ *
+ * AGENTS.md makes non-English output a first-class case (`language.output`
+ * governs "reports, tracker notes, PDFs, cover letters ... any user-visible
+ * prose"), so this is not an edge.
+ *
+ * Reporting it rather than blocking is the same choice jd-skill-gap.mjs's
+ * diagnoseExtraction() and story-provenance-check.mjs's diagnose() make, and
+ * for the reason story-provenance states outright: so "an empty/near-empty
+ * result isn't misread as 'scanned and clean'". Blocking instead would fail
+ * every non-English document, trading a silent gap for a wall.
+ *
+ * DELIBERATELY CONSERVATIVE. It fires only when the document has two or more
+ * count-shaped spans and the extractor produced NO count claim at all — a
+ * document where the lexicon reached something is assumed to be reaching it in
+ * the language it was written in. Under-reporting is the right direction for a
+ * signal added to a gate every generated document already runs.
+ *
+ * TWO KNOWN BLIND SPOTS, stated rather than implied:
+ *
+ *   - Coincidental coverage. French "3 sites" matches the English noun, so one
+ *     recognised count silences the warning for a French CV whose other counts
+ *     are invisible.
+ *   - CJK. This detector needs whitespace: it locates a count by a digit run
+ *     that is not preceded by a letter and is followed by one. Japanese and
+ *     Chinese put digits flush against the surrounding text ("3拠点で45名"),
+ *     so the second number is preceded by a letter and is not seen at all.
+ *     Relaxing the lookbehind to fix that would match digits inside Latin
+ *     identifiers, so it needs script-aware segmentation rather than a looser
+ *     regex — separate work, and the reason this is a partial answer.
+ *
+ * So this closes the silent pass for space-delimited languages (de, es, tr, pt,
+ * it, pl, ru, ...). A ja/zh CV can still reach 'pass' unchecked, which is why
+ * the real answer is a lexicon those languages are in, not a better detector.
+ *
+ * @param {string} targetText
+ * @returns {{reason: string, message: string, spans: string[]}|null}
+ */
+export function diagnoseCoverage(targetText) {
+  const spans = countShapedSpans(targetText);
+  if (spans.length < 2) return null;
+  COUNT_CLAIM_RE.lastIndex = 0;
+  const recognized = [...stripMarkup(String(targetText ?? '')).matchAll(COUNT_CLAIM_RE)];
+  if (recognized.length > 0) return null;
+  return {
+    reason: 'no-count-claims-recognized',
+    message:
+      `${spans.length} count-like claims are present but none matched the metric extractor, whose noun ` +
+      'list is English-only — so no count in this document was checked against your sources. ' +
+      'Percentages, currency and multipliers were still checked. Verify the counts by hand, or add ' +
+      'them to allow_metrics in config/cv-facts.json once confirmed.',
+    spans,
+  };
+}
+
 /**
  * Build the allow-list a metric claim is checked against.
  *
@@ -396,12 +511,18 @@ export function verifyFacts(targetText, {
   const warnings = config.warn_phrases
       .filter(Boolean)
       .filter(phrase => stripMarkup(targetText).toLowerCase().includes(String(phrase).toLowerCase()));
+  // Never downgrades a block and never creates one: a document that fails on
+  // real evidence still fails on that, and a coverage gap only turns a would-be
+  // 'pass' into 'warn' so the caller is told the gate could not read it.
+  const coverage = diagnoseCoverage(targetText);
+  const blocked = invented.length || unsupportedFacts.length || forbidden.length;
   return {
-    verdict: invented.length || unsupportedFacts.length || forbidden.length ? 'block' : warnings.length ? 'warn' : 'pass',
+    verdict: blocked ? 'block' : (warnings.length || coverage) ? 'warn' : 'pass',
     invented,
     unsupportedFacts,
     forbidden,
     warnings,
+    coverage,
   };
 }
 
@@ -735,6 +856,10 @@ export function runCli(args = process.argv.slice(2)) {
     if (result.verdict === 'warn') {
       console.error(`CV fact check warning: ${basename(targetPath)}`);
       for (const phrase of result.warnings) console.error(`  - advisory phrase: ${phrase}`);
+      if (result.coverage) {
+        console.error(`  - not checked: ${result.coverage.message}`);
+        for (const span of result.coverage.spans.slice(0, 8)) console.error(`      ${span}`);
+      }
       return 0;
     }
     console.error(`CV fact check failed: ${basename(targetPath)}`);
@@ -754,7 +879,7 @@ export function runCli(args = process.argv.slice(2)) {
     return 1;
   } catch (err) {
     if (parsed.json) {
-      console.log(JSON.stringify({ verdict: 'block', invented: [], unsupportedFacts: [], forbidden: [], warnings: [], errors: [err.message] }));
+      console.log(JSON.stringify({ verdict: 'block', invented: [], unsupportedFacts: [], forbidden: [], warnings: [], coverage: null, errors: [err.message] }));
       return 1;
     }
     console.error(`ERROR: ${err.message}`);


### PR DESCRIPTION
Fixes #3320.

`verify-cv-facts.mjs` is the last check before a generated document goes out (`generate-cover-letter.mjs` calls `assertFacts` on every cover letter; the CLI gates CVs). Its count extractor is keyed on `METRIC_NOUNS`, an English word list. Percentages, currency and multipliers are language-neutral and still checked everywhere — **a count is checked only in English.**

Same inflation, sources saying 20 and 2 in every case:

| | verdict before | verdict after |
|---|---|---|
| `Managed 45 staff across 3 facilities.` | block | block |
| `Gestioné 45 empleados en 3 instalaciones.` | **pass** | warn + coverage |
| `Leitete 45 Mitarbeiter an 3 Standorten.` | **pass** | warn + coverage |
| `3 tesiste 45 çalışanı yönetti.` | **pass** | warn + coverage |
| `Geri 45 funcionários em 3 unidades.` | **pass** | warn + coverage |

Counts are the class this file's own `METRIC_NOUNS` comment singles out — *"'Managed 45 staff' against a source saying 20 passed the gate silently, which is the exact fabrication class this script exists to catch."* For a non-English CV that is true of every count, not only the ones outside the list.

## What this does — and deliberately does not

The real answer is a lexicon those languages are in. I have **not** attempted that: it is ~70 nouns × 6+ languages and needs native speakers (cf. #3223). Inventing that vocabulary unreviewed would look done and not be.

What is unambiguous is that the gate should not return a confident `pass` on a document it could not read. `diagnoseCoverage()` reports the gap instead — the same choice `jd-skill-gap.mjs`'s `diagnoseExtraction()` and `story-provenance-check.mjs`'s `diagnose()` make, the latter documented as existing so *"an empty/near-empty result isn't misread as 'scanned and clean'"*.

It only ever turns a would-be `pass` into `warn`. It never creates a block and never masks one — blocking would fail every non-English document, trading a silent gap for a wall.

## Calibration, because this runs on every generated document

Fires only when there are **two or more** count-shaped spans and **no** recognised count at all. Spans the language-neutral patterns already own are excluded, derived from `SIMPLE_CLAIM_PATTERNS` so the two cannot drift.

That exclusion exists because the **existing suite caught a false positive** before this shipped:

```
❌ source-backed currency metrics were blocked:
   coverage.spans: ["120k and closed", "90,000 deal"]
```

`$120k and closed a $90,000 deal` is currency followed by prose — it reads as two counts to a detector with no lexicon, but those amounts *are* checked. Years are excluded for the same reason: `Led the 2024 migration` is the shape of a count and none of the meaning, and without that filter it fires on essentially every document.

## Two blind spots, asserted rather than described

- **Coincidental coverage.** French `3 sites` matches the English noun, so one recognised count silences the warning for a French CV whose other counts are invisible.
- **CJK.** `3拠点で45名` puts digits flush against the text, so the second number is preceded by a letter and the detector cannot locate it. Relaxing that would match digits inside Latin identifiers, so it needs script-aware segmentation, not a looser regex.

Both have tests. If a later change makes either fire, that is an improvement and the test should be updated deliberately — not something someone discovers by surprise.

## Verification

Reverting only the wiring, with tests kept:

```
✖ the same inflation in a space-delimited language is reported as unchecked
✖ the signal never creates or masks a block
ℹ pass 5  ℹ fail 2
```

`node verify-cv-facts.mjs --self-test` → 62 passed, 0 failed.
`node test-all.mjs --quick` → 5378 passed, 0 failed (3 pre-existing warnings).

Happy to follow up with a lexicon PR for whichever languages you want if you'd rather go at the root directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added broader detection for count-based claims across languages.
  - Added coverage diagnostics to identify claims that cannot be fully verified.
  - CLI and JSON results now include coverage warnings when verification is incomplete.

- **Bug Fixes**
  - Unsupported-language counts now produce warnings instead of being incorrectly treated as verified.
  - Coverage warnings no longer hide or override blocking verification failures.

- **Tests**
  - Added coverage for multilingual counts, clean metrics and years, coincidental matches, and known CJK detection gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->