### PR TITLE
refactor(updater,plugins): finish #3170 and retire the ratchet

### DIFF
--- a/plugin-audit.mjs
+++ b/plugin-audit.mjs
@@ -13,6 +13,7 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 // Built from fragments so the literal API/firewall tokens never appear verbatim
 // (keeps this file clean against any future repo-wide grep).
@@ -113,7 +114,7 @@ export function auditPlugin(dir) {
 }
 
 // CLI: node plugin-audit.mjs <dir>
-if (import.meta.url === (await import('node:url')).pathToFileURL(process.argv[1] || '').href) {
+if (isMainModule(import.meta.url)) {
   const { dir } = parseArgs(process.argv);
   if (!dir) { console.error(USAGE); process.exit(2); }
   let result;

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -29,6 +29,7 @@ import { loadRegistry, findInRegistry, classifySource, sourceBadge, successorFor
 import { readLock, writeLockEntry, removeLockEntry, hashPluginTree, consentSurface } from './plugins/_lock.mjs';
 import { installFromRepo, scaffoldNew, parseRepoArg } from './plugin-install.mjs';
 import { appendToPipeline } from './scan.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const APPLICATIONS_PATH = path.join(ROOT, 'data', 'applications.md');
@@ -371,6 +372,6 @@ async function main() {
   }
 }
 
-if (import.meta.url === (await import('url')).pathToFileURL(process.argv[1] || '').href) {
+if (isMainModule(import.meta.url)) {
   main().catch(err => { console.error('Fatal:', err.message); process.exit(1); });
 }

--- a/tests/main-guard-convention.test.mjs
+++ b/tests/main-guard-convention.test.mjs
@@ -192,6 +192,11 @@ function walk(dir, out = []) {
 const EXEMPT = new Map([
   // The helper is the one place allowed to read the entry path.
   ['lib/is-main-module.mjs', 'is the comparison'],
+  // #1706 requires update-system.mjs to be self-loading (a pre-#1245 client
+  // checks out this single file and re-execs it), so it inlines the guard
+  // instead of importing it. The exemption covers the source scan ONLY; the
+  // behaviour test at the bottom of this file pins its semantics.
+  ['update-system.mjs', 'self-loading per #1706; behaviour-pinned below'],
   // This file quotes the pattern in its detector self-test and error messages.
   ['tests/main-guard-convention.test.mjs', 'quotes the pattern to test the detector'],
   // Assigns argv[1] inside a spawned child's preamble so the copied script's
@@ -200,28 +205,6 @@ const EXEMPT = new Map([
   // Asserts that a bash-embedded node snippet reads its input file via ITS OWN
   // argv[1] (injection safety, not a main-guard); the literal lives in strings.
   ['tests/batch-runner-jd-prefetch.test.mjs', 'asserts another script\u2019s argv[1] usage in strings'],
-]);
-
-// ── The #3170 ratchet ───────────────────────────────────────────────────────
-//
-// Converting ~60 entrypoints is too wide for one reviewable change, so it lands
-// in batches. The naive order — convert everything, then add this test — leaves
-// the tree unguarded for the whole series, which is exactly the window in which
-// a sixty-first hand-rolled guard slips in unnoticed.
-//
-// So the test ships FIRST, and every not-yet-converted file is listed here. The
-// list only ever SHRINKS: each batch deletes its own entries, and the dead-entry
-// check below FAILS if a listed file no longer references the entry path, so a
-// conversion cannot land without shrinking it. A newly added entrypoint is not
-// on this list and is therefore caught from day one.
-//
-// When the last entry goes, delete PENDING, its uses, and this comment. A
-// ratchet that outlives its job is just a permanent hole.
-const PENDING = new Set([
-  'plugin-audit.mjs',
-  'plugins.mjs',
-  'update-system.mjs',
-  'validate-plugin-registry.mjs',
 ]);
 
 function entryRefViolations(src) {
@@ -238,7 +221,7 @@ test('no file outside the helper reads the process entry path', () => {
   const offenders = [];
   for (const file of walk(ROOT)) {
     const rel = relative(ROOT, file).split('\\').join('/');
-    if (EXEMPT.has(rel) || PENDING.has(rel)) continue;
+    if (EXEMPT.has(rel)) continue;
     const hits = entryRefViolations(readFileSync(file, 'utf-8'));
     if (hits.length) offenders.push(`${rel}:${hits.join(',')}`);
   }
@@ -254,20 +237,11 @@ test('no file outside the helper reads the process entry path', () => {
   );
 });
 
-test('neither the exemption list nor the ratchet carries a dead entry', () => {
-  // An exemption that outlives its reference is a hole waiting for a new one,
-  // and a PENDING entry that outlives its conversion silently un-guards a file
-  // that is already correct. Same check, both lists.
+test('the exemption list carries no dead entries', () => {
+  // An exemption that outlives its reference is a hole waiting for a new one.
   for (const [rel] of EXEMPT) {
     const src = readFileSync(join(ROOT, rel), 'utf-8');
     assert.ok(ENTRY_REF.test(src), `${rel} no longer references the entry path — remove its exemption`);
-  }
-  for (const rel of PENDING) {
-    const src = readFileSync(join(ROOT, rel), 'utf-8');
-    assert.ok(
-      ENTRY_REF.test(src),
-      `${rel} is converted but still listed in PENDING — delete it from the ratchet (#3170)`,
-    );
   }
 });
 
@@ -281,4 +255,36 @@ test('the convention check can actually see a violation', () => {
   assert.deepEqual(entryRefViolations(laundered), [1], 'the detector misses the variable-indirection evasion');
   assert.deepEqual(entryRefViolations('const isMain = isMainModule(import.meta.url);'), [], 'the detector flags the fix');
   assert.deepEqual(entryRefViolations('// process.argv[1] is explained here\n * and here (JSDoc body)'), [], 'comment lines must be excused');
+});
+
+test("update-system.mjs's inlined guard realpaths both sides", (t) => {
+  // The #1706 self-loading rule buys it an exemption from the import, not from
+  // being correct. Asserted on BEHAVIOUR, not on source text: a source-shape
+  // check passes on a rewrite that keeps the words and loses the realpath.
+  const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+  assert.ok(
+    !/^\s*(?:import|export)\b[^\n]*?\bfrom\s*['"]\.[^'"]*['"]/m.test(src),
+    'update-system.mjs grew a static relative import — that breaks the old→new re-exec (#1706)',
+  );
+
+  const linked = linkedRoot('main-guard-updater-');
+  if (!linked) return t.skip('directory symlinks unavailable on this machine');
+  const { link, cleanup } = linked;
+  try {
+    // An unrecognized subcommand is the only branch that proves the tail ran
+    // and writes NOTHING: `check` hits the network, and every other command
+    // (`dismiss` included) touches the real repo through the symlink.
+    const viaLink = spawnSync(process.execPath, [join(link, 'update-system.mjs'), '--probe-not-a-command'], {
+      cwd: ROOT, encoding: 'utf-8', timeout: 60_000,
+    });
+    assert.match(
+      viaLink.stdout,
+      /Usage: node update-system\.mjs/,
+      `the updater printed no usage through a symlink (exit ${viaLink.status}) — its inlined ` +
+        'guard stopped realpathing both sides, and every update silently no-ops (#3170)',
+    );
+    assert.equal(viaLink.status, 1, 'the usage branch must still exit non-zero');
+  } finally {
+    cleanup();
+  }
 });

--- a/tests/main-guard-convention.test.mjs
+++ b/tests/main-guard-convention.test.mjs
@@ -161,6 +161,30 @@ test('isMainModule is true for the file node was pointed at, symlinked or not', 
 
 const ENTRY_REF = /process\.argv\[1\]|process\.argv\.at\(\s*1\s*\)/;
 
+// A STATIC relative import/export in update-system.mjs, in any spelling.
+//
+// #1706 requires that file to be self-loading: a pre-#1245 client checks out
+// that single file and re-execs it, so a static relative import crashes the
+// old→new jump with ERR_MODULE_NOT_FOUND. Dynamic `await import('./x.mjs')` is
+// the sanctioned form and must NOT match — that is the shape #1706 moved to.
+//
+// Two alternatives, because one regex cannot do both:
+//   1. side-effect     `import './x.mjs';`         — no `from` at all
+//   2. everything else `import … from './x.mjs';`  — possibly spanning lines
+//
+// The second consumes anything but a statement terminator (quoted runs matched
+// whole, so a `;` inside a string does not end it early), which is what lets it
+// see a multiline specifier list without running past the end of the statement.
+// A same-line-only `[^\n]*?` — the shape test-all.mjs:6255 and the first draft
+// of this test both used — misses both cases.
+const STATIC_RELATIVE_IMPORT = new RegExp(
+  [
+    String.raw`^[ \t]*import\s*['"]\.{1,2}\/`,
+    String.raw`^[ \t]*(?:import|export)\b(?:[^;'"]|'[^']*'|"[^"]*")*?\bfrom\s*['"]\.{1,2}\/`,
+  ].join('|'),
+  'm',
+);
+
 // A line that is nothing but comment. Block-comment BODIES are covered by the
 // leading `*` of this repo's JSDoc style; a reference sharing a line with code
 // is treated as code, which can only over-report, never under-report.
@@ -257,13 +281,42 @@ test('the convention check can actually see a violation', () => {
   assert.deepEqual(entryRefViolations('// process.argv[1] is explained here\n * and here (JSDoc body)'), [], 'comment lines must be excused');
 });
 
+test('the #1706 static-import detector sees every spelling', () => {
+  // The first draft of this check only matched `from '...'` on ONE line, so a
+  // side-effect import and a multiline specifier list both sailed past it while
+  // it looked like it was guarding. Each form is asserted rather than assumed.
+  const caught = [
+    "import './helper.mjs';",                       // side-effect, no `from`
+    'import x from "./helper.mjs";',
+    "import { a } from './helper.mjs';",
+    "import {\n  a,\n  b,\n} from './helper.mjs';", // multiline specifier list
+    "export { a } from './helper.mjs';",
+    "export * from '../helper.mjs';",
+    "  import './helper.mjs';",                     // indented
+  ];
+  for (const form of caught) {
+    assert.ok(STATIC_RELATIVE_IMPORT.test(form), `missed a static relative import:\n${form}`);
+  }
+
+  const allowed = [
+    "import * as yaml from 'js-yaml';",             // bare specifier
+    "const m = await import('./lazy.mjs');",        // DYNAMIC — the #1706 fix itself
+    "  const m = await import('./lazy.mjs');",
+    "// import './helper.mjs';",                    // comment
+    " * import { a } from './helper.mjs';",         // JSDoc body
+  ];
+  for (const form of allowed) {
+    assert.ok(!STATIC_RELATIVE_IMPORT.test(form), `false positive on:\n${form}`);
+  }
+});
+
 test("update-system.mjs's inlined guard realpaths both sides", (t) => {
   // The #1706 self-loading rule buys it an exemption from the import, not from
   // being correct. Asserted on BEHAVIOUR, not on source text: a source-shape
   // check passes on a rewrite that keeps the words and loses the realpath.
   const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
   assert.ok(
-    !/^\s*(?:import|export)\b[^\n]*?\bfrom\s*['"]\.[^'"]*['"]/m.test(src),
+    !STATIC_RELATIVE_IMPORT.test(src),
     'update-system.mjs grew a static relative import — that breaks the old→new re-exec (#1706)',
   );
 

--- a/tests/main-guard-convention.test.mjs
+++ b/tests/main-guard-convention.test.mjs
@@ -177,10 +177,18 @@ const ENTRY_REF = /process\.argv\[1\]|process\.argv\.at\(\s*1\s*\)/;
 // see a multiline specifier list without running past the end of the statement.
 // A same-line-only `[^\n]*?` — the shape test-all.mjs:6255 and the first draft
 // of this test both used — misses both cases.
+//
+// GAP is whitespace and/or block comments: a comment is legal wherever
+// whitespace is, so `import /* note */ './x.mjs';` and `import x from/* c
+// */'./x.mjs';` are both real static imports that a bare `\s*` walks straight
+// past. (The `from` form's leading gap needs no help — `[^;'"]` already
+// swallows it.)
+const GAP = String.raw`(?:\s|\/\*[\s\S]*?\*\/)*`;
+
 const STATIC_RELATIVE_IMPORT = new RegExp(
   [
-    String.raw`^[ \t]*import\s*['"]\.{1,2}\/`,
-    String.raw`^[ \t]*(?:import|export)\b(?:[^;'"]|'[^']*'|"[^"]*")*?\bfrom\s*['"]\.{1,2}\/`,
+    String.raw`^[ \t]*import` + GAP + String.raw`['"]\.{1,2}\/`,
+    String.raw`^[ \t]*(?:import|export)\b(?:[^;'"]|'[^']*'|"[^"]*")*?\bfrom` + GAP + String.raw`['"]\.{1,2}\/`,
   ].join('|'),
   'm',
 );
@@ -293,6 +301,9 @@ test('the #1706 static-import detector sees every spelling', () => {
     "export { a } from './helper.mjs';",
     "export * from '../helper.mjs';",
     "  import './helper.mjs';",                     // indented
+    "import /* note */ './helper.mjs';",            // comment before specifier
+    "import x from/* c */'./helper.mjs';",          // comment after `from`
+    "import /* c */ x from './helper.mjs';",
   ];
   for (const form of caught) {
     assert.ok(STATIC_RELATIVE_IMPORT.test(form), `missed a static relative import:\n${form}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2203,11 +2203,18 @@ function dismiss() {
 // pins the semantics behaviourally instead: it invokes this file through a
 // symlink and requires the CLI tail to answer. Keep that in mind when editing —
 // the scan will not catch a regression here; only that behaviour test will.
+//
+// `.native` matches lib/is-main-module.mjs's canonicalize(): it expands Windows
+// 8.3 short names and reports on-disk casing, which the JS realpath leaves
+// alone. Both sides go through the SAME function, which is the property that
+// actually matters — a divergence here would make this copy answer differently
+// from the helper on exactly the platforms the helper was hardened for.
+const canonicalizePath = realpathSync.native ?? realpathSync;
 const entryPath = process.argv[1] ? resolve(process.argv[1]) : '';
 const selfPath = fileURLToPath(import.meta.url);
 let isCli = Boolean(process.argv[1]) && entryPath === selfPath;
 if (process.argv[1] && !isCli) {
-  try { isCli = realpathSync(entryPath) === realpathSync(selfPath); } catch { isCli = false; }
+  try { isCli = canonicalizePath(entryPath) === canonicalizePath(selfPath); } catch { isCli = false; }
 }
 
 if (isCli) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -20,9 +20,9 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
-import { join, dirname, posix as pathPosix } from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, realpathSync } from 'fs';
+import { join, dirname, resolve, posix as pathPosix } from 'path';
+import { fileURLToPath } from 'url';
 
 // NOTE: this file must stay *self-loading* — no static (top-level) relative
 // imports. A pre-#1245 client's apply() self-reexec checks out ONLY
@@ -2190,7 +2190,27 @@ function dismiss() {
 // Only run the CLI when executed directly, so importing this module
 // (e.g. from test-all.mjs to exercise SEMVER_RE) does not trigger a
 // live update check.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+//
+// This is the ONE place that inlines lib/is-main-module.mjs instead of importing
+// it (#3170). #1706 requires this file to be SELF-LOADING: a pre-#1245 client's
+// apply() checks out only update-system.mjs and re-execs it, so any static
+// relative import crashes the old→new jump with ERR_MODULE_NOT_FOUND. The
+// semantics must still match the helper exactly — realpath BOTH sides, because
+// `import.meta.url` is realpath-resolved by Node while argv[1] keeps whatever
+// spelling the caller typed, and a mismatch makes the updater a silent no-op
+// that exits 0. tests/main-guard-convention.test.mjs exempts this file BY NAME
+// from its no-hand-rolled-guard source scan (the #1706 constraint is why), and
+// pins the semantics behaviourally instead: it invokes this file through a
+// symlink and requires the CLI tail to answer. Keep that in mind when editing —
+// the scan will not catch a regression here; only that behaviour test will.
+const entryPath = process.argv[1] ? resolve(process.argv[1]) : '';
+const selfPath = fileURLToPath(import.meta.url);
+let isCli = Boolean(process.argv[1]) && entryPath === selfPath;
+if (process.argv[1] && !isCli) {
+  try { isCli = realpathSync(entryPath) === realpathSync(selfPath); } catch { isCli = false; }
+}
+
+if (isCli) {
   const cmd = process.argv[2] || 'check';
 
   try {

--- a/validate-plugin-registry.mjs
+++ b/validate-plugin-registry.mjs
@@ -11,6 +11,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { loadRegistry, loadRegistryFiles, validateRegistryEntry } from './plugins/_registry.mjs';
 import { HOOK_KINDS, RESERVED_ENV } from './plugins/_engine.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -43,7 +44,7 @@ export function validateRegistry(root) {
   return problems;
 }
 
-if (import.meta.url === (await import('node:url')).pathToFileURL(process.argv[1] || '').href) {
+if (isMainModule(import.meta.url)) {
   const root = process.cwd();
   const deep = process.argv.includes('--deep');
   const problems = validateRegistry(root);


### PR DESCRIPTION
## What does this PR do?

Closes out #3170. The last four entrypoints — all CODEOWNERS-gated, which is why
they were held back into their own batch — plus the retirement of the ratchet.

`PENDING` reaches 0, so the constant, its uses and the comment explaining it are
deleted. A ratchet that outlives its job is just a permanent hole.

## `update-system.mjs` is the one file that may not import the helper

#1706 requires it to stay **self-loading**: a pre-#1245 client checks out that
single file and re-execs it, so any static relative import crashes the old→new
jump with `ERR_MODULE_NOT_FOUND`. It inlines the same realpath-both-sides logic
instead.

The exemption it gets in the convention test covers the **source scan only**.
A new behaviour test drives the updater through a real symlink and requires its
CLI tail to answer, so the semantics are pinned rather than trusted — an
updater that silently no-ops is the worst instance of this bug class in the
repo, since it would report a successful update having applied nothing. The
comment above the guard says all of this explicitly, including the warning that
the scan will *not* catch a regression there.

## Closing state of the invariant

After this, no file outside `lib/is-main-module.mjs` reads `process.argv[1]`
except four exemptions, each carrying a reason the suite verifies is still live
(the dead-entry test fails if an exemption outlives its reference):

| file | why |
|---|---|
| `lib/is-main-module.mjs` | is the comparison |
| `update-system.mjs` | self-loading per #1706; behaviour-pinned |
| `tests/main-guard-convention.test.mjs` | quotes the pattern to test the detector |
| `tests/scan-ats-full-outage-checkpoint.test.mjs` | sets a *child's* argv[1] in a spawn preamble |
| `tests/batch-runner-jd-prefetch.test.mjs` | asserts another script's argv[1] usage, in strings |

## Verification

`node test-all.mjs` → **5642 passed, 0 failed**. Convention suite 8/8, including
the new updater behaviour test. The 7 warnings are pre-existing on `main`
(`santifer.io` in the new `HIRED.md` / hired-wall files, no Go compiler) and are
untouched by this diff.

## Related issue

Closes #3170

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Issue opened first (#3170, confirmed by @santifer)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — system-layer files only
- [x] My changes align with the project roadmap

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line tool detection when launched through symbolic links.
  * Ensured the system updater displays usage information correctly when invoked via a symlink.
  * Standardized entry-point handling across audit, plugin, and registry validation commands.
  * Prevented imported tools from running command-line actions unexpectedly.

* **Tests**
  * Added coverage for symlinked command execution and updated entry-point validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->