### PR TITLE
docs(scan): stop hard-coding provider names in description-filter comments

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -483,10 +483,11 @@ export function buildPostedDateFilter(afterIso, beforeIso) {
 // global `positive`/`negative` pair is the fallback for jobs whose matched
 // keyword(s) have no override entry.
 //
-// Provider support: only providers whose list API ships the description for
-// free (no extra per-job request, which would break the zero-token design)
-// populate `job.description`. Lever (`descriptionPlain`) does today; others
-// leave it empty and therefore always pass this filter.
+// Provider support: `job.description` is populated only when the provider's
+// list API returns the description body without a per-job request (the
+// zero-token constraint). Providers that don't supply one leave it empty, and
+// those jobs always pass this filter. The set shifts as providers are updated
+// — check it with `grep -l 'description:' providers/*.mjs`.
 
 // Normalize a keyword list (lowercase/trim/drop-empties) and compile each
 // survivor into a matcher, so a `word:`/`stem:` prefix is honoured and a bare
@@ -611,8 +612,9 @@ export function buildCountryEligibilityFilter(countryEligibilityFilter, candidat
 // Surfaces roles that sponsor a work visa (H-1B / H-1B1 / O-1 for the US, plus
 // the generic "visa sponsorship" wording) and drops roles that explicitly
 // refuse sponsorship. Like content_filter it reads the job DESCRIPTION text, so
-// it only has signal for providers whose list API ships a description (Lever
-// today); jobs without one fall back to the require_mention rule below.
+// it only has signal for providers that populate job.description (see the
+// content_filter header above); jobs without one fall back to the
+// require_mention rule below.
 //
 // Semantics (case-insensitive substring):
 //   - any `negative` keyword present → reject (an explicit "no sponsorship")

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -208,10 +208,11 @@
 #   - `positive` non-empty → at least one keyword must be present
 #   - If this entire block is absent, descriptions are not filtered (default)
 #
-# Provider support: the scanner is zero-token and only reads descriptions that
-# a provider already returns in its list payload — it never fetches each job
-# page. Currently Lever (`descriptionPlain`) supplies descriptions; jobs from
-# providers that don't always pass this filter (they're never silently dropped).
+# Provider support: the scanner is zero-token and only reads a description when
+# the provider's list API returns it for free — it never fetches each job page.
+# Jobs from a provider that doesn't supply one always pass this filter (never
+# silently dropped). Check which providers qualify:
+# `grep -l 'description:' providers/*.mjs`.
 #
 # Whole-word / stem matching (opt-in, per entry): a plain keyword is a
 # substring, so a negative "java" also rejects "JavaScript" and "ios" rejects
@@ -253,7 +254,8 @@
 # Surfaces roles that sponsor a work visa (H-1B / H-1B1 / O-1 for the US, plus
 # the generic "visa sponsorship" wording) and drops roles that explicitly refuse
 # it. Like content_filter it reads the job DESCRIPTION text, so it only has
-# signal for providers whose list API ships a description (Lever today).
+# signal for providers that populate job.description (see the content_filter
+# provider-support note above).
 # Semantics (case-insensitive substring):
 #   - Any `negative` keyword present → reject (an explicit "no sponsorship")
 #   - require_mention: false (default) → after clearing negatives, pass — jobs


### PR DESCRIPTION
## Summary

`content_filter` and `visa_filter` in `scan.mjs` read `job.description`. The comments explaining which providers populate that field name Lever as the only one that does. That has been stale for months:

| Provider | `job.description` populated in |
|---|---|
| OracleCloud | #1929 |
| Gem | #2024 |
| Workable | public-widget-API switch |
| Remotli | #2464 |
| Greenhouse / Ashby / Recruitee / opt-in SmartRecruiters | #3175 |

- `scan.mjs` — reworded the `content_filter` "Provider support" comment and the `visa_filter` coverage comment. They now state the invariant (a provider populates `job.description` only when its list API returns the body with no per-job request — the zero-token constraint) and point at `grep -l 'description:' providers/*.mjs` for the live set, instead of naming providers that go stale.
- `templates/portals.example.yml` — same two comments, same treatment; the `visa_filter` note now defers to the `content_filter` note rather than repeating a provider name.
- Comment-only. No code, schema, or behaviour change.

## Why

The stale wording is easy to trust and act on: it recently led to a wrong conclusion mid-task ("this Ashby-hosted role can't be content-filtered") when `content_filter` has in fact covered Ashby since #3175. A comment that states the rule plus how to check the current set can't rot the way an enumerated list does.

## Test plan

- [x] `npm run lint` — 579 .mjs files pass syntax check (covers `scan.mjs`)
- [x] `node validate-portals.mjs --file templates/portals.example.yml` — 0 errors, 0 warnings
