### PR TITLE
fix(calibrate): reads 7 of the 14 outcome types outcome.mjs writes (#3322)

### DIFF
--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -94,15 +94,15 @@ export function parseOutcomeJournal(text) {
   const feedback = [];
   for (const entry of entries) {
     const typeMatch = entry.match(/^- \*\*Outcome Type\*\*: *(\S+)/m);
-    // Resolved through the shared vocabulary, not looked up directly. An
-    // UNRECOGNIZED type must not leave `latestType` at its previous value
-    // either: that is precisely how a journal ending in `ghosted` reported the
-    // `interview_progress` above it — the happiest historical moment this
+    // Assigned UNCONDITIONALLY when the field is present, including when it
+    // resolves to null. The last entry is the truth, so a final entry this
+    // vocabulary cannot read must not leave the previous one standing —
+    // `interview_progress` then `withdrawn_by_employer` is not an application
+    // still progressing through interviews. Clearing it falls through to the
+    // tracker status, which is the honest answer for an outcome we cannot read;
+    // keeping the earlier one is the happiest-historical-moment behaviour this
     // function's contract forbids.
-    if (typeMatch) {
-      const canonical = canonicalOutcome(typeMatch[1]);
-      if (canonical) latestType = canonical;
-    }
+    if (typeMatch) latestType = canonicalOutcome(typeMatch[1]);
     // Feedback is a blockquote under "Verbatim Feedback"; "None recorded" is
     // the explicit empty marker outcome.mjs writes, not user content.
     const fbMatch = entry.match(/- \*\*Verbatim Feedback\*\*:\n((?:> .*\n?)+)/);

--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -35,6 +35,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { parseTrackerRow, resolveColumns, isSeparatorRow, isHeaderRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
+import { canonicalOutcome } from './lib/outcome-types.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 
@@ -45,7 +46,11 @@ const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // scoring picked a matchable role), and an offer is tier 2. `rejected` and
 // `no_response` are terminal negatives. `interview_only` means the process
 // ended after interviews with no offer — it still reached tier 1.
-const JOURNAL_OUTCOMES = {
+// Keyed by CANONICAL type only. outcome.mjs accepts fourteen spellings and
+// writes whichever one was typed straight into the journal, so every read goes
+// through canonicalOutcome() first — a private list of the seven canonical
+// names silently ignored the other seven (see lib/outcome-types.mjs).
+export const JOURNAL_OUTCOMES = {
   hired: { reachedInterview: true, reachedOffer: true, terminal: true },
   offer_received: { reachedInterview: true, reachedOffer: true, terminal: true },
   offer_declined: { reachedInterview: true, reachedOffer: true, terminal: true },
@@ -89,7 +94,15 @@ export function parseOutcomeJournal(text) {
   const feedback = [];
   for (const entry of entries) {
     const typeMatch = entry.match(/^- \*\*Outcome Type\*\*: *(\S+)/m);
-    if (typeMatch && JOURNAL_OUTCOMES[typeMatch[1]]) latestType = typeMatch[1];
+    // Resolved through the shared vocabulary, not looked up directly. An
+    // UNRECOGNIZED type must not leave `latestType` at its previous value
+    // either: that is precisely how a journal ending in `ghosted` reported the
+    // `interview_progress` above it — the happiest historical moment this
+    // function's contract forbids.
+    if (typeMatch) {
+      const canonical = canonicalOutcome(typeMatch[1]);
+      if (canonical) latestType = canonical;
+    }
     // Feedback is a blockquote under "Verbatim Feedback"; "None recorded" is
     // the explicit empty marker outcome.mjs writes, not user content.
     const fbMatch = entry.match(/- \*\*Verbatim Feedback\*\*:\n((?:> .*\n?)+)/);

--- a/lib/outcome-types.mjs
+++ b/lib/outcome-types.mjs
@@ -1,0 +1,96 @@
+/**
+ * outcome-types.mjs — the ONE vocabulary of application outcomes.
+ *
+ * `outcome.mjs` accepts a type on the command line, normalizes it, and writes
+ * it verbatim into `data/outcomes/{...}/outcome.md` as
+ * `- **Outcome Type**: {key}`. Anything that later READS that journal has to
+ * accept every spelling the writer accepts, or a recorded outcome is invisible
+ * to it.
+ *
+ * That is not hypothetical: `calibrate.mjs` shipped with a private 7-entry copy
+ * of a 14-entry vocabulary, so half the spellings `outcome.mjs` had always
+ * accepted resolved to nothing there. Two of them (`declined`, `ghosted`) were
+ * dropped from calibration entirely, and a journal whose LAST entry used an
+ * alias reported its previous, happier entry — the exact behaviour
+ * parseOutcomeJournal's docstring promises never happens.
+ *
+ * So the map lives here and both ends import it. `outcome.mjs` cannot be
+ * imported (it is a top-level CLI that exits on load), which is why a reader
+ * could not simply reuse its copy and ended up writing a second one.
+ */
+
+/**
+ * Every accepted outcome type → the tracker state it sets and its default note.
+ * Moved here verbatim from outcome.mjs; `outcome.mjs` remains the only writer.
+ */
+export const OUTCOME_MAP = {
+  interview_progress: { state: 'Interview', defaultNote: 'Stage updated' },
+  stage_reached: { state: 'Interview', defaultNote: 'Stage updated' },
+  interview: { state: 'Interview', defaultNote: 'Interview stage' },
+  offer_received: { state: 'Offer', defaultNote: 'Offer received' },
+  offer: { state: 'Offer', defaultNote: 'Offer received' },
+  hired: { state: 'Hired', defaultNote: 'Offer accepted' },
+  accepted: { state: 'Hired', defaultNote: 'Offer accepted' },
+  offer_declined: { state: 'Discarded', defaultNote: 'Offer declined by candidate' },
+  declined: { state: 'Discarded', defaultNote: 'Offer declined by candidate' },
+  rejected: { state: 'Rejected', defaultNote: 'Application rejected' },
+  rejection: { state: 'Rejected', defaultNote: 'Application rejected' },
+  no_response: { state: 'Discarded', defaultNote: 'No response / ghosted' },
+  ghosted: { state: 'Discarded', defaultNote: 'No response / ghosted' },
+  interview_only: { state: 'Interview', defaultNote: 'Interview process completed' },
+};
+
+/**
+ * The seven types `outcome.mjs`'s own USAGE line advertises. Every other key in
+ * OUTCOME_MAP is a synonym for one of these.
+ */
+export const CANONICAL_OUTCOMES = [
+  'interview_progress', 'interview_only', 'offer_received', 'hired',
+  'offer_declined', 'rejected', 'no_response',
+];
+
+/**
+ * Synonym → the canonical type that carries its meaning.
+ *
+ * Written out rather than derived. Deriving it from the `{state, defaultNote}`
+ * pairs above looks tighter and is wrong: `interview` shares a state with
+ * `interview_progress` but carries its own note, and `offer_declined`,
+ * `no_response` and their synonyms all share the state `Discarded` while
+ * meaning opposite things about the outcome. State is a tracker position, not a
+ * result. What stops an omission here is the coverage check below and the drift
+ * test, not cleverness.
+ */
+const ALIASES = {
+  stage_reached: 'interview_progress',
+  interview: 'interview_progress',
+  offer: 'offer_received',
+  accepted: 'hired',
+  declined: 'offer_declined',
+  rejection: 'rejected',
+  ghosted: 'no_response',
+};
+
+// A synonym added to OUTCOME_MAP without a meaning here is a real decision, not
+// a spelling. Fail loudly at load rather than let it read as unknown wherever
+// the journal is consumed — which is the failure this module exists to end.
+for (const key of Object.keys(OUTCOME_MAP)) {
+  if (!CANONICAL_OUTCOMES.includes(key) && !(key in ALIASES)) {
+    throw new Error(`outcome-types.mjs: "${key}" is accepted by outcome.mjs but has no canonical meaning; add it to ALIASES or CANONICAL_OUTCOMES`);
+  }
+}
+
+/**
+ * Resolve any accepted spelling to its canonical type.
+ *
+ * Applies the same normalization `outcome.mjs` applies before writing
+ * (lowercase, `-` → `_`), so a hand-edited journal saying `Offer-Declined`
+ * still resolves.
+ *
+ * @param {unknown} raw - A type as written in a journal or typed on the CLI.
+ * @returns {string|null} The canonical type, or null when unrecognized.
+ */
+export function canonicalOutcome(raw) {
+  const key = String(raw ?? '').trim().toLowerCase().replace(/-/g, '_');
+  if (CANONICAL_OUTCOMES.includes(key)) return key;
+  return ALIASES[key] ?? null;
+}

--- a/outcome.mjs
+++ b/outcome.mjs
@@ -23,6 +23,10 @@ import { join, dirname, resolve, extname } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import { parseTrackerRow, resolveColumns, extractTrackerReportNumbers } from './tracker-parse.mjs';
+// The vocabulary this CLI accepts is also READ by calibrate.mjs, which cannot
+// import this file (top-level CLI, exits on load). Shared so the two cannot
+// drift — they already had (#3315 shipped a 7-entry copy of these 14).
+import { OUTCOME_MAP } from './lib/outcome-types.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import {
   normalizeCompany,
@@ -56,22 +60,6 @@ function today() {
   return new Date().toISOString().split('T')[0];
 }
 
-const OUTCOME_MAP = {
-  interview_progress: { state: 'Interview', defaultNote: 'Stage updated' },
-  stage_reached: { state: 'Interview', defaultNote: 'Stage updated' },
-  interview: { state: 'Interview', defaultNote: 'Interview stage' },
-  offer_received: { state: 'Offer', defaultNote: 'Offer received' },
-  offer: { state: 'Offer', defaultNote: 'Offer received' },
-  hired: { state: 'Hired', defaultNote: 'Offer accepted' },
-  accepted: { state: 'Hired', defaultNote: 'Offer accepted' },
-  offer_declined: { state: 'Discarded', defaultNote: 'Offer declined by candidate' },
-  declined: { state: 'Discarded', defaultNote: 'Offer declined by candidate' },
-  rejected: { state: 'Rejected', defaultNote: 'Application rejected' },
-  rejection: { state: 'Rejected', defaultNote: 'Application rejected' },
-  no_response: { state: 'Discarded', defaultNote: 'No response / ghosted' },
-  ghosted: { state: 'Discarded', defaultNote: 'No response / ghosted' },
-  interview_only: { state: 'Interview', defaultNote: 'Interview process completed' },
-};
 
 const USAGE = `Usage: node outcome.mjs <report#|company> <outcome_type> [options]
 

--- a/tests/outcome-vocabulary-drift.test.mjs
+++ b/tests/outcome-vocabulary-drift.test.mjs
@@ -75,6 +75,22 @@ test('a hand-edited journal spelling still resolves', () => {
   assert.equal(parseOutcomeJournal(journal('REJECTED')).latestType, 'rejected');
 });
 
+test('an unrecognized FINAL entry clears the earlier one', () => {
+  // The same defect as the alias case, one step further out: a type genuinely
+  // outside the vocabulary must not leave the previous entry standing either.
+  // `interview_progress` then `withdrawn_by_employer` is not an application
+  // still progressing through interviews — null falls through to the tracker
+  // status, which is the honest answer for an outcome we cannot read.
+  assert.equal(parseOutcomeJournal(journal('interview_progress', 'withdrawn_by_employer')).latestType, null);
+  assert.equal(parseOutcomeJournal(journal('offer_received', 'something_new')).latestType, null);
+  // …and it really does fall through, rather than dropping the row.
+  const rows = [{ num: 1, company: 'Acme', score: 4.6, status: 'Rejected' }];
+  const journals = new Map([[1, parseOutcomeJournal(journal('offer_received', 'something_new'))]]);
+  const out = computeCalibration(rows, journals, { minBandN: 1 });
+  assert.equal(out.resolved, 1, 'the row must resolve from its tracker status');
+  assert.equal(out.bands.find((b) => b.band === '>=4.5').offers, 0, 'the stale offer must not survive');
+});
+
 test('an unrecognized type is still unrecognized', () => {
   // The widening must not turn into "accept anything": an unknown type has to
   // fall through to the tracker status, not invent a meaning.

--- a/tests/outcome-vocabulary-drift.test.mjs
+++ b/tests/outcome-vocabulary-drift.test.mjs
@@ -1,0 +1,101 @@
+// tests/outcome-vocabulary-drift.test.mjs — one vocabulary, two ends.
+//
+// outcome.mjs accepts an outcome type, normalizes it, and writes it VERBATIM
+// into data/outcomes/{...}/outcome.md as `- **Outcome Type**: {key}`. Anything
+// that later reads that journal must accept every spelling the writer accepts,
+// or a recorded outcome is invisible to it.
+//
+// calibrate.mjs (#3315) shipped with a private 7-entry copy of a 14-entry
+// vocabulary. Two consequences, and the second is the one that matters:
+//
+//   1. `declined` and `ghosted` resolved to nothing, and their tracker state is
+//      `Discarded`, which calibrate reads as "never applied — outside the
+//      population". So a declined OFFER — the strongest evidence the score
+//      predicted well — was dropped from calibration entirely.
+//   2. parseOutcomeJournal only advanced `latestType` on a RECOGNIZED type, so
+//      a journal whose last entry used an alias reported the entry above it.
+//      Its own docstring forbids exactly this: "an application that went
+//      interview_progress and later rejected must read as rejected, not as its
+//      happiest historical moment."
+//
+// The census below is what stops it recurring: it is derived from OUTCOME_MAP,
+// so a synonym added to the writer is covered on the day it is added.
+//
+// Run:  node --test tests/outcome-vocabulary-drift.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OUTCOME_MAP, CANONICAL_OUTCOMES, canonicalOutcome } from '../lib/outcome-types.mjs';
+import { parseOutcomeJournal, computeCalibration, JOURNAL_OUTCOMES } from '../calibrate.mjs';
+
+const journal = (...types) => types.map((t) => `## Entry: 2026-01-01\n- **Outcome Type**: ${t}\n`).join('');
+
+test('every spelling outcome.mjs accepts carries a meaning calibrate can read', () => {
+  const orphans = [];
+  for (const key of Object.keys(OUTCOME_MAP)) {
+    const canonical = canonicalOutcome(key);
+    if (!canonical) { orphans.push(`${key}: no canonical type`); continue; }
+    if (!JOURNAL_OUTCOMES[canonical]) orphans.push(`${key} -> ${canonical}: absent from calibrate's JOURNAL_OUTCOMES`);
+  }
+  assert.deepEqual(orphans, [], `outcome types the writer accepts and the reader cannot resolve:\n  ${orphans.join('\n  ')}`);
+});
+
+test('calibrate knows exactly the canonical set, no more and no less', () => {
+  // Both directions. A canonical type missing here is an outcome that cannot be
+  // scored; an extra one is a meaning no writer can produce.
+  assert.deepEqual(Object.keys(JOURNAL_OUTCOMES).sort(), [...CANONICAL_OUTCOMES].sort());
+});
+
+test('a journal written with an alias resolves to its canonical meaning', () => {
+  for (const [alias, canonical] of [
+    ['declined', 'offer_declined'],
+    ['ghosted', 'no_response'],
+    ['rejection', 'rejected'],
+    ['accepted', 'hired'],
+    ['offer', 'offer_received'],
+    ['interview', 'interview_progress'],
+    ['stage_reached', 'interview_progress'],
+  ]) {
+    assert.equal(parseOutcomeJournal(journal(alias)).latestType, canonical, `alias ${alias}`);
+  }
+});
+
+test('the LAST entry wins even when it is an alias', () => {
+  // The docstring's promise. Before the fix each of these reported the first
+  // entry, because the second was unrecognized and left latestType untouched.
+  assert.equal(parseOutcomeJournal(journal('interview_progress', 'ghosted')).latestType, 'no_response');
+  assert.equal(parseOutcomeJournal(journal('interview_progress', 'rejection')).latestType, 'rejected');
+  assert.equal(parseOutcomeJournal(journal('offer_received', 'declined')).latestType, 'offer_declined');
+});
+
+test('a hand-edited journal spelling still resolves', () => {
+  // outcome.mjs normalizes before writing, but the journal is a markdown file a
+  // user can edit. canonicalOutcome applies the same normalization.
+  assert.equal(parseOutcomeJournal(journal('Offer-Declined')).latestType, 'offer_declined');
+  assert.equal(parseOutcomeJournal(journal('REJECTED')).latestType, 'rejected');
+});
+
+test('an unrecognized type is still unrecognized', () => {
+  // The widening must not turn into "accept anything": an unknown type has to
+  // fall through to the tracker status, not invent a meaning.
+  assert.equal(parseOutcomeJournal(journal('withdrawn_by_employer')).latestType, null);
+  assert.equal(canonicalOutcome('nonsense'), null);
+  assert.equal(canonicalOutcome(''), null);
+  assert.equal(canonicalOutcome(null), null);
+});
+
+test('a declined offer counts as reaching an offer, whichever spelling recorded it', () => {
+  // The end-to-end consequence. Tracker state for both spellings is Discarded,
+  // which calibrate reads as outside the population — so before the fix the
+  // alias row vanished instead of counting as the strongest positive signal
+  // there is.
+  const rows = [{ num: 1, company: 'Acme', score: 4.6, status: 'Discarded' }];
+  for (const spelling of ['offer_declined', 'declined']) {
+    const journals = new Map([[1, parseOutcomeJournal(journal(spelling))]]);
+    const out = computeCalibration(rows, journals, { minBandN: 1 });
+    assert.equal(out.resolved, 1, `${spelling}: dropped from the population`);
+    const band = out.bands.find((b) => b.band === '>=4.5');
+    assert.equal(band.offers, 1, `${spelling}: not counted as reaching an offer`);
+    assert.equal(band.interviews, 1, `${spelling}: not counted as reaching an interview`);
+  }
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -157,6 +157,7 @@ const SYSTEM_PATHS = [
   'lib/gemini-node-floor.mjs',
   'lib/local-today.mjs',
   'lib/is-main-module.mjs',
+  'lib/outcome-types.mjs',
   'lib/latex-escape.mjs',
   'scan-hn.mjs',
   'scripts/check-syntax.mjs',


### PR DESCRIPTION
Fixes #3322.

`outcome.mjs` accepts **14** spellings of an outcome type and writes whichever was typed verbatim into the journal. `calibrate.mjs` (#3315) reads it against a private **7**-entry map.

## Two consequences

**A declined offer is dropped from calibration entirely.** `declined` resolves to nothing, so the row falls back to its tracker status — `Discarded`, which calibrate reads as *"never applied — outside calibration's population"* and skips. Not resolved, not in-flight, not counted. A declined offer is the strongest evidence a search can produce that the scoring picked well.

**The journal reports its happiest historical moment.** `latestType` only advanced on a recognized type, so an unrecognized final entry left the previous one standing:

| journal | before | after |
|---|---|---|
| `interview_progress` → `ghosted` | `interview_progress` | `no_response` |
| `interview_progress` → `rejection` | `interview_progress` | `rejected` |
| `offer_received` → `declined` | `offer_received` | `offer_declined` |
| `declined` | `null` | `offer_declined` |
| `ghosted` | `null` | `no_response` |

`parseOutcomeJournal`'s own docstring forbids exactly this:

> the LAST `## Entry:` block is the current truth — an application that went interview_progress and later rejected must read as rejected, **not as its happiest historical moment**.

For half the vocabulary it read as exactly that, inflating the interview-conversion rate the tool exists to measure.

## Why the copy existed

`outcome.mjs` is a top-level CLI that **exits on import** (`node -e "await import('./outcome.mjs')"` → prints usage, exit 1), so a reader cannot reuse its map. The fix gives the vocabulary one home rather than extending the copy.

## Change (three commits)

1. **`lib/outcome-types.mjs`** — `OUTCOME_MAP` moved verbatim, plus the canonical seven `outcome.mjs`'s USAGE advertises and `canonicalOutcome()`. `outcome.mjs` imports it; usage line and error text unchanged.
2. **`calibrate.mjs`** resolves through it, and no longer leaves a stale `latestType` standing.
3. **The census**, derived from `OUTCOME_MAP` so a synonym added to the writer is covered the day it is added.

The alias table is written out rather than derived from the `{state, defaultNote}` pairs. Deriving looks tighter and is wrong: `interview` shares a state with `interview_progress` but carries its own note, and `offer_declined`, `no_response` and their synonyms all share the state `Discarded` while meaning opposite things about the outcome. **State is a tracker position, not a result.** A load-time coverage check plus the drift test is what prevents an omission.

## Verification

Reverting only the lookup in `parseOutcomeJournal`, tests kept:

```
✖ a journal written with an alias resolves to its canonical meaning
✖ the LAST entry wins even when it is an alias
✖ a hand-edited journal spelling still resolves
✖ a declined offer counts as reaching an offer, whichever spelling recorded it
ℹ pass 3  ℹ fail 4
```

The three that pass either way are the guards: the census, the exact-canonical-set assertion, and *an unrecognized type is still unrecognized* — the widening must not become "accept anything".

`node calibrate.mjs --self-test` → all checks passed.
`node outcome.mjs --help` / invalid-type error → unchanged, all 14 types still listed.
`node test-all.mjs --quick` → 5380 passed, 0 failed (3 pre-existing warnings).

## Updater registration

`lib/outcome-types.mjs` is added to `SYSTEM_PATHS` — without it, `apply` ships the updated `outcome.mjs` to an existing install without the module it now imports. Confirmed by removing the entry and re-running `validate-system-paths-coverage.mjs`:

```
Coverage gap — tracked files not in SYSTEM_PATHS or USER_PATHS:
  lib/outcome-types.mjs
```

Worth knowing for the next person adding a lib file: that guard reads `git ls-files`, so it reported `OK: 1198 tracked files covered` while the file was still untracked and only flagged it after `git add`. Not a bug — but it means the check is worth re-running *after* staging, not before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outcome recognition across calibration and validation workflows.
  * Added consistent handling for aliases, capitalization differences, and unknown outcomes.
  * Ensured the most recent journal entry determines the final outcome.
  * Prevented stale outcomes from being retained when the final entry is unrecognized.
  * Correctly calibrates declined offers.

* **Chores**
  * Included updated outcome definitions in system updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->