### PR TITLE
feat(application-answers): read the evaluation's Block H draft answers

### DIFF
--- a/application-answers.mjs
+++ b/application-answers.mjs
@@ -316,6 +316,64 @@ export function parseApplicationAnswersSection(reportText, { strict = false } = 
   return snapshot;
 }
 
+/**
+ * Read the evaluation mode's `## H) Draft Application Answers` block.
+ *
+ * A DIFFERENT producer and a different format from the section above.
+ * `parseApplicationAnswersSection` reads a format this module also writes, so
+ * the two halves are pinned to each other. Nothing writes Block H from code:
+ * `modes/oferta.md:622` specifies its heading and nothing about its body, so
+ * the bold-question-then-paragraph shape below is a CONVENTION the evaluation
+ * happens to emit, not a contract. This reads the convention and degrades to an
+ * empty list when it does not hold, rather than guessing: a mispaired
+ * question/answer here would be re-submitted to an employer later.
+ *
+ * Worth reading despite that, because `modes/apply.md` already treats Block H
+ * as a legitimate base for a real application ("If there is a Section H or
+ * `## Application Answers` -> load previous answers as a base"), and until now
+ * nothing in the tree could load it. An evaluated report is the one case where
+ * answers exist before any form has been seen.
+ *
+ * Returns the primary key spelling (`question`/`answer`) and omits the keys
+ * Block H cannot carry, so the result is a partial snapshot that
+ * `normalizeApplicationAnswersSnapshot` accepts as-is.
+ *
+ * @param {string} reportText Full report markdown.
+ * @returns {{freeText: object[]} | null} `null` when the report has no Block H.
+ */
+export function parseDraftAnswersBlockH(reportText) {
+  const report = String(reportText ?? '').replace(/\r\n/g, '\n');
+  const heading = /^##\s+H\)\s*Draft Application Answers\s*$/m.exec(report);
+  if (!heading) return null;
+
+  const afterHeading = heading.index + heading[0].length;
+  const nextHeading = /^## .+$/m.exec(report.slice(afterHeading));
+  const body = report.slice(
+    afterHeading,
+    nextHeading ? afterHeading + nextHeading.index : report.length,
+  );
+
+  // A question is a line that is ENTIRELY bold. Bold used mid-sentence inside an
+  // answer therefore cannot be mistaken for the start of the next question, and
+  // the italic parenthetical the mode emits under the heading is not a question.
+  const questionLine = /^\*\*(.+?)\*\*\s*$/gm;
+  const marks = [...body.matchAll(questionLine)];
+  const freeText = [];
+  for (const [index, mark] of marks.entries()) {
+    const from = mark.index + mark[0].length;
+    const to = index + 1 < marks.length ? marks[index + 1].index : body.length;
+    const question = mark[1].trim();
+    if (!question) continue;
+    const answer = body
+      .slice(from, to)
+      // A trailing horizontal rule closes the report block, it is not an answer.
+      .replace(/^\s*-{3,}\s*$/gm, '')
+      .trim();
+    freeText.push({ question, answer });
+  }
+  return { freeText };
+}
+
 export function upsertApplicationAnswersSection(reportText, snapshot = {}) {
   const report = String(reportText ?? '').replace(/\r\n/g, '\n');
   const section = formatApplicationAnswersSection(snapshot).trimEnd();
@@ -341,6 +399,7 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') args.help = true;
     else if (arg === '--read') args.read = true;
+    else if (arg === '--read-draft') args.readDraft = true;
     else if (arg === '--strict') args.strict = true;
     else if (arg.startsWith('--')) {
       const value = argv[i + 1];
@@ -358,11 +417,16 @@ function usage() {
   return [
     'Usage: node application-answers.mjs --report <report.md> --input <answers.json> [--state filled|submitted] [--date YYYY-MM-DD]',
     '       node application-answers.mjs --report <report.md> --read [--strict]',
+    '       node application-answers.mjs --report <report.md> --read-draft',
     '',
     'The input JSON may contain: freeText, selections, fieldValues, files, date, state.',
     '--read prints the parsed ## Application Answers snapshot as JSON (null when the section is absent).',
     '--strict makes --read refuse a partially unreadable section, naming every line it could not parse,',
     'instead of skipping it. Recovery callers (modes/apply.md) want the refusal; the default stays total.',
+    '--read-draft prints the evaluation mode\'s ## H) Draft Application Answers block instead, as a partial',
+    'snapshot ({"freeText": [...]}), or null when the report has no Block H. Best-effort by construction:',
+    'modes/oferta.md fixes the heading and not the body, so an empty freeText means "drafted, unreadable",',
+    'which is why --strict does not apply to it.',
   ].join('\n');
 }
 
@@ -382,6 +446,29 @@ async function main() {
   if (args.strict && !args.read) {
     console.error(`--strict only applies to --read.\n\n${usage()}`);
     process.exitCode = 1;
+    return;
+  }
+  if (args.read && args.readDraft) {
+    console.error(`--read and --read-draft print different sections; pass one.\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.readDraft) {
+    if (args.input || args.state || args.date) {
+      console.error(`--read-draft is read-only and takes no --input, --state or --date.\n\n${usage()}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!args.report) {
+      console.error(usage());
+      process.exitCode = 1;
+      return;
+    }
+    // No strict counterpart on purpose. Block H's body is a convention, not a
+    // format this module writes, so "I could not read a line" is an expected
+    // outcome rather than a corrupted report worth refusing over.
+    const reportText = readFileSync(resolve(args.report), 'utf-8');
+    console.log(JSON.stringify(parseDraftAnswersBlockH(reportText), null, 2));
     return;
   }
   if (args.read) {

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -136,7 +136,15 @@ If a field matches, warn the candidate BEFORE generating or filling an answer fo
 
    - **Exit 0** → the JSON on stdout is the base snapshot of previous answers. `null` means the report has no section; treat it as a fresh application.
    - **Non-zero exit** → the section is partially unreadable and strict mode refused it, naming every unreadable line on stderr. Do NOT fall back to reading the section as prose, and do NOT proceed with a partial base — a silently dropped answer looks like an answer the candidate never gave, and an absorbed one corrupts an answer they did give. Show the candidate the named lines and ask whether to fix the report first or continue without the affected answers.
-   - A legacy **Section H** (reports that predate `## Application Answers`) has no structured reader; use it as prose context only and tell the candidate that is what it is.
+   - A **Section H** (`## H) Draft Application Answers`, drafted during evaluation before any form was seen) has its own reader, because its body is a convention rather than a format this repo writes:
+
+     ```bash
+     node application-answers.mjs --report reports/NNN-company-role-date.md --read-draft
+     ```
+
+     - Prints `{"freeText": [...]}`, or `null` when the report has no Block H. There is no `--strict` counterpart: an empty `freeText` means the block exists but did not follow the convention, which is an expected outcome and not a corrupted report.
+     - Prefer `## Application Answers` when both exist. Block H is what the evaluation *drafted*, not what the candidate actually sent.
+     - An empty `freeText` on a Block H that clearly has content is the one case to fall back to prose. Say that is what you are doing.
 5. If there is NO match → notify and offer to run a quick auto-pipeline
 
 ## Step 3 — Detect changes in the role

--- a/tests/application-answers-block-h.test.mjs
+++ b/tests/application-answers-block-h.test.mjs
@@ -1,0 +1,199 @@
+// tests/application-answers-block-h.test.mjs - Block H is a convention, not a format.
+//
+// `parseApplicationAnswersSection` reads a format this same module writes, so
+// the two halves are pinned to each other and a round-trip test is meaningful.
+// Block H has no writer in the tree: `modes/oferta.md:622` specifies the heading
+// and says nothing about the body, so the bold-question-then-paragraph shape is
+// something the evaluation happens to emit. There is no fixed point to assert.
+//
+// What is asserted instead is that the parser stays inside the block and never
+// invents a pairing, because a mispaired question/answer does not fail loudly:
+// it gets re-submitted to an employer as if the candidate wrote it.
+//
+//   - the four ways a naive parser over-reads: the italic parenthetical under
+//     the heading, bold used mid-sentence inside an answer, the horizontal rule
+//     that closes the block, and the next `## ` section;
+//
+//   - absence versus unreadability. No Block H returns null; a Block H whose
+//     body does not follow the convention returns an empty list. A caller has to
+//     be able to tell "nothing was drafted" from "something was drafted and I
+//     could not read it", and collapsing both to null hides the second one;
+//
+//   - the handoff. The result is a partial snapshot, so it must survive being
+//     passed straight to formatApplicationAnswersSection, which is the only
+//     reason to parse it at all (modes/apply.md loads Block H as a base).
+//
+// Anti-vacuity: the fixture is asserted to produce entries before any claim
+// about what it excluded, otherwise every exclusion assertion passes trivially.
+
+import { pass, fail, run, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\napplication-answers.mjs - Block H draft answers parse into question/answer pairs');
+
+try {
+  const {
+    formatApplicationAnswersSection,
+    parseDraftAnswersBlockH,
+  } = await import(pathToFileURL(join(ROOT, 'application-answers.mjs')).href);
+
+  // Every over-read trap in one fixture: the parenthetical, an answer carrying
+  // bold mid-sentence, a multi-line answer, the closing rule, and a following
+  // `## ` section whose body would look like an answer if the block leaked.
+  const report = [
+    '# Evaluation: Acme',
+    '',
+    '## G) Posting Legitimacy',
+    'Tier 1.',
+    '',
+    '## H) Draft Application Answers',
+    '',
+    '*(Score is 4.6/5, drafting the generic question set.)*',
+    '',
+    '**Why are you interested in this role?**',
+    'Because the mandate matches what I have been building toward.',
+    '',
+    'A second paragraph that belongs to the same answer.',
+    '',
+    '**Tell us about a relevant project.**',
+    'I tech-led a design system, including its **token** layer.',
+    '',
+    '---',
+    '',
+    '## Keywords extracted',
+    '**design systems**',
+    'Not an answer.',
+  ].join('\n');
+
+  const parsed = parseDraftAnswersBlockH(report);
+
+  // Anti-vacuity gate. Everything below asserts what the parser did NOT take,
+  // which is satisfied by a parser that takes nothing at all.
+  if (!parsed || parsed.freeText.length !== 2) {
+    fail(`Block H fixture did not yield its two questions: ${JSON.stringify(parsed)}`);
+  } else {
+    const [first, second] = parsed.freeText;
+    const checks = [
+      [first.question === 'Why are you interested in this role?', 'first question text'],
+      [
+        first.answer === 'Because the mandate matches what I have been building toward.\n\nA second paragraph that belongs to the same answer.',
+        'a multi-line answer keeps its paragraph break',
+      ],
+      [
+        !parsed.freeText.some((entry) => entry.question.startsWith('(')),
+        'the italic parenthetical under the heading is a note to the reader, not a question',
+      ],
+      [
+        second.answer === 'I tech-led a design system, including its **token** layer.',
+        'bold used mid-sentence stays inside the answer it belongs to',
+      ],
+      [
+        !second.answer.includes('---'),
+        'the horizontal rule closing the block is not part of the last answer',
+      ],
+      [
+        !JSON.stringify(parsed).includes('Keywords extracted') && !JSON.stringify(parsed).includes('Not an answer'),
+        'the block stops at the next `## ` heading',
+      ],
+    ];
+    const broken = checks.filter(([ok]) => !ok).map(([, detail]) => detail);
+    if (broken.length === 0) {
+      pass('Block H parser reads the convention without over-reading it');
+    } else {
+      fail(`Block H parser over-read:\n  ${broken.join('\n  ')}\n  got: ${JSON.stringify(parsed)}`);
+    }
+  }
+
+  // Absence and unreadability are different answers to different questions.
+  const noBlock = parseDraftAnswersBlockH('# Evaluation: Acme\n\n## A) Role\nBody.\n');
+  const unreadable = parseDraftAnswersBlockH(
+    '## H) Draft Application Answers\n\nThe evaluation wrote prose here instead.\n',
+  );
+  if (noBlock === null && unreadable !== null && unreadable.freeText.length === 0) {
+    pass('Block H parser separates "nothing was drafted" from "drafted, but unreadable"');
+  } else {
+    fail(
+      `Block H absence/unreadability collapsed: absent=${JSON.stringify(noBlock)} ` +
+      `unreadable=${JSON.stringify(unreadable)}`,
+    );
+  }
+
+  // A drafted-but-unanswered question is still a question the UI has to show.
+  const empty = parseDraftAnswersBlockH('## H) Draft Application Answers\n\n**Why us?**\n');
+  if (empty?.freeText.length === 1 && empty.freeText[0].answer === '') {
+    pass('Block H parser keeps a question whose answer was left blank');
+  } else {
+    fail(`Block H parser dropped an unanswered question: ${JSON.stringify(empty)}`);
+  }
+
+  // Windows line endings are the same report.
+  const crlf = parseDraftAnswersBlockH(report.replace(/\n/g, '\r\n'));
+  if (JSON.stringify(crlf) === JSON.stringify(parsed)) {
+    pass('Block H parser reads CRLF reports identically');
+  } else {
+    fail(`Block H parser disagreed with itself on CRLF input: ${JSON.stringify(crlf)}`);
+  }
+
+  // The point of parsing: modes/apply.md loads Block H as a base, which means
+  // handing the result to the formatter. A shape the formatter drops is useless.
+  const rendered = formatApplicationAnswersSection(parsed);
+  if (
+    rendered.includes('Why are you interested in this role?') &&
+    rendered.includes('Tell us about a relevant project.')
+  ) {
+    pass('Block H output is a partial snapshot the formatter accepts as-is');
+  } else {
+    fail(`formatApplicationAnswersSection dropped the Block H snapshot:\n${rendered}`);
+  }
+
+  // The CLI seam. modes/apply.md drives this module by shelling out, so an
+  // export nothing can reach from a mode is unreachable where it is needed.
+  const cliTmp = mkdtempSync(join(tmpdir(), 'block-h-cli-'));
+  try {
+    const reportPath = join(cliTmp, 'report.md');
+    const noBlockPath = join(cliTmp, 'no-block.md');
+    writeFileSync(reportPath, report, 'utf-8');
+    writeFileSync(noBlockPath, '# Evaluation: Acme\n\n## A) Role\nBody.\n', 'utf-8');
+
+    // stderr is piped, not inherited: the refusals below fail BY DESIGN and
+    // their messages belong in the assertion, not in the suite's output.
+    const cli = (...extra) =>
+      run('node', ['application-answers.mjs', ...extra], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const cliChecks = [];
+
+    const draftOut = cli('--report', reportPath, '--read-draft');
+    cliChecks.push([
+      draftOut !== null && JSON.stringify(JSON.parse(draftOut)) === JSON.stringify(parsed),
+      '--read-draft must print exactly what the library parse returns',
+    ]);
+
+    cliChecks.push([
+      cli('--report', noBlockPath, '--read-draft') === 'null',
+      '--read-draft on a report without Block H must print null',
+    ]);
+
+    cliChecks.push([
+      cli('--report', reportPath, '--read-draft', '--read') === null,
+      '--read-draft and --read print different sections, so together they must be refused',
+    ]);
+
+    cliChecks.push([
+      cli('--report', reportPath, '--read-draft', '--strict') === null,
+      '--strict has no Block H meaning and must be refused rather than silently ignored',
+    ]);
+
+    const broken = cliChecks.filter(([ok]) => !ok).map(([, detail]) => detail);
+    if (broken.length === 0) {
+      pass('CLI --read-draft exposes the Block H parser at the seam apply mode calls');
+    } else {
+      fail(`CLI Block H read path broken:\n  ${broken.join('\n  ')}`);
+    }
+  } finally {
+    rmSync(cliTmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
+} catch (e) {
+  fail(`Block H draft answer tests crashed: ${e.stack || e.message}`);
+}


### PR DESCRIPTION
## What does this PR do?

Gives `## H) Draft Application Answers` a structured reader (`parseDraftAnswersBlockH`), exposed at the CLI seam as `--read-draft`. `modes/apply.md` already treats Block H as a legitimate base for a real application, but its own text said Section H "has no structured reader; use it as prose context only" — an evaluated report is the one case where answers exist before any form has been seen, and nothing could load them.

**1 of 3 PRs that #2998 was split into**, on @santifer's routing note in #2994. This is the core half and depends on nothing. The other two are the planner extraction and the panel; neither is required for this to land.

## Related issue

Refs #2994. Deliberately not `Closes` — this is one part of that issue.

## Why it is weaker than its sibling, on purpose

`parseApplicationAnswersSection` reads a format this same module writes, so the two halves are pinned to each other and a fixed point is meaningful. Block H has no writer in the tree: `modes/oferta.md:622` fixes the heading and says nothing about the body, so the bold-question-then-paragraph shape is a **convention** the evaluation happens to emit, not a contract.

So this reads the convention and degrades to an empty list rather than guessing. A mispaired question and answer does not fail loudly here; it gets re-submitted to an employer as if the candidate wrote it.

That is also why there is no `--strict` counterpart. For Block H, "I could not read a line" is an expected outcome rather than a corrupted report worth refusing over. `null` (no block) and `{"freeText": []}` (a block that did not follow the convention) are kept distinct so a caller can tell those two apart.

## Shape

Returns the primary key spelling and omits the keys Block H cannot carry, so the result is a partial snapshot `normalizeApplicationAnswersSnapshot` accepts and `formatApplicationAnswersSection` renders unchanged. That handoff is pinned by a test, since it is the only reason to parse the block at all.

## Tests

`tests/application-answers-block-h.test.mjs`, in its own file per CONTRIBUTING.md rather than appended to `test-all.mjs`. Covers the four ways a naive parser over-reads (the italic parenthetical under the heading, bold used mid-sentence inside an answer, the closing horizontal rule, the next `## ` section), absence versus unreadability, a drafted-but-blank answer, CRLF, the handoff to the formatter, and the CLI seam including both refusals.

Mutation-checked: loosening the question regex to match bold anywhere produces a phantom question named `token` out of an answer's mid-sentence bold, and the suite catches it.

- `node test-all.mjs` → 6564 passed, 0 failed (11 warnings, all pre-existing and upstream's own)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (#2994)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (system-layer files only)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reading draft application answers from evaluation reports.
  - Added a `--read-draft` command-line option that outputs extracted answers as JSON.
  - Handles missing sections and unanswered questions gracefully.

- **Documentation**
  - Documented the draft-answer reading workflow, fallback behavior, and precedence rules.

- **Bug Fixes**
  - Improved compatibility with varied report formatting, including multiline answers and different line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->