### PR TITLE
test(skills): report a git failure instead of blaming the config pin

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6598,14 +6598,22 @@ console.log('\n12c. Materialized skill index mode');
     writeFileSync(join(canonicalDir, 'SKILL.md'), '---\nname: career-ops\n---\n');
 
     let staged = '';
+    // Keep the git failure: an unrelated breakage here (git missing from PATH,
+    // a corrupt fixture index) leaves `staged` empty and is then reported as
+    // "the runtime config layer is unpinned", which sends the reader to
+    // GIT_CONFIG_* pinning for a problem that has nothing to do with it. The
+    // assertion below is still the verdict; this only says why it failed.
+    let stagingError = '';
     try {
       gitRun(['add', '--', '.agents/skills/career-ops/SKILL.md']);
       staged = gitRun(['ls-files', '--', '.agents/skills/career-ops/SKILL.md']);
-    } catch {
-      // Left empty: the assertion below is the report.
+    } catch (e) {
+      stagingError = e.message;
     }
     if (staged) {
       pass('injected GIT_CONFIG_* core.excludesFile cannot reach the skill fixture (#2567)');
+    } else if (stagingError) {
+      fail(`injected GIT_CONFIG_* isolation check could not stage the fixture: ${stagingError}`);
     } else {
       fail('injected GIT_CONFIG_* core.excludesFile reached the fixture - the runtime config layer is unpinned (#2567)');
     }


### PR DESCRIPTION
The injected-`GIT_CONFIG_*` isolation check in section 12c swallowed the error from `git add` / `git ls-files` and inferred everything from `staged` coming back empty:

```js
} catch {
  // Left empty: the assertion below is the report.
}
```

Any unrelated git breakage - git absent from `PATH`, a corrupt fixture index, a permissions problem on the temp dir - lands in that same branch. The suite then reports:

> injected GIT_CONFIG_* core.excludesFile reached the fixture - the runtime config layer is unpinned (#2567)

which points whoever reads it at `GIT_CONFIG_*` pinning for a problem that has nothing to do with pinning. That is an expensive wrong turn: the pinning logic is subtle enough that someone would reasonably spend time there before suspecting their `PATH`.

## Change

Keep the message and branch on it. Three outcomes instead of two:

| condition | report |
|---|---|
| staging worked, nothing leaked | pass, unchanged |
| staging worked, fixture was reached | the original unpinned verdict, unchanged |
| staging itself failed | the real git error |

The isolation verdict is untouched in both cases where it applies. The new branch only covers the case that was previously being mislabelled.

## Verification

Exercised all three paths against the edited control flow:

```
git broken   -> FAIL(diagnostic): could not stage the fixture: git: command not found
leak (empty) -> FAIL(verdict): runtime config layer is unpinned (#2567)
healthy      -> PASS: isolation held
```

Full suite: `6552 passed`. The one red assertion is `set-status-tests.mjs` section 16, unrelated to this change, failing identically on a pristine worktree - filed separately as #3423.

Raised by CodeRabbit on #2726 and left unaddressed when that PR merged.
