### PR TITLE
fix(updater): parse git status with -z so quoted paths and renames match real files

### DIFF
--- a/tests/updater-status-paths.test.mjs
+++ b/tests/updater-status-paths.test.mjs
@@ -9,21 +9,27 @@
  * path is mangled no longer matches its real counterpart, so a violation can
  * slip past the abort.
  *
- * The corruption vector is `gitIn()`'s `.trim()`: `--porcelain` lines for
- * worktree/index changes begin with a space (` M path`), and trimming the WHOLE
- * buffer strips the first line's leading space, turning it into `M path`. The
- * parser's `path: line.slice(3)` then drops the path's first character — for
- * ` M data/user-file.md` the resulting `ata/user-file.md` matches nothing.
+ * Historical corruption vectors, all now closed by parsing `--porcelain -z`
+ * (NUL-delimited) instead of the newline form:
+ *   - `gitIn()`'s `.trim()`: worktree/index lines begin with a space (` M path`),
+ *     and trimming the whole buffer stripped the first line's leading space, so
+ *     `path: line.slice(3)` dropped the path's first character.
+ *   - Windows CRLF line endings gave every path a trailing `\r`; `-z` suppresses
+ *     line-ending translation, so there is nothing to strip.
+ *   - C-quoting: the newline form wraps any path with a space, a quote, or a
+ *     non-ASCII byte (under git's default core.quotepath) in `"…"` with octal
+ *     escapes; the safety check then compared a quoted string to a real file.
+ *   - renames: the newline form writes `R  old -> new` on ONE line, so the
+ *     "path" was the blob `old -> new`; `-z` writes destination and origin as
+ *     two NUL fields, and parsePorcelainStatus surfaces both as their own entry.
  *
- * The parser lives in parsePorcelainStatus() so its second disguise — a
- * Windows git whose CRLF line endings would give every path a trailing `\r` —
- * can be driven with a synthetic CRLF buffer instead of trusting whatever EOL
- * the local git happens to emit.
- *
- * These tests drive gitStatusEntries() against throwaway repos through the
- * same seam the production code uses (gitRawIn under a root), pinning the
- * whitespace-sensitive behaviour on both code shapes (` M` and `M `) and on the
- * first-line position that the old `gitIn`-based implementation corrupted.
+ * A mistyped path is a blind spot — gitStatusEntries() feeds the "did we touch
+ * a user file?" safety check (the pre-update dirty Set, the `changed` list, the
+ * commit-failure guard), all of which compare against the parsed `path`. These
+ * tests drive gitStatusEntries() against throwaway repos through the same seam
+ * production uses (gitRawIn under a root), plus a few synthetic `-z` buffers
+ * straight through parsePorcelainStatus() for the shapes a local git may not
+ * emit on demand.
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
@@ -32,13 +38,16 @@ import { join } from 'path';
 import { pass, fail } from './helpers.mjs';
 import { gitIn, gitStatusEntries, parsePorcelainStatus } from '../update-system.mjs';
 
-function makeRepo() {
+// quotepath: false in most repos here only to keep assertion strings readable —
+// with `-z` the parser never sees a quoted path regardless of the setting. The
+// non-ASCII test below deliberately leaves it at git's dangerous default (true).
+function makeRepo({ quotepath = false } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'co-status-paths-'));
   const g = (...args) => gitIn(dir, ...args);
   g('init', '-q', '-b', 'main', '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
-  g('config', 'core.quotepath', 'false');
+  g('config', 'core.quotepath', String(quotepath));
   return { dir, g };
 }
 
@@ -127,9 +136,7 @@ console.log('\n🧪 Testing updater git-status path parsing...');
 // ── 4. Mixed statuses ────────────────────────────────────────────────────
 // Order-insensitive: git's porcelain ordering is by path (untracked entries
 // can sort before tracked changes), so assert the entry SET, not a sequence.
-// NOTE: paths containing a space arrive C-quoted (git prints `"my notes.md"`)
-// and the parser keeps the quotes — a distinct limitation from the leading-
-// space trim bug under test, so space-free names are used here on purpose.
+// Paths with a space are covered on their own in case 8; plain names here.
 {
   const { dir, g } = makeRepo();
   try {
@@ -176,29 +183,57 @@ console.log('\n🧪 Testing updater git-status path parsing...');
   }
 }
 
-// ── 6. Entries carry no trailing CR (Windows line-ending robustness) ──────
-// The parser, not git's output, is what must be CRLF-robust: a Windows build
-// of git terminates `--porcelain` lines with CRLF (its native EOL), and the
-// CR is sliced off right where `path` begins. This has to be proven by feeding
-// a CRLF buffer straight through parsePorcelainStatus — on a machine where git
-// happens to emit LF the old test passed because git chose LF, not because the
-// parser handled CRLF. The direct input makes the assertion real.
+// ── 6. Synthetic `-z` buffers straight through parsePorcelainStatus ──────
+// `git status --porcelain -z` separates entries with NUL and never appends a
+// newline or CR, so there is no line-ending disguise left to handle — but the
+// parser must still (a) split on NUL not '\n', (b) drop the empty tail after
+// the final NUL, and (c) treat a rename/copy as TWO fields: destination first,
+// origin second, both surfaced as their own entry.
 {
-  const crlf = ' M b.mjs\r\n?? run-now.mjs\r\n';
-  const want = [
-    { code: ' M', path: 'b.mjs' },
-    { code: '??', path: 'run-now.mjs' },
+  const cases = [
+    {
+      label: 'plain NUL-delimited entries, trailing empty field ignored',
+      buf: ' M b.mjs\x00?? run-now.mjs\x00',
+      want: [
+        { code: ' M', path: 'b.mjs' },
+        { code: '??', path: 'run-now.mjs' },
+      ],
+    },
+    {
+      label: 'a CR inside a `-z` field is a real path byte, not stripped',
+      buf: ' M weird\rname.mjs\x00',
+      want: [{ code: ' M', path: 'weird\rname.mjs' }],
+    },
+    {
+      label: 'rename entry yields both destination and origin as real paths',
+      buf: 'R  modes/new.md\x00modes/old.md\x00',
+      want: [
+        { code: 'R ', path: 'modes/new.md' },
+        { code: 'R ', path: 'modes/old.md' },
+      ],
+    },
+    {
+      label: 'copy entry (C) also emits its origin field',
+      buf: 'C  data/copy.md\x00data/src.md\x00 M other.mjs\x00',
+      want: [
+        { code: 'C ', path: 'data/copy.md' },
+        { code: 'C ', path: 'data/src.md' },
+        { code: ' M', path: 'other.mjs' },
+      ],
+    },
   ];
-  const got = JSON.stringify(parsePorcelainStatus(crlf));
-  if (got === JSON.stringify(want)) {
-    pass('CRLF-terminated porcelain lines parse with no trailing carriage return');
-  } else {
-    fail(`CRLF porcelain damaged — parsed ${got}, expected ${JSON.stringify(want)}`);
+  for (const { label, buf, want } of cases) {
+    const got = JSON.stringify(parsePorcelainStatus(buf));
+    if (got === JSON.stringify(want)) {
+      pass(label);
+    } else {
+      fail(`${label} — parsed ${got}, expected ${JSON.stringify(want)}`);
+    }
   }
 }
 
-// And the real seam against an actual repo (LF here, CRLF on Windows runners)
-// still round-trips a dirty worktree file byte-for-byte.
+// And the real seam against an actual repo still round-trips a dirty worktree
+// file byte-for-byte.
 {
   const { dir, g } = makeRepo();
   try {
@@ -246,6 +281,76 @@ console.log('\n🧪 Testing updater git-status path parsing...');
       pass('#3048: dirty user file keeps its full path, so the initialStatusPaths guard matches');
     } else {
       fail(`#3048 guard misses the dirty user file — parsed ${JSON.stringify(entries)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 8. A path containing a space arrives unquoted ────────────────────────
+// The newline form prints ` M "data/my notes.md"` (quotes always, regardless
+// of core.quotepath). A safety check comparing `"data/my notes.md"` — quotes
+// included — to a real file matches nothing, so the modification slips past.
+{
+  const { dir, g } = makeRepo();
+  try {
+    mkdirSync(join(dir, 'data'));
+    writeFileSync(join(dir, 'data', 'my notes.md'), 'v1\n');
+    g('add', '-A');
+    g('commit', '-qm', 'base');
+    writeFileSync(join(dir, 'data', 'my notes.md'), 'v2\n');
+
+    assertRoundTrip(
+      'spaced path parses with no surrounding quotes',
+      dir,
+      [{ code: ' M', path: 'data/my notes.md' }],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 9. A non-ASCII path under git's DEFAULT core.quotepath (true) ────────
+// This is the dangerous default: the newline form would emit
+// ` M "data/caf\303\251.md"` (octal-escaped). `-z` ignores quotepath entirely.
+{
+  const { dir, g } = makeRepo({ quotepath: true });
+  try {
+    mkdirSync(join(dir, 'data'));
+    writeFileSync(join(dir, 'data', 'café.md'), 'v1\n');
+    g('add', '-A');
+    g('commit', '-qm', 'base');
+    writeFileSync(join(dir, 'data', 'café.md'), 'v2\n');
+
+    assertRoundTrip(
+      'non-ASCII path survives as real UTF-8 under default core.quotepath',
+      dir,
+      [{ code: ' M', path: 'data/café.md' }],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 10. A real `git mv` rename surfaces BOTH sides as real paths ─────────
+// The newline form writes `R  data/old.md -> data/new.md` on one line, so the
+// old slice yielded the blob `data/old.md -> data/new.md` as the "path" —
+// neither side matched a file, so a renamed user file was invisible to the
+// safety check. Assert both paths come back, order-insensitively.
+{
+  const { dir, g } = makeRepo();
+  try {
+    mkdirSync(join(dir, 'data'));
+    writeFileSync(join(dir, 'data', 'old.md'), 'v1\n');
+    g('add', '-A');
+    g('commit', '-qm', 'base');
+    g('mv', 'data/old.md', 'data/new.md');
+
+    const paths = new Set(gitStatusEntries(dir).map((e) => e.path));
+    if (paths.has('data/old.md') && paths.has('data/new.md') && paths.size === 2) {
+      pass('rename entry surfaces both origin and destination as real paths');
+    } else {
+      fail(`rename paths damaged — got ${JSON.stringify([...paths])}`);
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -776,35 +776,46 @@ function missingFromTargetManifest(targetPaths) {
   return missing;
 }
 
-// Must read UNTRIMMED output: gitIn() trims the whole buffer, and the
-// first `--porcelain` line of a worktree/index change begins with a space
-// (` M path`). Trimming rewrites it into `M path`, and the path parse below
-// then drops the first character — a mangled path that no longer matches the
-// real user file in the safety checks. gitRawIn keeps the leading space.
+// Parses the NUL-delimited output of `git status --porcelain -z`. `-z` is the
+// only form that round-trips every path byte-for-byte, which is what the
+// user-layer safety checks depend on — they compare the parsed `path` against
+// real files on disk, and a mangled path is a blind spot (#3048, and the
+// follow-up this replaces):
+//   - never quoted: the newline form C-quotes any path with a space, a quote,
+//     a control char, or (under git's default core.quotepath) a non-ASCII
+//     byte, e.g. ` M "data/my notes.md"` / ` M "data/caf\303\251.md"`. `-z`
+//     emits the raw path, so no dequoting is needed.
+//   - renames/copies as two fields, not one line: the newline form writes
+//     `R  old -> new` on a single line, so a naive slice yields the blob
+//     `old -> new` as the "path". `-z` writes the destination and origin as
+//     two separate NUL-delimited fields; both are surfaced as their own entry
+//     below so the safety check sees every path the move touched.
+//   - no CRLF: `-z` suppresses git's line-ending translation, so there is no
+//     trailing CR to strip on Windows.
 //
-// The parsing itself is extracted as parsePorcelainStatus so the CRLF case can
-// be unit-tested without a real repo: Windows git terminates the last
-// `--porcelain` line with CRLF (its native EOL), and without stripping the
-// trailing CR the sliced `path` would carry a phantom `\r` that matches
-// nothing (same bug class as #3048 — a safety check comparing a mangled path).
+// gitRawIn (not gitIn) because a `-z` field may legitimately begin or end with
+// a space, and trimming the buffer would rewrite it into a different path.
 export function parsePorcelainStatus(status) {
   if (!status) return [];
-  return status
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => {
-      // git never writes a CR inside a path, so a line-terminal '\r' is always
-      // the CRLF half of the line ending, never a path character.
-      const clean = line.endsWith('\r') ? line.slice(0, -1) : line;
-      return {
-        code: clean.slice(0, 2),
-        path: clean.slice(3),
-      };
-    });
+  const fields = status.split('\0');
+  const entries = [];
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i];
+    if (!field) continue;
+    const code = field.slice(0, 2);
+    entries.push({ code, path: field.slice(3) });
+    // R (rename) and C (copy) always sit in the first status column and are
+    // followed by one extra field — the origin path. Emit it too.
+    if (code[0] === 'R' || code[0] === 'C') {
+      const origin = fields[++i];
+      if (origin) entries.push({ code, path: origin });
+    }
+  }
+  return entries;
 }
 
 export function gitStatusEntries(root = ROOT) {
-  return parsePorcelainStatus(gitRawIn(root, 'status', '--porcelain'));
+  return parsePorcelainStatus(gitRawIn(root, 'status', '--porcelain', '-z'));
 }
 
 export function extractArrayFromSource(source, name) {


### PR DESCRIPTION
## What does this PR do?

`parsePorcelainStatus()` split `git status --porcelain` on newlines and sliced `path` at offset 3. Two porcelain v1 shapes came out mangled, and a mangled path is a hole in the user-layer safety check — it compares the parsed `path` against files on disk, so a mismatch lets a touched user file slip past the abort (same class as #3048):

- **C-quoted paths** — a path with a space, a quote, or (under git's default `core.quotepath`) a non-ASCII byte arrives as `` M "data/my notes.md"`` / `` M "data/caf\303\251.md"``. The slice kept the quotes and octal escapes, so the string matched no file.
- **Renames / copies** — `R  old -> new` is one line, so `path` became the blob `old -> new`, neither side a real path.

Fix: `gitStatusEntries()` now reads `git status --porcelain -z`, already the house pattern for this exact reason (`removeAdditionsNotInHead`, the staged-diff guard). `-z` is NUL-delimited, never quoted, and not line-ending translated, so it also retires the leading-space-trim and CRLF workarounds. Renames/copies come as two NUL fields (destination then origin); `parsePorcelainStatus()` emits both as their own entry, since the safety check only reads `.path`.

## Related issue

Closes #3417 (filed at @santifer's request in #3182).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Acceptance / tests

`tests/updater-status-paths.test.mjs`: replaced the CRLF direct-buffer case with synthetic `-z` buffers (plain, CR-as-real-byte, rename, copy) and added real-git cases for a spaced path, a non-ASCII path under default `core.quotepath`, and a `git mv` rename. All updater suites + `npm run lint` pass.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — issue-first exempt (issue filed anyway: #3417)
- [x] No personal data
- [x] Ran `node test-all.mjs` — updater suites and lint pass. 6 unrelated failures are pre-existing on this machine's Node 20 (repo requires ≥22: `node:sqlite`, `node --test` web suites, sqlite-backed tracker tests); identical on the parent commit.
- [x] Respects the Data Contract — no user-layer file changes; this hardens the check that protects them
- [x] Aligns with roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git status parsing for paths containing spaces, non-ASCII characters, and embedded carriage returns.
  * Correctly handles renamed and copied files by reporting both original and destination paths.
  * Improved reliability when processing empty or NUL-delimited status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->