### PR TITLE
fix(jobbankca): count raw entries for pagination

### DIFF
--- a/providers/jobbankca.mjs
+++ b/providers/jobbankca.mjs
@@ -281,11 +281,12 @@ export default {
           break;
         }
 
+        const rawEntryCount = (String(xml ?? '').match(/<entry\b[^>]*>[\s\S]*?<\/entry>/gi) || []).length;
         const parsed = parseJobBankFeed(xml);
         for (const job of parsed) {
           if (!byUrl.has(job.url)) byUrl.set(job.url, job);
         }
-        if (parsed.length < PAGE_SIZE) break; // short page — end of this keyword's results
+        if (rawEntryCount < PAGE_SIZE) break; // short feed page — end of this keyword's results
       }
       if (!keywordFailed) succeeded++;
     }

--- a/tests/providers/jobbankca.test.mjs
+++ b/tests/providers/jobbankca.test.mjs
@@ -413,6 +413,50 @@ try {
     else fail(`jobbankca.fetch() only slept ${slept}ms total for 2 requests`);
   }
 
+  // A page can contain the full 100 raw Atom entries even when one is
+  // filtered during parsing. Pagination is determined by the upstream page
+  // size, not by how many rows survive local validation.
+  {
+    const entry = (id, title = `role ${id}`) => `<entry>
+      ${title ? `<title><![CDATA[${title}]]></title>` : ''}
+      <link rel="alternate" href="https://www.jobbank.gc.ca/jobsearch/jobposting/${id}"/>
+      <id>${id}</id>
+      <updated>2026-08-20T08:00:00Z</updated>
+      <summary><![CDATA[<strong>Location:</strong> X]]></summary>
+    </entry>`;
+    const feed = (entries) => `<?xml version="1.0"?><feed>${entries.join('')}</feed>`;
+    const fullRawPage = [
+      ...Array.from({ length: 99 }, (_, i) => entry(i)),
+      entry('titleless', ''),
+    ];
+    const laterPage = [entry(100)];
+    const requested = [];
+
+    const fetched = await jobbankca.fetch(
+      { provider: 'jobbankca', name: 'Raw page size test', jobbankca: { keywords: ['developer'] } },
+      {
+        sleep: async () => {},
+        fetchText: async (url) => {
+          requested.push(url);
+          return new URL(url).searchParams.get('page') === '1'
+            ? feed(fullRawPage)
+            : feed(laterPage);
+        },
+      },
+    );
+
+    if (requested.length === 2) {
+      pass('jobbankca.fetch() paginates after a full 100-entry feed page even when one entry is filtered');
+    } else {
+      fail(`jobbankca.fetch() made ${requested.length} request(s) after a full raw page with one filtered entry (expected 2)`);
+    }
+    if (fetched.length === 100 && fetched.some((job) => job.title === 'role 100')) {
+      pass('jobbankca.fetch() returns only valid jobs while retaining jobs from the later page');
+    } else {
+      fail(`jobbankca.fetch() returned ${fetched.length} valid job(s) and later-page job=${fetched.some((job) => job.title === 'role 100')} (expected 100/true)`);
+    }
+  }
+
   // ── fetch(): entry.max_pages configures the run, ctx.maxPages only caps it ──
   {
     const feed = (n) => `<?xml version="1.0"?><feed>${Array.from({ length: n }, (_, i) => `<entry><title><![CDATA[r${i}]]></title><link rel="alternate" href="https://www.jobbank.gc.ca/jobsearch/jobposting/${i}"/><id>${i}</id><updated>2026-08-20T08:00:00Z</updated><summary><![CDATA[x]]></summary></entry>`).join('')}</feed>`;


### PR DESCRIPTION
Fixes #3249.

Changes:
- Base the short-page stop on raw Atom entry count.
- Keep invalid-row filtering unchanged.
- Add the confirmed 100-entry regression with one titleless row and a valid second page.

Verified with the focused Job Bank suite and the full test suite: 5,386 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job search pagination so results continue loading when a full page includes entries that cannot be displayed.
  - Prevented valid jobs from being omitted when some listings lack required details.

- **Tests**
  - Added coverage for pagination with incomplete job entries to ensure subsequent pages are requested correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->