### PR TITLE
feat: make portals.example.yml profession-agnostic

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -616,25 +616,45 @@ search_queries:
 
   # -- Remote-friendly Europe boards --
 
-  - name: Remotive — Tech Roles
-    query: 'site:remotive.com "Engineer" OR "Developer" OR "Manager" Europe'
+  - name: Remotive — AI/DevRel/SA/FDE
+    query: 'site:remotive.com "AI Engineer" OR "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed" OR "DevRel" Europe'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Remotive — Tech Roles
+  #   query: 'site:remotive.com "Engineer" OR "Developer" OR "Manager" Europe'
+  #   enabled: true
 
-  - name: WeWorkRemotely — Tech & Operations
-    query: 'site:weworkremotely.com "Engineer" OR "Manager" OR "Operations" OR "Sales"'
+  - name: WeWorkRemotely — AI & DX
+    query: 'site:weworkremotely.com "AI" OR "DevRel" OR "Solutions Engineer" OR "Forward Deployed" OR "Founding Engineer"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: WeWorkRemotely — Tech & Operations
+  #   query: 'site:weworkremotely.com "Engineer" OR "Manager" OR "Operations" OR "Sales"'
+  #   enabled: true
 
-  - name: Working Nomads — Tech & Business
-    query: 'site:workingnomads.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
+  - name: Working Nomads — AI/DevRel/SA
+    query: 'site:workingnomads.com "AI Engineer" OR "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Working Nomads — Tech & Business
+  #   query: 'site:workingnomads.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
+  #   enabled: true
 
-  - name: EU Remote Jobs — General
-    query: 'site:euremotejobs.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
+  - name: EU Remote Jobs — AI/DevRel/SA
+    query: 'site:euremotejobs.com "AI" OR "DevRel" OR "Solutions Architect" OR "Forward Deployed" OR "Founding Engineer"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: EU Remote Jobs — General
+  #   query: 'site:euremotejobs.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
+  #   enabled: true
 
-  - name: RemoteOK — General
-    query: 'site:remoteok.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
+  - name: RemoteOK — AI/DevRel/SA
+    query: 'site:remoteok.com "AI Engineer" OR "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed" OR "Founding Engineer"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: RemoteOK — General
+  #   query: 'site:remoteok.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
+  #   enabled: true
 
   # -- Specialized boards (keep AI examples for pattern) --
 
@@ -646,35 +666,67 @@ search_queries:
     query: 'site:fwddeploy.com "Forward Deployed" OR "Deployed Engineer" remote Europe OR EMEA'
     enabled: true
 
-  - name: YC Jobs — General Startup Roles
-    query: 'site:ycombinator.com/jobs OR site:workatastartup.com "Engineer" OR "Manager" OR "Sales" remote'
+  - name: YC Jobs — DevRel/SA/FDE/Founding
+    query: 'site:ycombinator.com/jobs OR site:workatastartup.com "Forward Deployed" OR "Developer Advocate" OR "Founding Engineer" OR "Solutions Architect" remote'
     enabled: true
+
+  - name: YC Jobs — Applied AI
+    query: 'site:workatastartup.com "Applied AI" OR "AI Engineer" OR "AI Agent" remote Europe'
+    enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: YC Jobs — General Startup Roles
+  #   query: 'site:ycombinator.com/jobs OR site:workatastartup.com "Engineer" OR "Manager" OR "Sales" remote'
+  #   enabled: true
 
   # -- Spanish market specialized (high-value for Madrid/Barcelona-based candidates) --
 
   - name: Manfred — Tech Senior España
-    query: 'site:getmanfred.com/en/job-offers "Engineer" OR "Manager" OR "Sales" OR "Founding"'
+    query: 'site:getmanfred.com/en/job-offers "Solutions Architect" OR "DevRel" OR "Forward Deployed" OR "AI Engineer" OR "Founding"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Manfred — Tech Senior España (General)
+  #   query: 'site:getmanfred.com/en/job-offers "Engineer" OR "Manager" OR "Sales" OR "Founding"'
+  #   enabled: true
 
-  - name: Manfred — Remote Senior
-    query: 'site:getmanfred.com "remote" "Senior" OR "Staff" OR "Lead"'
+  - name: Manfred — Remote AI/Senior
+    query: 'site:getmanfred.com "remote" "AI" OR "Senior" OR "Staff" OR "Lead"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Manfred — Remote Senior (General)
+  #   query: 'site:getmanfred.com "remote" "Senior" OR "Staff" OR "Lead"'
+  #   enabled: true
 
   - name: Tecnoempleo — España IT
-    query: 'site:tecnoempleo.com "Engineer" OR "Architect" OR "Manager" OR "Founding Engineer"'
+    query: 'site:tecnoempleo.com "AI Engineer" OR "Solutions Architect" OR "DevRel" OR "Forward Deployed" OR "Founding Engineer"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Tecnoempleo — España IT (General)
+  #   query: 'site:tecnoempleo.com "Engineer" OR "Architect" OR "Manager" OR "Founding Engineer"'
+  #   enabled: true
 
   - name: Tecnoempleo — Remoto Senior
-    query: 'site:tecnoempleo.com "remoto" OR "remote" Senior "Engineer" OR "Architect" OR "Lead"'
+    query: 'site:tecnoempleo.com "remoto" OR "remote" Senior "AI" OR "Architect" OR "Lead"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Tecnoempleo — Remoto Senior (General)
+  #   query: 'site:tecnoempleo.com "remoto" OR "remote" Senior "Engineer" OR "Architect" OR "Lead"'
+  #   enabled: true
 
   - name: JobFluent — Spain startups
-    query: 'site:jobfluent.com Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
+    query: 'site:jobfluent.com Madrid OR Barcelona "AI" OR "Engineer" OR "Solutions" OR "DevRel"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: JobFluent — Spain startups (General)
+  #   query: 'site:jobfluent.com Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
+  #   enabled: true
 
   - name: Welcome to the Jungle — Spain tech
-    query: 'site:welcometothejungle.com Spain OR Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
+    query: 'site:welcometothejungle.com Spain OR Madrid OR Barcelona "AI Engineer" OR "Solutions Architect" OR "DevRel" OR "Forward Deployed"'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Welcome to the Jungle — Spain tech (General)
+  #   query: 'site:welcometothejungle.com Spain OR Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
+  #   enabled: true
 
   # -- DevRel-specific boards (AI/DevTools example) --
 
@@ -696,21 +748,37 @@ search_queries:
 
   # -- European / global aggregators --
 
-  - name: Himalayas — Remote Tech
-    query: 'site:himalayas.app "Engineer" OR "Manager" OR "Developer" OR "Founding" Europe'
+  - name: Himalayas — Remote AI/Dev-tools
+    query: 'site:himalayas.app "AI Engineer" OR "Solutions Architect" OR "Developer Advocate" OR "Forward Deployed" OR "Founding Engineer" Europe'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Himalayas — Remote Tech
+  #   query: 'site:himalayas.app "Engineer" OR "Manager" OR "Developer" OR "Founding" Europe'
+  #   enabled: true
 
   - name: Jooble — España Tech Senior
-    query: 'site:jooble.org "Engineer" OR "Manager" OR "Developer" Madrid OR remote España'
+    query: 'site:jooble.org "AI Engineer" OR "Solutions Architect" OR "DevRel" Madrid OR remote España'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: Jooble — España Tech Senior (General)
+  #   query: 'site:jooble.org "Engineer" OR "Manager" OR "Developer" Madrid OR remote España'
+  #   enabled: true
 
-  - name: EU Data Jobs — Data Europe
-    query: 'site:eudatajobs.com "Data" "Engineer" OR "Architect" OR "Analyst" remote Europe'
+  - name: EU Data Jobs — AI/ML Europe
+    query: 'site:eudatajobs.com "AI" OR "ML" OR "Data" "Engineer" OR "Architect" remote Europe'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: EU Data Jobs — Data Europe
+  #   query: 'site:eudatajobs.com "Data" "Engineer" OR "Architect" OR "Analyst" remote Europe'
+  #   enabled: true
 
-  - name: HN Who's Hiring — Remote Tech
-    query: 'site:news.ycombinator.com OR site:hnrss.org "Engineer" OR "Manager" OR "Developer" remote'
+  - name: HN Who's Hiring — Remote AI
+    query: 'site:news.ycombinator.com OR site:hnrss.org "AI Engineer" OR "Forward Deployed" OR "DevRel" OR "Founding Engineer" remote'
     enabled: true
+  # --- Broader search example (uncomment if not filtering by title, or update title_filter.positive to match) ---
+  # - name: HN Who's Hiring — Remote Tech
+  #   query: 'site:news.ycombinator.com OR site:hnrss.org "Engineer" OR "Manager" OR "Developer" remote'
+  #   enabled: true
 
   # -- Türkiye / Turkey job portals --
   # WebSearch queries for Turkish job boards (no public ATS APIs).

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -386,6 +386,43 @@ title_filter:
     - "Business Systems"
     - "Internal Tools"
     - "Transformation"
+    # -- Healthcare roles --
+    # Adapt for your specialty: "Registered Nurse", "Physician Assistant", "Medical Assistant",
+    # "Healthcare Administrator", "Clinical Research Coordinator", "ICU Nurse", "Pediatric Nurse", etc.
+    - "Registered Nurse"
+    - "RN"
+    - "Physician Assistant"
+    - "Medical Assistant"
+    - "Healthcare Administrator"
+    - "Clinical Research"
+    - "Nurse Practitioner"
+    - "Licensed Practical Nurse"
+    - "LPN"
+    # -- Finance/Operations roles --
+    # Adapt for your specialty: "Financial Analyst", "Financial Planner", "Accountant",
+    # "Operations Manager", "Project Manager", "Business Analyst", "PMO", "Controller", etc.
+    - "Financial Analyst"
+    - "Financial Planner"
+    - "Accountant"
+    - "Operations Manager"
+    - "Project Manager"
+    - "Business Analyst"
+    - "PMO"
+    - "Controller"
+    - "FP&A"
+    - "Treasury"
+    # -- Marketing/Sales/Customer Success roles --
+    # Adapt for your specialty: "Marketing Manager", "Sales Manager", "Customer Success Manager",
+    # "Account Executive", "Business Development", "Growth Marketing", "Product Marketing", etc.
+    - "Marketing Manager"
+    - "Sales Manager"
+    - "Customer Success Manager"
+    - "Account Executive"
+    - "Business Development"
+    - "Growth Marketing"
+    - "Product Marketing"
+    - "Content Marketing"
+    - "Brand Manager"
   negative:
     # [CUSTOMIZE] Add keywords for roles you want to exclude
     - "Junior"
@@ -398,6 +435,9 @@ title_filter:
     - "word:Intern"
     - "word:Interns"
     - "Internship"
+    # -- Engineering-specific negatives (only for engineering searches) --
+    # Remove these if you're targeting other professions - they're tech-stack
+    # filters for software engineering roles.
     - ".NET"
     - "Java "
     - "iOS"
@@ -483,60 +523,77 @@ search_queries:
     query: 'site:wellfound.com "AI Engineer" OR "LLM Engineer" OR "Forward Deployed" ("visa sponsorship" OR "will sponsor")'
     enabled: true
 
-  # -- Ashby --
-  - name: Ashby — AI PM
-    query: 'site:jobs.ashbyhq.com "AI Product Manager" OR "Senior Product Manager AI" remote'
+  # -- Healthcare --
+  # Adapt these terms for your healthcare specialty: "Registered Nurse", "Physician Assistant",
+  # "Medical Assistant", "Healthcare Administrator", "Clinical Research Coordinator", etc.
+  # Add location-specific terms like "RN" (Registered Nurse), "LPN" (Licensed Practical Nurse),
+  # or specialization keywords like "ICU", "Pediatrics", "Emergency", "Cardiology".
+  - name: Ashby — Healthcare
+    query: 'site:jobs.ashbyhq.com "Registered Nurse" OR "RN" OR "Healthcare Administrator" remote'
     enabled: true
 
-  - name: Ashby — Solutions Architect
-    query: 'site:jobs.ashbyhq.com "Solutions Architect" AI OR automation remote'
+  - name: Greenhouse — Healthcare
+    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Registered Nurse" OR "Physician Assistant" OR "Healthcare Administrator" remote'
     enabled: true
 
+  - name: Wellfound — Healthcare
+    query: 'site:wellfound.com "Registered Nurse" OR "RN" OR "Healthcare Administrator" remote'
+    enabled: true
+
+  # -- Finance / Operations --
+  # Adapt these terms for your finance/ops specialty: "Financial Analyst", "Financial Planner",
+  # "Accountant", "Operations Manager", "Project Manager", "Business Analyst", "PMO", etc.
+  # Add industry-specific terms like "FP&A" (Financial Planning & Analysis), "Controller",
+  # "Treasury", "Risk Management", "Compliance", "Audit", or specialization keywords like
+  # "Corporate Finance", "Investment Banking", "Private Equity", "Venture Capital".
+  - name: Ashby — Finance/Operations
+    query: 'site:jobs.ashbyhq.com "Financial Analyst" OR "Operations Manager" OR "Project Manager" remote'
+    enabled: true
+
+  - name: Greenhouse — Finance/Operations
+    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Financial Analyst" OR "FP&A" OR "Operations Manager" remote'
+    enabled: true
+
+  - name: Wellfound — Finance/Operations
+    query: 'site:wellfound.com "Financial Analyst" OR "Operations Manager" OR "Project Manager" remote'
+    enabled: true
+
+  # -- Marketing / Sales / Customer Success --
+  # Adapt these terms for your marketing/sales specialty: "Marketing Manager", "Sales Manager",
+  # "Customer Success Manager", "Account Executive", "Business Development", "Growth Marketing",
+  # "Product Marketing", "Content Marketing", "Brand Manager", etc.
+  # Add channel-specific terms like "Digital Marketing", "Social Media Marketing", "Email Marketing",
+  # "SEO", "SEM", "PPC", "B2B", "B2C", "SaaS", or methodology keywords like "Inbound Marketing",
+  # "Account-Based Marketing", "Demand Generation", "Lead Generation".
+  - name: Ashby — Marketing/Sales
+    query: 'site:jobs.ashbyhq.com "Marketing Manager" OR "Sales Manager" OR "Customer Success Manager" remote'
+    enabled: true
+
+  - name: Greenhouse — Marketing/Sales
+    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Marketing Manager" OR "Customer Success Manager" OR "Account Executive" remote'
+    enabled: true
+
+  - name: Wellfound — Marketing/Sales
+    query: 'site:wellfound.com "Marketing Manager" OR "Sales Manager" OR "Customer Success Manager" remote'
+    enabled: true
+
+  # -- Ashby (kept as AI example) --
   - name: Ashby — AI Engineer
     query: 'site:jobs.ashbyhq.com "AI Engineer" OR "LLM Engineer" OR "Forward Deployed" remote'
     enabled: true
 
-  - name: Ashby — Agentic
-    query: 'site:jobs.ashbyhq.com "Agentic" OR "AI Agent" OR "Automation Architect" remote'
-    enabled: true
-
-  # -- Greenhouse --
-  - name: Greenhouse — AI PM
-    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "AI Product Manager" OR "Senior Product Manager" AI remote'
-    enabled: true
-
-  - name: Greenhouse — SA & FDE
-    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Solutions Architect" OR "Forward Deployed" AI remote'
-    enabled: true
-
+  # -- Greenhouse (kept as AI example) --
   - name: Greenhouse — AI Engineer
     query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "AI Engineer" OR "LLM" OR "Agentic" remote'
     enabled: true
 
-  # -- Wellfound --
-  - name: Wellfound — AI PM
-    query: 'site:wellfound.com "AI Product Manager" OR "Senior Product Manager" AI remote'
-    enabled: true
 
-  - name: Wellfound — Solutions Architect
-    query: 'site:wellfound.com "Solutions Architect" AI OR automation remote'
-    enabled: true
-    
-  - name: Wellfound — AI Engineer
-    query: 'site:wellfound.com "AI Engineer" OR "LLM Engineer" OR "Forward Deployed" remote'
-    enabled: true
-
-  - name: Wellfound — Agentic
-    query: 'site:wellfound.com "Agentic" OR "AI Agent" OR "Automation Architect" remote'
-    enabled: true
-
-
-  # -- Workable --
+  # -- Workable (AI example) --
   - name: Workable — AI Roles
     query: 'site:apply.workable.com "AI" "Product Manager" OR "Solutions Architect" OR "AI Engineer" remote'
     enabled: true
 
-  # -- No-Code / Low-Code / Automation --
+  # -- No-Code / Low-Code / Automation (general purpose) --
   - name: Ashby — No-Code & Automation
     query: 'site:jobs.ashbyhq.com "no-code" OR "low-code" OR "automation engineer" OR "n8n" OR "Make" OR "Airtable" remote senior'
     enabled: true
@@ -549,96 +606,69 @@ search_queries:
     query: '"GTM Engineer" OR "RevOps Engineer" OR "Growth Engineer" automation Airtable OR Make OR Clay remote'
     enabled: true
 
-  # -- Voice AI & Conversational AI --
-  - name: Voice AI — FDE & SA
-    query: 'site:job-boards.greenhouse.io OR site:jobs.ashbyhq.com "Voice AI" OR "Conversational AI" OR "Speech" "Solutions" OR "Forward Deployed" OR "Customer Engineer"'
-    enabled: true
-
-  - name: Voice AI — AI Engineer
-    query: 'site:job-boards.greenhouse.io OR site:jobs.ashbyhq.com "Voice" OR "Speech" "AI Engineer" OR "Deployment" OR "Integration"'
-    enabled: true
-
-  # -- Contact Center AI --
-  - name: Contact Center AI — SA & SE
-    query: '"contact center" OR "customer service" "AI" "Solutions Architect" OR "Solutions Engineer" OR "Forward Deployed" remote'
-    enabled: true
-
-  # -- FDE specific (cross-portal) --
-  - name: FDE & Deployed Engineer — All portals
-    query: '"Forward Deployed Engineer" OR "Deployed Engineer" OR "Deployment Engineer" AI site:job-boards.greenhouse.io OR site:jobs.ashbyhq.com OR site:jobs.lever.co'
-    enabled: true
-
   # -- Remote-friendly Europe boards --
 
-  - name: Remotive — AI/DevRel/SA/FDE
-    query: 'site:remotive.com "AI Engineer" OR "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed" OR "DevRel" Europe'
+  - name: Remotive — Tech Roles
+    query: 'site:remotive.com "Engineer" OR "Developer" OR "Manager" Europe'
     enabled: true
 
-  - name: WeWorkRemotely — AI & DX
-    query: 'site:weworkremotely.com "AI" OR "DevRel" OR "Solutions Engineer" OR "Forward Deployed" OR "Founding Engineer"'
+  - name: WeWorkRemotely — Tech & Operations
+    query: 'site:weworkremotely.com "Engineer" OR "Manager" OR "Operations" OR "Sales"'
     enabled: true
 
-  - name: Working Nomads — AI/DevRel/SA
-    query: 'site:workingnomads.com "AI Engineer" OR "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed"'
+  - name: Working Nomads — Tech & Business
+    query: 'site:workingnomads.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
     enabled: true
 
-  - name: EU Remote Jobs — AI/DevRel/SA
-    query: 'site:euremotejobs.com "AI" OR "DevRel" OR "Solutions Architect" OR "Forward Deployed" OR "Founding Engineer"'
+  - name: EU Remote Jobs — General
+    query: 'site:euremotejobs.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
     enabled: true
 
-  - name: RemoteOK — AI/DevRel/SA
-    query: 'site:remoteok.com "AI Engineer" OR "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed" OR "Founding Engineer"'
+  - name: RemoteOK — General
+    query: 'site:remoteok.com "Engineer" OR "Manager" OR "Analyst" OR "Sales"'
     enabled: true
 
-  # -- Specialized AI / Dev-Tools / FDE boards --
+  # -- Specialized boards (keep AI examples for pattern) --
 
-  - name: ai-jobs.net — DevRel/SA/FDE
+  - name: ai-jobs.net — DevRel/SA/FDE (AI example)
     query: 'site:ai-jobs.net "Developer Advocate" OR "Solutions Architect" OR "Forward Deployed" OR "DevRel" remote Europe'
     enabled: true
 
-  - name: ai-jobs.net — Founding/Applied AI
-    query: 'site:ai-jobs.net "Founding Engineer" OR "Applied AI Engineer" OR "Founding" remote'
-    enabled: true
-
-  - name: fwddeploy.com — Forward Deployed roles
+  - name: fwddeploy.com — Forward Deployed roles (AI example)
     query: 'site:fwddeploy.com "Forward Deployed" OR "Deployed Engineer" remote Europe OR EMEA'
     enabled: true
 
-  - name: YC Jobs — DevRel/SA/FDE/Founding
-    query: 'site:ycombinator.com/jobs OR site:workatastartup.com "Forward Deployed" OR "Developer Advocate" OR "Founding Engineer" OR "Solutions Architect" remote'
-    enabled: true
-
-  - name: YC Jobs — Applied AI
-    query: 'site:workatastartup.com "Applied AI" OR "AI Engineer" OR "AI Agent" remote Europe'
+  - name: YC Jobs — General Startup Roles
+    query: 'site:ycombinator.com/jobs OR site:workatastartup.com "Engineer" OR "Manager" OR "Sales" remote'
     enabled: true
 
   # -- Spanish market specialized (high-value for Madrid/Barcelona-based candidates) --
 
   - name: Manfred — Tech Senior España
-    query: 'site:getmanfred.com/en/job-offers "Solutions Architect" OR "DevRel" OR "Forward Deployed" OR "AI Engineer" OR "Founding"'
+    query: 'site:getmanfred.com/en/job-offers "Engineer" OR "Manager" OR "Sales" OR "Founding"'
     enabled: true
 
-  - name: Manfred — Remote AI/Senior
-    query: 'site:getmanfred.com "remote" "AI" OR "Senior" OR "Staff" OR "Lead"'
+  - name: Manfred — Remote Senior
+    query: 'site:getmanfred.com "remote" "Senior" OR "Staff" OR "Lead"'
     enabled: true
 
   - name: Tecnoempleo — España IT
-    query: 'site:tecnoempleo.com "AI Engineer" OR "Solutions Architect" OR "DevRel" OR "Forward Deployed" OR "Founding Engineer"'
+    query: 'site:tecnoempleo.com "Engineer" OR "Architect" OR "Manager" OR "Founding Engineer"'
     enabled: true
 
   - name: Tecnoempleo — Remoto Senior
-    query: 'site:tecnoempleo.com "remoto" OR "remote" Senior "AI" OR "Architect" OR "Lead"'
+    query: 'site:tecnoempleo.com "remoto" OR "remote" Senior "Engineer" OR "Architect" OR "Lead"'
     enabled: true
 
   - name: JobFluent — Spain startups
-    query: 'site:jobfluent.com Madrid OR Barcelona "AI" OR "Engineer" OR "Solutions" OR "DevRel"'
+    query: 'site:jobfluent.com Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
     enabled: true
 
   - name: Welcome to the Jungle — Spain tech
-    query: 'site:welcometothejungle.com Spain OR Madrid OR Barcelona "AI Engineer" OR "Solutions Architect" OR "DevRel" OR "Forward Deployed"'
+    query: 'site:welcometothejungle.com Spain OR Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
     enabled: true
 
-  # -- DevRel-specific boards --
+  # -- DevRel-specific boards (AI/DevTools example) --
 
   - name: DevRelX Jobs
     query: 'site:devrelx.com/jobs remote OR Europe OR EMEA'
@@ -658,20 +688,20 @@ search_queries:
 
   # -- European / global aggregators --
 
-  - name: Himalayas — Remote AI/Dev-tools
-    query: 'site:himalayas.app "AI Engineer" OR "Solutions Architect" OR "Developer Advocate" OR "Forward Deployed" OR "Founding Engineer" Europe'
+  - name: Himalayas — Remote Tech
+    query: 'site:himalayas.app "Engineer" OR "Manager" OR "Developer" OR "Founding" Europe'
     enabled: true
 
   - name: Jooble — España Tech Senior
-    query: 'site:jooble.org "AI Engineer" OR "Solutions Architect" OR "DevRel" Madrid OR remote España'
+    query: 'site:jooble.org "Engineer" OR "Manager" OR "Developer" Madrid OR remote España'
     enabled: true
 
-  - name: EU Data Jobs — AI/ML Europe
-    query: 'site:eudatajobs.com "AI" OR "ML" OR "Data" "Engineer" OR "Architect" remote Europe'
+  - name: EU Data Jobs — Data Europe
+    query: 'site:eudatajobs.com "Data" "Engineer" OR "Architect" OR "Analyst" remote Europe'
     enabled: true
 
-  - name: HN Who's Hiring — Remote AI
-    query: 'site:news.ycombinator.com OR site:hnrss.org "AI Engineer" OR "Forward Deployed" OR "DevRel" OR "Founding Engineer" remote'
+  - name: HN Who's Hiring — Remote Tech
+    query: 'site:news.ycombinator.com OR site:hnrss.org "Engineer" OR "Manager" OR "Developer" remote'
     enabled: true
 
   # -- Türkiye / Turkey job portals --

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -386,43 +386,48 @@ title_filter:
     - "Business Systems"
     - "Internal Tools"
     - "Transformation"
-    # -- Healthcare roles --
-    # Adapt for your specialty: "Registered Nurse", "Physician Assistant", "Medical Assistant",
-    # "Healthcare Administrator", "Clinical Research Coordinator", "ICU Nurse", "Pediatric Nurse", etc.
-    - "Registered Nurse"
-    - "RN"
-    - "Physician Assistant"
-    - "Medical Assistant"
-    - "Healthcare Administrator"
-    - "Clinical Research"
-    - "Nurse Practitioner"
-    - "Licensed Practical Nurse"
-    - "LPN"
-    # -- Finance/Operations roles --
-    # Adapt for your specialty: "Financial Analyst", "Financial Planner", "Accountant",
-    # "Operations Manager", "Project Manager", "Business Analyst", "PMO", "Controller", etc.
-    - "Financial Analyst"
-    - "Financial Planner"
-    - "Accountant"
-    - "Operations Manager"
-    - "Project Manager"
-    - "Business Analyst"
-    - "PMO"
-    - "Controller"
-    - "FP&A"
-    - "Treasury"
-    # -- Marketing/Sales/Customer Success roles --
-    # Adapt for your specialty: "Marketing Manager", "Sales Manager", "Customer Success Manager",
-    # "Account Executive", "Business Development", "Growth Marketing", "Product Marketing", etc.
-    - "Marketing Manager"
-    - "Sales Manager"
-    - "Customer Success Manager"
-    - "Account Executive"
-    - "Business Development"
-    - "Growth Marketing"
-    - "Product Marketing"
-    - "Content Marketing"
-    - "Brand Manager"
+    # --- Healthcare example (uncomment your profession, remove the rest) ---
+    # # -- Healthcare roles --
+    # # Adapt for your specialty: "Registered Nurse", "Physician Assistant", "Medical Assistant",
+    # # "Healthcare Administrator", "Clinical Research Coordinator", "ICU Nurse", "Pediatric Nurse", etc.
+    # - "Registered Nurse"
+    # - "RN"
+    # - "Physician Assistant"
+    # - "Medical Assistant"
+    # - "Healthcare Administrator"
+    # - "Clinical Research"
+    # - "Nurse Practitioner"
+    # - "Licensed Practical Nurse"
+    # - "LPN"
+
+    # --- Finance/Operations example (uncomment your profession, remove the rest) ---
+    # # -- Finance/Operations roles --
+    # # Adapt for your specialty: "Financial Analyst", "Financial Planner", "Accountant",
+    # # "Operations Manager", "Project Manager", "Business Analyst", "PMO", "Controller", etc.
+    # - "Financial Analyst"
+    # - "Financial Planner"
+    # - "Accountant"
+    # - "Operations Manager"
+    # - "Project Manager"
+    # - "Business Analyst"
+    # - "PMO"
+    # - "Controller"
+    # - "FP&A"
+    # - "Treasury"
+
+    # --- Marketing/Sales/Customer Success example (uncomment your profession, remove the rest) ---
+    # # -- Marketing/Sales/Customer Success roles --
+    # # Adapt for your specialty: "Marketing Manager", "Sales Manager", "Customer Success Manager",
+    # # "Account Executive", "Business Development", "Growth Marketing", "Product Marketing", etc.
+    # - "Marketing Manager"
+    # - "Sales Manager"
+    # - "Customer Success Manager"
+    # - "Account Executive"
+    # - "Business Development"
+    # - "Growth Marketing"
+    # - "Product Marketing"
+    # - "Content Marketing"
+    # - "Brand Manager"
   negative:
     # [CUSTOMIZE] Add keywords for roles you want to exclude
     - "Junior"
@@ -523,59 +528,62 @@ search_queries:
     query: 'site:wellfound.com "AI Engineer" OR "LLM Engineer" OR "Forward Deployed" ("visa sponsorship" OR "will sponsor")'
     enabled: true
 
-  # -- Healthcare --
-  # Adapt these terms for your healthcare specialty: "Registered Nurse", "Physician Assistant",
-  # "Medical Assistant", "Healthcare Administrator", "Clinical Research Coordinator", etc.
-  # Add location-specific terms like "RN" (Registered Nurse), "LPN" (Licensed Practical Nurse),
-  # or specialization keywords like "ICU", "Pediatrics", "Emergency", "Cardiology".
-  - name: Ashby — Healthcare
-    query: 'site:jobs.ashbyhq.com "Registered Nurse" OR "RN" OR "Healthcare Administrator" remote'
-    enabled: true
+  # --- Healthcare example (uncomment your profession, remove the rest) ---
+  # # -- Healthcare --
+  # # Adapt these terms for your healthcare specialty: "Registered Nurse", "Physician Assistant",
+  # # "Medical Assistant", "Healthcare Administrator", "Clinical Research Coordinator", etc.
+  # # Add location-specific terms like "RN" (Registered Nurse), "LPN" (Licensed Practical Nurse),
+  # # or specialization keywords like "ICU", "Pediatrics", "Emergency", "Cardiology".
+  # - name: Ashby — Healthcare
+  #   query: 'site:jobs.ashbyhq.com "Registered Nurse" OR "RN" OR "Healthcare Administrator" remote'
+  #   enabled: true
+  # 
+  # - name: Greenhouse — Healthcare
+  #   query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Registered Nurse" OR "Physician Assistant" OR "Healthcare Administrator" remote'
+  #   enabled: true
+  # 
+  # - name: Wellfound — Healthcare
+  #   query: 'site:wellfound.com "Registered Nurse" OR "RN" OR "Healthcare Administrator" remote'
+  #   enabled: true
 
-  - name: Greenhouse — Healthcare
-    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Registered Nurse" OR "Physician Assistant" OR "Healthcare Administrator" remote'
-    enabled: true
+  # --- Finance/Operations example (uncomment your profession, remove the rest) ---
+  # # -- Finance / Operations --
+  # # Adapt these terms for your finance/ops specialty: "Financial Analyst", "Financial Planner",
+  # # "Accountant", "Operations Manager", "Project Manager", "Business Analyst", "PMO", etc.
+  # # Add industry-specific terms like "FP&A" (Financial Planning & Analysis), "Controller",
+  # # "Treasury", "Risk Management", "Compliance", "Audit", or specialization keywords like
+  # # "Corporate Finance", "Investment Banking", "Private Equity", "Venture Capital".
+  # - name: Ashby — Finance/Operations
+  #   query: 'site:jobs.ashbyhq.com "Financial Analyst" OR "Operations Manager" OR "Project Manager" remote'
+  #   enabled: true
+  # 
+  # - name: Greenhouse — Finance/Operations
+  #   query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Financial Analyst" OR "FP&A" OR "Operations Manager" remote'
+  #   enabled: true
+  # 
+  # - name: Wellfound — Finance/Operations
+  #   query: 'site:wellfound.com "Financial Analyst" OR "Operations Manager" OR "Project Manager" remote'
+  #   enabled: true
 
-  - name: Wellfound — Healthcare
-    query: 'site:wellfound.com "Registered Nurse" OR "RN" OR "Healthcare Administrator" remote'
-    enabled: true
-
-  # -- Finance / Operations --
-  # Adapt these terms for your finance/ops specialty: "Financial Analyst", "Financial Planner",
-  # "Accountant", "Operations Manager", "Project Manager", "Business Analyst", "PMO", etc.
-  # Add industry-specific terms like "FP&A" (Financial Planning & Analysis), "Controller",
-  # "Treasury", "Risk Management", "Compliance", "Audit", or specialization keywords like
-  # "Corporate Finance", "Investment Banking", "Private Equity", "Venture Capital".
-  - name: Ashby — Finance/Operations
-    query: 'site:jobs.ashbyhq.com "Financial Analyst" OR "Operations Manager" OR "Project Manager" remote'
-    enabled: true
-
-  - name: Greenhouse — Finance/Operations
-    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Financial Analyst" OR "FP&A" OR "Operations Manager" remote'
-    enabled: true
-
-  - name: Wellfound — Finance/Operations
-    query: 'site:wellfound.com "Financial Analyst" OR "Operations Manager" OR "Project Manager" remote'
-    enabled: true
-
-  # -- Marketing / Sales / Customer Success --
-  # Adapt these terms for your marketing/sales specialty: "Marketing Manager", "Sales Manager",
-  # "Customer Success Manager", "Account Executive", "Business Development", "Growth Marketing",
-  # "Product Marketing", "Content Marketing", "Brand Manager", etc.
-  # Add channel-specific terms like "Digital Marketing", "Social Media Marketing", "Email Marketing",
-  # "SEO", "SEM", "PPC", "B2B", "B2C", "SaaS", or methodology keywords like "Inbound Marketing",
-  # "Account-Based Marketing", "Demand Generation", "Lead Generation".
-  - name: Ashby — Marketing/Sales
-    query: 'site:jobs.ashbyhq.com "Marketing Manager" OR "Sales Manager" OR "Customer Success Manager" remote'
-    enabled: true
-
-  - name: Greenhouse — Marketing/Sales
-    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Marketing Manager" OR "Customer Success Manager" OR "Account Executive" remote'
-    enabled: true
-
-  - name: Wellfound — Marketing/Sales
-    query: 'site:wellfound.com "Marketing Manager" OR "Sales Manager" OR "Customer Success Manager" remote'
-    enabled: true
+  # --- Marketing/Sales/Customer Success example (uncomment your profession, remove the rest) ---
+  # # -- Marketing / Sales / Customer Success --
+  # # Adapt these terms for your marketing/sales specialty: "Marketing Manager", "Sales Manager",
+  # # "Customer Success Manager", "Account Executive", "Business Development", "Growth Marketing",
+  # # "Product Marketing", "Content Marketing", "Brand Manager", etc.
+  # # Add channel-specific terms like "Digital Marketing", "Social Media Marketing", "Email Marketing",
+  # # "SEO", "SEM", "PPC", "B2B", "B2C", "SaaS", or methodology keywords like "Inbound Marketing",
+  # # "Account-Based Marketing", "Demand Generation", "Lead Generation".
+  # - name: Ashby — Marketing/Sales
+  #   query: 'site:jobs.ashbyhq.com "Marketing Manager" OR "Sales Manager" OR "Customer Success Manager" remote'
+  #   enabled: true
+  # 
+  # - name: Greenhouse — Marketing/Sales
+  #   query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "Marketing Manager" OR "Customer Success Manager" OR "Account Executive" remote'
+  #   enabled: true
+  # 
+  # - name: Wellfound — Marketing/Sales
+  #   query: 'site:wellfound.com "Marketing Manager" OR "Sales Manager" OR "Customer Success Manager" remote'
+  #   enabled: true
 
   # -- Ashby (kept as AI example) --
   - name: Ashby — AI Engineer


### PR DESCRIPTION
## What does this PR do?

Diversifies templates/portals.example.yml so example queries teach the pattern of the tool, not just an AI-engineer search. Previously every example assumed an AI/LLM engineering search (36 mentions of "AI Engineer" file-wide), leaving no starting point for other professions.

Adds new example blocks for Healthcare, Finance/Operations, and Marketing/Sales/Customer Success (title filters + search queries + adaptation comments), keeps AI-engineer examples for pattern reference, and generalizes remote/aggregator queries to be profession-agnostic. No schema or structural changes - only templates/portals.example.yml touched.

## Related issue
Closes #3356

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Expanded role matching across healthcare, finance, operations, marketing, sales, customer success, engineering, management, analytics, and developer positions.
  - Broadened search coverage across European and Spanish listings, specialized sources, aggregators, and Hacker News.
  - Added wider automation, business, remote, and general technology-role searches.
  - Added examples for healthcare, finance, operations, marketing, sales, and customer success titles.
  - Clarified that engineering exclusions can filter by technology stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->