### PR TITLE
test(verify-cv-facts): pin the canonical form of an ordinary decimal

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -693,6 +693,13 @@ function runSelfTest() {
   // exactly-three-digit window is for.
   equal('a decimal is not read as grouping',
     auditClaims('Cut build time to 2.5 hours', 'Cut build time to 2.5 hours.').invented, []);
+  // Assert the canonical form directly, not just that the two sides agree:
+  // the case above puts '2.5 hours' on BOTH sides of auditClaims, so a
+  // regression that stripped the period from every claim would keep them
+  // equal and stay green while silently folding 2.5 into 25. Pinning the
+  // output of normalizeClaim is what makes this case able to fail.
+  equal('an ordinary decimal survives normalization',
+    normalizeClaim('2.5 hours'), '2.5 hours');
   // A four-digit left part is a year, not a group: nothing is joined.
   equal('a year is not glued to the next number', auditClaims('Joined in 2026 100 users', foldSource).invented, ['100 users']);
 


### PR DESCRIPTION
The decimal regression case put the same string on both sides of `auditClaims`:

```js
equal('a decimal is not read as grouping',
  auditClaims('Cut build time to 2.5 hours', 'Cut build time to 2.5 hours.').invented, []);
```

So it only asserts that the two sides **agree**, not that either is right. A regression that stripped the period from every claim keeps them agreeing, and the case stays green while `2.5` silently folds into `25` - which is the exact class of number-mangling this script exists to catch.

## Change

Assert the canonical form directly, alongside the existing case rather than replacing it. The round-trip check still has value; it just cannot fail for this reason on its own.

```js
equal('an ordinary decimal survives normalization',
  normalizeClaim('2.5 hours'), '2.5 hours');
```

## Verification

Confirmed the blind spot was real rather than theoretical. With period-stripping introduced into `normalizeClaim`, the failure list contains only the new assertion:

```
FAIL: an ordinary decimal survives normalization
```

`a decimal is not read as grouping` stays green under that same mutation - it cannot see the regression, which is the whole point.

Self-test `62 passed` → `63 passed`. Full suite `6552 passed`; the one red assertion is `set-status-tests.mjs` section 16, unrelated to this change and failing identically on a pristine worktree, filed separately as #3423.

Raised by CodeRabbit on #2722 and left unaddressed when that PR merged.
