### PR TITLE
fix(providers): a16z treats a non-positive total_pages as "one page" and truncates the board to 50

### DIFF
--- a/providers/a16z-speedrun-talent.mjs
+++ b/providers/a16z-speedrun-talent.mjs
@@ -185,12 +185,17 @@ export default {
       //      that rotates mid-sweep is NOT the last page; treating it as one
       //      ended the sweep silently, at a clean exit code — the cap warning
       //      below is gated on max_pages and is never reached from here.
-      //   3. A short page, only as the fallback for feeds that omit
-      //      total_pages entirely. Demoting it (rather than merely reordering
-      //      the two checks) is what fixes #2547: a 49-row page fails the
-      //      total_pages test and would still break out on the next line.
+      //      A non-positive total_pages is not a statement about board size,
+      //      so it counts as absent: a feed reporting 0 alongside 50 real
+      //      rows contradicts itself, and the rows win. Trusting them can
+      //      only cost requests (bounded by rule 1 and max_pages), never jobs.
+      //   3. A short page, only as the fallback for feeds whose total_pages is
+      //      absent or non-positive. Demoting it (rather than merely
+      //      reordering the two checks) is what fixes #2547: a 49-row page
+      //      fails the total_pages test and would still break out on the
+      //      next line.
       if (json.jobs.length === 0) break;
-      if (Number.isInteger(json.total_pages)) {
+      if (Number.isInteger(json.total_pages) && json.total_pages > 0) {
         if (page + 1 >= json.total_pages) break;
       } else if (json.jobs.length < PER_PAGE) {
         break;

--- a/tests/providers/a16z-speedrun-talent.test.mjs
+++ b/tests/providers/a16z-speedrun-talent.test.mjs
@@ -208,10 +208,43 @@ try {
   if (underCalls.length === 2 && under.length === 100) pass('fetch() honours total_pages as the terminator even when the feed under-reports (#2547, deliberate)');
   else fail(`under-reported total_pages = ${JSON.stringify({ calls: underCalls.length, jobs: under.length })}`);
 
+  // A non-positive total_pages counts as ABSENT, not as "one page". A feed
+  // reporting 0 (or a negative) alongside 50 real rows contradicts itself, and
+  // `page + 1 >= 0` is true at page 0 — so the metadata branch used to end the
+  // sweep immediately and hand back exactly 50 jobs, the #2419 failure shape,
+  // while the SAME feed with the field omitted swept the full budget. The
+  // assertion is that asymmetry: each non-positive value must produce the same
+  // pages and the same job count as the field-absent control, so the two arms
+  // cannot drift apart later. (CodeRabbit, PR #3358.)
+  const sweep = async (total_pages) => {
+    const calls = [];
+    const ctx = {
+      fetchJson: async (url) => {
+        const page = Number(new URL(url).searchParams.get('page'));
+        calls.push(page);
+        const body = { jobs: Array.from({ length: 50 }, (_, i) => mk(page * 50 + i)) };
+        if (total_pages !== undefined) body.total_pages = total_pages;
+        return body;
+      },
+    };
+    const jobs = await provider.fetch({ max_pages: 6 }, ctx);
+    return { pages: calls.join(','), jobs: jobs.length };
+  };
+  const absent = await sweep(undefined);
+  const zero = await sweep(0);
+  const negative = await sweep(-1);
+  const matchesAbsent = (r) => r.pages === absent.pages && r.jobs === absent.jobs;
+  if (absent.pages === '0,1,2,3,4,5' && absent.jobs === 300 && matchesAbsent(zero) && matchesAbsent(negative)) {
+    pass('fetch() treats total_pages 0 and -1 as absent, sweeping identically to a feed that omits the field');
+  } else {
+    fail(`non-positive total_pages = ${JSON.stringify({ absent, zero, negative })}`);
+  }
+
   // PER_PAGE fallback pinned from both directions when the response omits
-  // page_size/total_pages — the ONLY path on which a short page still ends
-  // iteration (#2547): a full 50-row page continues (fails if PER_PAGE
-  // regresses above 50), a 49-row page stops (fails if it regresses below 50).
+  // page_size/total_pages — the path a short page still ends iteration on
+  // (#2547; shared with the non-positive total_pages case above): a full
+  // 50-row page continues (fails if PER_PAGE regresses above 50), a 49-row
+  // page stops (fails if it regresses below 50).
   const bareCalls = [];
   const bareCtx = {
     fetchJson: async (url) => {


### PR DESCRIPTION
Follow-up to #3358 (merged as `e34be83b`). Caught by CodeRabbit on that PR — the finding arrived before the merge and the merge landed first, so it's now in `main`. Credit to the bot; this closes the last member of the same silent-truncation family.

## The bug

`page + 1 >= json.total_pages` is true at page 0 whenever `total_pages` is `0` or negative, so the metadata branch ends the sweep immediately. A feed reporting `total_pages: 0` while serving 50 real rows hands back exactly 50 jobs — the #2419 failure shape — while **the same feed with the field omitted sweeps the full budget.**

That asymmetry is the defect. Measured on `e34be83b`, a feed serving full 50-row pages under `max_pages: 6`:

| `total_pages` | pages requested | jobs returned |
|---|---|---|
| `0` | `[0]` | 50 |
| `-1` | `[0]` | 50 |
| absent | `[0,1,2,3,4,5]` | 300 |
| `6` (control) | `[0,1,2,3,4,5]` | 300 |

**This is pre-existing, not something #3358 introduced.** On the pre-merge `main` a full 50-row page failed `jobs.length < PER_PAGE`, so the `total_pages` check ran and `0 + 1 >= 0` broke at page 0 — same `[0]` / 50 jobs. The reorder neither caused it nor fixed it. Noting this because CodeRabbit's merge-risk line reads as though the fix created the exposure.

## The change

One clause:

```js
if (Number.isInteger(json.total_pages) && json.total_pages > 0) {
```

A non-positive count is not a statement about board size. A feed reporting `0` alongside 50 real rows contradicts itself, and the rows win — so the value counts as **absent** and the short-page fallback governs, exactly as it does for a feed that omits the field. The direction is deliberately conservative: trusting the rows can only cost requests (still bounded by the unconditional empty-page break and `max_pages`), never jobs.

The cap warning is untouched — its condition already requires `json.total_pages > maxPages` with `maxPages >= 1`, so a non-positive value could never reach it.

## Tests

One assertion, and it pins **the asymmetry** rather than two independent counts: each non-positive value must produce the same pages *and* the same job count as the field-absent control, so the two arms cannot quietly drift apart later. Without the guard it fails with the shape of the bug spelled out:

```
❌ non-positive total_pages = {"absent":{"pages":"0,1,2,3,4,5","jobs":300},
                              "zero":{"pages":"0","jobs":50},
                              "negative":{"pages":"0","jobs":50}}
```

The empty-feed test (`total_pages: 0` with `jobs: []`) is unaffected and still passes at one call — the unconditional empty-page break catches it before the metadata branch is reached. Also corrected one comment that claimed the metadata-absent path was "the ONLY path" a short page can end iteration on; it now shares that path with the non-positive case.

**Verification** (Windows 11 / Node 24.12.0):
- `node tests/providers/a16z-speedrun-talent.test.mjs` — 34 passed, 0 failed.
- `node test-all.mjs` — 5608 passed, 2 failed. Both failures are **pre-existing on clean `e34be83b`** (verified by stashing this diff and re-running) and both are artifacts of this Windows box rather than of the repo: unprivileged symlink creation is off here, so `tests/outcome.test.mjs` hits `EPERM` creating a symlink at runtime, and `tests/skill-project-root.test.mjs` reads the checked-out CLI skill entrypoints as 43-byte path strings because `core.symlinks=false` materializes repo symlinks as plain files. Nothing to fix upstream; flagging only for any reviewer on Windows without developer mode.
- Probe table above re-run after the change: all four rows now `[0,1,2,3,4,5]` / 300.

**Breaking changes:** None — bug fix, sent straight in per CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination for feeds reporting zero or negative page totals.
  * Results now continue loading correctly when pagination metadata is missing or invalid, while still stopping appropriately on short pages.

* **Tests**
  * Added regression coverage for zero, negative, and omitted page-total values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->