### PR TITLE
fix(scan): opt-in word:/stem: anchoring for content_filter keywords

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -52,7 +52,7 @@ import { resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-par
 import { normalizeCompany } from './tracker-utils.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
-import { compileKeyword, compilePositiveKeyword, buildTitleFilter } from './title-keywords.mjs';
+import { compileKeyword, compilePositiveKeyword, compileContentKeyword, buildTitleFilter } from './title-keywords.mjs';
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { withPortalHealthLock } from './portal-health-lock.mjs';
 import { localToday } from './lib/local-today.mjs';
@@ -100,13 +100,15 @@ const CONCURRENCY = 10;
 
 // ── Title filter ────────────────────────────────────────────────────
 
-// How a title_filter matches a title lives in title-keywords.mjs, because
+// How a keyword matches text lives in title-keywords.mjs, because
 // openrouter-runner.mjs filters titles too and cannot import this file (scan.mjs
 // creates data/ at import time). It called a second, hand-kept copy of this
 // logic until the two drifted; there is now one implementation and this file
 // re-exports it, so existing importers — scan-ats-full.mjs and test-all.mjs's
 // sections 11b and 44 among them — keep resolving it from here.
-export { compileKeyword, compilePositiveKeyword, buildTitleFilter };
+// compileContentKeyword shares the `word:`/`stem:` prefix machinery but skips
+// the title filter's short-acronym auto-anchor (#3274).
+export { compileKeyword, compilePositiveKeyword, compileContentKeyword, buildTitleFilter };
 
 // Compiled-matcher cache for matchedTitleKeywords(), keyed by the
 // `title_filter.positive` array reference. The scan loop calls this once per
@@ -463,6 +465,14 @@ export function buildPostedDateFilter(afterIso, beforeIso) {
 //   - `positive` empty → pass (already cleared negatives)
 //   - `positive` non-empty → at least one keyword must be present
 //
+// A keyword may opt in to boundary-anchored matching with a `word:` or `stem:`
+// prefix (identical to `title_filter` — see title-keywords.mjs). Without a
+// prefix an entry is a plain substring, so a bare negative `java` rejects every
+// posting mentioning "JavaScript" and `ios` rejects "curiosity"; `word:java` /
+// `stem:ios` fix that one entry while leaving the rest of the list untouched
+// (#3274). The substring default is deliberate and unchanged: flipping it would
+// silently narrow every configured install.
+//
 // `content_filter.by_title_keyword` (optional): scopes a stricter positive/
 // negative pair to only the jobs whose title matched a specific
 // `title_filter.positive` keyword, so e.g. an "AI Engineer" title-match can
@@ -478,18 +488,26 @@ export function buildPostedDateFilter(afterIso, beforeIso) {
 // populate `job.description`. Lever (`descriptionPlain`) does today; others
 // leave it empty and therefore always pass this filter.
 
+// Normalize a keyword list (lowercase/trim/drop-empties) and compile each
+// survivor into a matcher, so a `word:`/`stem:` prefix is honoured and a bare
+// keyword keeps its substring behaviour. The `.length` checks downstream still
+// read as "did the user configure any keyword here".
+function compileContentKeywordList(value) {
+  return normalizeKeywordList(value).map(compileContentKeyword);
+}
+
 export function buildContentFilter(contentFilter) {
   if (!contentFilter) return () => true;
-  const positive = normalizeKeywordList(contentFilter.positive);
-  const negative = normalizeKeywordList(contentFilter.negative);
+  const positive = compileContentKeywordList(contentFilter.positive);
+  const negative = compileContentKeywordList(contentFilter.negative);
 
   const byTitleKeyword = new Map();
   if (contentFilter.by_title_keyword && typeof contentFilter.by_title_keyword === 'object' && !Array.isArray(contentFilter.by_title_keyword)) {
     for (const [kw, rule] of Object.entries(contentFilter.by_title_keyword)) {
       if (typeof kw !== 'string' || !kw.trim()) continue;
       byTitleKeyword.set(kw.trim().toLowerCase(), {
-        positive: normalizeKeywordList(rule?.positive),
-        negative: normalizeKeywordList(rule?.negative),
+        positive: compileContentKeywordList(rule?.positive),
+        negative: compileContentKeywordList(rule?.negative),
       });
     }
   }
@@ -505,15 +523,15 @@ export function buildContentFilter(contentFilter) {
 
     if (overrides.length > 0) {
       return overrides.some(rule => {
-        if (rule.negative.length > 0 && rule.negative.some(k => lower.includes(k))) return false;
+        if (rule.negative.length > 0 && rule.negative.some(m => m(lower))) return false;
         if (rule.positive.length === 0) return true;
-        return rule.positive.some(k => lower.includes(k));
+        return rule.positive.some(m => m(lower));
       });
     }
 
-    if (negative.length > 0 && negative.some(k => lower.includes(k))) return false;
+    if (negative.length > 0 && negative.some(m => m(lower))) return false;
     if (positive.length === 0) return true;
-    return positive.some(k => lower.includes(k));
+    return positive.some(m => m(lower));
   };
 }
 

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -213,6 +213,17 @@
 # page. Currently Lever (`descriptionPlain`) supplies descriptions; jobs from
 # providers that don't always pass this filter (they're never silently dropped).
 #
+# Whole-word / stem matching (opt-in, per entry): a plain keyword is a
+# substring, so a negative "java" also rejects "JavaScript" and "ios" rejects
+# "curiosity". Prefix an entry with `word:` or `stem:` — identical semantics to
+# title_filter (see that section above for the full table):
+#   - `word:java`   whole word only — keeps "JavaScript", still blocks a Java shop
+#   - `stem:ios`    left boundary only — keeps "curiosity", still blocks "iOS"
+# A keyword that STARTS the unwanted word ("java" in "javascript") needs
+# `word:`; one that lands MID-word ("ios" in "curiosity") is closed by `stem:`
+# too. Entries without a prefix are unchanged, so existing configs behave
+# exactly as before.
+#
 # Example: keep roles that mention Rust/Go, drop legacy PHP/WordPress shops
 # content_filter:
 #   positive:

--- a/tests/content-filter-word-prefix.test.mjs
+++ b/tests/content-filter-word-prefix.test.mjs
@@ -1,0 +1,153 @@
+// tests/content-filter-word-prefix.test.mjs — a `content_filter` keyword may
+// opt in to boundary-anchored matching with a `word:` or `stem:` prefix, and a
+// bare keyword must keep its plain-substring behaviour byte-for-byte.
+//
+// The bug this guards (#3274): `buildContentFilter` matched every keyword with
+// `String.includes()`, so a negative `java` rejected every posting that merely
+// mentioned "JavaScript", and `ios` rejected any description containing
+// "curiosity". Combined with the scanner recording only what PASSED, those
+// postings vanished with no trace — the same silent-narrowing shape #3103
+// found in `title_filter`, and the reason the fix is opt-in rather than a
+// changed default.
+//
+// content_filter reads the job DESCRIPTION, not the title, so unlike
+// `compileKeyword` there is no short-acronym auto-anchor: a 2-3 letter run
+// inside a paragraph of prose ("aws", "sql", "go") is routinely intended.
+// Section 3 pins that difference directly.
+
+import { pass, fail, ROOT } from './helpers.mjs';
+import { buildContentFilter, compileContentKeyword } from '../scan.mjs';
+
+console.log('\ncontent filter — `word:` / `stem:` prefixes (#3274)');
+
+// ── 1. The three settings, negative side, on one description each ─────
+// A TRIPLE per row (plain / stem: / word:), same discipline as
+// tests/title-stem-prefix.test.mjs: the interesting property is that `stem:`
+// sits strictly between a plain substring and `word:`, which a pair against
+// one neighbour alone cannot show.
+const TRIPLES = [
+  // keyword, description, plainRejects, stemRejects, wordRejects
+  //
+  // "java" STARTS "javascript", so it is the #3103 "Solanaceae" class: stem:
+  // anchors the left edge only and still rejects it — only word: closes it.
+  ['java', 'We ship TypeScript and JavaScript', true, true, false],
+  ['java', 'A Kotlin and Java 21 backend', true, true, true],
+  ['java', 'Migrating our Javadoc tooling', true, true, false],
+  // "ios" lands MID-word in "curiosity" — the case stem: does close.
+  ['ios', 'We value curiosity and rigor', true, false, false],
+  ['ios', 'Build our iOS app in Swift', true, true, true],
+  ['go', 'A Django and Mongo shop', true, false, false],
+  ['go', 'Everything is written in Go', true, true, true],
+];
+const wrong = [];
+for (const [kw, desc, wantPlain, wantStem, wantWord] of TRIPLES) {
+  const rejects = (entry) => buildContentFilter({ negative: [entry] })(desc) === false;
+  const got = [rejects(kw), rejects(`stem:${kw}`), rejects(`word:${kw}`)];
+  const want = [wantPlain, wantStem, wantWord];
+  if (String(got) !== String(want)) wrong.push(`"${kw}" vs "${desc}": rejects ${got}, want ${want}`);
+}
+if (wrong.length === 0) {
+  pass('a content_filter negative: plain ⊇ stem: ⊇ word:, each anchoring one more edge');
+} else {
+  fail(`content_filter prefix semantics wrong: ${JSON.stringify(wrong)}`);
+}
+
+// The distinguishing property on its own, so a regression cannot hide in the
+// table: some case stem: rejects and word: does not, and some the plain form
+// rejects and stem: does not.
+const loosenedByStem = TRIPLES.some(([, , , s, w]) => s && !w);
+const tightenedByStem = TRIPLES.some(([, , p, s]) => p && !s);
+if (loosenedByStem && tightenedByStem) {
+  pass('stem: is neither word: nor the plain default on the content filter either');
+} else {
+  fail(`stem: collapsed into a neighbour: looser-than-word=${loosenedByStem} tighter-than-default=${tightenedByStem}`);
+}
+
+// ── 2. The plain default is unchanged ───────────────────────────────
+// Every pre-#3274 semantic still holds for a keyword with no prefix.
+const bareJava = buildContentFilter({ negative: ['java'] });
+if (bareJava('We ship TypeScript and JavaScript') === false && bareJava('A pure Rust team') === true) {
+  pass('a bare negative keyword still matches as a plain substring (JavaScript still rejected)');
+} else {
+  fail('the plain-substring default changed for an unprefixed keyword');
+}
+
+// Multi-word phrases are meant to match anywhere and take no prefix.
+const phrase = buildContentFilter({ negative: ['security clearance'] });
+if (phrase('Requires an active security clearance') === false && phrase('Remote, no clearance needed') === true) {
+  pass('a multi-word negative keeps exact-substring semantics with no prefix');
+} else {
+  fail('multi-word negative behaviour drifted');
+}
+
+// A config that never uses a prefix is byte-for-byte identical to before.
+const legacy = buildContentFilter({ positive: ['rust', 'golang'], negative: ['php', 'wordpress'] });
+const legacyCases = [
+  ['We build in Rust and a little Go', true],
+  ['Legacy PHP and WordPress maintenance', false],
+  ['A Rust shop with some PHP scripts', false],
+  ['A Python and Java team', false],
+  ['', true],
+];
+const drifted = legacyCases.filter(([d, want]) => legacy(d) !== want);
+if (drifted.length === 0) {
+  pass('a prefix-free content_filter behaves exactly as it did before #3274');
+} else {
+  fail(`prefix-free content_filter verdicts moved: ${JSON.stringify(drifted)}`);
+}
+
+// ── 3. No short-acronym auto-anchor — the difference from compileKeyword ─
+// compileKeyword anchors "go"/"aws"/"sql" because "COO" inside "Coordinator"
+// is always wrong in a title. In description prose it is not, so
+// compileContentKeyword must leave a bare short keyword as a substring.
+const shortPos = buildContentFilter({ positive: ['go'] });
+if (shortPos('We use MongoDB heavily') === true && shortPos('A pure Ruby shop') === false) {
+  pass('a bare 2-3 letter content_filter keyword stays a substring (no title-style auto-anchor)');
+} else {
+  fail('compileContentKeyword auto-anchored a short keyword — it should not');
+}
+// And the prefix still works at that length when asked for explicitly.
+if (compileContentKeyword('word:go')('everything in go') === true &&
+    compileContentKeyword('word:go')('mongo and django') === false) {
+  pass('word: still anchors a short keyword when the entry opts in');
+} else {
+  fail('word: did not anchor a short content_filter keyword');
+}
+
+// ── 4. Positive side and by_title_keyword overrides honour the prefix ─
+const wordPositive = buildContentFilter({ positive: ['word:java'] });
+if (wordPositive('Senior Java engineer, Spring Boot') === true &&
+    wordPositive('Frontend, heavy JavaScript') === false) {
+  pass('word: on a positive requires a whole-word match');
+} else {
+  fail('word: positive did not anchor');
+}
+
+const scoped = buildContentFilter({
+  by_title_keyword: { 'Backend Engineer': { negative: ['word:java'] } },
+});
+if (scoped('Laravel with some JavaScript on the side', ['Backend Engineer']) === true &&
+    scoped('Spring Boot and Java 21', ['Backend Engineer']) === false) {
+  pass('content_filter.by_title_keyword honours a word:/stem: prefix inside an override rule');
+} else {
+  fail('by_title_keyword override ignored a word: prefix');
+}
+
+// ── 5. Shared plumbing: a bare prefix, and regex metacharacters ──────
+// A stray `word:` / `stem:` with nothing after it matches nothing — the safe
+// half of "a silent drop of one entry over a silent flood", same as
+// title-keywords.mjs.
+const bare = buildContentFilter({ negative: ['word:', 'stem:'] });
+if (bare('any description text at all') === true) {
+  pass('a bare word:/stem: negative is a no-op, not a veto');
+} else {
+  fail('a bare word:/stem: negative vetoed a posting');
+}
+
+// Metacharacters in the keyword are literal, exactly as under the title filter.
+const dotnet = compileContentKeyword('word:.net');
+if (dotnet('our stack is .net 8') === true && dotnet('anet internal tool') === false) {
+  pass('word: escapes regex metacharacters (".net" is not "any char + net")');
+} else {
+  fail('word: leaked regex metacharacters into the content_filter pattern');
+}

--- a/title-keywords.mjs
+++ b/title-keywords.mjs
@@ -54,6 +54,45 @@ const anchoredPattern = (body) => new RegExp(`(?<!${WORD_CHAR})${body}(?!${WORD_
 // may continue past it.
 const stemPattern = (body) => new RegExp(`(?<!${WORD_CHAR})${body}`, 'u');
 
+// `word:` and `stem:` mean the same thing wherever a keyword list is matched
+// against text, so their handling lives here once rather than being copied into
+// each compiler — the drift this module exists to prevent. Returns a matcher
+// when `kw` carries a recognised prefix, or null when it is an ordinary keyword
+// the caller compiles its own way (the title filter auto-anchors short
+// acronyms and falls back to substring; the content filter goes straight to
+// substring — see #3103, #3274).
+//
+// Explicit alphanumeric lookarounds rather than \b, because \b's meaning
+// depends on the characters at the keyword's own edges: for `word:c++` a
+// trailing \b would sit after "+" and assert the opposite of the intent.
+// WORD_CHAR rather than [a-z0-9_]: an ASCII-only lookaround treats every
+// accented letter as a separator, so `word:intern` matched inside "preintern"
+// spelled with an accent and vetoed exactly the international titles this
+// prefix exists to protect. \p{M} covers combining marks, so a decomposed "é"
+// does not split a word either.
+function compilePrefixedKeyword(kw) {
+  if (kw.startsWith(WORD_PREFIX)) {
+    const bare = kw.slice(WORD_PREFIX.length).trim();
+    // A bare `word:` is a config typo. Matching NOTHING is the safe reading: as
+    // a positive it simply contributes no match, while the alternative — an
+    // empty pattern matching everything — would veto an entire scan from one
+    // stray colon. Same trade as the "C++" note on scan.mjs's AND_SEPARATOR:
+    // prefer a silent drop of one entry over a silent flood.
+    if (!bare) return () => false;
+    const re = anchoredPattern(escapeForRegExp(bare));
+    return (lower) => re.test(lower);
+  }
+  if (kw.startsWith(STEM_PREFIX)) {
+    const bare = kw.slice(STEM_PREFIX.length).trim();
+    // Same reading as a bare `word:`: a stray prefix with nothing after it is a
+    // typo, and matching nothing is the safe half of that trade.
+    if (!bare) return () => false;
+    const re = stemPattern(escapeForRegExp(bare));
+    return (lower) => re.test(lower);
+  }
+  return null;
+}
+
 /**
  * Compile a lowercased keyword into a matcher.
  *
@@ -68,33 +107,8 @@ const stemPattern = (body) => new RegExp(`(?<!${WORD_CHAR})${body}`, 'u');
  * @returns {(lower: string) => boolean}
  */
 export function compileKeyword(kw) {
-  if (kw.startsWith(WORD_PREFIX)) {
-    const bare = kw.slice(WORD_PREFIX.length).trim();
-    // A bare `word:` is a config typo. Matching NOTHING is the safe reading: as
-    // a positive it simply contributes no match, while the alternative — an
-    // empty pattern matching every title — would veto an entire scan from one
-    // stray colon. Same trade as the "C++" note on scan.mjs's AND_SEPARATOR:
-    // prefer a silent drop of one entry over a silent flood.
-    if (!bare) return () => false;
-    // Explicit alphanumeric lookarounds rather than \b, because \b's meaning
-    // depends on the characters at the keyword's own edges: for `word:c++` a
-    // trailing \b would sit after "+" and assert the opposite of the intent.
-    // WORD_CHAR rather than [a-z0-9_]: an ASCII-only lookaround treats every
-    // accented letter as a separator, so `word:intern` matched inside
-    // "preintern" spelled with an accent and vetoed exactly the international
-    // titles this prefix exists to protect. \p{M} covers combining marks, so a
-    // decomposed "é" does not split a word either.
-    const re = anchoredPattern(escapeForRegExp(bare));
-    return (lower) => re.test(lower);
-  }
-  if (kw.startsWith(STEM_PREFIX)) {
-    const bare = kw.slice(STEM_PREFIX.length).trim();
-    // Same reading as a bare `word:`: a stray prefix with nothing after it is a
-    // typo, and matching nothing is the safe half of that trade.
-    if (!bare) return () => false;
-    const re = stemPattern(escapeForRegExp(bare));
-    return (lower) => re.test(lower);
-  }
+  const prefixed = compilePrefixedKeyword(kw);
+  if (prefixed) return prefixed;
   if (/^[a-z]{2,3}$/.test(kw)) {
     // The same boundary as above, not \b: \b is ASCII-only, so "vp" matched
     // inside an accented word while `word:vp` did not. Two spellings of one
@@ -103,6 +117,31 @@ export function compileKeyword(kw) {
     return (lower) => re.test(lower);
   }
   return (lower) => lower.includes(kw);
+}
+
+/**
+ * Compile a lowercased `content_filter` keyword into a matcher.
+ *
+ * `content_filter` matches against the job DESCRIPTION, not the title, and its
+ * default has always been a plain case-insensitive substring. That default is
+ * why a bare negative `java` rejects every posting that merely mentions
+ * "JavaScript", and `ios` rejects "curiosity" (#3274). Flipping the default is
+ * a breaking change for every configured install — the same conclusion #3103
+ * reached for `title_filter` — so the fix is opt-in: a `word:` or `stem:`
+ * prefix asks for boundary-anchored matching on that one entry (identical
+ * semantics to the title filter), and every other entry keeps the substring
+ * behaviour byte-for-byte.
+ *
+ * Unlike compileKeyword(), there is no automatic anchoring of short keywords.
+ * The title filter anchors 2-3 letter acronyms because "COO" inside
+ * "Coordinator" is always wrong; a 2-3 letter run inside a paragraph of
+ * description prose is routinely intended ("aws", "gcp", "sql", "go").
+ *
+ * @param {string} kw - already trimmed and lowercased.
+ * @returns {(lower: string) => boolean}
+ */
+export function compileContentKeyword(kw) {
+  return compilePrefixedKeyword(kw) ?? ((lower) => lower.includes(kw));
 }
 
 // An AND-group: " + " (whitespace-delimited) between terms means EVERY term


### PR DESCRIPTION
## What

`buildContentFilter()` in `scan.mjs` matches every `content_filter` keyword with plain `String.includes()`. Single-token negatives therefore reject postings that merely *mention* them inside another word:

```js
buildContentFilter({ negative: ['java'] })('We ship TypeScript/JavaScript') // → false
buildContentFilter({ negative: ['ios'] })('We value curiosity and rigor')   // → false
```

Combined with discards leaving no record, those postings vanish silently.

## Approach

Per the direction in #3274 (and the #3103 / #3225 precedent for `title_filter`): **opt-in, per entry, default untouched.** A `word:` or `stem:` prefix asks for boundary-anchored matching on that one keyword; every unprefixed entry keeps plain substring behaviour byte-for-byte, so no configured `portals.yml` changes meaning.

- `word:java` — whole word only: keeps "JavaScript", still blocks a Java shop
- `stem:ios` — left boundary only: keeps "curiosity", still blocks "iOS"

Semantics are identical to `title_filter`'s prefixes. The shared `word:`/`stem:` handling is factored out of `compileKeyword` into `compilePrefixedKeyword` so there is still one definition. `compileContentKeyword` reuses it but **skips the title filter's 2–3 letter auto-anchor** — a short run inside a paragraph of description prose ("aws", "sql", "go") is routinely intended, unlike "COO" inside "Coordinator" in a title.

## Changes

| File | Change |
|---|---|
| `title-keywords.mjs` | Extract `compilePrefixedKeyword`; add `compileContentKeyword` |
| `scan.mjs` | `buildContentFilter` compiles `positive`, `negative`, and every `by_title_keyword` rule list through it |
| `templates/portals.example.yml` | Document the prefixes in the `content_filter` section |
| `tests/content-filter-word-prefix.test.mjs` | New suite (auto-discovered) |

`scan-ats-full.mjs` imports `buildContentFilter` from `scan.mjs`, so reverse sweeps get this for free.

## Tests

New suite (11 assertions) covers: the `plain ⊇ stem: ⊇ word:` ordering on the negative side, the unchanged substring default (incl. a full prefix-free legacy config), the absent short-acronym anchor, positive-side + `by_title_keyword` coverage, and the bare-prefix / regex-metacharacter plumbing.

- `node test-all.mjs --only prefix` → 43/43
- Full discovered suite green (one unrelated pre-existing failure on my local checkout: `SKILL.md: missing cwd-independent routing rule`).

Closes #3274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `word:` matching for whole-word keyword detection.
  * Added optional `stem:` matching for left-boundary keyword detection.
  * Existing unprefixed keywords continue using substring matching.
  * Matching is supported across global content filters and title-based rules.

* **Documentation**
  * Added configuration examples explaining the new keyword matching options.

* **Bug Fixes**
  * Improved content filtering accuracy by preventing unintended partial matches when boundary matching is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->