### PR TITLE
fix(verify-pipeline): recover a report number from a link target written with backslashes

### DIFF
--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -344,7 +344,7 @@ for (const e of entries) {
   }
   for (const lt of linkTexts) referencedNums.add(parseInt(lt[1], 10));
   for (const lt of linkTargets) {
-    const m = lt[1].split('/').pop().match(/^(\d+)-/);
+    const m = lt[1].split(/[\\/]/).pop().match(/^(\d+)-/);
     if (m) referencedNums.add(parseInt(m[1], 10));
   }
 }


### PR DESCRIPTION
## What does this PR do?

`verify-pipeline.mjs` derives a report number from a tracker link target by splitting on `/` only, so a target written with backslashes keeps its whole path and the leading number never matches. One-line fix: split on either separator.

## Related issue

None — sending straight in per the template’s bug-fix exemption.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Scope

This is narrow, and worth saying so plainly. The link **text** is parsed independently just above (`linkTexts`), so the usual `[901](…901-acme.md)` form already recovers the number and is unaffected either way.

The change is only observable when the link text is **not** a bare number **and** the target uses backslashes:

| Report cell | before | after |
|---|---|---|
| `[901](../reports/901-a.md)` | `901` | `901` |
| `[901](..\reports\901-a.md)` | `901` | `901` |
| `[see report](..\reports\901-a.md)` | *(missed)* | `901` |
| `[901](…901-a.md) / [902](..\reports\902-b.md)` | `901, 902` | `901, 902` |

When it does bite, the row stops counting its own report and surfaces as a false orphan warning — a wrong number in a health check rather than a crash.

Sending it because the surrounding comment reasons carefully about when "the row number is the only signal available", and a separator assumption is cheap to harden while someone is already looking at that block.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — 5692 passed, 0 failed, 6 warnings (pre-existing: absent user-layer data)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphan report detection for links using Windows-style backslash paths.
  * Report numbers are now extracted consistently from both Windows and POSIX paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->