### PR TITLE
test(1706): retire the weaker duplicate of the static-import check

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6243,21 +6243,21 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
       fail(`relativeImportSpecifiers mismatch: got ${JSON.stringify(specs)}`);
     }
 
-    // #1706: update-system.mjs must be SELF-LOADING — no static (top-level)
-    // relative imports. A pre-#1245 client's apply() self-reexec checks out
-    // ONLY update-system.mjs before re-execing it, so a static top-level
-    // relative import crashes that re-exec with ERR_MODULE_NOT_FOUND on the
-    // old→new jump. Relative modules must be pulled in lazily instead. Matched
-    // line-anchored (not via relativeImportSpecifiers, whose loose regex also
-    // matches such specifiers inside prose/comments) so only real top-level
-    // import/export statements count.
-    const liveSource = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
-    const staticRelativeImport = /^\s*(?:import|export)\b[^\n]*?\bfrom\s*['"]\.[^'"]*['"]|^\s*import\s*['"]\.[^'"]*['"]/m;
-    if (!staticRelativeImport.test(liveSource)) {
-      pass('update-system.mjs has no static relative imports — self-loading (#1706)');
-    } else {
-      fail('update-system.mjs has a static relative import that breaks old→new re-exec (#1706)');
-    }
+    // The #1706 "update-system.mjs must be SELF-LOADING" source check used to
+    // live here. It now lives in tests/main-guard-convention.test.mjs, beside
+    // the exemption that depends on it, and it is auto-discovered from here so
+    // nothing is lost by the move.
+    //
+    // Moved rather than duplicated because the copy that stood here was WEAKER,
+    // and silently so: its single-line `from '...'` match walked past a
+    // multiline specifier list and past a comment between the keyword and the
+    // specifier (`import /* c */ './x.mjs';`) — both real static relative
+    // imports that break the old→new re-exec. Two checks for one rule at two
+    // strengths is how a guard rots; the surviving one carries a self-test
+    // pinning ten caught spellings against five allowed ones.
+    //
+    // The behavioural backstop below is untouched and remains definitive: it
+    // imports update-system.mjs standalone, so it catches any spelling at all.
   } catch (e) {
     fail(`relativeImportSpecifiers test crashed: ${e.message}`);
   }


### PR DESCRIPTION
## What does this PR do?

Follow-up to the #3170 series, flagged during #3383's review and deliberately
left out of it to keep that PR scoped to its four CODEOWNERS-gated files.

`test-all.mjs` and `tests/main-guard-convention.test.mjs` both assert that
`update-system.mjs` has no static relative import (#1706). **Two checks for one
rule, at two different strengths — and the one in `test-all.mjs` was the
weaker.** Its single-line `from '...'` match walked past:

```js
import {                       // multiline specifier list
  localToday,
} from './lib/local-today.mjs';

import /* c */ './helper.mjs'; // comment between keyword and specifier
```

Both are real static relative imports, and both crash the old→new re-exec with
`ERR_MODULE_NOT_FOUND` — the exact failure #1706 exists to prevent.

## Why retire it rather than sync it

Keeping two copies at two strengths is how a guard rots, and the weaker one sat
in the file people actually read. The version in the discovered suite was
hardened in #3383 to cover every spelling and carries a self-test pinning **ten
caught forms against five allowed ones** — including dynamic `await import()`,
which must keep passing, since that is the form #1706 moved *to*.

## Nothing is lost

- `tests/main-guard-convention.test.mjs` is **auto-discovered from `test-all.mjs`**,
  so the assertion still runs on every suite invocation — now beside the
  exemption that depends on it.
- The **behavioural backstop directly below the removed block is untouched** and
  remains definitive: it imports `update-system.mjs` standalone into an empty
  dir, so it catches any spelling at all, regex or no regex.

Both survivors confirmed running in the suite output:

```
✅ update-system.mjs imports standalone without scaffolder/ present (#1706)
✅ tests/main-guard-convention.test.mjs — node:test suite passed (9 tests)
```

## Verification

Coverage was checked by **negative control**, not by reading: injecting the
multiline import above into `update-system.mjs` makes the surviving check fail
with `update-system.mjs grew a static relative import`. The retired regex
returns `false` on that same input.

`node test-all.mjs` → **5690 passed, 0 failed**.

## Related issue

Refs #3170, #1706. Follow-up to #3383.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Bug-fix/test change — exempt from issue-first
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — system-layer only
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Reorganized the self-loading source validation into the dedicated convention test suite.
  - Preserved the standalone behavioral check for the system update process.
  - This improves test organization while maintaining existing safeguards and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->