### PR TITLE
test(outcome): junction on Windows, so the delete-safety guard actually runs

### DIFF
--- a/tests/outcome.test.mjs
+++ b/tests/outcome.test.mjs
@@ -386,7 +386,19 @@ try {
 
     const victim = join(outsideDir, 'acme.pdf');
     writeFileSync(victim, 'IRREPLACEABLE-USER-DATA');
-    symlinkSync(outsideDir, join(symWs, 'output', 'link'));
+    // A directory SYMLINK needs SeCreateSymbolicLinkPrivilege on Windows, which a
+    // non-elevated shell lacks unless Developer Mode is on, so this call threw
+    // EPERM and took the whole suite -- all 58 checks, this safety guard among
+    // them -- down on a default Windows box. A junction needs no privilege and
+    // is what the repo already uses for the same reason (test-all.mjs's e2e
+    // fixture, generate-pdf-page-budget, contacts, plugin-symlink-discovery
+    // since #3267). It exercises the guard identically: pathIsInsideCanonical()
+    // calls realpathSync, which resolves a junction exactly as it resolves a
+    // symlink, so the escape is still detected. Verified by mutation -- with the
+    // canonicalization removed, this check goes red and the victim file is
+    // actually deleted. The target is absolute and a directory on a local
+    // volume, the two constraints junctions add. Ignored off Windows.
+    symlinkSync(outsideDir, join(symWs, 'output', 'link'), process.platform === 'win32' ? 'junction' : 'dir');
 
     const symRes = JSON.parse(execFileSync(NODE, [
       OUTCOME_SCRIPT, '1', 'rejected', '--cv', join('output', 'link', 'acme.pdf'), '--clean-output', '--json',


### PR DESCRIPTION
Same class as #3259/#3267, in a suite merged this morning — and this time the check that never ran is a delete-safety guard.

## What happens

`tests/outcome.test.mjs` (added with #2653) calls `symlinkSync` unguarded at line 389. On Windows 11, non-elevated shell, Developer Mode off — the default configuration — the suite dies there:

```
❌ tests\outcome.test.mjs — suite threw and was contained (EPERM):
   symlink '...\cops-outcome-symlink-Hf6YlQ\outside'
        -> '...\cops-outcome-symlink-Hf6YlQ\ws\output\link'
```

All 58 checks lost as one contained failure.

## Why this one is worth more than the count

The call it dies on sets up this:

```js
const victim = join(outsideDir, 'acme.pdf');
writeFileSync(victim, 'IRREPLACEABLE-USER-DATA');
symlinkSync(outsideDir, join(symWs, 'output', 'link'));
...
check('A symlinked path escaping output/ is never deleted', existsSync(victim));
```

`--clean-output` removes files from `output/`, and `outcome.mjs`'s own comment says why the boundary is canonical rather than lexical: *"resolve() does not follow symlinks, so a link inside output/ pointing elsewhere would otherwise spell itself as contained and have its target deleted. Deletion is unrecoverable."*

So the guard against unrecoverably deleting a user's files has never been exercised on the platform where creating that link needs a privilege most users do not have.

## The fix, and the proof it is not a free pass

Junction — same as #3267, same expression already in `test-all.mjs`'s e2e fixture, `generate-pdf-page-budget` and `contacts`.

The thing that had to be checked is whether a junction still drives the guard or quietly sidesteps it. `pathIsInsideCanonical()` canonicalizes with `realpathSync`, which resolves a junction exactly as it resolves a symlink — so it should. Measured, by reducing that function to its lexical half with the junction in place:

```
❌ A symlinked path escaping output/ is never deleted
❌ ENOENT: no such file or directory, open '...\outside\acme.pdf'
```

The victim file is **gone**. The test does not merely fail on a broken guard, it reproduces the data loss the guard exists to prevent — which is as strong as this kind of evidence gets, and it means the junction is genuinely driving that code path rather than passing beside it.

## Verification

```
before   EPERM at line 389, 0 of 58 checks reached
after    58 passed, 0 failed, 0 skipped
full     node test-all.mjs -> 5610 passed, 1 failed
```

That one failure is **not** from this branch: `.claude/skills/career-ops/SKILL.md: missing cwd-independent routing rule`, repeated across all seven CLI mirrors. It reproduces on a clean `origin/main` worktree with no changes at all, so I have left it alone here. Happy to open it separately once I have measured whether it is Windows-specific — the paths in the message are backslash-separated, which is suggestive but not evidence yet.

## Note on the pattern

This is the third suite in the same family (#2828 `intake`, #3259 `plugin-symlink-discovery`, now `outcome`), and the second in four days. Each was written on a platform where `symlinkSync` just works. If it is worth a standing check rather than a third one-off, an assertion that no suite calls `symlinkSync` on a directory without a platform argument would catch the fourth before it merges — but that is a separate PR and a separate decision, and it should not delay this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform cleanup safety test coverage.
  * Windows tests now use directory junctions to avoid privilege-related failures while preserving escape-detection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->