### PR TITLE
feat: add structured resume integration and service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Alternatives: gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking-exp
 # GEMINI_MODEL=gemini-2.0-flash
 
+# Optional: local structured resume service
+# CAREER_OPS_RESUME_PORT=3010
+
 # ── Other integrations (add your own below) ──────────────────────────────────
 # ANTHROPIC_API_KEY=your_anthropic_key_here   # For Claude-based workflows
 # OPENAI_API_KEY=your_openai_key_here          # Future OpenAI integration

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,17 @@
 # Personal data (user fills these)
 cv.md
+article-digest.md
 data/applications.md
 data/pipeline.md
 data/scan-history.tsv
+data/resume.json
+data/shortlist-*.md
+data/application-materials/
+data/cover-letters/
+data/resume-variants/
+data/follow-ups.md
+interview-prep/story-bank.md
+interview-prep/*.md
 reports/*.md
 !reports/.gitkeep
 output/*
@@ -28,6 +37,8 @@ modes/_profile.md
 
 # Generated
 .resolved-prompt-*
+tmp-structured-request*.json
+structured-request*.json
 node_modules/
 bun.lock
 

--- a/cv-sync-check.mjs
+++ b/cv-sync-check.mjs
@@ -81,6 +81,25 @@ if (existsSync(digestPath)) {
   }
 }
 
+// 5. Check optional structured resume source
+const structuredResumePath = join(projectRoot, 'data', 'resume.json');
+if (existsSync(structuredResumePath)) {
+  try {
+    const structuredResume = JSON.parse(readFileSync(structuredResumePath, 'utf-8'));
+    if (!structuredResume.personalDetails?.fullName) {
+      warnings.push('data/resume.json exists but personalDetails.fullName is missing.');
+    }
+    if (!structuredResume.content?.work?.entries?.length) {
+      warnings.push('data/resume.json exists but work.entries is empty.');
+    }
+    if (!structuredResume.content?.skill?.entries?.length) {
+      warnings.push('data/resume.json exists but skill.entries is empty.');
+    }
+  } catch (error) {
+    errors.push(`data/resume.json is not valid JSON: ${error.message}`);
+  }
+}
+
 // Output results
 console.log('\n=== career-ops sync check ===\n');
 

--- a/docs/STRUCTURED_RESUME.md
+++ b/docs/STRUCTURED_RESUME.md
@@ -1,0 +1,152 @@
+# Structured Resume Integration
+
+Career-ops now supports an alternate structured resume source at `data/resume.json`.
+
+This integration is adapted from your `job-automation-n8n` repo, but wired into the current `career-ops` setup instead of replacing it.
+
+## What It Adds
+
+- Patch-based resume tailoring using stable entry IDs
+- Validation before patch application
+- A local HTTP service for:
+  - `GET /health`
+  - `GET /context`
+  - `POST /generate-resume`
+  - `POST /generate-coverletter`
+- A CLI bundle generator that fits the existing `career-ops` tracker flow
+- Resume PDF rendering that reuses the current `career-ops` fonts and CV template
+
+## Import Your Existing resume.json
+
+If your older repo exists next to `career-ops`, run:
+
+```bash
+npm run resume:import
+```
+
+Or import from a custom file path:
+
+```bash
+node import-resume-json.mjs /absolute/path/to/resume.json
+```
+
+## Start The Local Service
+
+```bash
+npm run resume:server
+```
+
+Default port: `3010`
+
+Override with `CAREER_OPS_RESUME_PORT`.
+
+## Generate An Application Bundle
+
+Use the shared CLI bridge when you want the structured resume engine to participate in the normal `career-ops` application flow.
+
+```bash
+npm run resume:bundle -- path/to/request.json
+```
+
+The request JSON can include:
+
+```json
+{
+  "company": "Example Co",
+  "role": "Backend Engineer",
+  "language": "en",
+  "format": "a4",
+  "patch": {
+    "jobTitle": "Backend Engineer",
+    "profile": "<p>Backend-focused software developer...</p>",
+    "competencies": ["Backend Engineering", "REST APIs", "Node.js", "AWS"]
+  },
+  "coverLetter": {
+    "companyAddress": "Berlin, Germany",
+    "paragraph1": "Why this company and role",
+    "paragraph2": "Why your background fits",
+    "paragraph3": "Why you want to continue the conversation"
+  },
+  "tracker": {
+    "num": 11,
+    "date": "2026-04-22",
+    "score": "4.40/5",
+    "status": "Evaluated",
+    "report": "reports/011-example-co-backend-engineer-2026-04-22.md",
+    "notes": "Strong backend fit with good Berlin alignment"
+  }
+}
+```
+
+What it writes:
+
+- Tailored resume HTML + PDF
+- Tailored cover letter HTML + PDF
+- Bundle manifest JSON under `output/structured/YYYY-MM-DD/Applications/`
+- Optional tracker TSV under `batch/tracker-additions/`
+
+If you include `tracker`, the TSV is ready for `node merge-tracker.mjs`.
+
+## Endpoints
+
+### `GET /health`
+
+Returns service status and whether `data/resume.json` exists.
+
+### `GET /context`
+
+Returns the structured resume in plain-text AI-friendly form:
+
+- `currentJobTitle`
+- `currentProfile`
+- `currentWork`
+- `currentSkills`
+- `currentProjects`
+
+### `POST /generate-resume`
+
+Accepts a patch and renders a tailored resume HTML + PDF.
+
+Example body:
+
+```json
+{
+  "company": "Example Co",
+  "role": "Backend Engineer",
+  "language": "en",
+  "format": "a4",
+  "patch": {
+    "jobTitle": "Backend Engineer",
+    "profile": "<p>Backend-focused software developer...</p>",
+    "competencies": ["Backend Engineering", "REST APIs", "Node.js", "AWS"],
+    "work": [
+      {
+        "id": "286ca64e-9ab1-4d32-9905-0996d5d6a5c1",
+        "description": "<ul><li><p>Tailored bullet...</p></li></ul>"
+      }
+    ]
+  }
+}
+```
+
+### `POST /generate-coverletter`
+
+Accepts role/company paragraphs and renders a cover letter HTML + PDF.
+
+## Output Paths
+
+Generated files are written to:
+
+```text
+output/structured/YYYY-MM-DD/Resume/
+output/structured/YYYY-MM-DD/Coverletter/
+output/structured/YYYY-MM-DD/Applications/
+```
+
+## Design Notes
+
+- `career-ops` remains the primary workflow and tracker
+- `cv.md`, `profile.yml`, and reports are still the main human-facing layer
+- `data/resume.json` is an alternate machine-friendly source for patch-based generation
+- `generate-structured-application.mjs` is the bridge into the standard tracker/report pipeline
+- This reuses the strongest architecture from `job-automation-n8n` without abandoning the newer repo

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -76,6 +76,14 @@ function checkCv() {
   };
 }
 
+function checkStructuredResume() {
+  const structuredPath = join(projectRoot, 'data', 'resume.json');
+  if (existsSync(structuredPath)) {
+    return { pass: true, label: 'Structured resume source found (data/resume.json)' };
+  }
+  return { pass: true, label: 'Structured resume source not configured (optional)' };
+}
+
 function checkProfile() {
   if (existsSync(join(projectRoot, 'config', 'profile.yml'))) {
     return { pass: true, label: 'config/profile.yml found' };
@@ -158,6 +166,7 @@ async function main() {
     checkDependencies(),
     await checkPlaywright(),
     checkCv(),
+    checkStructuredResume(),
     checkProfile(),
     checkPortals(),
     checkFonts(),

--- a/generate-structured-application.mjs
+++ b/generate-structured-application.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { generateStructuredApplicationBundle, closeStructuredResumeRenderer } from './lib/structured-resume/generate-assets.mjs';
+
+function printUsage() {
+  console.error('Usage: node generate-structured-application.mjs <request.json>');
+}
+
+async function main() {
+  const [inputPath] = process.argv.slice(2);
+
+  if (!inputPath) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const resolvedPath = resolve(inputPath);
+  const request = JSON.parse(readFileSync(resolvedPath, 'utf-8'));
+  const result = await generateStructuredApplicationBundle(request);
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error.message);
+    if (error.details) {
+      console.error(JSON.stringify({ details: error.details, warnings: error.warnings || [] }, null, 2));
+    }
+    process.exit(1);
+  })
+  .finally(async () => {
+    await closeStructuredResumeRenderer();
+  });

--- a/import-resume-json.mjs
+++ b/import-resume-json.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { copyFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { projectRoot, structuredResumePath } from './lib/structured-resume/common.mjs';
+
+const defaultSource = resolve(projectRoot, '..', 'job-automation-n8n', 'data', 'resume.json');
+const source = process.argv[2] ? resolve(process.argv[2]) : defaultSource;
+
+if (!existsSync(source)) {
+  console.error(`Source resume.json not found: ${source}`);
+  process.exit(1);
+}
+
+mkdirSync(dirname(structuredResumePath), { recursive: true });
+copyFileSync(source, structuredResumePath);
+console.log(`Imported structured resume source to ${structuredResumePath}`);

--- a/lib/structured-resume/apply-patch.mjs
+++ b/lib/structured-resume/apply-patch.mjs
@@ -1,0 +1,56 @@
+export function applyStructuredResumePatch(baseResume, patch = {}) {
+  const resume = JSON.parse(JSON.stringify(baseResume));
+
+  if (patch.jobTitle) {
+    resume.personalDetails.jobTitle = patch.jobTitle;
+  }
+
+  if (patch.profile) {
+    resume.content.profile.entries[0].text = patch.profile;
+  }
+
+  if (Array.isArray(patch.work)) {
+    for (const workPatch of patch.work) {
+      const entry = resume.content.work.entries.find((item) => item.id === workPatch.id);
+      if (!entry) continue;
+      if (workPatch.description) entry.description = workPatch.description;
+      if (workPatch.jobTitle) entry.jobTitle = workPatch.jobTitle;
+      if (workPatch.employer) entry.employer = workPatch.employer;
+    }
+  }
+
+  if (Array.isArray(patch.skills)) {
+    for (const skillPatch of patch.skills) {
+      const entry = resume.content.skill.entries.find((item) => item.id === skillPatch.id);
+      if (!entry) continue;
+      if (skillPatch.skill) entry.skill = skillPatch.skill;
+      if (skillPatch.infoHtml) entry.infoHtml = skillPatch.infoHtml;
+    }
+  }
+
+  if (Array.isArray(patch.projects)) {
+    for (const projectPatch of patch.projects) {
+      const entry = resume.content.project?.entries?.find((item) => item.id === projectPatch.id);
+      if (!entry) continue;
+      if (projectPatch.name) entry.name = projectPatch.name;
+      if (projectPatch.techStack) entry.techStack = projectPatch.techStack;
+      if (projectPatch.description) entry.description = projectPatch.description;
+    }
+  }
+
+  resume.meta = resume.meta || {};
+
+  if (patch.showCertificates === false) {
+    resume.meta.showCertificates = false;
+  }
+
+  if (patch.showProjects === false) {
+    resume.meta.showProjects = false;
+  }
+
+  if (Array.isArray(patch.competencies) && patch.competencies.length > 0) {
+    resume.meta.competencies = patch.competencies;
+  }
+
+  return resume;
+}

--- a/lib/structured-resume/common.mjs
+++ b/lib/structured-resume/common.mjs
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+export const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+export const structuredResumePath = join(projectRoot, 'data', 'resume.json');
+export const resumeTemplatePath = join(projectRoot, 'templates', 'cv-template.html');
+export const fontsDir = join(projectRoot, 'fonts');
+
+const ALLOWED_TAGS = new Set(['p', 'ul', 'ol', 'li', 'strong', 'em', 'b', 'i', 'br', 'span']);
+
+export function loadStructuredResumeOrThrow() {
+  if (!existsSync(structuredResumePath)) {
+    throw new Error(`Structured resume source not found: ${structuredResumePath}`);
+  }
+  return JSON.parse(readFileSync(structuredResumePath, 'utf-8'));
+}
+
+export function readResumeTemplate() {
+  return readFileSync(resumeTemplatePath, 'utf-8');
+}
+
+export function escapeHtml(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+export function sanitizeHtml(html = '') {
+  return String(html).replace(/<\/?([a-z0-9]+)[^>]*>/gi, (match, tag) =>
+    ALLOWED_TAGS.has(tag.toLowerCase()) ? match : ''
+  );
+}
+
+export function stripHtml(html = '') {
+  return String(html).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function stripHtmlPreserveBullets(html = '') {
+  return String(html)
+    .replace(/<\/li>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n\s*/g, '\n')
+    .replace(/^\n+|\n+$/g, '')
+    .trim();
+}
+
+export function inlineHtml(html = '') {
+  return sanitizeHtml(html)
+    .replace(/<\/?(p|ul|ol|li)[^>]*>/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function toSlug(str = '') {
+  return String(str)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'item';
+}
+
+export function formatPageSize(format = 'a4') {
+  return String(format).toLowerCase() === 'letter' ? '8.5in' : '210mm';
+}
+
+export function pickFormat(format = 'a4') {
+  return String(format).toLowerCase() === 'letter' ? 'Letter' : 'A4';
+}

--- a/lib/structured-resume/context.mjs
+++ b/lib/structured-resume/context.mjs
@@ -1,0 +1,31 @@
+import { loadStructuredResumeOrThrow, stripHtml, stripHtmlPreserveBullets } from './common.mjs';
+
+export function getStructuredResumeContext() {
+  const resume = loadStructuredResumeOrThrow();
+
+  return {
+    currentJobTitle: resume.personalDetails.jobTitle || '',
+    currentProfile: stripHtml(resume.content.profile?.entries?.[0]?.text || ''),
+    currentWork: (resume.content.work?.entries || []).map((entry) => ({
+      id: entry.id,
+      employer: entry.employer,
+      jobTitle: entry.jobTitle,
+      location: entry.location,
+      startDate: entry.startDateNew,
+      endDate: entry.endDateNew,
+      description: stripHtmlPreserveBullets(entry.description || ''),
+    })),
+    currentSkills: (resume.content.skill?.entries || []).map((entry) => ({
+      id: entry.id,
+      skill: entry.skill,
+      details: stripHtml(entry.infoHtml || ''),
+    })),
+    currentProjects: (resume.content.project?.entries || []).map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      techStack: entry.techStack,
+      url: entry.url || null,
+      description: stripHtmlPreserveBullets(entry.description || ''),
+    })),
+  };
+}

--- a/lib/structured-resume/font-css.mjs
+++ b/lib/structured-resume/font-css.mjs
@@ -1,0 +1,39 @@
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { fontsDir } from './common.mjs';
+
+function fontUrl(fileName) {
+  return pathToFileURL(join(fontsDir, fileName)).href;
+}
+
+export function buildStructuredFontCss() {
+  return `
+  @font-face {
+    font-family: 'Space Grotesk';
+    src: url('${fontUrl('space-grotesk-latin.woff2')}') format('woff2');
+    font-weight: 300 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Space Grotesk';
+    src: url('${fontUrl('space-grotesk-latin-ext.woff2')}') format('woff2');
+    font-weight: 300 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('${fontUrl('dm-sans-latin.woff2')}') format('woff2');
+    font-weight: 100 1000;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('${fontUrl('dm-sans-latin-ext.woff2')}') format('woff2');
+    font-weight: 100 1000;
+    font-style: normal;
+    font-display: swap;
+  }`;
+}

--- a/lib/structured-resume/generate-assets.mjs
+++ b/lib/structured-resume/generate-assets.mjs
@@ -1,0 +1,260 @@
+import { chromium } from 'playwright';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import { applyStructuredResumePatch } from './apply-patch.mjs';
+import { loadStructuredResumeOrThrow, pickFormat, projectRoot, toSlug } from './common.mjs';
+import { buildStructuredManifestPath, buildStructuredOutputPaths } from './output-paths.mjs';
+import { buildStructuredCoverLetterHtml } from './render-cover-letter-html.mjs';
+import { buildResumeHtmlFromStructuredResume } from './render-resume-html.mjs';
+import { validateStructuredResumePatch } from './validate-patch.mjs';
+
+let browserPromise = null;
+
+function normalizePathForMarkdown(path) {
+  return String(path).replace(/\\/g, '/');
+}
+
+function toRelativeProjectPath(path) {
+  return normalizePathForMarkdown(relative(projectRoot, path));
+}
+
+function parseWhen(value) {
+  if (!value) return new Date();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+function hasCoverLetterContent(input = {}) {
+  return Boolean(
+    input.companyAddress ||
+    input.paragraph1 ||
+    input.paragraph2 ||
+    input.paragraph3
+  );
+}
+
+function normalizeBundleInput(input = {}) {
+  const coverLetter = input.coverLetter && typeof input.coverLetter === 'object'
+    ? input.coverLetter
+    : {};
+
+  return {
+    company: input.company || coverLetter.company || 'company',
+    role: input.role || coverLetter.role || 'role',
+    language: input.language || coverLetter.language || 'en',
+    format: input.format || coverLetter.format || 'a4',
+    jobId: input.jobId || coverLetter.jobId || null,
+    patch: input.patch || null,
+    coverLetter: {
+      company: input.company || coverLetter.company || 'company',
+      role: input.role || coverLetter.role || 'role',
+      companyAddress: coverLetter.companyAddress || input.companyAddress || '',
+      paragraph1: coverLetter.paragraph1 || input.paragraph1 || '',
+      paragraph2: coverLetter.paragraph2 || input.paragraph2 || '',
+      paragraph3: coverLetter.paragraph3 || input.paragraph3 || '',
+      language: coverLetter.language || input.language || 'en',
+      format: coverLetter.format || input.format || 'a4',
+      jobId: coverLetter.jobId || input.jobId || null,
+    },
+    tracker: input.tracker || null,
+    when: parseWhen(input.when),
+  };
+}
+
+function validateBundleInput(input) {
+  if (!input.company || !String(input.company).trim()) {
+    throw new Error('company is required');
+  }
+
+  if (!input.role || !String(input.role).trim()) {
+    throw new Error('role is required');
+  }
+
+  if (!input.patch && !hasCoverLetterContent(input.coverLetter)) {
+    throw new Error('bundle must include a patch, cover letter content, or both');
+  }
+}
+
+async function getBrowser() {
+  if (!browserPromise) {
+    browserPromise = chromium.launch({ headless: true });
+  }
+  return browserPromise;
+}
+
+async function renderPdf({ html, pdfPath, format = 'a4' }) {
+  const browser = await getBrowser();
+  const context = await browser.newContext();
+
+  try {
+    const page = await context.newPage();
+    await page.setContent(html, { waitUntil: 'load' });
+    await page.evaluate(() => document.fonts.ready);
+    await page.pdf({
+      path: pdfPath,
+      format: pickFormat(format),
+      printBackground: true,
+      margin: { top: '0.6in', right: '0.6in', bottom: '0.6in', left: '0.6in' },
+    });
+  } finally {
+    await context.close();
+  }
+}
+
+function writeTrackerAddition({ company, role, tracker, resumeResult }) {
+  if (!tracker) return null;
+
+  const num = String(tracker.num || '').trim();
+  const date = String(tracker.date || '').trim();
+  const score = String(tracker.score || '').trim();
+  const report = String(tracker.report || '').trim();
+
+  if (!num || !date || !score || !report) {
+    throw new Error('tracker requires num, date, score, and report');
+  }
+
+  const status = String(tracker.status || 'Evaluated').trim();
+  const pdf = String(tracker.pdf || resumeResult?.relativePdfPath || '❌').trim();
+  const notes = String(tracker.notes || '').trim();
+  const fileName = `${String(num).padStart(3, '0')}-${toSlug(company)}.tsv`;
+  const outputPath = join(projectRoot, 'batch', 'tracker-additions', fileName);
+  const content = [
+    num,
+    date,
+    company,
+    role,
+    status,
+    score,
+    pdf,
+    report,
+    notes,
+  ].join('\t');
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, content, 'utf-8');
+
+  return {
+    path: outputPath,
+    relativePath: toRelativeProjectPath(outputPath),
+    fileName,
+  };
+}
+
+export async function generateStructuredResume(input = {}) {
+  const baseResume = loadStructuredResumeOrThrow();
+  const patch = input.patch || input;
+  const validation = validateStructuredResumePatch(baseResume, patch);
+
+  if (!validation.valid) {
+    const error = new Error('Invalid structured resume patch');
+    error.details = validation.errors;
+    error.warnings = validation.warnings;
+    throw error;
+  }
+
+  const company = input.company || patch.company || 'company';
+  const role = input.role || patch.role || baseResume.personalDetails?.jobTitle || 'role';
+  const language = input.language || patch.language || 'en';
+  const format = input.format || patch.format || 'a4';
+  const when = parseWhen(input.when);
+  const output = buildStructuredOutputPaths('resume', company, role, when);
+  const mergedResume = applyStructuredResumePatch(baseResume, patch);
+  const html = buildResumeHtmlFromStructuredResume(mergedResume, { language, format });
+
+  mkdirSync(dirname(output.htmlPath), { recursive: true });
+  writeFileSync(output.htmlPath, html, 'utf-8');
+  await renderPdf({ html, pdfPath: output.pdfPath, format });
+
+  return {
+    success: true,
+    htmlPath: output.htmlPath,
+    pdfPath: output.pdfPath,
+    relativeHtmlPath: toRelativeProjectPath(output.htmlPath),
+    relativePdfPath: toRelativeProjectPath(output.pdfPath),
+    fileName: output.fileName,
+    warnings: validation.warnings,
+    jobId: input.jobId || patch.jobId || null,
+  };
+}
+
+export async function generateStructuredCoverLetter(input = {}) {
+  const company = input.company || 'company';
+  const role = input.role || 'role';
+  const format = input.format || 'a4';
+  const when = parseWhen(input.when);
+  const output = buildStructuredOutputPaths('coverletter', company, role, when);
+  const html = buildStructuredCoverLetterHtml(input);
+
+  mkdirSync(dirname(output.htmlPath), { recursive: true });
+  writeFileSync(output.htmlPath, html, 'utf-8');
+  await renderPdf({ html, pdfPath: output.pdfPath, format });
+
+  return {
+    success: true,
+    htmlPath: output.htmlPath,
+    pdfPath: output.pdfPath,
+    relativeHtmlPath: toRelativeProjectPath(output.htmlPath),
+    relativePdfPath: toRelativeProjectPath(output.pdfPath),
+    fileName: output.fileName,
+    jobId: input.jobId || null,
+  };
+}
+
+export async function generateStructuredApplicationBundle(input = {}) {
+  const normalized = normalizeBundleInput(input);
+  validateBundleInput(normalized);
+
+  const result = {
+    success: true,
+    generatedAt: normalized.when.toISOString(),
+    company: normalized.company,
+    role: normalized.role,
+    language: normalized.language,
+    format: normalized.format,
+    jobId: normalized.jobId,
+  };
+
+  if (normalized.patch) {
+    result.resume = await generateStructuredResume({
+      company: normalized.company,
+      role: normalized.role,
+      language: normalized.language,
+      format: normalized.format,
+      jobId: normalized.jobId,
+      patch: normalized.patch,
+      when: normalized.when,
+    });
+  }
+
+  if (hasCoverLetterContent(normalized.coverLetter)) {
+    result.coverLetter = await generateStructuredCoverLetter({
+      ...normalized.coverLetter,
+      company: normalized.company,
+      role: normalized.role,
+      when: normalized.when,
+    });
+  }
+
+  if (normalized.tracker) {
+    result.tracker = writeTrackerAddition({
+      company: normalized.company,
+      role: normalized.role,
+      tracker: normalized.tracker,
+      resumeResult: result.resume,
+    });
+  }
+
+  const manifest = buildStructuredManifestPath(normalized.company, normalized.role, normalized.when);
+  writeFileSync(manifest.manifestPath, JSON.stringify(result, null, 2), 'utf-8');
+  result.manifestPath = manifest.manifestPath;
+  result.relativeManifestPath = toRelativeProjectPath(manifest.manifestPath);
+
+  return result;
+}
+
+export async function closeStructuredResumeRenderer() {
+  if (!browserPromise) return;
+  const browser = await browserPromise;
+  browserPromise = null;
+  await browser.close();
+}

--- a/lib/structured-resume/output-paths.mjs
+++ b/lib/structured-resume/output-paths.mjs
@@ -1,0 +1,47 @@
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import { projectRoot, toSlug } from './common.mjs';
+
+function datePart(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function timePart(date) {
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  const ss = String(date.getSeconds()).padStart(2, '0');
+  return `${hh}${mm}${ss}`;
+}
+
+export function buildStructuredOutputPaths(kind, company, role, when = new Date()) {
+  const date = datePart(when);
+  const time = timePart(when);
+  const folder = kind === 'coverletter' ? 'Coverletter' : 'Resume';
+  const prefix = kind === 'coverletter' ? 'coverletter' : 'resume';
+  const base = role
+    ? `${toSlug(company)}--${toSlug(role)}-${time}`
+    : `${toSlug(company)}-${time}`;
+
+  const dir = join(projectRoot, 'output', 'structured', date, folder);
+  mkdirSync(dir, { recursive: true });
+
+  return {
+    htmlPath: join(dir, `${prefix}-${base}.html`),
+    pdfPath: join(dir, `${prefix}-${base}.pdf`),
+    fileName: `${prefix}-${base}.pdf`,
+  };
+}
+
+export function buildStructuredManifestPath(company, role, when = new Date()) {
+  const date = datePart(when);
+  const time = timePart(when);
+  const dir = join(projectRoot, 'output', 'structured', date, 'Applications');
+  const fileName = `application-${toSlug(company)}--${toSlug(role)}-${time}.json`;
+
+  mkdirSync(dir, { recursive: true });
+
+  return {
+    manifestPath: join(dir, fileName),
+    fileName,
+  };
+}

--- a/lib/structured-resume/render-cover-letter-html.mjs
+++ b/lib/structured-resume/render-cover-letter-html.mjs
@@ -1,0 +1,143 @@
+import { buildStructuredFontCss } from './font-css.mjs';
+import { escapeHtml } from './common.mjs';
+
+function wrapParagraph(text = '') {
+  if (!text) return '';
+  if (String(text).trimStart().startsWith('<')) return text;
+  return `<p>${escapeHtml(text)}</p>`;
+}
+
+export function buildStructuredCoverLetterHtml(content = {}) {
+  const {
+    role = 'Software Engineer',
+    company = '',
+    companyAddress = '',
+    paragraph1 = '',
+    paragraph2 = '',
+    paragraph3 = '',
+    language = 'en',
+  } = content;
+
+  const isGerman = language === 'de';
+  const dateText = new Date().toLocaleDateString(isGerman ? 'de-DE' : 'en-GB', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+
+  return `<!DOCTYPE html>
+<html lang="${isGerman ? 'de' : 'en'}">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cover Letter - Karan Patel</title>
+  <style>
+    ${buildStructuredFontCss()}
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'DM Sans', sans-serif;
+      font-size: 11pt;
+      line-height: 1.6;
+      color: #1a1a1a;
+      background: #fff;
+    }
+    .page {
+      width: 210mm;
+      min-height: 297mm;
+      margin: 0 auto;
+      padding: 18mm 20mm 16mm 20mm;
+      display: flex;
+      flex-direction: column;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      border-bottom: 2px solid hsl(187, 74%, 32%);
+      padding-bottom: 10px;
+      margin-bottom: 18px;
+    }
+    .header-name {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 20pt;
+      font-weight: 700;
+      color: #1e3a5f;
+    }
+    .header-title {
+      font-size: 10pt;
+      color: hsl(187, 74%, 32%);
+      margin-top: 2px;
+    }
+    .header-contact {
+      text-align: right;
+      font-size: 9pt;
+      color: #444;
+      line-height: 1.7;
+    }
+    .subject {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 12pt;
+      font-weight: 700;
+      color: #1e3a5f;
+      margin: 18px 0;
+      border-left: 3px solid hsl(187, 74%, 32%);
+      padding-left: 10px;
+    }
+    .body-text p {
+      margin-bottom: 13px;
+      text-align: justify;
+      hyphens: auto;
+    }
+    .closing {
+      margin-top: 24px;
+    }
+    .footer {
+      margin-top: auto;
+      padding-top: 10px;
+      border-top: 1px solid #d1d5db;
+      font-size: 8.5pt;
+      color: #666;
+      display: flex;
+      justify-content: space-between;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="header">
+      <div>
+        <div class="header-name">Karan Patel</div>
+        <div class="header-title">${escapeHtml(role)}</div>
+      </div>
+      <div class="header-contact">
+        khpatel0104@gmail.com<br/>
+        +49 15210894179<br/>
+        Hesse, Germany<br/>
+        linkedin.com/in/patelkaran0104/<br/>
+        karanpatel.live
+      </div>
+    </div>
+    <div style="text-align:right; font-size:10pt; color:#555; margin-bottom:18px;">${escapeHtml(dateText)}</div>
+    <div style="margin-bottom:18px; font-size:10.5pt; line-height:1.8;">
+      <div>${escapeHtml(company)}</div>
+      <div>${escapeHtml(companyAddress)}</div>
+    </div>
+    <div class="subject">${isGerman ? `Bewerbung als ${escapeHtml(role)}` : `Application for ${escapeHtml(role)}`}</div>
+    <div style="margin-bottom:13px;">${isGerman ? 'Sehr geehrte Damen und Herren,' : 'Dear Hiring Team,'}</div>
+    <div class="body-text">
+      ${wrapParagraph(paragraph1)}
+      ${wrapParagraph(paragraph2)}
+      ${wrapParagraph(paragraph3)}
+    </div>
+    <div class="closing">
+      <div style="margin-bottom:32px;">${isGerman ? 'Mit freundlichen Grussen,' : 'Best regards,'}</div>
+      <div style="font-weight:700;">Karan Patel</div>
+      <div style="font-size:9.5pt; color:#555;">${escapeHtml(role)}</div>
+    </div>
+    <div class="footer">
+      <span>Karan Patel · khpatel0104@gmail.com · +49 15210894179</span>
+      <span>${escapeHtml(company)}</span>
+    </div>
+  </div>
+</body>
+</html>`;
+}

--- a/lib/structured-resume/render-resume-html.mjs
+++ b/lib/structured-resume/render-resume-html.mjs
@@ -1,0 +1,147 @@
+import { escapeHtml, formatPageSize, inlineHtml, readResumeTemplate, sanitizeHtml, stripHtml } from './common.mjs';
+
+function inferCompetencies(resume) {
+  if (Array.isArray(resume.meta?.competencies) && resume.meta.competencies.length > 0) {
+    return resume.meta.competencies.slice(0, 8);
+  }
+
+  const seen = new Set();
+  const picks = [];
+  const maybeAdd = (value) => {
+    const cleaned = String(value || '').trim();
+    if (!cleaned) return;
+    const key = cleaned.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    picks.push(cleaned);
+  };
+
+  const defaults = [
+    'Software Engineering',
+    'APIs',
+    'Automation',
+    'React',
+    'TypeScript',
+    'Node.js',
+    'Cloud Infrastructure',
+    'AI-Assisted Engineering',
+  ];
+
+  for (const value of defaults) maybeAdd(value);
+  for (const skill of resume.content.skill?.entries || []) maybeAdd(skill.skill);
+
+  return picks.slice(0, 8);
+}
+
+function renderCompetencies(resume) {
+  return inferCompetencies(resume)
+    .map((value) => `<span class="competency-tag">${escapeHtml(value)}</span>`)
+    .join('\n');
+}
+
+function renderExperience(resume) {
+  return (resume.content.work?.entries || []).map((entry) => {
+    const period = [entry.startDateNew, entry.endDateNew].filter(Boolean).join(' - ');
+    const roleLine = [entry.jobTitle, entry.location].filter(Boolean).join(' | ');
+    return `
+      <div class="job">
+        <div class="job-header">
+          <div class="job-company">${escapeHtml(entry.employer || '')}</div>
+          <div class="job-period">${escapeHtml(period)}</div>
+        </div>
+        <div class="job-role">${escapeHtml(roleLine)}</div>
+        ${sanitizeHtml(entry.description || '')}
+      </div>`;
+  }).join('\n');
+}
+
+function renderProjects(resume) {
+  if (resume.meta?.showProjects === false) return '';
+  return (resume.content.project?.entries || []).slice(0, 4).map((entry) => `
+      <div class="project">
+        <div class="project-title">${escapeHtml(entry.name || '')}</div>
+        ${entry.techStack ? `<div class="project-tech">${escapeHtml(entry.techStack)}</div>` : ''}
+        <div class="project-desc">${inlineHtml(entry.description || '')}</div>
+      </div>`).join('\n');
+}
+
+function renderEducation(resume) {
+  return (resume.content.education?.entries || []).map((entry) => {
+    const period = [entry.startDateNew, entry.endDateNew].filter(Boolean).join(' - ');
+    const title = [entry.degree, entry.school].filter(Boolean).join(' - ');
+    const description = entry.description ? `<div class="edu-desc">${inlineHtml(entry.description)}</div>` : '';
+    return `
+      <div class="edu-item">
+        <div class="edu-header">
+          <div class="edu-title">${escapeHtml(title)}</div>
+          <div class="edu-year">${escapeHtml(period)}</div>
+        </div>
+        ${entry.location ? `<div class="edu-desc">${escapeHtml(entry.location)}</div>` : ''}
+        ${description}
+      </div>`;
+  }).join('\n');
+}
+
+function renderCertifications(resume) {
+  if (resume.meta?.showCertificates === false) return '';
+  return (resume.content.certificate?.entries || []).map((entry) => `
+      <div class="cert-item">
+        <div class="cert-title">${escapeHtml(entry.certificate || '')}</div>
+      </div>`).join('\n');
+}
+
+function renderSkills(resume) {
+  return `
+    <div class="skills-grid">
+      ${(resume.content.skill?.entries || []).map((entry) => `
+        <div class="skill-item">
+          <span class="skill-category">${escapeHtml(entry.skill || '')}:</span>
+          ${inlineHtml(entry.infoHtml || '')}
+        </div>`).join('\n')}
+    </div>`;
+}
+
+export function buildResumeHtmlFromStructuredResume(resume, options = {}) {
+  const template = readResumeTemplate();
+  const personal = resume.personalDetails || {};
+  const format = options.format || 'a4';
+  const linkedinDisplay = personal.social?.linkedIn?.display || '';
+  const linkedinUrl = linkedinDisplay.startsWith('http') ? linkedinDisplay : `https://${linkedinDisplay}`;
+  const websiteDisplay = personal.website || '';
+  const websiteUrl = websiteDisplay.startsWith('http') ? websiteDisplay : `https://${websiteDisplay}`;
+  const summaryText = stripHtml(resume.content.profile?.entries?.[0]?.text || '');
+
+  const replacements = {
+    '{{LANG}}': options.language || 'en',
+    '{{PAGE_WIDTH}}': formatPageSize(format),
+    '{{NAME}}': escapeHtml(personal.fullName || ''),
+    '{{PHONE}}': escapeHtml(personal.phone || ''),
+    '{{EMAIL}}': escapeHtml(personal.displayEmail || ''),
+    '{{LINKEDIN_URL}}': escapeHtml(linkedinUrl),
+    '{{LINKEDIN_DISPLAY}}': escapeHtml(linkedinDisplay),
+    '{{PORTFOLIO_URL}}': escapeHtml(websiteUrl),
+    '{{PORTFOLIO_DISPLAY}}': escapeHtml(websiteDisplay),
+    '{{LOCATION}}': escapeHtml(personal.address || ''),
+    '{{SECTION_SUMMARY}}': 'Professional Summary',
+    '{{SUMMARY_TEXT}}': escapeHtml(summaryText),
+    '{{SECTION_COMPETENCIES}}': 'Core Competencies',
+    '{{COMPETENCIES}}': renderCompetencies(resume),
+    '{{SECTION_EXPERIENCE}}': 'Work Experience',
+    '{{EXPERIENCE}}': renderExperience(resume),
+    '{{SECTION_PROJECTS}}': 'Projects',
+    '{{PROJECTS}}': renderProjects(resume),
+    '{{SECTION_EDUCATION}}': 'Education',
+    '{{EDUCATION}}': renderEducation(resume),
+    '{{SECTION_CERTIFICATIONS}}': 'Certifications',
+    '{{CERTIFICATIONS}}': renderCertifications(resume),
+    '{{SECTION_SKILLS}}': 'Skills',
+    '{{SKILLS}}': renderSkills(resume),
+  };
+
+  let html = template;
+  for (const [needle, value] of Object.entries(replacements)) {
+    html = html.split(needle).join(value);
+  }
+
+  return html;
+}

--- a/lib/structured-resume/validate-patch.mjs
+++ b/lib/structured-resume/validate-patch.mjs
@@ -1,0 +1,63 @@
+export function validateStructuredResumePatch(baseResume, patch) {
+  const errors = [];
+  const warnings = [];
+
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    errors.push('patch must be a plain object');
+    return { valid: false, errors, warnings };
+  }
+
+  const workIds = new Set((baseResume.content.work?.entries || []).map((entry) => entry.id));
+  const skillIds = new Set((baseResume.content.skill?.entries || []).map((entry) => entry.id));
+  const projectIds = new Set((baseResume.content.project?.entries || []).map((entry) => entry.id));
+
+  const hasActionableContent = Boolean(
+    (typeof patch.jobTitle === 'string' && patch.jobTitle.trim()) ||
+    (typeof patch.profile === 'string' && patch.profile.trim()) ||
+    (Array.isArray(patch.work) && patch.work.length > 0) ||
+    (Array.isArray(patch.skills) && patch.skills.length > 0) ||
+    (Array.isArray(patch.projects) && patch.projects.length > 0) ||
+    patch.showCertificates === false ||
+    patch.showProjects === false ||
+    (Array.isArray(patch.competencies) && patch.competencies.length > 0)
+  );
+
+  if (!hasActionableContent) {
+    errors.push('patch has no actionable content');
+    return { valid: false, errors, warnings };
+  }
+
+  if (patch.work !== undefined && !Array.isArray(patch.work)) errors.push('patch.work must be an array if present');
+  if (patch.skills !== undefined && !Array.isArray(patch.skills)) errors.push('patch.skills must be an array if present');
+  if (patch.projects !== undefined && !Array.isArray(patch.projects)) errors.push('patch.projects must be an array if present');
+
+  if (errors.length > 0) {
+    return { valid: false, errors, warnings };
+  }
+
+  for (const item of patch.work || []) {
+    if (!item?.id) {
+      warnings.push('work item missing id');
+      continue;
+    }
+    if (!workIds.has(item.id)) warnings.push(`unknown work id "${item.id}" will be ignored`);
+  }
+
+  for (const item of patch.skills || []) {
+    if (!item?.id) {
+      warnings.push('skill item missing id');
+      continue;
+    }
+    if (!skillIds.has(item.id)) warnings.push(`unknown skill id "${item.id}" will be ignored`);
+  }
+
+  for (const item of patch.projects || []) {
+    if (!item?.id) {
+      warnings.push('project item missing id');
+      continue;
+    }
+    if (!projectIds.has(item.id)) warnings.push(`unknown project id "${item.id}" will be ignored`);
+  }
+
+  return { valid: true, errors, warnings };
+}

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -1,5 +1,15 @@
 # Modo: pdf — Generación de PDF ATS-Optimizado
 
+## Structured Resume Bridge
+
+Si existe `data/resume.json`, puedes usar el flujo estructurado para integrarlo con el pipeline principal:
+
+1. Genera un `request.json` con `company`, `role`, `patch` y opcionalmente `coverLetter` y `tracker`
+2. Ejecuta `npm run resume:bundle -- request.json`
+3. Usa el manifest JSON y el TSV opcional para seguir con `merge-tracker.mjs`
+
+Este puente reutiliza el motor patch-based sin crear lógica paralela al tracker principal.
+
 ## Pipeline completo
 
 1. Lee `cv.md` como fuentes de verdad

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
-    "gemini:eval": "node gemini-eval.mjs"
+    "gemini:eval": "node gemini-eval.mjs",
+    "resume:import": "node import-resume-json.mjs",
+    "resume:server": "node resume-service.mjs",
+    "resume:bundle": "node generate-structured-application.mjs"
   },
   "keywords": [
     "ai",
@@ -34,6 +37,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "dotenv": "^16.4.5",
+    "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "playwright": "^1.58.1"
   }

--- a/resume-service.mjs
+++ b/resume-service.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import express from 'express';
+import { existsSync, mkdirSync } from 'fs';
+import { projectRoot, structuredResumePath } from './lib/structured-resume/common.mjs';
+import { getStructuredResumeContext } from './lib/structured-resume/context.mjs';
+import { closeStructuredResumeRenderer, generateStructuredCoverLetter, generateStructuredResume } from './lib/structured-resume/generate-assets.mjs';
+
+const port = Number(process.env.CAREER_OPS_RESUME_PORT || 3010);
+const app = express();
+app.use(express.json({ limit: '10mb' }));
+
+mkdirSync(projectRoot, { recursive: true });
+
+app.get('/health', (_req, res) => {
+  res.json({
+    ok: true,
+    service: 'career-ops structured resume service',
+    port,
+    resumeJsonPresent: existsSync(structuredResumePath),
+  });
+});
+
+app.get('/context', (_req, res) => {
+  try {
+    res.json(getStructuredResumeContext());
+  } catch (error) {
+    res.status(404).json({ success: false, error: error.message });
+  }
+});
+
+app.post('/generate-resume', async (req, res) => {
+  try {
+    const result = await generateStructuredResume(req.body);
+    res.json({
+      success: true,
+      html: result.htmlPath,
+      file: result.pdfPath,
+      fileName: result.fileName,
+      warnings: result.warnings,
+      jobId: result.jobId,
+    });
+  } catch (error) {
+    const statusCode = Array.isArray(error.details) ? 422 : 500;
+    res.status(statusCode).json({
+      success: false,
+      error: error.message,
+      details: error.details || [],
+      warnings: error.warnings || [],
+    });
+  }
+});
+
+app.post('/generate-coverletter', async (req, res) => {
+  try {
+    const result = await generateStructuredCoverLetter(req.body);
+    res.json({
+      success: true,
+      html: result.htmlPath,
+      file: result.pdfPath,
+      fileName: result.fileName,
+      jobId: result.jobId,
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+const server = app.listen(port, '0.0.0.0', () => {
+  console.log(`career-ops structured resume service running on port ${port}`);
+});
+
+async function shutdown() {
+  server.close(async () => {
+    await closeStructuredResumeRenderer();
+    process.exit(0);
+  });
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
- Implemented a new function `checkStructuredResume` to verify the presence of a structured resume source at `data/resume.json`.
- Added a new command `resume:import` to import existing structured resumes from a specified path.
- Introduced a local HTTP service for generating structured resumes and cover letters with endpoints for health checks and context retrieval.
- Created a new CLI command `resume:bundle` to generate application bundles using structured resumes.
- Developed a patch-based resume tailoring system that validates and applies changes to the base resume.
- Added HTML and PDF rendering capabilities for tailored resumes and cover letters.
- Updated documentation to reflect the new structured resume features and usage instructions.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [ ] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured resume import, validation, customization, and PDF generation.
  * Added tailored cover-letter and application-bundle generation with manifests and tracker integration.
  * Added an optional local resume service with health and generation endpoints.
  * Added configurable formatting, localization, font support, and output organization.

* **Documentation**
  * Added setup, usage, request-format, endpoint, and workflow guidance for structured resumes.

* **Bug Fixes**
  * Added health checks and warnings for missing or incomplete resume data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->