### PR TITLE
fix(stats,calibrate): ledger-aware funnel + calibration (#1428, #1724)

### DIFF
--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -24,9 +24,12 @@
  *     It is excluded from every rate and reported separately as in-flight.
  *   - No percentage is printed on a band below the sample floor. "2 of 3
  *     got interviews" is an anecdote wearing a rate's clothes.
- *   - The outcome journal (data/outcomes/) outranks the tracker status: the
- *     journal records what actually happened (outcome.mjs), the status is a
- *     workflow position. Where both exist, the journal wins.
+ *   - Evidence precedence: the outcome journal (data/outcomes/) wins, then the
+ *     transition ledger (data/status-log.tsv), then the tracker status. The
+ *     journal records what actually happened (outcome.mjs); the ledger records
+ *     the stages a row passed through (set-status.mjs), so a declined offer now
+ *     sitting in Discarded still counts as an offer; the current status is only
+ *     a workflow snapshot and loses that history.
  */
 
 import { readFileSync, readdirSync, existsSync } from 'fs';
@@ -107,10 +110,11 @@ export function parseOutcomeJournal(text) {
  *
  * @param {Array<{num:number, company:string, score:number|null, status:string}>} rows
  * @param {Map<number, {latestType:string|null, feedback:string[]}>} journals
- * @param {{minBandN?: number}} [opts]
+ * @param {{minBandN?: number, reached?: Map<number, {reachedInterview:boolean, reachedOffer:boolean}>}} [opts]
  */
 export function computeCalibration(rows, journals, opts = {}) {
   const minBandN = opts.minBandN ?? 5;
+  const reached = opts.reached ?? new Map();
 
   const resolved = [];
   const inFlight = [];
@@ -123,13 +127,21 @@ export function computeCalibration(rows, journals, opts = {}) {
       for (const fb of journal.feedback) allFeedback.push({ num: row.num, company: row.company, feedback: fb });
     }
     let verdict = null;
+    const led = reached.get(row.num);
     if (journal?.latestType) {
       verdict = { source: 'journal', type: journal.latestType, ...JOURNAL_OUTCOMES[journal.latestType] };
+    } else if (led && (led.reachedInterview || led.reachedOffer)) {
+      // Ledger evidence: the row passed through interview/offer per its
+      // transition history, so it resolves at that tier even though its current
+      // status is now terminal (a declined offer reads as Discarded, an
+      // interview that ended in rejection reads as Rejected). Offer implies
+      // interview, so reachedInterview is always true on this branch.
+      verdict = { source: 'ledger', type: led.reachedOffer ? 'offer' : 'interview', reachedInterview: true, reachedOffer: !!led.reachedOffer };
     } else {
       const s = String(row.status || '').replace(/\*\*/g, '').trim().toLowerCase().replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '');
       if (TRACKER_TERMINAL[s]) verdict = { source: 'tracker', type: s, ...TRACKER_TERMINAL[s] };
       else if (['applied', 'responded'].includes(s)) { inFlight.push(row.num); continue; }
-      else continue; // evaluated / discarded / skip: never applied — outside calibration's population
+      else continue; // evaluated / discarded / skip with no stage history — outside calibration's population
     }
     if (!Number.isFinite(row.score) || row.score <= 0) { unscored.push(row.num); continue; }
     resolved.push({ num: row.num, score: row.score, ...verdict });
@@ -218,6 +230,35 @@ function loadJournals(workspaceRoot) {
     journals.set(parseInt(numMatch[1], 10), parseOutcomeJournal(readFileSync(logPath, 'utf-8')));
   }
   return journals;
+}
+
+/**
+ * Per-row stage-reached evidence from the transition ledger data/status-log.tsv
+ * ({num}\t{date}\t{from}\t{to}\t{source}\t{note}). A row reached interview if any
+ * transition entered OR left Interview/Offer/Hired; reached offer if it entered
+ * OR left Offer/Hired. Offer implies interview. Missing file → empty Map (the
+ * calibration falls back to journals + current status, exactly as before).
+ * @returns {Map<number, {reachedInterview:boolean, reachedOffer:boolean}>}
+ */
+export function loadLedgerReached(workspaceRoot) {
+  const reached = new Map();
+  const logPath = join(workspaceRoot, 'data', 'status-log.tsv');
+  if (!existsSync(logPath)) return reached;
+  const INTERVIEW_PLUS = new Set(['interview', 'offer', 'hired']);
+  const OFFER_PLUS = new Set(['offer', 'hired']);
+  for (const line of readFileSync(logPath, 'utf-8').split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const c = line.split('\t');
+    const num = parseInt(c[0], 10);
+    if (!Number.isFinite(num)) continue;
+    const from = String(c[2] || '').trim().toLowerCase();
+    const to = String(c[3] || '').trim().toLowerCase();
+    const cur = reached.get(num) || { reachedInterview: false, reachedOffer: false };
+    if (INTERVIEW_PLUS.has(from) || INTERVIEW_PLUS.has(to)) cur.reachedInterview = true;
+    if (OFFER_PLUS.has(from) || OFFER_PLUS.has(to)) { cur.reachedOffer = true; cur.reachedInterview = true; }
+    reached.set(num, cur);
+  }
+  return reached;
 }
 
 function renderHuman(result) {
@@ -313,6 +354,25 @@ function selfTest() {
   const pop = computeCalibration([mk(1, 4.2, 'Evaluated'), mk(2, 2.1, 'Discarded')], new Map(), { minBandN: 2 });
   t('never-applied excluded', pop.resolved === 0 && pop.inFlight === 0);
 
+  // Ledger evidence resolves stage-reached even when the current status is
+  // terminal: a declined offer (now Discarded) counts as reachedOffer, an
+  // interview that ended in Rejected counts as reachedInterview, and a Discarded
+  // row with no ledger history stays outside the population.
+  const led = computeCalibration(
+    [mk(1, 4.6, 'Discarded'), mk(2, 4.5, 'Rejected'), mk(3, 4.2, 'Discarded')],
+    new Map(),
+    { minBandN: 2, reached: new Map([[1, { reachedInterview: true, reachedOffer: true }], [2, { reachedInterview: true, reachedOffer: false }]]) },
+  );
+  const ledHigh = led.bands.find((b) => b.band === '>=4.5');
+  t('ledger resolves declined offer as reachedOffer', ledHigh.offers === 1 && ledHigh.interviews === 2 && led.resolved === 2);
+  t('ledger leaves history-less Discarded excluded', led.bands.find((b) => b.band === '4.0-4.4').n === 0);
+  // A journal still outranks the ledger (explicit /outcome record wins).
+  const ledVsJournal = computeCalibration(
+    [mk(1, 4.6, 'Discarded')], new Map([[1, J('rejected')]]),
+    { minBandN: 1, reached: new Map([[1, { reachedInterview: true, reachedOffer: true }]]) },
+  );
+  t('journal outranks ledger', ledVsJournal.bands.find((b) => b.band === '>=4.5').offers === 0);
+
   if (failures.length) {
     console.error(`❌ calibrate self-test: ${failures.length} failure(s):\n  - ${failures.join('\n  - ')}`);
     process.exit(1);
@@ -346,7 +406,8 @@ if (isMainModule(import.meta.url)) {
   const workspaceRoot = resolveWorkspaceRoot(appsFile);
   const rows = loadTrackerRows(appsFile);
   const journals = loadJournals(workspaceRoot);
-  const result = computeCalibration(rows, journals, { minBandN });
+  const reached = loadLedgerReached(workspaceRoot);
+  const result = computeCalibration(rows, journals, { minBandN, reached });
   if (argv.includes('--json')) console.log(JSON.stringify(result, null, 2));
   else console.log(renderHuman(result));
 }

--- a/stats.mjs
+++ b/stats.mjs
@@ -31,6 +31,7 @@ const APPS_FILE = join(ROOT, 'data', 'applications.md');
 const SCAN_HISTORY_FILE = join(ROOT, 'data', 'scan-history.tsv');
 const FOLLOWUPS_FILE = join(ROOT, 'data', 'follow-ups.md');
 const SCAN_RUNS_FILE = join(ROOT, 'data', 'scan-runs.tsv');
+const STATUS_LOG_FILE = join(ROOT, 'data', 'status-log.tsv');
 const PORTALS_FILE = join(ROOT, 'portals.yml');
 const PORTAL_HEALTH_FILE = join(ROOT, 'data', 'portal-health.tsv');
 
@@ -174,6 +175,76 @@ export function computeFunnel(byStatus) {
     interviewRate: pct(everInterview, everApplied),
     offerRate: pct(everOffer, everApplied),
     smallSample: everApplied < 10,
+  };
+}
+
+// Canonical pipeline depth per stage, for "ever reached" math. Terminal and
+// pre-pipeline states (Rejected/Discarded/Evaluated/SKIP/Unknown) are absent →
+// depth 0; the ledger's from/to history is what proves the stages a row passed
+// through before it landed on a terminal snapshot.
+const STAGE_RANK = { Applied: 1, Responded: 2, Interview: 3, Offer: 4, Hired: 5 };
+
+/**
+ * Parse data/status-log.tsv into per-row transition observations. Columns are
+ * {num}\t{date}\t{from}\t{to}\t{source}\t{note}; only num/from/to are read here.
+ * Torn or non-numeric-num rows are skipped — this is a display aid, never throws.
+ * @returns {Array<{num:number, from:string, to:string}>}
+ */
+export function parseStatusLogStages(content) {
+  const out = [];
+  for (const line of String(content ?? '').replace(/\r/g, '').split('\n')) {
+    if (!line.trim()) continue;
+    const c = line.split('\t');
+    const num = parseInt(c[0], 10);
+    if (Number.isNaN(num)) continue;
+    out.push({ num, from: (c[2] || '').trim(), to: (c[3] || '').trim() });
+  }
+  return out;
+}
+
+/**
+ * Ledger-aware funnel: everX counts DISTINCT tracker rows that ever reached
+ * stage X, folding the transition ledger so a row now sitting in a terminal
+ * snapshot still counts for the stages it passed through — an Offer that was
+ * declined (now Discarded) counts into everOffer; a Rejected that reached
+ * Interview counts into everInterview. This resolves the snapshot limitation
+ * computeFunnel() documents (#1428) for every row the ledger covers; a row with
+ * no ledger history falls back to its current status alone, so pre-ledger middle
+ * stages stay lower bounds. A current Rejected still proves everApplied (rank 1)
+ * with no ledger, matching the snapshot math. Same shape as computeFunnel() plus
+ * `basis:'ledger'`.
+ *
+ * @param {Map<number,string>} statusByNum - num → current canonical status.
+ * @param {Array<{num:number,from:string,to:string}>} ledger - parseStatusLogStages output.
+ */
+export function computeFunnelWithHistory(statusByNum, ledger) {
+  const reached = new Map(); // num → highest stage rank ever held (distinct rows)
+  const bump = (num, rank) => { if (rank > (reached.get(num) || 0)) reached.set(num, rank); };
+  for (const [num, status] of statusByNum) {
+    bump(num, STAGE_RANK[status] || (status === 'Rejected' ? 1 : 0));
+  }
+  for (const { num, from, to } of ledger) {
+    if (!statusByNum.has(num)) continue; // ledger row whose tracker row is gone
+    bump(num, STAGE_RANK[from] || 0);
+    bump(num, STAGE_RANK[to] || 0);
+  }
+  let everApplied = 0, everResponded = 0, everInterview = 0, everOffer = 0;
+  for (const rank of reached.values()) {
+    if (rank >= 1) everApplied++;
+    if (rank >= 2) everResponded++;
+    if (rank >= 3) everInterview++;
+    if (rank >= 4) everOffer++;
+  }
+  return {
+    everApplied,
+    everResponded,
+    everInterview,
+    everOffer,
+    responseRate: pct(everResponded, everApplied),
+    interviewRate: pct(everInterview, everApplied),
+    offerRate: pct(everOffer, everApplied),
+    smallSample: everApplied < 10,
+    basis: 'ledger',
   };
 }
 
@@ -493,6 +564,7 @@ export function computeAllStats({
   scanRunsFile = SCAN_RUNS_FILE,
   portalsFile = PORTALS_FILE,
   portalHealthFile = PORTAL_HEALTH_FILE,
+  statusLogFile = STATUS_LOG_FILE,
 } = {}) {
   const read = (f) => (existsSync(f) ? readFileSync(f, 'utf-8') : null);
   const apps = read(appsFile);
@@ -501,6 +573,7 @@ export function computeAllStats({
   const portals = read(portalsFile);
   const runs = read(scanRunsFile);
   const portalHealth = read(portalHealthFile);
+  const statusLog = read(statusLogFile);
   const trackerBase = apps ? computeTrackerStats(apps) : null;
   const scan = scanHist ? computeScanStats(scanHist) : null;
 
@@ -538,10 +611,17 @@ export function computeAllStats({
         portals: !!portals,
         scanRuns: !!runs,
         portalHealth: !!portalHealth,
+        statusLog: !!statusLog,
       },
     },
     tracker,
-    funnel: tracker ? computeFunnel(tracker.byStatus) : null,
+    // Prefer the ledger-aware funnel once a transition log exists (#1428); fall
+    // back to the pure status snapshot when it does not, so nothing regresses.
+    funnel: !tracker
+      ? null
+      : statusLog
+        ? computeFunnelWithHistory(trackerStatusByNum(apps), parseStatusLogStages(statusLog))
+        : computeFunnel(tracker.byStatus),
     scan,
     portals: portals ? computePortalStats(portals, scan, scanHist ? scanCompanyNames(scanHist) : [], portalHealth) : null,
     followups: fups && apps ? computeFollowupStats(fups, trackerStatusByNum(apps)) : null,
@@ -573,7 +653,8 @@ function printSummary(stats) {
   const f = stats.funnel;
   if (f) {
     const small = f.smallSample ? ' (small sample — rates indicative only)' : '';
-    console.log(`Funnel:     ever applied ${f.everApplied} → responded ${f.everResponded} (${f.responseRate}%) → interview ${f.everInterview} (${f.interviewRate}%) → offer ${f.everOffer} (${f.offerRate}%)${small}`);
+    const basis = f.basis === 'ledger' ? ' · ledger-adjusted (folds status-log history)' : '';
+    console.log(`Funnel:     ever applied ${f.everApplied} → responded ${f.everResponded} (${f.responseRate}%) → interview ${f.everInterview} (${f.interviewRate}%) → offer ${f.everOffer} (${f.offerRate}%)${small}${basis}`);
   }
   const s = stats.scan;
   if (s) {

--- a/tests/stats.test.mjs
+++ b/tests/stats.test.mjs
@@ -67,6 +67,26 @@ try {
     fail('computeFunnel should flag everApplied < 10 as smallSample');
   }
 
+  // Ledger-aware funnel (#1428): a declined offer (now Discarded) and a
+  // rejected-after-interview must count for the stages they passed through,
+  // which the status snapshot alone cannot see. Row 3 has no ledger history and
+  // must fall back to its current status (Rejected proves everApplied only).
+  const statusByNum = new Map([[1, 'Discarded'], [2, 'Rejected'], [3, 'Rejected'], [4, 'Interview']]);
+  const ledgerTsv = [
+    '1\t2026-08-19\tInterview\tOffer\tset-status\t',   // row 1 reached Offer, then declined
+    '1\t2026-08-25\tOffer\tDiscarded\tset-status\t',
+    '2\t2026-08-25\tInterview\tRejected\tset-status\t', // row 2 reached Interview, then rejected
+    'torn-line-no-num',
+  ].join('\n');
+  const ledgerParsed = stats.parseStatusLogStages(ledgerTsv);
+  const fl = stats.computeFunnelWithHistory(statusByNum, ledgerParsed);
+  if (ledgerParsed.length === 3 && fl.everApplied === 4 && fl.everInterview === 3 && fl.everOffer === 1
+      && fl.basis === 'ledger') {
+    pass('computeFunnelWithHistory folds ledger history (declined offer counts into everOffer)');
+  } else {
+    fail(`computeFunnelWithHistory wrong output: parsed=${ledgerParsed.length} ${JSON.stringify(fl)}`);
+  }
+
   // Lifetime scan totals — CRLF input, torn row skipped, fingerprint column tolerated.
   const scanTsv = [
     'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation',


### PR DESCRIPTION
## What

`stats.mjs` (the ever-stage funnel) and `calibrate.mjs` (score-vs-outcome calibration) both read only the **current** tracker status. A row that reached Offer or Interview and then landed on a terminal status — `Discarded` after a declined offer, `Rejected` after interviews — was undercounted or dropped from the population entirely. Now that `data/status-log.tsv` records transitions, both can fold that history and report what actually happened.

Completes two documented follow-ups:
- **#1428** — `computeFunnel`'s own comment: *"middle stages are lower bounds ... until status-transition logging exists."* The log now exists.
- **#1724** — the learning loop (calibrate reading real outcomes).

## Changes

**`stats.mjs`**
- Add `parseStatusLogStages` + `computeFunnelWithHistory`: `everX` counts distinct rows that reached stage X per the ledger's `from`/`to` history (a declined offer now in `Discarded` still counts into `everOffer`; a `Rejected`-after-interview counts into `everInterview`).
- `computeFunnel(byStatus)` is **unchanged** — `funnel-velocity.mjs` and the existing tests depend on it. The ledger path is used only when `status-log.tsv` is present; otherwise the summary is byte-for-byte the previous status-only funnel.
- Summary line gains a `· ledger-adjusted` marker and the JSON gains `basis: 'ledger'`, so the source is explicit.

**`calibrate.mjs`**
- Add `loadLedgerReached` + a `reached` option on `computeCalibration`.
- Evidence precedence is now **journal > ledger > status**: a declined offer (now `Discarded`) counts as `reachedOffer`; an interview that ended in `Rejected` counts as `reachedInterview`. A `Discarded` row with no interview/offer history stays outside the population, as before.

## Backward compatibility

- `computeFunnel` signature and output are unchanged.
- Both scripts behave exactly as before when `data/status-log.tsv` is absent (the new arg defaults to an empty map / the file read returns an empty map).
- No scoring rules, thresholds, or user files are touched — `calibrate` stays strictly advisory.

## Tests

- `tests/stats.test.mjs`: new `computeFunnelWithHistory` case (declined offer counts into `everOffer`; distinct-row counting; torn ledger line skipped). Existing `computeFunnel` cases unchanged and green.
- `calibrate.mjs --self-test`: new cases — ledger resolves a declined offer as `reachedOffer`; a history-less `Discarded` stays excluded; a journal outranks the ledger. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Funnel reporting now reflects historical stage progression, including applications that later reached interviews or offers.
  - Calibration prioritizes outcome journals and stage history for more accurate results.
  - Reports indicate when historical status data contributes to funnel calculations.

- **Bug Fixes**
  - Terminal applications without supporting stage history are excluded from historical-stage counts.
  - Declined offers and rejected interviews retain their previously reached stages.
  - Missing or malformed history data safely falls back to current-status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->