### PR TITLE
refactor(cv): adopt isMainModule for the document generators (#3170)

### DIFF
--- a/application-answers.mjs
+++ b/application-answers.mjs
@@ -2,7 +2,7 @@
 
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 export const APPLICATION_ANSWERS_HEADING = '## Application Answers';
 
@@ -424,7 +424,7 @@ async function main() {
   console.log(JSON.stringify({ report: reportPath, date: normalized.date, state: normalized.state }, null, 2));
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     console.error(err.message);
     process.exitCode = 1;

--- a/application-artifacts.mjs
+++ b/application-artifacts.mjs
@@ -11,8 +11,8 @@
 import { mkdirSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { parseArgs } from 'util';
-import { fileURLToPath } from 'url';
 import { validateFlags } from './lib/cli-flags.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const DEFAULT_OUTPUT_ROOT = resolve('output');
 const DECISIONS = new Set(['reuse', 'reuse-with-edits', 'regenerate']);
@@ -154,7 +154,7 @@ async function main() {
   console.log(JSON.stringify(paths, null, 2));
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+if (isMainModule(import.meta.url)) {
   main().catch((error) => {
     console.error(`application-artifacts: ${error.message}`);
     process.exitCode = 1;

--- a/archive-posting.mjs
+++ b/archive-posting.mjs
@@ -26,10 +26,11 @@ import { chromium } from 'playwright';
 import { writeFile, readFile } from 'fs/promises';
 import { existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath } from 'url';
 import { reportPrefix } from './jd-capture.mjs';
 import { rejectPrivateOrInvalid, validateUrlSecurity } from './liveness-browser.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const JDS_DIR = join(ROOT, 'jds');
@@ -471,7 +472,7 @@ async function main() {
   if (failed > 0) process.exit(1);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url)) {
   parseCliArgs(process.argv.slice(2));
   main().catch(err => {
     console.error('❌  Fatal:', err.message);

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -8,6 +8,7 @@ import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_TEMPLATES_DIR = resolve(__dirname, 'templates');
@@ -277,7 +278,7 @@ export function resolveTemplate(kind, name, opts = {}) {
 }
 
 // ---- CLI ----
-const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
   const argv = process.argv.slice(2);
   const cmd = argv[0];

--- a/extract-latex-content.mjs
+++ b/extract-latex-content.mjs
@@ -15,8 +15,8 @@
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { resolve, basename } from 'path';
-import { pathToFileURL } from 'url';
 import { buildManifest } from './lib/latex-content.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 async function main() {
   const args = process.argv.slice(2).filter(a => a !== '--help');
@@ -57,6 +57,6 @@ async function main() {
   process.exit(manifest.supported ? 0 : 1);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -16,10 +16,11 @@
 
 import { readFileSync, existsSync, mkdirSync } from "fs";
 import { dirname, resolve, join, relative, isAbsolute } from "path";
-import { fileURLToPath, pathToFileURL } from "url";
+import { fileURLToPath } from "url";
 import { parseArgs } from "util";
 import { assertFacts } from "./verify-cv-facts.mjs";
 import { resolveTemplate } from "./cv-templates.mjs";
+import { isMainModule } from "./lib/is-main-module.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_ROOT = resolve(__dirname, "output");
@@ -347,5 +348,5 @@ Usage:
   }
 }
 
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const isMain = isMainModule(import.meta.url);
 if (isMain) main();

--- a/generate-latex.mjs
+++ b/generate-latex.mjs
@@ -17,7 +17,7 @@ import { readFile, writeFile, stat, copyFile, rm } from 'fs/promises';
 import { resolve, basename, dirname, join } from 'path';
 import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const MIN_SECTIONS = 4;
 
@@ -249,6 +249,6 @@ async function main() {
   process.exit(report.compiled ? 0 : (report.valid ? 1 : 1));
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/img-to-pdf.mjs
+++ b/img-to-pdf.mjs
@@ -28,7 +28,7 @@ import { chromium } from 'playwright';
 import { resolve, dirname, extname } from 'path';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const MIME_TYPES = {
   '.png': 'image/png',
@@ -253,7 +253,7 @@ async function main() {
   }
 }
 
-const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
   main();
 }

--- a/patch-latex-content.mjs
+++ b/patch-latex-content.mjs
@@ -16,8 +16,8 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { resolve, dirname } from 'path';
-import { pathToFileURL } from 'url';
 import { applyPatches } from './lib/latex-content.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 async function main() {
   const args = process.argv.slice(2).filter(a => a !== '--help');
@@ -81,6 +81,6 @@ async function main() {
   console.log(JSON.stringify(report, null, 2));
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/tests/main-guard-convention.test.mjs
+++ b/tests/main-guard-convention.test.mjs
@@ -218,21 +218,11 @@ const EXEMPT = new Map([
 // When the last entry goes, delete PENDING, its uses, and this comment. A
 // ratchet that outlives its job is just a permanent hole.
 const PENDING = new Set([
-  'application-answers.mjs',
-  'application-artifacts.mjs',
-  'archive-posting.mjs',
-  'cv-templates.mjs',
-  'extract-latex-content.mjs',
-  'generate-cover-letter.mjs',
-  'generate-latex.mjs',
-  'img-to-pdf.mjs',
-  'patch-latex-content.mjs',
   'plugin-audit.mjs',
   'plugins.mjs',
   'update-system.mjs',
   'validate-plugin-registry.mjs',
-  'verify-cv-facts.mjs',
-  ]);
+]);
 
 function entryRefViolations(src) {
   const hits = [];

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -14,7 +14,8 @@
 
 import { existsSync, readFileSync } from 'fs';
 import { isAbsolute, join, dirname, basename } from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath } from 'url';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SOURCES = ['cv.md', 'article-digest.md'];
@@ -887,6 +888,6 @@ export function runCli(args = process.argv.slice(2)) {
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url)) {
   process.exitCode = runCli();
 }


### PR DESCRIPTION
## What does this PR do?

Converts the 10 CV, cover-letter and artifact generators to `isMainModule()`
from #3278.

This is where the silent-success failure mode was most expensive. Through a
symlinked checkout `generate-latex`, `img-to-pdf` and `generate-cover-letter`
produced no file and exited 0 — so `apply` and `pdf` recorded an artifact that
was never written, and the tracker's PDF column said ✅ for a file that does not
exist.

`PENDING` drops by 10.

## One ordering note

`cv-templates.mjs` is also rewritten by `feature/template-packs` (parseMeta /
resolveTemplate). Whichever lands second needs a trivial rebase — the change
here is an import plus one line.

## Part of the #3170 series

Batch 3 of 6. #3278 landed the shared helper, the convention test and its
`PENDING` ratchet; this is one of the mechanical conversion batches.

**Batches 2–5 are order-free** — they touch disjoint files and can merge in any
order. The only overlap is the `PENDING` list in
`tests/main-guard-convention.test.mjs`, which is *derived* data: when a sibling
merges, this branch's list is regenerated from the tree rather than hand-merged.
Batch 6 (updater + plugin governance) must land last, because it deletes the
ratchet.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Issue opened first (#3170, confirmed by @santifer)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass (5388 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — system-layer files only
- [x] My changes align with the project roadmap

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized command-line entry-point detection across multiple tools.
  - Improved consistency when scripts are run directly or imported as modules.
  - Preserved existing command-line behavior and exit-code handling.

- **Tests**
  - Updated convention checks to reflect the reduced number of remaining scripts requiring conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->