### PR TITLE
feat(providers): JobsDB Hong Kong via the existing jobstreet provider

### DIFF
--- a/providers/jobstreet.mjs
+++ b/providers/jobstreet.mjs
@@ -24,6 +24,11 @@
 //   ID-Main  → id.jobstreet.com (Indonesia)
 //   SG-Main  → sg.jobstreet.com (Singapore)
 //   MY-Main  → my.jobstreet.com (Malaysia)
+//   HK-Main  → hk.jobsdb.com    (Hong Kong)
+//
+// Hong Kong runs under the JobsDB brand rather than Jobstreet, but it is the
+// same SEEK platform behind the same v5 endpoint, so it needs no separate
+// provider — only its hostname in the allowlist below and siteKey: HK-Main.
 
 const DEFAULT_API = 'https://id.jobstreet.com/api/jobsearch/v5/search';
 const DEFAULT_SITE_KEY = 'ID-Main';
@@ -38,6 +43,8 @@ const ALLOWED_JOBSTREET_HOSTS = new Set([
   'jobstreet.co.id',
   'sg.jobstreet.com',
   'my.jobstreet.com',
+  // SEEK's Hong Kong property keeps the JobsDB brand; same v5 search API.
+  'hk.jobsdb.com',
   'www.seek.com.au',
   'www.seek.co.nz',
 ]);

--- a/tests/providers/jobstreet.test.mjs
+++ b/tests/providers/jobstreet.test.mjs
@@ -165,6 +165,28 @@ try {
   if (hostRejected) pass('jobstreet.fetch() rejects untrusted hostnames');
   else fail('jobstreet.fetch() should reject non-jobstreet hostnames');
 
+  // fetch() — accepts SEEK's Hong Kong host (JobsDB brand, same v5 API)
+  let hkReached = false;
+  const hkJobs = await jobstreet.fetch(
+    {
+      name: 'JobsDB HK',
+      provider: 'jobstreet',
+      api: 'https://hk.jobsdb.com/api/jobsearch/v5/search',
+      siteKey: 'HK-Main',
+      searchKeywords: 'business intelligence',
+    },
+    {
+      transport: 'http',
+      fetchJson: async (url) => {
+        hkReached = String(url).startsWith('https://hk.jobsdb.com/');
+        return { data: [], totalCount: 0 };
+      },
+      fetchText: async () => { throw new Error('should not be called'); },
+    },
+  );
+  if (hkReached && hkJobs.length === 0) pass('jobstreet.fetch() accepts hk.jobsdb.com (HK-Main)');
+  else fail('jobstreet.fetch() should accept hk.jobsdb.com and query it directly');
+
   // fetch() — handles non-array data field
   const badDataCtx = {
     transport: 'http',


### PR DESCRIPTION
## What

Adds `hk.jobsdb.com` to `ALLOWED_JOBSTREET_HOSTS` and documents the `HK-Main` site key. Two files, 29 insertions, no behaviour change for existing markets.

## Why

SEEK runs Hong Kong under the **JobsDB** brand rather than Jobstreet, but it is the same platform behind the same v5 endpoint the provider already speaks. Verified live:

```
GET https://hk.jobsdb.com/api/jobsearch/v5/search
    ?siteKey=HK-Main&sourcesystem=houston&keywords=business+intelligence

→ HTTP 200 · totalCount 5872
→ items carry advertiser.description and jobLocation.label
  e.g. "Business Intelligence Manager / Senior Business Intelligence Analyst"
       — IT Channel (Asia) Limited — Central, Central and Western District
```

Because the host was not allowlisted, every Hong Kong entry failed the SSRF guard with `jobstreet: untrusted hostname "hk.jobsdb.com"`, so HK had no zero-token path at all.

The WebSearch fallback is not an adequate substitute for this board. Three `site:hk.jobsdb.com` queries returned only category landing pages (`/business-intelligence-jobs`, `/power-bi-analyst-jobs`) — Google indexes JobsDB's facets, not its listings — so zero addressable postings reached `pipeline.md`.

More broadly, HK corporates are poorly served by the ATS providers: probing 58 endpoints across Greenhouse / Lever / Ashby / SmartRecruiters / Workday for major Hong Kong employers produced only 4 live boards. JobsDB is the practical entry point for the market.

## Why not a new provider

Same platform, same endpoint, same response shape, same parser. `parseJobstreetItem` handles the payload unchanged. A separate module would be a copy of this one with one string altered.

## Test

Adds `jobstreet.fetch() accepts hk.jobsdb.com (HK-Main)`, mirroring the existing untrusted-host case: asserts the request is issued against the `hk.jobsdb.com` origin and parses cleanly. Full `tests/providers/jobstreet.test.mjs` passes (16/16).

## Suite status

`node test-all.mjs` has one failure on this branch, `web/tests/lib/explore-ai-dedup.test.mjs` — **pre-existing and unrelated**. Reproduced on the unmodified base with these changes stashed (362 pass / 1 fail / 1 skipped in `web/tests/lib`). Nothing in this PR touches `web/`.

## Routing note

`CONTRIBUTING.md` asks for an issue first on anything feature-shaped. This sits between a fix and a market addition, and the rule of thumb routes provider modules to core — happy to convert it to an issue instead if that is the preferred door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tkgwATcJzC4gbeEtEBjj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing job listings on the Hong Kong JobsDB website.
  * Requests to `hk.jobsdb.com` are now recognized and handled correctly.

* **Bug Fixes**
  * Improved handling of Hong Kong searches when no job results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->