### PR TITLE
fix(build-cv-latex): render markdown bold in bullets as \textbf

### DIFF
--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -13,6 +13,50 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = resolve(__dirname, 'templates', 'cv-template.tex');
 const PLACEHOLDER_RE = /\{\{[A-Z_]+\}\}/g;
 
+// Markdown bold inside bullets — the LaTeX half of #1728, which taught the HTML
+// path to render `**text**` as <strong> (normalizeTextForATS in generate-pdf.mjs).
+// escapeLatex() leaves `*` alone because it is not a LaTeX special character, so
+// the markers reached the .tex verbatim and printed as literal asterisks (#3351).
+//
+// Order is the safety property, and it mirrors the HTML twin: escapeLatex() runs
+// FIRST, so every backslash and brace in the payload is already neutralized
+// (`\` becomes \textbackslash{}, braces become \{ \}). Nothing the candidate wrote
+// can survive as a real control sequence — this pass only reinterprets the `**`
+// markers, which escaping deliberately left untouched. Same regex as the HTML
+// path so the two twins agree on what counts as bold.
+//
+// The gate covers every field this builder emits inside a \resumeItem: experience
+// bullets, project bullets, and the education coursework line. Coursework does not
+// carry the payload key `bullets`, but it renders as a bullet, and a bullet whose
+// emphasis silently prints as `**` is the bug being fixed — the shape of the
+// output decides what goes through the gate, not the name of the payload field.
+const MARKDOWN_BOLD_RE = /\*\*([^*]+?)\*\*/g;
+
+/**
+ * Escape bullet text, then restore markdown bold as \textbf.
+ *
+ * Use this for every value that ends up inside a \resumeItem; use escapeLatex
+ * directly everywhere else, where `**` is meant to stay literal.
+ *
+ * @param {string} text raw payload text, not yet escaped
+ * @returns {string} LaTeX-safe text with `**…**` spans rendered as \textbf{…}
+ */
+function escapeLatexBullet(text) {
+  // Replacer FUNCTION, not a string: escaped text is full of `\$` and `\&`, and a
+  // string replacement would reinterpret `$&` and friends as match references
+  // (same trap the render path documents below).
+  return escapeLatex(text).replace(MARKDOWN_BOLD_RE, (_, inner) => `\\textbf{${inner}}`);
+}
+
+/**
+ * Render the Education section as \resumeSubheading blocks.
+ *
+ * An entry's optional `coursework` becomes a single \resumeItem line, which is
+ * why it goes through escapeLatexBullet rather than escapeLatex.
+ *
+ * @param {Array<object>} entries `education[]` from the payload
+ * @returns {string} LaTeX for the section body, or '' when there is nothing to render
+ */
 function buildEducation(entries) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
   const blocks = [];
@@ -20,7 +64,7 @@ function buildEducation(entries) {
     if (!e) continue;
     let block = `    \\resumeSubheading\n      {${escapeLatex(e.institution)}}{${escapeLatex(e.location)}}\n      {${escapeLatex(e.degree)}}{${escapeLatex(e.dates)}}`;
     if (Array.isArray(e.coursework) && e.coursework.length > 0) {
-      const courses = e.coursework.map(c => escapeLatex(c)).join(', ');
+      const courses = e.coursework.map(c => escapeLatexBullet(c)).join(', ');
       block += `\n        \\resumeItemListStart\n            \\resumeItem{\\textbf{Coursework:} ${courses}}\n        \\resumeItemListEnd`;
     }
     blocks.push(block);
@@ -28,17 +72,32 @@ function buildEducation(entries) {
   return blocks.join('\n\n');
 }
 
+/**
+ * Render the Work Experience section as \resumeSubheading blocks.
+ *
+ * @param {Array<object>} entries `experience[]` from the payload
+ * @returns {string} LaTeX for the section body, or '' when there is nothing to render
+ */
 function buildExperience(entries) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
   const blocks = [];
   for (const e of entries) {
     if (!e) continue;
-    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatex(b)}}`).join('\n') : '';
+    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatexBullet(b)}}`).join('\n') : '';
     blocks.push(`    \\resumeSubheading\n      {${escapeLatex(e.company)}}{${escapeLatex(e.dates)}}\n      {${escapeLatex(e.role)}}{${escapeLatex(e.location)}}\n      \\resumeItemListStart\n${bullets}\n      \\resumeItemListEnd`);
   }
   return blocks.join('\n\n');
 }
 
+/**
+ * Render the Projects section as \resumeProjectHeading blocks.
+ *
+ * A valid `url` turns the project name into an \href link (#3198); the name
+ * itself stays escaped either way.
+ *
+ * @param {Array<object>} entries `projects[]` from the payload
+ * @returns {string} LaTeX for the section body, or '' when there is nothing to render
+ */
 function buildProjects(entries) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
   const blocks = [];
@@ -49,7 +108,7 @@ function buildProjects(entries) {
     const nameFormatted = url
       ? `\\href{${escapeLatex(url, 'url')}}{\\textbf{${escapeLatex(e.name)}}}`
       : `\\textbf{${escapeLatex(e.name)}}`;
-    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatex(b)}}`).join('\n') : '';
+    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatexBullet(b)}}`).join('\n') : '';
     blocks.push(`    \\resumeProjectHeading\n      {${nameFormatted}${context}}{${escapeLatex(e.dates || '')}}\n      \\resumeItemListStart\n${bullets}\n      \\resumeItemListEnd`);
   }
   return blocks.join('\n\n');

--- a/modes/latex.md
+++ b/modes/latex.md
@@ -95,17 +95,17 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 | `education[].location` | string | Institution location |
 | `education[].degree` | string | Degree name |
 | `education[].dates` | string | Date range |
-| `education[].coursework` | string[] | Optional — generates a coursework line if present |
+| `education[].coursework` | string[] | Optional — generates a coursework line if present. Renders as a bullet, so it supports the same `**…**` emphasis |
 | `experience[]` | object[] | Optional — omit the key or pass `[]` and the Work Experience section is dropped, header included. For candidates with no professional history yet (students, new graduates, career changers); never drop it to hide a gap |
 | `experience[].company` | string | From cv.md Experience |
 | `experience[].role` | string | Job title |
 | `experience[].location` | string | Work location |
 | `experience[].dates` | string | Date range |
-| `experience[].bullets` | string[] | Reordered and keyword-injected achievement bullets |
+| `experience[].bullets` | string[] | Reordered and keyword-injected achievement bullets. Wrap a span in `**…**` to emphasise it — the builder renders it as `\textbf{…}` after escaping (see **Markdown bold in bullets** below) |
 | `projects[].name` | string | From cv.md Projects |
 | `projects[].context` | string | Tech stack — appears next to project name |
 | `projects[].dates` | string | Date range (or empty) |
-| `projects[].bullets` | string[] | Selected project achievements |
+| `projects[].bullets` | string[] | Selected project achievements. Supports the same `**…**` emphasis |
 | `awards[].title` | string | Award name, from cv.md Awards / Honors |
 | `awards[].org` | string | Optional — issuing body, rendered after the title |
 | `awards[].year` | string | Optional — year, right-aligned |
@@ -132,6 +132,24 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 | `→` | `$\rightarrow$` |
 
 **Exception:** URLs inside `\href{}` are NOT escaped by the LaTeX escaper, but `sanitizeUrl()` still validates the scheme (mailto/http/https) and removes dangerous characters to prevent injection.
+
+## Markdown Bold in Bullets
+
+`experience[].bullets`, `projects[].bullets` and `education[].coursework` accept `**…**` around a span you want emphasised — typically the quantified result a recruiter should catch in the six-second scan:
+
+```json
+"bullets": ["Cut p99 latency from 840 ms to **120 ms** across 14 services"]
+```
+
+renders as `\textbf{…}` in the `.tex`. This is the LaTeX half of the same support the HTML path has had since #1728, so **in bullets** one payload emphasises the same way in both output formats.
+
+**The support is bullet-scoped on this side.** Everything this builder emits inside a `\resumeItem` goes through it — `experience[].bullets`, `projects[].bullets`, and the `education[].coursework` line. Every other field (`projects[].name`, `projects[].context`, `awards[].title`, `skills[].category`, `skills[].items`) still renders `**` literally here, while the HTML path bolds them. Keep `**…**` out of those fields unless you are producing HTML only.
+
+**The escaping runs first, and that order is the safety property.** `escapeLatex()` neutralises every backslash and brace before the `**` markers are reinterpreted, so a literal `\textbf{...}` typed into a bullet stays inert text and a bold span keeps its `\&`, `\$`, `\%` escaping intact. Only `**`-delimited spans are affected; single asterisks and unmatched markers stay literal.
+
+**A bold span cannot contain a `*`.** `**tripled *3x* throughput**` matches nothing and ships the asterisks literally — no error, no warning. Rewrite it as `**tripled 3x throughput**` rather than nesting emphasis. The HTML path has the same limit (it is the same regex), so this is a rule about the payload, not about the output format.
+
+Emphasis is not a substitute for evidence — bold reorders attention, it does not add claims. The no-fabrication rule applies to bolded text exactly as it does to the rest of the bullet.
 
 ## ATS Rules (same as pdf mode)
 

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -200,9 +200,9 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `candidate.photo` | string | Opt-in profile photo (#264): a local path or `data:` URL. Empty/absent emits **no `<img>`**, rendering pixel-for-pixel identical to the photoless layout (US/UK/many-market ATS penalize photos; opt in for DACH/European markets). |
 | `candidate.photo_style` | string | Optional photo framing: `rounded` (default), `circle`, or `square`. Read it from `candidate.photo_style` in `config/profile.yml`; invalid values fail before HTML is written. |
 | `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. |
-| `summary` | string | Personalized summary with keywords. |
+| `summary` | string | Personalized summary with keywords. Supports `**…**` emphasis (see **Markdown bold** below). |
 | `competencies` | string[] | 6-8 keyword phrases → competency tags. |
-| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
+| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected; `**…**` emphasis supported). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
 | `projects[]` | object | `name`, `url` (optional project/repo link), `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |
@@ -210,6 +210,24 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `skills[]` | object | `category` + `items` (comma-separated string or string array). |
 
 `build-cv-html.mjs` errors out (non-zero exit) if any template placeholder is left unresolved, so a malformed payload fails loudly instead of shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.
+
+### Markdown bold
+
+Wrap a span in `**…**` to emphasise it — typically the quantified result a recruiter should catch in the six-second scan:
+
+```json
+"bullets": ["Cut p99 latency from 840 ms to **120 ms** across 14 services"]
+```
+
+`generate-pdf.mjs` converts it to `<strong>` during ATS normalization (#1728), and the template styles it in both the summary and job bullets. On the HTML path the conversion walks every text node, so **any** field can carry `**…**`.
+
+**The LaTeX twin is narrower — check `modes/latex.md` before reusing a payload across both.** `build-cv-latex.mjs` renders `**…**` as `\textbf{…}` (#3351) only in what it emits inside a `\resumeItem`: `experience[].bullets`, `projects[].bullets`, and the `education[].coursework` line. It has no `summary` field at all, and `projects[].name`, `awards[].title` and the `skills[]` fields print `**` literally. Bullets emphasise the same way in both formats; nothing else is guaranteed to.
+
+**The escaping runs first, and that order is the safety property.** `build-cv-html.mjs` owns the HTML escaping, and only the `**` markers it left untouched are reinterpreted afterwards — a literal `<script>` typed into a bullet stays escaped inside the bold span. Only `**`-delimited spans are affected; single asterisks and unmatched markers stay literal.
+
+**A bold span cannot contain a `*`.** `**tripled *3x* throughput**` matches nothing and ships the asterisks literally — no error, no warning. Rewrite it as `**tripled 3x throughput**` rather than nesting emphasis.
+
+Emphasis is not a substitute for evidence — bold reorders attention, it does not add claims. The no-fabrication rule applies to bolded text exactly as it does to the rest of the bullet, and bolding every other phrase emphasises nothing.
 
 ### Profile photo (opt-in, market-specific)
 

--- a/tests/cv-latex-bullet-bold.test.mjs
+++ b/tests/cv-latex-bullet-bold.test.mjs
@@ -1,0 +1,130 @@
+// tests/cv-latex-bullet-bold.test.mjs — the LaTeX mirror of #1728 (#3351).
+//
+// #1728 taught the HTML path to render `**text**` as <strong>, in
+// normalizeTextForATS (generate-pdf.mjs). The conversion walks every text node,
+// so it already covered experience and project bullets, and cv-template.html
+// ships `.job li strong` to style them. build-cv-latex.mjs had no equivalent:
+// escapeLatex() leaves `*` alone because it is not a LaTeX special character,
+// so the markers reached the .tex verbatim and printed as literal asterisks —
+// the same payload emphasised in the HTML PDF and showed `**1018 KB**` in the
+// LaTeX one, with the builder reporting "valid": true and exiting 0.
+//
+// End-to-end through the real builder and the shipped template, because
+// build-cv-latex.mjs exports nothing.
+import { pass, fail, ROOT, NODE, run, lastRunFailure } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nbuild-cv-latex — markdown bold in bullets (#3351)');
+
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Bold Bullets', email: 'bold@example.com' },
+  summary: 'Summary.',
+  competencies: ['Competency'],
+  experience: [{
+    company: 'Corp',
+    role: 'Engineer',
+    location: 'Remote',
+    dates: '2024 - Present',
+    bullets: [
+      // Bold applied, and LaTeX specials inside the span still escaped.
+      'Cut cold start to **1018 KB** on a **$2M budget & 99.9% uptime**',
+      // Injection probe: a literal \textbf typed by the candidate must stay
+      // inert text rather than becoming a control sequence.
+      'Wrote \\textbf{this} by hand and left 5 * 3 and *single* asterisks alone',
+      // An unmatched marker has no closing pair, so it stays literal.
+      'Unmatched **marker stays literal',
+      // A bold span cannot contain a `*`, so this one matches nothing. Pinned
+      // because it fails silently — the builder still exits 0 with valid:true.
+      'Nested **a *b* c** markers',
+    ],
+  }],
+  projects: [{
+    // Not a \resumeItem — name and context are outside the gate (see NOT_COVERED).
+    name: '**BoldName**',
+    context: '**BoldContext**',
+    dates: '2024',
+    bullets: ['Built a REST API with **test coverage exceeding 90%**'],
+  }],
+  // Coursework carries no `bullets` key but renders inside a \resumeItem, so it
+  // goes through the same gate — the output shape decides, not the field name.
+  education: [{
+    institution: 'Uni',
+    degree: 'BSc',
+    dates: '2019',
+    coursework: ['**Distributed Systems**', 'Algorithms'],
+  }],
+  awards: [{ title: '**BoldAward**', year: '2023' }],
+  skills: [{ category: '**BoldCat**', items: '**BoldItem**, plain' }],
+};
+
+// The other half of the contract: the fields bold does NOT reach on this side.
+// modes/latex.md and modes/pdf.md both name this exact list, and a doc that says
+// "these render `**` literally" goes stale silently unless something fails when
+// it stops being true. Widening the gate is fine — but it has to come with the
+// doc edit, and that is what these assertions force.
+const NOT_COVERED = [
+  ['projects[].name', '**BoldName**'],
+  ['projects[].context', '**BoldContext**'],
+  ['awards[].title', '**BoldAward**'],
+  ['skills[].category', '**BoldCat**'],
+  ['skills[].items', '**BoldItem**'],
+];
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-latex-bold-'));
+try {
+  const input = join(dir, 'bold.json');
+  const output = join(dir, 'bold.tex');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+
+  if (run(NODE, [join(ROOT, 'build-cv-latex.mjs'), input, output]) === null) {
+    const f = lastRunFailure();
+    fail(`build-cv-latex.mjs crashed (exit ${f?.status}) - ${(f?.stderr || '').trim().split('\n').pop()}`);
+  } else if (!existsSync(output)) {
+    fail('build-cv-latex.mjs exited 0 but wrote no output file');
+  } else {
+    const tex = readFileSync(output, 'utf-8');
+
+    // The bug, asserted directly: the markers must not reach the .tex.
+    tex.includes('**1018 KB**')
+      ? fail('markdown bold reached the .tex as literal asterisks (**1018 KB**)')
+      : pass('the bold markers do not survive into the .tex as literal asterisks');
+
+    const checks = [
+      ['experience bullets render bold as \\textbf', '\\textbf{1018 KB}'],
+      ['project bullets render bold as \\textbf', '\\textbf{test coverage exceeding 90\\%}'],
+      // Coursework is emitted inside a \resumeItem, so it is a bullet in the
+      // output even though the payload key is not `bullets`.
+      ['coursework renders bold as \\textbf', '\\textbf{Distributed Systems}'],
+      // Escaping runs FIRST, so a bold span keeps its \$ \& \% intact.
+      ['LaTeX specials inside a bold span stay escaped', '\\textbf{\\$2M budget \\& 99.9\\% uptime}'],
+      // ...and nothing the candidate typed can become a real control sequence.
+      ['a literal \\textbf in payload text stays inert', '\\textbackslash{}textbf\\{this\\}'],
+      // Single asterisks are not emphasis.
+      ['single asterisks are left alone', '5 * 3 and *single* asterisks'],
+      // An odd marker is not emphasis either.
+      ['an unmatched ** marker stays literal', 'Unmatched **marker stays literal'],
+      // Known limit, pinned rather than fixed: a `*` inside the span breaks the
+      // match, and the markers ship literally with no error. Same regex as the
+      // HTML twin, so changing it here alone would re-open the divergence.
+      ['a bold span containing * matches nothing', 'Nested **a *b* c** markers'],
+    ];
+
+    for (const [what, needle] of checks) {
+      tex.includes(needle)
+        ? pass(what)
+        : fail(`${what} — expected to find ${JSON.stringify(needle)} in the .tex`);
+    }
+
+    for (const [field, marker] of NOT_COVERED) {
+      tex.includes(marker)
+        ? pass(`${field} is outside the gate and keeps its literal **`)
+        : fail(`${field} no longer renders ${JSON.stringify(marker)} literally — the gate widened, so update the field lists in modes/latex.md and modes/pdf.md to match`);
+    }
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What does this PR do?

Teaches `build-cv-latex.mjs` to render `**text**` as `\textbf{text}`, the LaTeX half of the support #1728 added to the HTML path. Before this, the same payload emphasised correctly in the HTML PDF and printed literal `**1018 KB**` in the LaTeX one, with the builder reporting `"valid": true` and exiting 0.

## Related issue

Closes #3351

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The fix

`escapeLatex()` leaves `*` alone because it is not a LaTeX special character, so the markers survived into the `.tex`. The restore runs **after** escaping:

```js
const MARKDOWN_BOLD_RE = /\*\*([^*]+?)\*\*/g;   // same regex as the HTML path

function escapeLatexBullet(text) {
  return escapeLatex(text).replace(MARKDOWN_BOLD_RE, (_, inner) => `\\textbf{${inner}}`);
}
```

**That order is the safety property.** `escapeLatex()` has already turned every backslash into `\textbackslash{}` and every brace into `\{`/`\}`, so nothing the candidate wrote can come back as a control sequence — this pass only reinterprets the `**` markers, which escaping deliberately left untouched. A bullet containing a hand-typed `\textbf{this}` comes out as `\textbackslash{}textbf\{this\}`, inert.

The replacer is a **function, not a string**, for the same reason the render path below it documents: escaped text is full of `\$` and `\&`, and a string replacement would reinterpret `$&` as a match reference.

### Scope: every `\resumeItem` exit, not every field named `bullets`

The gate covers all three places this builder emits a `\resumeItem` — `experience[].bullets`, `projects[].bullets`, and the `education[].coursework` line. Coursework carries no `bullets` key but renders as a bullet, and a bullet whose emphasis prints as `**` is the bug being fixed. The shape of the output decides membership, not the payload field name.

Bold stays bullet-scoped on this side. `projects[].name`, `projects[].context`, `awards[].title` and the `skills[]` fields still print `**` literally while the HTML path bolds them, and this builder has no `summary` field at all. Both mode docs now say exactly that, field by field, instead of claiming the two formats emphasise identically — happy to widen the scope if you'd rather close that divergence in one go.

## Verification

**Payloads that contain no `**` produce a byte-identical `.tex`** — `cmp` clean against the pre-change builder. Existing users see no change at all.

New `tests/cv-latex-bullet-bold.test.mjs` (modeled on `tests/cv-latex-numeric-scalars.test.mjs` from #2916, the same twin-divergence shape), 9 assertions end-to-end through the real builder:

- experience / project / coursework bullets render `\textbf{…}`
- LaTeX specials inside a bold span keep their escaping: `\textbf{\$2M budget \& 99.9\% uptime}`
- a hand-typed `\textbf` stays inert
- single asterisks and unmatched `**` stay literal
- a bold span containing a `*` (`**a *b* c**`) matches nothing — pinned as a known limit rather than fixed, since it is the HTML path's behaviour too and changing it here alone would re-open the divergence. Documented in both mode files.

Mutation-checked: reverting any one call site to `escapeLatex`, or inverting the escape order, makes assertions fail. The tests exercise the real path rather than re-deriving the transform.

`node test-all.mjs`: **4910 passed, 1 failed**. The failure is `analyze() appDateSource end-to-end check` — `followup-cadence.mjs` copied to a temp dir cannot resolve `js-yaml`. It reproduces identically on a clean tree with this branch stashed (baseline 4901 passed, 1 failed), so it is a local environment artifact, unrelated to this change.

### Two things I could not fully verify

**`pdflatex` is not installed on my machine**, so the `.tex` was never compiled to a PDF. Verification stops at the `.tex` content.

**The issue body says `stripMarkup` in `verify-cv-facts.mjs` already handles `\textbf` — that is only half right, and I want to correct it here rather than leave it standing.** It holds for a standalone `\textbf{X}`, but its brace matching is `[^}]*`, not balanced, so a `\textbf{}` *nested inside* `\resumeItem{}` leaks a bare `textbf` token and misplaces the brace boundary. This is **pre-existing** — the shipped template's `\resumeItem{\textbf{Coursework:} …}` leaks it with an unmodified builder and no `**` in the payload at all. No verdict flip showed up in realistic before/after runs (all words survive; only the braces move), but this PR does raise how often it is hit, from once per CV to once per bolded span. Happy to open a separate issue for it; `lib/latex-content.mjs` already has a balanced `findMatchingBrace` that could back a fix.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Bug fix — issue #3351 opened first anyway
- [x] My PR does not include personal data (all fixtures are synthetic)
- [x] I ran `node test-all.mjs` — 4910 passed, 1 pre-existing env failure documented above
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — system layer only
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Markdown bold syntax (`**text**`) now renders as bold text in generated LaTeX CVs.
  - Supported in coursework, experience bullets, and project bullets.
  - Text remains safely escaped while preserving literal content and handling invalid markers predictably.

- **Documentation**
  - Updated LaTeX and PDF mode documentation with supported syntax, field coverage, escaping behavior, and usage restrictions.

- **Tests**
  - Added coverage for bold rendering, escaping, unmatched markers, and nested asterisk patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->