### PR TITLE
fix: resolve latex bold bullet merge conflict

### DIFF
--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -13,6 +13,32 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = resolve(__dirname, 'templates', 'cv-template.tex');
 const PLACEHOLDER_RE = /\{\{[A-Z_]+\}\}/g;
 
+// Markdown bold inside bullets — the LaTeX half of #1728, which taught the HTML
+// path to render `**text**` as <strong> (normalizeTextForATS in generate-pdf.mjs).
+// escapeLatex() leaves `*` alone because it is not a LaTeX special character, so
+// the markers reached the .tex verbatim and printed as literal asterisks (#3351).
+//
+// Order is the safety property, and it mirrors the HTML twin: escapeLatex() runs
+// FIRST, so every backslash and brace in the payload is already neutralized
+// (`\` becomes \textbackslash{}, braces become \{ \}). Nothing the candidate wrote
+// can survive as a real control sequence — this pass only reinterprets the `**`
+// markers, which escaping deliberately left untouched. Same regex as the HTML
+// path so the two twins agree on what counts as bold.
+//
+// The gate covers every field this builder emits inside a \resumeItem: experience
+// bullets, project bullets, and the education coursework line. Coursework does not
+// carry the payload key `bullets`, but it renders as a bullet, and a bullet whose
+// emphasis silently prints as `**` is the bug being fixed — the shape of the
+// output decides what goes through the gate, not the name of the payload field.
+const MARKDOWN_BOLD_RE = /\*\*([^*]+?)\*\*/g;
+
+function escapeLatexBullet(text) {
+  // Replacer FUNCTION, not a string: escaped text is full of `\$` and `\&`, and a
+  // string replacement would reinterpret `$&` and friends as match references
+  // (same trap the render path documents below).
+  return escapeLatex(text).replace(MARKDOWN_BOLD_RE, (_, inner) => `\\textbf{${inner}}`);
+}
+
 function buildEducation(entries) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
   const blocks = [];
@@ -20,7 +46,7 @@ function buildEducation(entries) {
     if (!e) continue;
     let block = `    \\resumeSubheading\n      {${escapeLatex(e.institution)}}{${escapeLatex(e.location)}}\n      {${escapeLatex(e.degree)}}{${escapeLatex(e.dates)}}`;
     if (Array.isArray(e.coursework) && e.coursework.length > 0) {
-      const courses = e.coursework.map(c => escapeLatex(c)).join(', ');
+      const courses = e.coursework.map(c => escapeLatexBullet(c)).join(', ');
       block += `\n        \\resumeItemListStart\n            \\resumeItem{\\textbf{Coursework:} ${courses}}\n        \\resumeItemListEnd`;
     }
     blocks.push(block);
@@ -33,7 +59,7 @@ function buildExperience(entries) {
   const blocks = [];
   for (const e of entries) {
     if (!e) continue;
-    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatex(b)}}`).join('\n') : '';
+    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatexBullet(b)}}`).join('\n') : '';
     blocks.push(`    \\resumeSubheading\n      {${escapeLatex(e.company)}}{${escapeLatex(e.dates)}}\n      {${escapeLatex(e.role)}}{${escapeLatex(e.location)}}\n      \\resumeItemListStart\n${bullets}\n      \\resumeItemListEnd`);
   }
   return blocks.join('\n\n');
@@ -45,7 +71,7 @@ function buildProjects(entries) {
   for (const e of entries) {
     if (!e) continue;
     const context = e.context ? ` \\emph{$|$ ${escapeLatex(e.context)}}` : '';
-    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatex(b)}}`).join('\n') : '';
+    const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatexBullet(b)}}`).join('\n') : '';
     blocks.push(`    \\resumeProjectHeading\n      {\\textbf{${escapeLatex(e.name)}}${context}}{${escapeLatex(e.dates)}}\n      \\resumeItemListStart\n${bullets}\n      \\resumeItemListEnd`);
   }
   return blocks.join('\n\n');

--- a/modes/latex.md
+++ b/modes/latex.md
@@ -95,17 +95,17 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 | `education[].location` | string | Institution location |
 | `education[].degree` | string | Degree name |
 | `education[].dates` | string | Date range |
-| `education[].coursework` | string[] | Optional — generates a coursework line if present |
+| `education[].coursework` | string[] | Optional — generates a coursework line if present. Renders as a bullet, so it supports the same `**…**` emphasis |
 | `experience[]` | object[] | Optional — omit the key or pass `[]` and the Work Experience section is dropped, header included. For candidates with no professional history yet (students, new graduates, career changers); never drop it to hide a gap |
 | `experience[].company` | string | From cv.md Experience |
 | `experience[].role` | string | Job title |
 | `experience[].location` | string | Work location |
 | `experience[].dates` | string | Date range |
-| `experience[].bullets` | string[] | Reordered and keyword-injected achievement bullets |
+| `experience[].bullets` | string[] | Reordered and keyword-injected achievement bullets. Wrap a span in `**…**` to emphasise it — the builder renders it as `\textbf{…}` after escaping (see **Markdown bold in bullets** below) |
 | `projects[].name` | string | From cv.md Projects |
 | `projects[].context` | string | Tech stack — appears next to project name |
 | `projects[].dates` | string | Date range (or empty) |
-| `projects[].bullets` | string[] | Selected project achievements |
+| `projects[].bullets` | string[] | Selected project achievements. Supports the same `**…**` emphasis |
 | `awards[].title` | string | Award name, from cv.md Awards / Honors |
 | `awards[].org` | string | Optional — issuing body, rendered after the title |
 | `awards[].year` | string | Optional — year, right-aligned |
@@ -132,6 +132,24 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 | `→` | `$\rightarrow$` |
 
 **Exception:** URLs inside `\href{}` are NOT escaped by the LaTeX escaper, but `sanitizeUrl()` still validates the scheme (mailto/http/https) and removes dangerous characters to prevent injection.
+
+## Markdown Bold in Bullets
+
+`experience[].bullets`, `projects[].bullets` and `education[].coursework` accept `**…**` around a span you want emphasised — typically the quantified result a recruiter should catch in the six-second scan:
+
+```json
+"bullets": ["Cut p99 latency from 840 ms to **120 ms** across 14 services"]
+```
+
+renders as `\textbf{…}` in the `.tex`. This is the LaTeX half of the same support the HTML path has had since #1728, so **in bullets** one payload emphasises the same way in both output formats.
+
+**The support is bullet-scoped on this side.** Everything this builder emits inside a `\resumeItem` goes through it — `experience[].bullets`, `projects[].bullets`, and the `education[].coursework` line. Every other field (`projects[].name`, `projects[].context`, `awards[].title`, `skills[].category`, `skills[].items`) still renders `**` literally here, while the HTML path bolds them. Keep `**…**` out of those fields unless you are producing HTML only.
+
+**The escaping runs first, and that order is the safety property.** `escapeLatex()` neutralises every backslash and brace before the `**` markers are reinterpreted, so a literal `\textbf{...}` typed into a bullet stays inert text and a bold span keeps its `\&`, `\$`, `\%` escaping intact. Only `**`-delimited spans are affected; single asterisks and unmatched markers stay literal.
+
+**A bold span cannot contain a `*`.** `**tripled *3x* throughput**` matches nothing and ships the asterisks literally — no error, no warning. Rewrite it as `**tripled 3x throughput**` rather than nesting emphasis. The HTML path has the same limit (it is the same regex), so this is a rule about the payload, not about the output format.
+
+Emphasis is not a substitute for evidence — bold reorders attention, it does not add claims. The no-fabrication rule applies to bolded text exactly as it does to the rest of the bullet.
 
 ## ATS Rules (same as pdf mode)
 

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -200,9 +200,9 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `candidate.photo` | string | Opt-in profile photo (#264): a local path or `data:` URL. Empty/absent emits **no `<img>`**, rendering pixel-for-pixel identical to the photoless layout (US/UK/many-market ATS penalize photos; opt in for DACH/European markets). |
 | `candidate.photo_style` | string | Optional photo framing: `rounded` (default), `circle`, or `square`. Read it from `candidate.photo_style` in `config/profile.yml`; invalid values fail before HTML is written. |
 | `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. |
-| `summary` | string | Personalized summary with keywords. |
+| `summary` | string | Personalized summary with keywords. Supports `**…**` emphasis (see **Markdown bold** below). |
 | `competencies` | string[] | 6-8 keyword phrases → competency tags. |
-| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
+| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected; `**…**` emphasis supported). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
 | `projects[]` | object | `name`, `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |
@@ -210,6 +210,24 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `skills[]` | object | `category` + `items` (comma-separated string or string array). |
 
 `build-cv-html.mjs` errors out (non-zero exit) if any template placeholder is left unresolved, so a malformed payload fails loudly instead of shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.
+
+### Markdown bold
+
+Wrap a span in `**…**` to emphasise it — typically the quantified result a recruiter should catch in the six-second scan:
+
+```json
+"bullets": ["Cut p99 latency from 840 ms to **120 ms** across 14 services"]
+```
+
+`generate-pdf.mjs` converts it to `<strong>` during ATS normalization (#1728), and the template styles it in both the summary and job bullets. On the HTML path the conversion walks every text node, so **any** field can carry `**…**`.
+
+**The LaTeX twin is narrower — check `modes/latex.md` before reusing a payload across both.** `build-cv-latex.mjs` renders `**…**` as `\textbf{…}` (#3351) only in what it emits inside a `\resumeItem`: `experience[].bullets`, `projects[].bullets`, and the `education[].coursework` line. It has no `summary` field at all, and `projects[].name`, `awards[].title` and the `skills[]` fields print `**` literally. Bullets emphasise the same way in both formats; nothing else is guaranteed to.
+
+**The escaping runs first, and that order is the safety property.** `build-cv-html.mjs` owns the HTML escaping, and only the `**` markers it left untouched are reinterpreted afterwards — a literal `<script>` typed into a bullet stays escaped inside the bold span. Only `**`-delimited spans are affected; single asterisks and unmatched markers stay literal.
+
+**A bold span cannot contain a `*`.** `**tripled *3x* throughput**` matches nothing and ships the asterisks literally — no error, no warning. Rewrite it as `**tripled 3x throughput**` rather than nesting emphasis.
+
+Emphasis is not a substitute for evidence — bold reorders attention, it does not add claims. The no-fabrication rule applies to bolded text exactly as it does to the rest of the bullet, and bolding every other phrase emphasises nothing.
 
 ### Profile photo (opt-in, market-specific)
 

--- a/tests/cv-latex-bullet-bold.test.mjs
+++ b/tests/cv-latex-bullet-bold.test.mjs
@@ -1,0 +1,107 @@
+// tests/cv-latex-bullet-bold.test.mjs — the LaTeX mirror of #1728 (#3351).
+//
+// #1728 taught the HTML path to render `**text**` as <strong>, in
+// normalizeTextForATS (generate-pdf.mjs). The conversion walks every text node,
+// so it already covered experience and project bullets, and cv-template.html
+// ships `.job li strong` to style them. build-cv-latex.mjs had no equivalent:
+// escapeLatex() leaves `*` alone because it is not a LaTeX special character,
+// so the markers reached the .tex verbatim and printed as literal asterisks —
+// the same payload emphasised in the HTML PDF and showed `**1018 KB**` in the
+// LaTeX one, with the builder reporting "valid": true and exiting 0.
+//
+// End-to-end through the real builder and the shipped template, because
+// build-cv-latex.mjs exports nothing.
+import { pass, fail, ROOT, NODE, run, lastRunFailure } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nbuild-cv-latex — markdown bold in bullets (#3351)');
+
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Bold Bullets', email: 'bold@example.com' },
+  summary: 'Summary.',
+  competencies: ['Competency'],
+  experience: [{
+    company: 'Corp',
+    role: 'Engineer',
+    location: 'Remote',
+    dates: '2024 - Present',
+    bullets: [
+      // Bold applied, and LaTeX specials inside the span still escaped.
+      'Cut cold start to **1018 KB** on a **$2M budget & 99.9% uptime**',
+      // Injection probe: a literal \textbf typed by the candidate must stay
+      // inert text rather than becoming a control sequence.
+      'Wrote \\textbf{this} by hand and left 5 * 3 and *single* asterisks alone',
+      // An unmatched marker has no closing pair, so it stays literal.
+      'Unmatched **marker stays literal',
+      // A bold span cannot contain a `*`, so this one matches nothing. Pinned
+      // because it fails silently — the builder still exits 0 with valid:true.
+      'Nested **a *b* c** markers',
+    ],
+  }],
+  projects: [{
+    name: 'Proj',
+    dates: '2024',
+    bullets: ['Built a REST API with **test coverage exceeding 90%**'],
+  }],
+  // Coursework carries no `bullets` key but renders inside a \resumeItem, so it
+  // goes through the same gate — the output shape decides, not the field name.
+  education: [{
+    institution: 'Uni',
+    degree: 'BSc',
+    dates: '2019',
+    coursework: ['**Distributed Systems**', 'Algorithms'],
+  }],
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-latex-bold-'));
+try {
+  const input = join(dir, 'bold.json');
+  const output = join(dir, 'bold.tex');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+
+  if (run(NODE, [join(ROOT, 'build-cv-latex.mjs'), input, output]) === null) {
+    const f = lastRunFailure();
+    fail(`build-cv-latex.mjs crashed (exit ${f?.status}) - ${(f?.stderr || '').trim().split('\n').pop()}`);
+  } else if (!existsSync(output)) {
+    fail('build-cv-latex.mjs exited 0 but wrote no output file');
+  } else {
+    const tex = readFileSync(output, 'utf-8');
+
+    // The bug, asserted directly: the markers must not reach the .tex.
+    tex.includes('**1018 KB**')
+      ? fail('markdown bold reached the .tex as literal asterisks (**1018 KB**)')
+      : pass('the bold markers do not survive into the .tex as literal asterisks');
+
+    const checks = [
+      ['experience bullets render bold as \\textbf', '\\textbf{1018 KB}'],
+      ['project bullets render bold as \\textbf', '\\textbf{test coverage exceeding 90\\%}'],
+      // Coursework is emitted inside a \resumeItem, so it is a bullet in the
+      // output even though the payload key is not `bullets`.
+      ['coursework renders bold as \\textbf', '\\textbf{Distributed Systems}'],
+      // Escaping runs FIRST, so a bold span keeps its \$ \& \% intact.
+      ['LaTeX specials inside a bold span stay escaped', '\\textbf{\\$2M budget \\& 99.9\\% uptime}'],
+      // ...and nothing the candidate typed can become a real control sequence.
+      ['a literal \\textbf in payload text stays inert', '\\textbackslash{}textbf\\{this\\}'],
+      // Single asterisks are not emphasis.
+      ['single asterisks are left alone', '5 * 3 and *single* asterisks'],
+      // An odd marker is not emphasis either.
+      ['an unmatched ** marker stays literal', 'Unmatched **marker stays literal'],
+      // Known limit, pinned rather than fixed: a `*` inside the span breaks the
+      // match, and the markers ship literally with no error. Same regex as the
+      // HTML twin, so changing it here alone would re-open the divergence.
+      ['a bold span containing * matches nothing', 'Nested **a *b* c** markers'],
+    ];
+
+    for (const [what, needle] of checks) {
+      tex.includes(needle)
+        ? pass(what)
+        : fail(`${what} — expected to find ${JSON.stringify(needle)} in the .tex`);
+    }
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Resolves PR #3352 merge conflicts against current `main`.
- Preserves the main-branch project URL/link rendering in `build-cv-latex.mjs`.
- Preserves the contributor markdown-bold support for LaTeX experience/project/coursework bullets plus docs/tests.

## Test plan
- `node build-cv-latex.mjs --test`
- `node tests/cv-latex-bullet-bold.test.mjs`
- `npm run lint`
- `git diff --check`

Bridge for #3352 because the original branch is currently `mergeStateStatus=DIRTY`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Markdown bold support using `**text**` in CV coursework, experience bullets, project bullets, summaries, and descriptions.
  - Bold text is rendered appropriately in generated PDF and LaTeX outputs.

- **Bug Fixes**
  - Improved escaping of special characters while preserving supported bold formatting.
  - Clarified handling of unmatched, nested, or unsupported asterisk markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->