### PR TITLE
fix(doctor): survive a null entry in installed_plugins.json

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -289,7 +289,15 @@ function isPlaywrightMcpFromPlugin() {
   return Object.entries(enabled).some(([key, on]) => {
     if (on !== true) return false;
     const entries = Array.isArray(installed[key]) ? installed[key] : [];
-    return entries.some(({ installPath } = {}) => {
+    // Read installPath off the entry rather than destructuring it: the `= {}`
+    // default only covers `undefined`, so a manifest carrying a literal `null`
+    // entry - valid JSON, and what a half-written install leaves behind - threw
+    // a TypeError here. That is worse than the miss this function was added to
+    // fix (#2752): doctor dies before printing, so every other check vanishes
+    // with it and the output looks like a broken install rather than one
+    // unconfigured plugin.
+    return entries.some((entry) => {
+      const installPath = entry?.installPath;
       if (typeof installPath !== 'string' || !installPath) return false;
       return hasPlaywrightIn(readConfigIfPresent(join(installPath, '.mcp.json')), { bare: true });
     });

--- a/tests/playwright-mcp-detection.test.mjs
+++ b/tests/playwright-mcp-detection.test.mjs
@@ -621,6 +621,39 @@ try {
     }
   }
 
+  // 26. A literal `null` inside a plugin's entry array. This is valid JSON and
+  //     a half-written install can leave it behind, so doctor has to survive
+  //     it. Destructuring the entry threw a TypeError - `= {}` defaults only
+  //     for `undefined`, never for `null` - which killed the run before the
+  //     report printed, turning one unconfigured plugin into "career-ops is
+  //     broken here". The assertion is that doctor still WARNS: a crash and a
+  //     clean miss both leave playwright_mcp false, so only checking the flag
+  //     would pass on the bug.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-26-'));
+    const home = mkdtempSync(join(tmpdir(), 'co-mcp-nullentry-'));
+    try {
+      mkdirSync(join(home, 'plugins'), { recursive: true });
+      writeFileSync(join(home, 'settings.json'), JSON.stringify({ enabledPlugins: { [PLUGIN_KEY]: true } }));
+      writeFileSync(
+        join(home, 'plugins', 'installed_plugins.json'),
+        JSON.stringify({ version: 2, plugins: { [PLUGIN_KEY]: [null] } }),
+      );
+      const state = runDoctor(dir, [], { CLAUDE_CONFIG_DIR: home });
+      if (state._error) {
+        fail(`#26 null plugin entry crashed doctor: ${state._error}`);
+      } else if (state.playwright_mcp?.claude === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('null entry in installed_plugins.json → warns cleanly, no crash');
+      } else {
+        fail(`#26 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
 } catch (e) {
   fail(`opencode-mcp-detection tests crashed: ${e.message}`);
 } finally {


### PR DESCRIPTION
`isPlaywrightMcpFromPlugin` destructured each entry with a `= {}` default, which only fires for `undefined`. A manifest carrying a literal `null` entry is valid JSON, and a half-written install leaves exactly that, so the destructuring threw:

```
TypeError: Cannot destructure property 'installPath' of '(intermediate value)' as it is null.
```

The cost is not the missed plugin. `doctor.mjs` is the onboarding entrypoint, so it dies before printing and every other check disappears with it - the output reads as "career-ops is broken here" rather than "one plugin is unconfigured". That is the same shape as the crash this function was added to fix in #2752, arriving through the fix itself.

## Change

Read `installPath` off the entry instead of destructuring it. One line of logic, plus the comment explaining why the obvious `= {}` form is not enough - `undefined` is covered by the default, `null` never is.

## Test

Regression case #26 in `tests/playwright-mcp-detection.test.mjs`, following the existing fixture shape in that file.

It asserts doctor still **warns**, not merely that the flag is false. A crash and a clean miss both leave `playwright_mcp.claude` false, so a flag-only assertion would have passed on the bug - the same blind spot the case exists to close.

Verified by mutation rather than assumed:

| | result |
|---|---|
| guard reverted | `#26 null plugin entry crashed doctor: Command failed: ... doctor.mjs --json --target ...` |
| guard in place | `null entry in installed_plugins.json → warns cleanly, no crash` |

Full suite: `6552 passed` before, `6553 passed` after (this adds one assertion).

The one red assertion in both runs is `set-status-tests.mjs` section 16, which is unrelated to this change and fails identically on a pristine worktree - filed separately as #3423.

Raised by CodeRabbit on #2753 and left unaddressed when that PR merged.
