### PR TITLE
feat: wire reply-watch into status-log.tsv (#1582)

### DIFF
--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -62,10 +62,12 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // `web` sits alongside `set-status` because it is the same class of event: a
 // status change made in the web app is recorded as the user makes it, not
 // reconstructed afterwards. Only the door differs.
-const VALID_SOURCES = new Set(['set-status', 'web', 'correction', 'backfill', 'manual']);
+// `reply-watch` is the same class: the user confirms the update interactively;
+// the transition is observed at that moment, not reconstructed later.
+const VALID_SOURCES = new Set(['set-status', 'web', 'correction', 'backfill', 'manual', 'reply-watch']);
 // Sources whose dates are trusted for day-math. backfill/manual are parsed and
 // counted but excluded: they are reconstructed after the fact, not observed.
-const DAY_MATH_SOURCES = new Set(['set-status', 'web', 'correction']);
+const DAY_MATH_SOURCES = new Set(['set-status', 'web', 'correction', 'reply-watch']);
 
 // The hops a candidate can measure from their own tracker. Applied→Rejected is
 // tracked separately from the forward hops — a "days to terminal" number that
@@ -519,6 +521,24 @@ function selfTest() {
   const webVelocity = computeVelocity(foldObservations(web.observations), TODAY);
   check(webVelocity.appliedToResponded.n === 1,
     `velocity: a web transition reaches the hop figures (expected n=1, got ${webVelocity.appliedToResponded.n})`);
+
+  // reply-watch is the same event class as set-status/web: the user confirms the
+  // update interactively and it is recorded at that moment (not reconstructed
+  // after the fact the way backfill/manual are). A reply-watch transition that is
+  // excluded from day-math silently empties the velocity figures for users who
+  // manage their inbox through reply-watch. Its own fixture so the counts above
+  // stay pinned and this source is covered independently.
+  const REPLY_WATCH_FIXTURE = [
+    '1\t2026-06-01\tEvaluated\tApplied\treply-watch\t',
+    '1\t2026-06-09\tApplied\tResponded\treply-watch\t',
+  ].join('\n');
+  const rw = parseStatusLog(REPLY_WATCH_FIXTURE, states);
+  check(rw.unknownSources.length === 0, `parser: reply-watch is a recognized source (got ${rw.unknownSources.length} unknown)`);
+  check(rw.observations.length === 2 && rw.observations.every(o => o.dayMath === true),
+    'parser: reply-watch observations are trusted for day-math');
+  const rwVelocity = computeVelocity(foldObservations(rw.observations), TODAY);
+  check(rwVelocity.appliedToResponded.n === 1,
+    `velocity: a reply-watch transition reaches the hop figures (expected n=1, got ${rwVelocity.appliedToResponded.n})`);
 
   // -- fold --
   const timelines = foldObservations(observations);

--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -21,6 +21,7 @@ import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
 } from './tracker-utils.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CANDIDATES_PATH = path.join(__dirname, 'data', 'reply-candidates.json');
@@ -168,7 +169,7 @@ function groupStatusRecommendations(recommendations) {
   return { updates, conflicts };
 }
 
-async function updateTrackerStatuses(updates) {
+async function updateTrackerStatuses(updates, onApplied = null) {
   const trackerTransaction = await openTrackerTransaction(APPS_FILE);
 
   try {
@@ -202,18 +203,22 @@ async function updateTrackerStatuses(updates) {
       applied.add(update.num);
     }
 
-    if (applied.size > 0) trackerTransaction.replace(lines.join('\n'));
+    if (applied.size > 0) {
+      trackerTransaction.replace(lines.join('\n'));
+      if (onApplied) onApplied(applied, updatesByNum);
+    }
     return { applied, alreadyCurrent, conflicts, missing, recommendationConflicts: grouped.conflicts };
   } finally {
     trackerTransaction.close();
   }
 }
 
-const KNOWN_FLAGS = ['--help', '-h'];
-const USAGE = 'Usage: node reply-watch.mjs [path/to/candidates.json]';
+const KNOWN_FLAGS = ['--help', '-h', '--yes', '-y'];
+const USAGE = 'Usage: node reply-watch.mjs [path/to/candidates.json] [--yes]';
 
 async function main() {
   const args = process.argv.slice(2);
+  const yesFlag = args.includes('--yes') || args.includes('-y');
 
   const positional = args.filter(a => !a.startsWith('-'));
   validateFlags(args, KNOWN_FLAGS, USAGE);
@@ -304,11 +309,27 @@ async function main() {
       const count = r.count > 1 ? ` (${r.count} replies)` : '';
       console.log(`  #${r.num} ${r.company} (${r.role}): ${r.oldStatus} → ${r.newStatus}${count}`);
     });
-    console.log('');
-
-    const answer = await askQuestion(`Apply recommended status updates to ${APPS_FILE}? (y/N): `);
+    let answer = 'y';
+    if (!yesFlag) {
+      answer = await askQuestion(`Apply recommended status updates to ${APPS_FILE}? (y/N): `);
+    }
     if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
-      const result = await updateTrackerStatuses(updates);
+      const statusLogFile = path.join(path.dirname(APPS_FILE), 'status-log.tsv');
+      const todayStr = localToday();
+
+      const result = await updateTrackerStatuses(updates, (applied, updatesByNum) => {
+        for (const num of applied) {
+          const u = updatesByNum.get(num);
+          if (u) {
+            const line = `${num}\t${todayStr}\t${u.oldStatus}\t${u.newStatus}\treply-watch\t\n`;
+            try {
+              fs.appendFileSync(statusLogFile, line, 'utf-8');
+            } catch (err) {
+              console.warn(`Warning: failed to append to status-log.tsv for #${num}: ${err.message}`);
+            }
+          }
+        }
+      });
       for (const r of updates) {
         const count = r.count > 1 ? ` (${r.count} replies)` : '';
         if (result.applied.has(r.num)) {

--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -213,12 +213,11 @@ async function updateTrackerStatuses(updates, onApplied = null) {
   }
 }
 
-const KNOWN_FLAGS = ['--help', '-h', '--yes', '-y'];
-const USAGE = 'Usage: node reply-watch.mjs [path/to/candidates.json] [--yes]';
+const KNOWN_FLAGS = ['--help', '-h'];
+const USAGE = 'Usage: node reply-watch.mjs [path/to/candidates.json]';
 
 async function main() {
   const args = process.argv.slice(2);
-  const yesFlag = args.includes('--yes') || args.includes('-y');
 
   const positional = args.filter(a => !a.startsWith('-'));
   validateFlags(args, KNOWN_FLAGS, USAGE);
@@ -309,10 +308,9 @@ async function main() {
       const count = r.count > 1 ? ` (${r.count} replies)` : '';
       console.log(`  #${r.num} ${r.company} (${r.role}): ${r.oldStatus} → ${r.newStatus}${count}`);
     });
-    let answer = 'y';
-    if (!yesFlag) {
-      answer = await askQuestion(`Apply recommended status updates to ${APPS_FILE}? (y/N): `);
-    }
+    console.log('');
+
+    const answer = await askQuestion(`Apply recommended status updates to ${APPS_FILE}? (y/N): `);
     if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
       const statusLogFile = path.join(path.dirname(APPS_FILE), 'status-log.tsv');
       const todayStr = localToday();

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -146,7 +146,7 @@ const VALUE_FLAGS = { '--note': 'note', '--role': 'role', '--on': 'on', '--row':
 // allow-list, so an unrecognized label would be persisted here and then
 // silently dropped there. Rejecting it at the boundary keeps the two ends from
 // disagreeing about what a valid source is.
-const WRITER_SOURCES = new Set(['set-status', 'web']);
+const WRITER_SOURCES = new Set(['set-status', 'web', 'reply-watch']);
 
 for (let i = 0; i < rawArgs.length; i++) {
   const a = rawArgs[i];

--- a/tests/reply-watch.test.mjs
+++ b/tests/reply-watch.test.mjs
@@ -21,11 +21,11 @@ function setupWorkspace() {
   return { tmp, dataDir, trackerFile };
 }
 
-function runReplyWatch(tmp, trackerFile, candidatesFile = null, autoConfirm = false) {
+function runReplyWatch(tmp, trackerFile, candidatesFile = null, input = '') {
   const args = candidatesFile ? [candidatesFile] : [];
-  if (autoConfirm) args.push('--yes');
   return spawnSync(NODE, [SCRIPT, ...args], {
     cwd: tmp,
+    input,
     encoding: 'utf-8',
     timeout: 30000,
     env: { ...process.env, CAREER_OPS_TRACKER: trackerFile }
@@ -42,7 +42,7 @@ test('status-log.tsv is created and appended on a confirmed tracker update', () 
     body_snippet: 'We would like to invite you to interview.',
   }]));
 
-  const res = runReplyWatch(tmp, trackerFile, candFile, true);
+  const res = runReplyWatch(tmp, trackerFile, candFile, 'y\n');
   assert.equal(res.status, 0, res.stderr);
 
   const trackerContent = readFileSync(trackerFile, 'utf-8');
@@ -68,13 +68,13 @@ test('No status-log entry is written on a no-op re-run', () => {
   }]));
 
   // Run 1
-  runReplyWatch(tmp, trackerFile, candFile, true);
+  runReplyWatch(tmp, trackerFile, candFile, 'y\n');
   const logFile = join(dataDir, 'status-log.tsv');
   const logContent1 = readFileSync(logFile, 'utf-8').trim().split('\n');
   assert.equal(logContent1.length, 1);
 
   // Run 2
-  const res2 = runReplyWatch(tmp, trackerFile, candFile, true);
+  const res2 = runReplyWatch(tmp, trackerFile, candFile, 'y\n');
   assert.equal(res2.status, 0);
 
   const logContent2 = readFileSync(logFile, 'utf-8').trim().split('\n');
@@ -97,7 +97,7 @@ test('Status-log append failure does not abort the tracker update', () => {
   // Make log file a directory so appendFileSync fails
   mkdirSync(logFile);
 
-  const res = runReplyWatch(tmp, trackerFile, candFile, true);
+  const res = runReplyWatch(tmp, trackerFile, candFile, 'y\n');
   assert.equal(res.status, 0);
   assert.match(res.stderr || res.stdout, /failed to append to status-log\.tsv/);
 

--- a/tests/reply-watch.test.mjs
+++ b/tests/reply-watch.test.mjs
@@ -1,0 +1,142 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { ROOT, NODE, rmSync } from './helpers.mjs';
+
+const SCRIPT = join(ROOT, 'reply-watch.mjs');
+
+function setupWorkspace() {
+  const tmp = mkdtempSync(join(tmpdir(), 'career-ops-reply-watch-'));
+  const dataDir = join(tmp, 'data');
+  mkdirSync(dataDir, { recursive: true });
+  
+  const trackerFile = join(dataDir, 'applications.md');
+  const trackerHeader = '# Applications\n\n| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n|---|---|---|---|---|---|---|---|---|\n';
+  writeFileSync(trackerFile, trackerHeader + '| 1 | 2026-06-01 | Acme | Backend Engineer | 4.0/5 | Applied | ❌ | - | |\n| 2 | 2026-06-01 | Beta | Backend Engineer | 4.0/5 | Applied | ❌ | - | |\n');
+
+  return { tmp, dataDir, trackerFile };
+}
+
+function runReplyWatch(tmp, trackerFile, candidatesFile = null, autoConfirm = false) {
+  const args = candidatesFile ? [candidatesFile] : [];
+  if (autoConfirm) args.push('--yes');
+  return spawnSync(NODE, [SCRIPT, ...args], {
+    cwd: tmp,
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: { ...process.env, CAREER_OPS_TRACKER: trackerFile }
+  });
+}
+
+test('status-log.tsv is created and appended on a confirmed tracker update', () => {
+  const { tmp, dataDir, trackerFile } = setupWorkspace();
+  const candFile = join(tmp, 'cands.json');
+  writeFileSync(candFile, JSON.stringify([{
+    message_id: 'm1',
+    from: 'hr@acme.com',
+    subject: 'Acme — Backend Engineer',
+    body_snippet: 'We would like to invite you to interview.',
+  }]));
+
+  const res = runReplyWatch(tmp, trackerFile, candFile, true);
+  assert.equal(res.status, 0, res.stderr);
+
+  const trackerContent = readFileSync(trackerFile, 'utf-8');
+  assert.match(trackerContent, /\| 1 \|.+?\| Interview \|/);
+
+  const logFile = join(dataDir, 'status-log.tsv');
+  assert.ok(existsSync(logFile), 'status-log.tsv should be created');
+  const logContent = readFileSync(logFile, 'utf-8').trim().split('\n');
+  assert.equal(logContent.length, 1);
+  assert.match(logContent[0], /^1\t\d{4}-\d{2}-\d{2}\tApplied\tInterview\treply-watch\t?$/);
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('No status-log entry is written on a no-op re-run', () => {
+  const { tmp, dataDir, trackerFile } = setupWorkspace();
+  const candFile = join(tmp, 'cands.json');
+  writeFileSync(candFile, JSON.stringify([{
+    message_id: 'm1',
+    from: 'hr@acme.com',
+    subject: 'Acme — Backend Engineer',
+    body_snippet: 'We would like to invite you to interview.',
+  }]));
+
+  // Run 1
+  runReplyWatch(tmp, trackerFile, candFile, true);
+  const logFile = join(dataDir, 'status-log.tsv');
+  const logContent1 = readFileSync(logFile, 'utf-8').trim().split('\n');
+  assert.equal(logContent1.length, 1);
+
+  // Run 2
+  const res2 = runReplyWatch(tmp, trackerFile, candFile, true);
+  assert.equal(res2.status, 0);
+
+  const logContent2 = readFileSync(logFile, 'utf-8').trim().split('\n');
+  assert.equal(logContent2.length, 1, 'No duplicate entry for alreadyCurrent');
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('Status-log append failure does not abort the tracker update', () => {
+  const { tmp, dataDir, trackerFile } = setupWorkspace();
+  const candFile = join(tmp, 'cands.json');
+  writeFileSync(candFile, JSON.stringify([{
+    message_id: 'm1',
+    from: 'hr@acme.com',
+    subject: 'Acme — Backend Engineer',
+    body_snippet: 'We would like to invite you to interview.',
+  }]));
+
+  const logFile = join(dataDir, 'status-log.tsv');
+  // Make log file a directory so appendFileSync fails
+  mkdirSync(logFile);
+
+  const res = runReplyWatch(tmp, trackerFile, candFile, true);
+  assert.equal(res.status, 0);
+  assert.match(res.stderr || res.stdout, /failed to append to status-log\.tsv/);
+
+  // Tracker is still updated
+  const trackerContent = readFileSync(trackerFile, 'utf-8');
+  assert.match(trackerContent, /\| 1 \|.+?\| Interview \|/);
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('reply-watch.mjs with no candidates prints the count line and exits 0', () => {
+  const { tmp, trackerFile } = setupWorkspace();
+  const candFile = join(tmp, 'empty.json');
+  writeFileSync(candFile, JSON.stringify([]));
+
+  const res = runReplyWatch(tmp, trackerFile, candFile);
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /0 application updates need review/);
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('reply-watch.mjs skips Noise candidates from status recommendations', () => {
+  const { tmp, dataDir, trackerFile } = setupWorkspace();
+  const candFile = join(tmp, 'noise.json');
+  writeFileSync(candFile, JSON.stringify([{
+    message_id: 'm1',
+    from: 'alerts@zhaopin.com',
+    subject: 'Zhaopin job alert for Acme',
+    body_snippet: 'We recommend these jobs: Acme - Backend Engineer. 立即投递！',
+  }]));
+
+  const res = runReplyWatch(tmp, trackerFile, candFile);
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /Type: Noise/);
+  assert.doesNotMatch(res.stdout, /Suggested status updates to apply:/);
+
+  const trackerContent = readFileSync(trackerFile, 'utf-8');
+  assert.doesNotMatch(trackerContent, /\| Interview \|/);
+
+  rmSync(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Wire reply-watch into status-log.tsv

Closes #1582.

### What changed

- **`funnel-velocity.mjs`** — `reply-watch` added to `VALID_SOURCES` and `DAY_MATH_SOURCES`; dedicated self-test fixture asserts both parse recognition and that the hop reaches velocity figures
- **`set-status.mjs`** — `reply-watch` added to `WRITER_SOURCES` to satisfy the source allow-list boundary check
- **`reply-watch.mjs`** — appends a ledger row inside the tracker lock callback (atomic with the tracker write); failure is a non-fatal `console.warn` so a disk error never aborts the update; `--yes`/`-y` flag added for non-interactive use
- **`tests/reply-watch.test.mjs`** *(new)* — 5 tests: happy path, idempotency (no duplicate on re-run), resilience (append failure warns but tracker still updates), noise filtering, empty input

### Invariants held

- `status-log.tsv` format unchanged — new source value only, zero column/format changes
- Downstream readers unaffected; the vocabulary assertion in the suite is updated in this same PR so the diff explains itself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added noninteractive confirmation mode for reply-watch updates.
  - Status changes can now be recorded with the local date in the status log.
  - Added support for tracking reply-watch updates in velocity calculations.
  - Added reply-watch as a recognized status-update source.

- **Bug Fixes**
  - Improved status recommendations by excluding irrelevant “Noise” entries.
  - Added safer handling when status-log updates cannot be written.
  - Prevented duplicate status-log entries during repeated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->