### PR TITLE
fix(merge-tracker): --backfill-urls leaves unfillable rows one cell s…

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -864,13 +864,33 @@ if (BACKFILL_URLS) {
     if (!line.startsWith('|')) return line;
     const app = parseAppLine(line);
     if (!app) return line;
-    if ((app.url || '').trim()) { already++; return line; }
+    // Rebuilt, not returned verbatim — a row can carry a URL and STILL be short
+    // of the header on a layout with user-owned columns after `URL`. Returning
+    // `line` there leaves the same unreadable row this fix exists to prevent.
+    if ((app.url || '').trim()) { already++; return buildRow({ ...app }); }
     // Shared derivation with the merge loop — one place that knows how to turn a
     // report link into the posting URL. Tracker links may be root-relative
     // (`reports/...`) or data-relative (`../reports/...`); both resolve.
     const resolved = resolveReportUrl(app.report);
-    if (resolved.reason === 'no-report') { noReport++; return line; }
-    if (resolved.reason === 'no-url') { noUrl++; return line; }
+    // A row we cannot fill is still rebuilt, with an empty URL cell.
+    //
+    // Returning the original line leaves a pre-URL-column row one cell short of
+    // the header, and #3016 established that a short row is exactly what
+    // parseTrackerRow must reject: "a row must span the full header width,
+    // otherwise a missing interior cell would silently shift every later column
+    // one position left". That guard is correct; this writer was producing rows
+    // it correctly refuses. Every reader built on tracker-parse.mjs then skips
+    // the row for good — set-status.mjs reports "No tracker row with #N".
+    //
+    // parseAppLine's guard is `parts.length <= maxIdx`, one cell looser than
+    // parseTrackerRow's `parts.length < width`, which is why the backfill can
+    // still see and repair precisely the rows the readers cannot.
+    //
+    // The DELIMITER is added, never a value: buildRow writes `put('url', '')`,
+    // and an empty URL falls back to the report-number and fuzzy company+role
+    // dedup tiers exactly as it does today. Nothing is fabricated.
+    if (resolved.reason === 'no-report') { noReport++; return buildRow({ ...app, url: '' }); }
+    if (resolved.reason === 'no-url') { noUrl++; return buildRow({ ...app, url: '' }); }
     filled++;
     return buildRow({ ...app, url: resolved.url });
   });

--- a/tests/merge-tracker-backfill-row-width.test.mjs
+++ b/tests/merge-tracker-backfill-row-width.test.mjs
@@ -1,0 +1,186 @@
+// tests/merge-tracker-backfill-row-width.test.mjs — `--backfill-urls` must leave
+// every row it touches at the header's full width, including rows it cannot fill.
+//
+// A row written before the URL column existed is one cell short of the header.
+// #3016 established that a short row is exactly what parseTrackerRow must
+// reject — "a row must span the full header width, otherwise a missing interior
+// cell would silently shift every later column one position left". The guard is
+// correct; the backfill was returning such rows unchanged, so they stayed
+// permanently unreadable to every reader built on tracker-parse.mjs.
+//
+// Driven as a CLI integration test through the CAREER_OPS_TRACKER /
+// CAREER_OPS_ADDITIONS overrides, matching tests/merge-tracker.test.mjs:
+// importing merge-tracker.mjs runs the CLI at import time.
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolveColumns, parseTrackerRow } from '../tracker-parse.mjs';
+
+console.log('\nmerge-tracker.mjs — --backfill-urls row width');
+
+const HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL |';
+const SEP = '|---|------|---------|------|-------|--------|-----|--------|-------|-----|';
+
+// A row as written before the URL column existed: nine cells, no URL delimiter.
+const SHORT_ROW = (n, note) =>
+  `| ${n} | 2026-08-01 | Acme | Director, Test | 4.5/5 | Evaluated | ✅ | [${n}](reports/${n}-acme.md) | ${note} |`;
+
+/** One --backfill-urls run in an isolated workspace. Returns the tracker text. */
+function runBackfill({ rows, reports }) {
+  const dir = mkdtempSync(join(tmpdir(), 'backfill-width-'));
+  try {
+    mkdirSync(join(dir, 'reports'), { recursive: true });
+    for (const [name, body] of Object.entries(reports || {})) {
+      writeFileSync(join(dir, 'reports', name), body);
+    }
+    const tracker = join(dir, 'applications.md');
+    writeFileSync(tracker, ['# Applications Tracker', '', HEADER, SEP, ...rows, ''].join('\n'));
+    const out = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs'), '--backfill-urls'], {
+      cwd: dir,
+      encoding: 'utf-8',
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: join(dir, 'none') },
+    });
+    return { tracker: readFileSync(tracker, 'utf-8'), output: out, dir };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const rowFor = (text, n) => text.split('\n').find((l) => l.startsWith(`| ${n} |`)) || '';
+const readable = (text, n) => {
+  const lines = text.split('\n');
+  const row = rowFor(text, n);
+  return row ? parseTrackerRow(row, resolveColumns(lines)) : null;
+};
+
+// parseTrackerRow deliberately exposes no `url` field, so asserting on
+// `parsed.url` would pass vacuously (undefined ?? '' === ''). Read the cell.
+const urlCell = (text, n) => {
+  const cols = resolveColumns(text.split('\n'));
+  const row = rowFor(text, n);
+  if (!row || cols.url == null) return null;
+  return (row.split('|').map((c) => c.trim())[cols.url]) ?? null;
+};
+
+// ── PATH 1: report exists and carries **URL:** — the already-covered fill path.
+// Asserted here only as a control, so a regression in the fix cannot pass by
+// breaking the path it was not supposed to touch.
+{
+  const r = runBackfill({
+    rows: [SHORT_ROW(1, 'has a url')],
+    reports: { '1-acme.md': '# Eval\n\n**URL:** https://example.com/jobs/1\n' },
+  });
+  const row = rowFor(r.tracker, 1);
+  if (/https:\/\/example\.com\/jobs\/1/.test(row) && readable(r.tracker, 1)) {
+    pass('control: a fillable row is still filled and is readable');
+  } else {
+    fail(`fillable row mishandled: ${row.trim()}`);
+  }
+}
+
+// ── PATH 2: the report has no **URL:** — `no-url`. The defect under test.
+{
+  const r = runBackfill({
+    rows: [SHORT_ROW(2, 'warm contact, no public posting')],
+    reports: { '2-acme.md': '# Eval\n\n**URL:** none — confidential pre-posting enquiry\n' },
+  });
+  const row = rowFor(r.tracker, 2);
+  const parsed = readable(r.tracker, 2);
+  if (parsed && parsed.num === 2) {
+    pass('a row whose report has no **URL:** is padded to header width and stays readable');
+  } else {
+    fail(`no-url row left unreadable by parseTrackerRow: ${row.trim()}`);
+  }
+  if (parsed && urlCell(r.tracker, 2) === '') {
+    pass('the padded cell is EMPTY — a delimiter, not a fabricated value');
+  } else {
+    fail(`padded row carries a fabricated url: ${JSON.stringify(urlCell(r.tracker, 2))}`);
+  }
+}
+
+// ── PATH 3: no report link at all — `no-report`. Second unfillable branch.
+{
+  const r = runBackfill({ rows: ['| 3 | 2026-08-01 | Acme | Director, Test | N/A | Evaluated | ❌ | — | referral |'] });
+  if (readable(r.tracker, 3)) {
+    pass('a row with no report link is padded to header width and stays readable');
+  } else {
+    fail(`no-report row left unreadable: ${rowFor(r.tracker, 3).trim()}`);
+  }
+}
+
+// ── PATH 4: the row's other cells must survive the rebuild unchanged.
+{
+  const r = runBackfill({ rows: [SHORT_ROW(4, 'keep me verbatim')] });
+  const parsed = readable(r.tracker, 4);
+  if (parsed && parsed.company === 'Acme' && parsed.role === 'Director, Test'
+      && parsed.score === '4.5/5' && parsed.status === 'Evaluated' && parsed.notes === 'keep me verbatim') {
+    pass('padding preserves every other cell verbatim');
+  } else {
+    fail(`padding altered other cells: ${JSON.stringify(parsed)}`);
+  }
+}
+
+// ── PATH 5: idempotence. A second run must not widen the row again.
+{
+  const rows = [SHORT_ROW(5, 'run twice')];
+  const first = runBackfill({ rows });
+  const firstRow = rowFor(first.tracker, 5);
+  const second = runBackfill({ rows: [firstRow] });
+  const secondRow = rowFor(second.tracker, 5);
+  if (firstRow === secondRow) {
+    pass('re-running --backfill-urls is idempotent on an already-padded row');
+  } else {
+    fail(`second run changed the row:\n  1: ${firstRow.trim()}\n  2: ${secondRow.trim()}`);
+  }
+}
+
+// ── PATH 6: the counters still report the row as unfilled, not as filled.
+{
+  const r = runBackfill({
+    rows: [SHORT_ROW(6, 'no url')],
+    reports: { '6-acme.md': '# Eval\n\nno url header here\n' },
+  });
+  if (/0 filled/.test(r.output) && /report has no \*\*URL:\*\*/.test(r.output)) {
+    pass('an unfillable row is still counted as unfilled, not as filled');
+  } else {
+    fail(`counters misreport the unfillable row: ${r.output.trim()}`);
+  }
+}
+
+// ── PATH 7: `already set` — a row can carry a URL and STILL be short of the
+// header when the layout has user-owned columns AFTER `URL`. That branch also
+// returned the line verbatim, leaving the same unreadable row.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'backfill-width-wide-'));
+  try {
+    mkdirSync(join(dir, 'reports'), { recursive: true });
+    const tracker = join(dir, 'applications.md');
+    writeFileSync(tracker, [
+      '# Applications Tracker', '',
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL | Follow-up |',
+      '|---|------|---------|------|-------|--------|-----|--------|-------|-----|-----------|',
+      '| 7 | 2026-08-01 | Acme | Director, Test | 4.5/5 | Evaluated | ✅ | [7](reports/7-acme.md) | has a url | https://example.com/j/7 |',
+      '',
+    ].join('\n'));
+    const out = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs'), '--backfill-urls'], {
+      cwd: dir, encoding: 'utf-8',
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: join(dir, 'none') },
+    });
+    const text = readFileSync(tracker, 'utf-8');
+    const parsed = readable(text, 7);
+    if (parsed && /1 already set/.test(out)) {
+      pass('an already-set row short of a wider header is padded and stays readable');
+    } else {
+      fail(`already-set short row left unreadable: ${rowFor(text, 7).trim()}`);
+    }
+    if (parsed && urlCell(text, 7) === 'https://example.com/j/7') {
+      pass('padding an already-set row preserves its URL');
+    } else {
+      fail(`already-set row lost its URL: ${JSON.stringify(urlCell(text, 7))}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
hort

## What does this PR do?

`--backfill-urls` rebuilds the tracker rows it can fill and hands back the rows it cannot — unchanged, and therefore one cell narrower than the header. Every reader built on `tracker-parse.mjs` then refuses those rows permanently, so `set-status.mjs` reports `No tracker row with #N` for a row that is plainly there. This routes all three of those branches through the same header-aware `buildRow` that #3016 introduced.

## Related issue

No issue — bug fix. Directly complementary to **#3016** / `8668ac1`, which made `buildRow` write at the header's actual width; this fixes the call sites that were bypassing it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## Summary

`--backfill-urls` rebuilds the rows it *can* fill and returns the rows it *cannot* unchanged. On a tracker whose rows predate the URL column, an unfillable row therefore stays **one cell narrower than the header** — and every reader built on `tracker-parse.mjs` then refuses it for good.

This is the same failure class as **#3016**, from the other direction. That issue established that the reader's width guard is *deliberate and correct*:

> `parseTrackerRow` enforces a dynamic width guard — a row must span the full header width, otherwise a missing interior cell would silently shift every later column one position left.

**This PR agrees with that guard.** It fixes the writer that was producing rows the guard correctly rejects.

## The defect

The backfill is the one place this can be repaired, because of a second asymmetry: `parseAppLine` guards with `parts.length <= maxIdx`, while `parseTrackerRow` guards with `parts.length < width` (`maxIdx + 2` for a pipe-terminated row). **The backfill is one cell more permissive than the readers — so it can still see, and repair, precisely the rows they cannot read.** It sees them and hands them back unchanged.

```js
if ((app.url || '').trim()) { already++; return line; }             // ← original width
const resolved = resolveReportUrl(app.report);
if (resolved.reason === 'no-report') { noReport++; return line; }   // ← original width
if (resolved.reason === 'no-url')    { noUrl++;    return line; }   // ← original width
filled++;
return buildRow({ ...app, url: resolved.url });                     // ← header width
```

**Three** of the four branches return `line`, so the row keeps its old width forever:

* the row has no report link at all;
* the linked report genuinely has no `**URL:**` — a referral, a warm-contact lead, a confidential pre-posting enquiry;
* **the row already has a URL.** This one still matters: on a layout carrying user-owned columns *after* `URL`, a row can hold a URL and *still* be short of the header. `--backfill-urls` reports it as `1 already set` and leaves it unreadable.

## Reproduction — clean install, no local state

Run from a checkout of `main`:

```bash
mkdir -p /tmp/repro/reports

cat > /tmp/repro/applications.md <<'EOF'
# Applications Tracker

| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL |
|---|------|---------|------|-------|--------|-----|--------|-------|-----|
| 1 | 2026-08-01 | Acme | Director, Test | 4.5/5 | Evaluated | ✅ | [1](reports/1-acme.md) | warm contact, no public posting |
EOF

cat > /tmp/repro/reports/1-acme.md <<'EOF'
# Evaluation: Acme — Director, Test

**URL:** none — confidential pre-posting enquiry, no public JD
EOF

CAREER_OPS_TRACKER=/tmp/repro/applications.md node merge-tracker.mjs --backfill-urls
CAREER_OPS_TRACKER=/tmp/repro/applications.md node set-status.mjs --row 1 Applied --dry-run
```

**Before this PR:**

```
✅ Backfill URLs: 0 filled, 0 already set, 0 no/missing report, 1 report has no **URL:**.
   row is 11 fields; header is 12
❌ Tracker at /tmp/repro/applications.md has no data rows
```

**After:**

```
✅ Backfill URLs: 0 filled, 0 already set, 0 no/missing report, 1 report has no **URL:**.
   row is 12 fields
✅ #1 Acme — Director, Test: would set Evaluated → Applied
```

The backfill's own counters are unchanged in both runs — it still correctly reports the row as unfilled. Only the width changes.

### The `already set` branch

A row can hold a real URL and *still* be short of the header, when the layout carries a user-owned column **after** `URL` — a hand-kept `Follow-up` date, say. The backfill sees the URL, counts the row as `already set`, and returns it untouched at its old width.

```bash
mkdir -p /tmp/repro2/reports

cat > /tmp/repro2/applications.md <<'EOF'
# Applications Tracker

| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL | Follow-up |
|---|------|---------|------|-------|--------|-----|--------|-------|-----|-----------|
| 1 | 2026-08-01 | Acme | Director, Test | 4.5/5 | Evaluated | ✅ | [1](reports/1-acme.md) | referred by a colleague | https://acme.example/jobs/1 |
EOF

cat > /tmp/repro2/reports/1-acme.md <<'EOF'
# Evaluation: Acme — Director, Test

**URL:** https://acme.example/jobs/1
EOF

CAREER_OPS_TRACKER=/tmp/repro2/applications.md node merge-tracker.mjs --backfill-urls
CAREER_OPS_TRACKER=/tmp/repro2/applications.md node set-status.mjs --row 1 Applied --dry-run
```

**Before this PR:**

```
🧭 Detected URL column (deterministic dedup active).
✅ Backfill URLs: 0 filled, 1 already set, 0 no/missing report, 0 report has no **URL:**.
   row is 12 fields; header is 13
❌ Tracker at /tmp/repro2/applications.md has no data rows
```

**After:**

```
🧭 Detected URL column (deterministic dedup active).
✅ Backfill URLs: 0 filled, 1 already set, 0 no/missing report, 0 report has no **URL:**.
   row is 13 fields; URL cell still https://acme.example/jobs/1
✅ #1 Acme — Director, Test: would set Evaluated → Applied
```

The URL is preserved, not blanked — the row is rebuilt from its own cells. Padding a row and losing its URL would be a worse defect than the one being fixed.

## Why it is worth fixing

**The affected rows are not a random subset.** A row has no URL when the lead did not come from a job board — which is the definition of a referral, a warm-contact lead, or a confidential pre-posting enquiry. So the rows the canonical write path cannot address are systematically the *best-sourced* ones a user has.

The failure is also permanent rather than transient. `--backfill-urls` is the documented repair for a tracker that predates the URL column, so a user who hits this runs the one tool built to fix it, sees a success line, and still cannot change those rows' status. There is no second pass that would catch them.

**The diagnostics point away from the cause.** `set-status.mjs` reports `No tracker row with #N` (or, as above, `has no data rows`), which reads as *the row does not exist* rather than *the row is one cell short*.

## The fix

Rebuild on all three branches. Unfillable rows get an empty URL cell; the already-set row is rebuilt from its own cells and keeps its URL.

**The delimiter is added, never a value.** `buildRow` writes `put('url', cell(o.url) || '')`, and an empty URL falls back to the report-number and fuzzy company+role dedup tiers exactly as it does today — no dedup behaviour changes. Nothing is fabricated.

`buildRow` is already the function this code path uses for filled rows. With `o.raw` set it copies the row's existing cells verbatim before overwriting only the fields career-ops owns, so user-owned columns survive and the report link is written back unchanged (`normalizeReportLink` runs on other paths, not here).

## Code paths this change creates or alters

| Path | Covered by the existing suite? | Covered here |
|---|---|---|
| `no-url` — report exists, has no `**URL:**` | ❌ no | ✅ padded, readable, empty cell |
| `no-report` — no report link at all | ❌ no | ✅ padded, readable |
| `already set` — row already has a URL, layout wider than `URL` | ❌ no | ✅ padded, readable, URL preserved |
| fillable — report carries `**URL:**` | ✅ yes | ✅ re-asserted as a control |
| other cells survive the rebuild | ❌ no | ✅ every mapped field compared |
| idempotence on re-run | partially (fill path) | ✅ asserted for the padded row |
| counters still report unfilled | ❌ no | ✅ `0 filled … 1 report has no **URL:**` |

Per **#2879**, the tests live in their own auto-discovered file — `tests/merge-tracker-backfill-row-width.test.mjs` — not appended to `test-all.mjs`.

**Verified the tests fail without the fix**: restoring `merge-tracker.mjs` from pristine `main` and keeping the test file fails **6 of 9** cases. The three that still pass are the fillable control, the counter assertion (width-independent), and idempotence (vacuous while the row stays short) — stated plainly rather than counted as evidence.

## Testing

```
node test-all.mjs   →  5633 passed, 0 failed, 2 warnings
```

Full suite, not `--only`, on a clean checkout of `main` plus this branch.

## Notes

Written with Claude Code, which this project uses itself. Every figure above is measured on the branch rather than estimated: both reproductions were run on a clean tree in both directions, the suite count is a full run, and the failure-without-fix check was run by restoring `merge-tracker.mjs` from pristine `main` (`cd378fb`) and re-running the test — stashing only the uncommitted hunk undercounted it at 2 of 9.

One thing worth surfacing about the tests themselves: an earlier draft asserted on `parsed.url` from `parseTrackerRow`, which exposes no `url` field — so `(parsed.url ?? '') === ''` passed whether or not the cell was empty. The assertions now read the cell out of the row directly. It was the third branch's failure that exposed it.

The diff is 4 functional lines plus explanation; the rest is the test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL backfilling to consistently preserve existing row data.
  * Ensured tracker rows match the header width, including rows with missing or extra cells.
  * Maintained accurate counts for filled, unresolved, and already populated URLs.
  * Repeated backfill runs now produce consistent results without altering valid data.

* **Tests**
  * Added coverage for fillable rows, missing URLs or reports, existing URLs, varying header widths, and repeated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->