### PR TITLE
refactor(web): lift the apply planner out of the prefill route

### DIFF
--- a/web/src/app/api/apply/prefill/route.ts
+++ b/web/src/app/api/apply/prefill/route.ts
@@ -1,9 +1,10 @@
-import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { getSession } from "@/lib/apply/session";
+import { buildAnswerPrompt } from "@/lib/apply/answer-prompt.mjs";
+import { runPlanner } from "@/lib/apply/planner";
 import { extractJsonObject } from "@/lib/extract-json-object.mjs";
 
 export const runtime = "nodejs";
@@ -67,76 +68,21 @@ export async function POST(req: Request) {
       if (!resolved) return fail(`CLI '${cliId}' not found on this machine`);
       const { spec, binPath } = resolved;
 
-      const fieldsList = s.fields
-        .map((f) => `${f.id}\t${f.type}${f.required ? "*" : ""}\t${f.label}${f.options ? `\t[options: ${f.options.join(" | ")}]` : ""}`)
-        .join("\n");
       const mem = readMemory().trim();
-      const prompt = `You are pre-filling a job application for the user (company/role: ${s.title}). Read cv.md and config/profile.yml; if a matching report for this company exists in reports/, read it too. Ground EVERY answer in the REAL candidate — never invent facts.${mem ? `\n\nDurable notes about the user:\n${mem}` : ""}
-
-FIELDS (id ⇥ type ⇥ label ⇥ options):
-${fieldsList}
-
-For each field give the best answer:
-- identity/contact (name, email, phone, github, linkedin, location) → from profile/cv.
-- free-text (Why us?, cover-letter, "most impactful thing you've built", etc.) → a concise, honest, concrete answer in the candidate's own voice (no buzzwords, active voice, real metrics only). Keep each under ~120 words.
-- select/radio → choose the best-matching option using the EXACT option text from the list.
-- NEVER fill legal / visa / work-authorization / salary / demographic / sensitive fields → set needs_confirmation:true and value:"".
-
-Output ONLY a compact JSON object mapping each field id → {"value": "...", "needs_confirmation": boolean}. No prose, no markdown, no code fence.`;
+      const prompt = buildAnswerPrompt({ title: s.title, fields: s.fields, memory: mem });
 
       log(`Form: "${s.title}" · ${s.fields.length} fields · prompt ${prompt.length} chars · memory ${mem.length} chars`);
       log(`Planner: ${cliId} (${binPath})`);
 
-      const isClaude = cliId === "claude";
-      // --strict-mcp-config with no --mcp-config = load ZERO MCP servers → much
-      // faster startup (skips the user's global playwright/gmail/linear/… servers
-      // the planner doesn't need; it only reads local files).
-      const args = isClaude
-        ? ["-p", prompt, "--permission-mode", "acceptEdits", "--strict-mcp-config", "--allowedTools", "Read,Glob,Grep", "--disallowedTools", "Bash,Write,Edit,NotebookEdit,Task,WebFetch,WebSearch"]
-        : spec.args(prompt);
-      // Scale the timeout with form size (big forms = more drafting). Cap < maxDuration.
-      const killMs = Math.min(300_000, 150_000 + s.fields.length * 6_000);
-      log(`Spawning planner (timeout ${Math.round(killMs / 1000)}s)…`);
-
-      const result = await new Promise<{ buf: string; code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-        // spawnHeadlessCli closes stdin right after spawning, so the CLI doesn't
-        // wait on piped input that will never arrive.
-        const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: process.env });
-        let buf = "";
-        let firstByteAt = 0;
-        const hb = setInterval(() => {
-          log(`…running ${Math.round((Date.now() - t0) / 1000)}s · ${buf.length} chars received`);
-        }, 4000);
-        child.stdout.on("data", (d: Buffer) => {
-          if (!firstByteAt) {
-            firstByteAt = Date.now();
-            log(`first output byte at ${Math.round((firstByteAt - t0) / 1000)}s`);
-          }
-          buf += d.toString();
-        });
-        child.stderr.on("data", (d: Buffer) => {
-          const e = d.toString().trim();
-          if (e) log(`stderr: ${e.slice(0, 160).replace(/\s+/g, " ")}`);
-        });
-        const killer = setTimeout(() => {
-          log("TIMEOUT reached → SIGTERM");
-          try {
-            child.kill("SIGTERM");
-          } catch {
-            /* ignore */
-          }
-        }, killMs);
-        child.on("close", (code, signal) => {
-          clearTimeout(killer);
-          clearInterval(hb);
-          resolve({ buf, code, signal });
-        });
-        child.on("error", (e) => {
-          clearTimeout(killer);
-          clearInterval(hb);
-          log(`spawn error: ${e.message}`);
-          resolve({ buf, code: null, signal: null });
-        });
+      const result = await runPlanner({
+        cliId,
+        spec,
+        binPath,
+        prompt,
+        fieldCount: s.fields.length,
+        cwd: careerOpsRoot(),
+        t0,
+        log,
       });
 
       log(`Planner exited code=${result.code} signal=${result.signal} · ${result.buf.length} chars total`);

--- a/web/src/lib/apply/answer-prompt.mjs
+++ b/web/src/lib/apply/answer-prompt.mjs
@@ -1,0 +1,49 @@
+/**
+ * answer-prompt.mjs - build the planner's pre-fill instruction from a form.
+ *
+ * Plain .mjs with no imports, for the same reason extract-json-object.mjs is:
+ * the prompt is the part of apply/prefill that decides what the model is
+ * allowed to answer, and it was unreachable by a test while it lived inline in
+ * the route. The sensitive-field carve-out on the fourth bullet is the line that
+ * matters - it is what keeps legal, visa, work-authorization, salary and
+ * demographic questions from being auto-filled - and nothing pinned it.
+ *
+ * Moved verbatim from api/apply/prefill/route.ts. The wording, the
+ * tab-separated field list and the arrows are the prompt the planner has been
+ * receiving all along; this is a relocation, not a rewrite.
+ */
+
+/**
+ * One form control, as much of it as the prompt needs. Structurally satisfied by
+ * ApplyField, without importing it: extract.ts pulls in playwright-core, and a
+ * module that does cannot be loaded by `node --test`.
+ *
+ * @typedef {Object} PromptField
+ * @property {string} id
+ * @property {string} type
+ * @property {string} label
+ * @property {boolean} [required]
+ * @property {string[]} [options]
+ */
+
+/**
+ * @param {{title: string, fields: PromptField[], memory?: string}} opts
+ * @returns {string}
+ */
+export function buildAnswerPrompt({ title, fields, memory = "" }) {
+  const fieldsList = fields
+    .map((f) => `${f.id}\t${f.type}${f.required ? "*" : ""}\t${f.label}${f.options ? `\t[options: ${f.options.join(" | ")}]` : ""}`)
+    .join("\n");
+  return `You are pre-filling a job application for the user (company/role: ${title}). Read cv.md and config/profile.yml; if a matching report for this company exists in reports/, read it too. Ground EVERY answer in the REAL candidate — never invent facts.${memory ? `\n\nDurable notes about the user:\n${memory}` : ""}
+
+FIELDS (id ⇥ type ⇥ label ⇥ options):
+${fieldsList}
+
+For each field give the best answer:
+- identity/contact (name, email, phone, github, linkedin, location) → from profile/cv.
+- free-text (Why us?, cover-letter, "most impactful thing you've built", etc.) → a concise, honest, concrete answer in the candidate's own voice (no buzzwords, active voice, real metrics only). Keep each under ~120 words.
+- select/radio → choose the best-matching option using the EXACT option text from the list.
+- NEVER fill legal / visa / work-authorization / salary / demographic / sensitive fields → set needs_confirmation:true and value:"".
+
+Output ONLY a compact JSON object mapping each field id → {"value": "...", "needs_confirmation": boolean}. No prose, no markdown, no code fence.`;
+}

--- a/web/src/lib/apply/planner.ts
+++ b/web/src/lib/apply/planner.ts
@@ -1,0 +1,103 @@
+import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
+import type { CliSpec } from "@/lib/clis";
+
+/**
+ * planner.ts - spawn the read-only planner CLI and collect what it wrote.
+ *
+ * Moved out of api/apply/prefill/route.ts unchanged. The route is a streaming
+ * NDJSON handler wrapped around ~50 lines that are not about streaming at all:
+ * choosing the CLI's argv, scaling the kill timer to the form size, and draining
+ * stdout/stderr with a heartbeat. Those are planner concerns, and a second
+ * caller cannot reuse them while they sit inside a ReadableStream's start().
+ *
+ * Everything here is a relocation. The argv, the Claude carve-out and its
+ * reasoning, the timeout formula, the heartbeat interval, and the resolve-on-
+ * error behaviour are byte-for-byte what the route did.
+ */
+
+/**
+ * One form control, as much of it as the planner needs. Structurally satisfied
+ * by ApplyField; kept separate so this module does not import extract.ts and
+ * with it playwright-core.
+ */
+export type PlannerField = {
+  id: string;
+  type: string;
+  label: string;
+  required?: boolean;
+  options?: string[];
+};
+
+/**
+ * A finished planner run. `code: null` with `signal: null` means the spawn
+ * itself failed; the caller decides whether that is fatal, which is why this
+ * resolves rather than rejecting.
+ */
+export type PlannerRun = { buf: string; code: number | null; signal: NodeJS.Signals | null };
+
+export function runPlanner(opts: {
+  /** Undefined is not an error here: only the Claude carve-out below reads it. */
+  cliId: string | undefined;
+  spec: CliSpec;
+  binPath: string;
+  prompt: string;
+  fieldCount: number;
+  cwd: string;
+  /** Request start, so elapsed times in the log stay relative to the same t0 the caller reports. */
+  t0: number;
+  log: (m: string) => void;
+}): Promise<PlannerRun> {
+  const { cliId, spec, binPath, prompt, fieldCount, cwd, t0, log } = opts;
+
+  const isClaude = cliId === "claude";
+  // --strict-mcp-config with no --mcp-config = load ZERO MCP servers → much
+  // faster startup (skips the user's global playwright/gmail/linear/… servers
+  // the planner doesn't need; it only reads local files).
+  const args = isClaude
+    ? ["-p", prompt, "--permission-mode", "acceptEdits", "--strict-mcp-config", "--allowedTools", "Read,Glob,Grep", "--disallowedTools", "Bash,Write,Edit,NotebookEdit,Task,WebFetch,WebSearch"]
+    : spec.args(prompt);
+  // Scale the timeout with form size (big forms = more drafting). Cap < maxDuration.
+  const killMs = Math.min(300_000, 150_000 + fieldCount * 6_000);
+  log(`Spawning planner (timeout ${Math.round(killMs / 1000)}s)…`);
+
+  return new Promise<PlannerRun>((resolve) => {
+    // spawnHeadlessCli closes stdin right after spawning, so the CLI doesn't
+    // wait on piped input that will never arrive.
+    const child = spawnHeadlessCli(binPath, args, { cwd, env: process.env });
+    let buf = "";
+    let firstByteAt = 0;
+    const hb = setInterval(() => {
+      log(`…running ${Math.round((Date.now() - t0) / 1000)}s · ${buf.length} chars received`);
+    }, 4000);
+    child.stdout.on("data", (d: Buffer) => {
+      if (!firstByteAt) {
+        firstByteAt = Date.now();
+        log(`first output byte at ${Math.round((firstByteAt - t0) / 1000)}s`);
+      }
+      buf += d.toString();
+    });
+    child.stderr.on("data", (d: Buffer) => {
+      const e = d.toString().trim();
+      if (e) log(`stderr: ${e.slice(0, 160).replace(/\s+/g, " ")}`);
+    });
+    const killer = setTimeout(() => {
+      log("TIMEOUT reached → SIGTERM");
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+    }, killMs);
+    child.on("close", (code, signal) => {
+      clearTimeout(killer);
+      clearInterval(hb);
+      resolve({ buf, code, signal });
+    });
+    child.on("error", (e) => {
+      clearTimeout(killer);
+      clearInterval(hb);
+      log(`spawn error: ${e.message}`);
+      resolve({ buf, code: null, signal: null });
+    });
+  });
+}

--- a/web/tests/lib/answer-prompt.test.mjs
+++ b/web/tests/lib/answer-prompt.test.mjs
@@ -1,0 +1,85 @@
+// buildAnswerPrompt is the instruction the read-only planner receives before it
+// drafts an answer for every field on a real application form
+// (apply/prefill/route.ts). Factored into its own .mjs for the same reason
+// extract-json-object.mjs was: no @/ alias, no Node-only deps, so it can be
+// exercised directly here. It spent its life inline in a ReadableStream's
+// start(), which is why none of this was pinned.
+//
+// The assertion that carries weight is the sensitive-field carve-out. That one
+// line is the only thing standing between an automated form-filler and a
+// fabricated answer to a visa, salary or demographic question, and it fails
+// silently: a prompt that quietly loses it still returns well-formed JSON, still
+// renders in the UI, and is wrong in a way the candidate discovers after they
+// have already submitted. The rest of the file covers the shape the planner is
+// told to read (the field table) and write (the JSON contract), since a drift
+// there means every answer comes back unusable.
+//
+// Run:  node --test tests/lib/answer-prompt.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildAnswerPrompt } from "../../src/lib/apply/answer-prompt.mjs";
+
+const FIELDS = [
+  { id: "f1", type: "text", label: "Full name", required: true },
+  { id: "f2", type: "textarea", label: "Why us?", required: false },
+  { id: "f3", type: "select", label: "Work authorization", required: true, options: ["Yes", "No"] },
+];
+
+test("the sensitive-field carve-out survives, naming every category it protects", () => {
+  const prompt = buildAnswerPrompt({ title: "Acme - Staff Engineer", fields: FIELDS });
+  for (const category of ["legal", "visa", "work-authorization", "salary", "demographic"]) {
+    assert.ok(
+      prompt.includes(category),
+      `the planner must be told never to fill ${category} fields; that instruction is gone`,
+    );
+  }
+  assert.match(prompt, /NEVER fill[^\n]*needs_confirmation:true and value:""/);
+});
+
+test("the output contract the route parses back is stated in the prompt", () => {
+  const prompt = buildAnswerPrompt({ title: "Acme", fields: FIELDS });
+  // extractJsonObject reads exactly this shape out of the planner's answer.
+  assert.match(prompt, /\{"value": "\.\.\.", "needs_confirmation": boolean\}/);
+  assert.match(prompt, /No prose, no markdown, no code fence\./);
+});
+
+test("each field becomes one tab-separated row, required marked with an asterisk", () => {
+  const prompt = buildAnswerPrompt({ title: "Acme", fields: FIELDS });
+  assert.ok(prompt.includes("f1\ttext*\tFull name"), "a required field is starred");
+  assert.ok(prompt.includes("f2\ttextarea\tWhy us?"), "an optional field is not starred");
+});
+
+test("options are appended only for the fields that have them", () => {
+  const prompt = buildAnswerPrompt({ title: "Acme", fields: FIELDS });
+  assert.ok(prompt.includes("f3\tselect*\tWork authorization\t[options: Yes | No]"));
+  // A field without options must not grow an empty bracket the model then tries
+  // to choose from.
+  assert.ok(!prompt.includes("[options: ]"));
+});
+
+test("the role title reaches the prompt, so the planner is not drafting blind", () => {
+  assert.ok(buildAnswerPrompt({ title: "Acme - Staff Engineer", fields: FIELDS }).includes("Acme - Staff Engineer"));
+});
+
+test("durable notes appear under their own heading when present, and not at all when empty", () => {
+  const withMemory = buildAnswerPrompt({ title: "Acme", fields: FIELDS, memory: "Prefers remote." });
+  assert.match(withMemory, /Durable notes about the user:\nPrefers remote\./);
+
+  // Both spellings of "no memory", since the route passes readMemory().trim().
+  for (const empty of [undefined, ""]) {
+    const without = buildAnswerPrompt({ title: "Acme", fields: FIELDS, memory: empty });
+    assert.ok(!without.includes("Durable notes about the user"), `memory=${JSON.stringify(empty)} left the heading behind`);
+  }
+});
+
+test("a form with no fields still produces a well-formed prompt", () => {
+  // openSession can hand back an empty field list; the planner should receive an
+  // empty table rather than the string "undefined".
+  const prompt = buildAnswerPrompt({ title: "Acme", fields: [] });
+  assert.ok(!prompt.includes("undefined"));
+  // The empty field list collapses to a blank line, which is what the template
+  // has always produced here. Pinned as-is rather than tidied: this PR moves the
+  // prompt, it does not reword it.
+  assert.match(prompt, /FIELDS \(id ⇥ type ⇥ label ⇥ options\):\n\n\nFor each field/);
+});


### PR DESCRIPTION
## What does this PR do?

Lifts the apply planner out of `api/apply/prefill/route.ts`. **No behaviour change.**

The route is a streaming NDJSON handler wrapped around ~50 lines that have nothing to do with streaming: building the planner's prompt, choosing the CLI's argv, scaling the kill timer to the form size, and draining stdout/stderr with a heartbeat. None of it is reachable by a second caller, or by a test, while it sits inside a `ReadableStream`'s `start()`. The route drops from 165 lines to 111.

**2 of 3 PRs that #2998 was split into**, on @santifer's routing note in #2994 — "the planner extraction should be its own PR: it changes a route that already works, and mixing a refactor of working code with a new capability makes both harder to review." Agreed, so here it is on its own.

## Related issue

Refs #2994.

## Two modules rather than one

Following the precedent `extract-json-object.mjs` set in #3142:

- **`answer-prompt.mjs`** is plain `.mjs` with no imports, because the prompt is the half worth testing and `web/`'s runner is `node --test tests/**/*.test.mjs`. A `.ts` file, or one reaching through the `@/` alias, cannot be loaded there.
- **`planner.ts`** keeps `runPlanner` and the types, since it needs `spawnHeadlessCli`.

`PlannerField` is declared structurally rather than importing `ApplyField`: `extract.ts` pulls in `playwright-core`, and a module that does is unloadable by the test runner.

## The move is verbatim

The prompt wording, the tab-separated field table, the Claude `--strict-mcp-config` carve-out and its reasoning, the `150_000 + fields * 6_000` timeout, the 4s heartbeat, and resolve-on-spawn-error are byte-for-byte what the route did.

I checked the prompt rather than asserting it: rebuilt it from the pre-change template and diffed the two across a fixture set including an empty form and non-ASCII input. Identical.

`cwd` and `t0` are passed in rather than read from module scope, so the function's inputs are visible at the call site. That is the only shape change.

## Tests

`web/tests/lib/answer-prompt.test.mjs`, 7 assertions. The one that earns its place is the **sensitive-field carve-out**: that single prompt line is what stops an automated form-filler drafting an answer to a visa, salary or demographic question, and it fails silently — a prompt that quietly loses it still returns well-formed JSON, still renders in the UI, and is wrong in a way the candidate discovers after submitting. The rest pin the field-table shape the planner is told to read and the JSON contract `extractJsonObject` parses back.

- `node test-all.mjs` → 6558 passed, 0 failed
- `web`: `npm test` → 374 passed, 0 failed
- `tsc --noEmit` → clean

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (#2994)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (system-layer files only)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved application pre-fill planning with clearer form-field instructions and support for durable notes.
  * Sensitive fields now require confirmation instead of being automatically completed.
  * Planner execution is more resilient, with improved handling for timeouts, errors, and large forms.

* **Bug Fixes**
  * Prevented malformed prompts when forms contain no fields.
  * Improved structured JSON output reliability for pre-filled answers.

* **Tests**
  * Added coverage for prompt formatting, sensitive fields, optional notes, field options, and empty forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->