### PR TITLE
fix(providers): a16z short-page break preempts total_pages — one 49-row page mid-sweep silently ends the board

### DIFF
--- a/providers/a16z-speedrun-talent.mjs
+++ b/providers/a16z-speedrun-talent.mjs
@@ -28,8 +28,9 @@ const TRUSTED_HOST = 'speedrun-talent-network.com';
 const PER_PAGE = 50;
 const DEFAULT_MAX_PAGES = 6; // × PER_PAGE = the 300-job default scan
 // Runaway bound, not a coverage target: iteration already stops at the
-// feed's reported total_pages (or a short page), so on an honest feed the
-// cap costs nothing and full-board sweeps keep working as the board grows.
+// feed's reported total_pages (or, when the feed omits it, a short page), so
+// on an honest feed the cap costs nothing and full-board sweeps keep working
+// as the board grows.
 // It only bites a misbehaving feed or an absurd max_pages entry — so it
 // sits well above plausible board size (~353 pages / ~17.6k jobs as of
 // 2026-08), same policy as workday.mjs's cap.
@@ -175,9 +176,25 @@ export default {
         const normalized = normalizeSpeedrunJob(j, fallbackCompany);
         if (normalized) out.push(normalized);
       }
-      // Stop at the last page: a short page, or past the reported total_pages.
-      if (json.jobs.length < PER_PAGE) break;
-      if (Number.isInteger(json.total_pages) && page + 1 >= json.total_pages) break;
+      // Stop at the last page. Termination priority (#2547):
+      //   1. An empty page always ends iteration — nothing left to read, and
+      //      it bounds a feed that over-reports total_pages instead of burning
+      //      requests up to max_pages.
+      //   2. The feed's own total_pages when present. A page that comes back
+      //      49/50 because a listing was deleted between requests on a board
+      //      that rotates mid-sweep is NOT the last page; treating it as one
+      //      ended the sweep silently, at a clean exit code — the cap warning
+      //      below is gated on max_pages and is never reached from here.
+      //   3. A short page, only as the fallback for feeds that omit
+      //      total_pages entirely. Demoting it (rather than merely reordering
+      //      the two checks) is what fixes #2547: a 49-row page fails the
+      //      total_pages test and would still break out on the next line.
+      if (json.jobs.length === 0) break;
+      if (Number.isInteger(json.total_pages)) {
+        if (page + 1 >= json.total_pages) break;
+      } else if (json.jobs.length < PER_PAGE) {
+        break;
+      }
       // Cap warning (same pattern as jibeapply/workday): the feed had more
       // pages than we were allowed to read — surface it, with the fix.
       if (page + 1 >= maxPages && Number.isInteger(json.total_pages) && json.total_pages > maxPages) {

--- a/tests/providers/a16z-speedrun-talent.test.mjs
+++ b/tests/providers/a16z-speedrun-talent.test.mjs
@@ -141,8 +141,76 @@ try {
   if (liveWarnings.some((w) => w.includes('truncated at max_pages=2'))) pass('fetch() warns when max_pages truncates the live-shape feed');
   else fail(`live-shape truncation warning missing; captured = ${JSON.stringify(liveWarnings)}`);
 
+  // #2547: total_pages outranks the short-page break. On a board that rotates
+  // while a sweep runs, a page can legitimately come back 49/50 because a
+  // listing was deleted between requests — that is not the last page, and the
+  // feed's own total_pages says so. Before the fix iteration stopped there and
+  // returned 149 of 300 jobs, silently: the truncation warning is gated on
+  // max_pages, and page 2 of 6 never reaches the cap. Repro shape from
+  // @FReptar0 on #2547.
+  const rotCalls = [];
+  const rotCtx = {
+    fetchJson: async (url) => {
+      const page = Number(new URL(url).searchParams.get('page'));
+      rotCalls.push(page);
+      const rows = page === 2 ? 49 : 50;
+      return { jobs: Array.from({ length: rows }, (_, i) => mk(page * 50 + i)), total: 300, page, page_size: 50, total_pages: 6 };
+    },
+  };
+  const rotWarnings = [];
+  const rotRealConsoleError = console.error;
+  let rotated;
+  try {
+    console.error = (...args) => rotWarnings.push(args.join(' '));
+    rotated = await provider.fetch({ max_pages: 6 }, rotCtx);
+  } finally {
+    console.error = rotRealConsoleError;
+  }
+  if (rotCalls.join(',') === '0,1,2,3,4,5' && rotated.length === 299) {
+    pass('fetch() keeps paginating past a short-but-nonempty page while total_pages says there is more (#2547)');
+  } else {
+    fail(`#2547 mid-sweep short page = ${JSON.stringify({ pages: rotCalls, jobs: rotated?.length })}`);
+  }
+  // A sweep that lands exactly on max_pages === total_pages is complete, not
+  // truncated: no false "raise max_pages" warning on a board read in full.
+  if (rotWarnings.length === 0) pass('fetch() does not warn when max_pages exactly covers total_pages');
+  else fail(`unexpected warning on a complete sweep = ${JSON.stringify(rotWarnings)}`);
+
+  // Trusting total_pages is only safe because an empty page ends iteration
+  // unconditionally: an OVER-reporting feed stops at the first empty response
+  // instead of burning the page budget. This is the lying-server risk that
+  // sank the page_size variant in #2419, bounded here.
+  const overCalls = [];
+  const overCtx = {
+    fetchJson: async (url) => {
+      const page = Number(new URL(url).searchParams.get('page'));
+      overCalls.push(page);
+      return { jobs: page < 3 ? Array.from({ length: 50 }, (_, i) => mk(page * 50 + i)) : [], total_pages: 50 };
+    },
+  };
+  const over = await provider.fetch({ max_pages: 20 }, overCtx);
+  if (overCalls.length === 4 && over.length === 150) pass('fetch() stops at the first empty page when total_pages over-reports (#2547)');
+  else fail(`over-reported total_pages = ${JSON.stringify({ calls: overCalls.length, jobs: over.length })}`);
+
+  // The other direction, pinned as deliberate: an UNDER-reporting total_pages
+  // truncates, and that is the accepted trade-off — the feed's own count is
+  // the best available statement of board size, and ignoring it is the bug
+  // above. Do not "fix" this back into a short-page race.
+  const underCalls = [];
+  const underCtx = {
+    fetchJson: async (url) => {
+      const page = Number(new URL(url).searchParams.get('page'));
+      underCalls.push(page);
+      return { jobs: Array.from({ length: 50 }, (_, i) => mk(page * 50 + i)), total_pages: 2 };
+    },
+  };
+  const under = await provider.fetch({ max_pages: 10 }, underCtx);
+  if (underCalls.length === 2 && under.length === 100) pass('fetch() honours total_pages as the terminator even when the feed under-reports (#2547, deliberate)');
+  else fail(`under-reported total_pages = ${JSON.stringify({ calls: underCalls.length, jobs: under.length })}`);
+
   // PER_PAGE fallback pinned from both directions when the response omits
-  // page_size/total_pages: a full 50-row page continues (fails if PER_PAGE
+  // page_size/total_pages — the ONLY path on which a short page still ends
+  // iteration (#2547): a full 50-row page continues (fails if PER_PAGE
   // regresses above 50), a 49-row page stops (fails if it regresses below 50).
   const bareCalls = [];
   const bareCtx = {


### PR DESCRIPTION
Fixes part 1 of #2547, `confirmed` and scoped by @santifer. Repro by @FReptar0.

## The bug

`providers/a16z-speedrun-talent.mjs` evaluated the short-page break **before** the `total_pages` check:

```js
if (json.jobs.length < PER_PAGE) break;
if (Number.isInteger(json.total_pages) && page + 1 >= json.total_pages) break;
```

On a board of ~17.6K listings that rotates while a sweep runs, a mid-scan page can legitimately return 49 rows because a listing was deleted between requests. The loop treated that as the last page.

It is **silent**. The truncation warning at `:183` is gated on `page + 1 >= maxPages`, so a stop at page 2 of 6 never reaches the cap and prints nothing. Half a board disappears at exit 0.

## Evidence

@FReptar0's repro on `a4706e3b`, before and after:

```
                          pages requested    jobs    stderr
before   CONTROL          [0,1,2,3,4,5]      300     (none)
before   page 2 → 49      [0,1,2]            149     (none)   ← silent
after    CONTROL          [0,1,2,3,4,5]      300     (none)
after    page 2 → 49      [0,1,2,3,4,5]      299     (none)
```

## Why this is a gate, not a swap

The issue was scoped as "swap the check order", but reordering alone does **not** fix it — the 49-row page fails the `total_pages` test and still falls into the short-page break on the next line. Applied on its own, the swap prints byte-identical repro output (`[0,1,2]` / 149).

So the short-page break is **demoted to a fallback** that runs only when `total_pages` is absent, and an empty page terminates unconditionally:

```js
if (json.jobs.length === 0) break;
if (Number.isInteger(json.total_pages)) {
  if (page + 1 >= json.total_pages) break;
} else if (json.jobs.length < PER_PAGE) {
  break;
}
```

Termination priority: **empty page > `total_pages` when present > short page when `total_pages` is absent.**

## The lying-server question

This is the risk that sank the "prefer the server's `page_size`" variant in #2419, so both directions are bounded and pinned:

| Feed misbehaviour | Outcome | Pinned by |
|---|---|---|
| **Over-reports** `total_pages` | First empty page ends iteration — no request burn. Removing that one line makes the over-report case request **20 pages instead of 4** (measured), so the break is load-bearing, not decorative. | `stops at the first empty page when total_pages over-reports` |
| **Under-reports** `total_pages` | Truncates. Deliberate: the feed's own count is the best available statement of board size, and ignoring it is the bug being fixed. Documented in the test so it is not "fixed" back into a short-page race. | `honours total_pages ... even when the feed under-reports` |

Same shape as `providers/nofluffjobs.mjs:160-162` — server totals first, empty-page break second, no short-page heuristic. The unconditional empty-page break is near-universal across providers (`alibaba.mjs:170`, `beesite.mjs:162`, `dassault.mjs:173`, `smartrecruiters.mjs:78`, ~14 more).

## Tests

One regression test plus three guards on the termination contract:

- **49-row page mid-board** — 6 pages requested, 299 jobs. Fails on `main` with `{"pages":[0,1,2],"jobs":149}`; the only new assert that does.
- Over-reporting `total_pages` stops at the first empty page (4 calls, not 20).
- Under-reporting `total_pages` is honoured, marked deliberate.
- A sweep landing exactly on `max_pages === total_pages` is complete, not truncated — no false "raise max_pages" warning.

**No existing assertion changed.** Every current case was traced against the new order: the `total_pages: 2` pagination test, the `max_pages` cap, the 337-page live shape, the bare no-`total_pages` fallback (which now pins the fallback path specifically), the empty feed, `MAX_PAGES_CAP` boundaries, and the #2506 retry group.

## Scope

Part 1 only, per your scoping. Part 2 asks for the opposite of the decision documented above the fetch ("a silent partial board would be worse than a loud empty one", #2506) and is not challenged here; part 3 is largely absorbed by that retry's backoff. `Refs #2547` rather than `Closes` so both stay visible for you to close or split.

**Verification** (Windows 11 / Node 24.12.0):
- `node tests/providers/a16z-speedrun-talent.test.mjs` — all green, 4 new asserts.
- `node test-all.mjs` — **5571 passed, 1 failed locally**, and the local failure is an artifact of my Windows checkout rather than of this diff or of `main`. The CLI skill entrypoints (`.claude/skills/career-ops/SKILL.md` and its six siblings) are symlinks to `.agents/skills/career-ops/SKILL.md`; with `core.symlinks=false` — the default when a Windows box has unprivileged symlink creation off — git materializes them as 43-byte text files containing the target path, so `tests/skill-project-root.test.mjs` reads the path string and reports "missing cwd-independent routing rule" for all seven. Green on ubuntu, macos and windows in CI here. Flagging only because the same setup will trip any reviewer on Windows without developer mode; nothing to fix upstream.
- Repro re-run on both sides of the fix (table above).

**Breaking changes:** None — bug fix, sent straight in per CONTRIBUTING.md.

@santifer — ping as offered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination handling for the a16z Speedrun Talent feed.
  * Ensured reported page totals are honored, while empty pages stop further loading.
  * Preserved short-page fallback behavior when pagination metadata is unavailable.

* **Tests**
  * Added coverage for conflicting, missing, over-reported, and under-reported pagination metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
