### PR TITLE
fix(scan): location filter drops in-region roles via bad word boundaries

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -188,13 +188,21 @@ function normalizeKeywordList(value) {
 // only boundary-anchors 2-3 letter acronyms. Location keywords need boundaries on
 // every keyword, so they get their own compiler rather than changing title-matching
 // behaviour. Returns a predicate, mirroring compileKeyword()'s shape.
+// The boundary classes are Unicode-aware (\p{L}\p{N}, `u` flag) rather than
+// [a-z0-9]. An ASCII-only lookbehind treats every accented letter as a word
+// boundary, so a keyword can anchor in the MIDDLE of a place name: the allow
+// keyword "al," matches inside "montréal, quebec, can", because the "é" before
+// it is outside [a-z0-9]. Every non-ASCII place name is exposed the same way —
+// Bogotá, Málaga, München, São Paulo — and it fails in the dangerous direction,
+// since a stray match on an `allow` keyword admits a location the user blocks.
 function compileLocationKeyword(keyword) {
   const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const startsWord = /[a-z0-9]/.test(keyword[0]);
-  const endsWord = /[a-z0-9]/.test(keyword[keyword.length - 1]);
-  const prefix = startsWord ? '(?<![a-z0-9])' : '';
-  const suffix = endsWord ? '(?![a-z0-9])' : '';
-  const re = new RegExp(`${prefix}${escaped}${suffix}`);
+  const WORD = /[\p{L}\p{N}]/u;
+  const startsWord = WORD.test(keyword[0]);
+  const endsWord = WORD.test(keyword[keyword.length - 1]);
+  const prefix = startsWord ? '(?<![\\p{L}\\p{N}])' : '';
+  const suffix = endsWord ? '(?![\\p{L}\\p{N}])' : '';
+  const re = new RegExp(`${prefix}${escaped}${suffix}`, 'u');
   return (lower) => re.test(lower);
 }
 
@@ -224,6 +232,18 @@ export function locationHintFromUrl(url) {
   const segments = pathname.split('/').filter(Boolean);
   const jobIdx = segments.lastIndexOf('job');
   if (jobIdx === -1 || jobIdx === segments.length - 1) return '';
+  // Workday emits TWO url shapes and only one carries a location:
+  //   /job/{Location}/{Title}_{ReqId}   → segment after `job` is the location
+  //   /job/{Title}_{ReqId}              → segment after `job` is the TITLE
+  // Reading the second shape as a location is worse than having no hint at all.
+  // A job title matches no `allow` keyword, but it IS a non-empty hint, so it
+  // defeats buildLocationFilter's "nothing to judge on either field → pass"
+  // escape and the posting is rejected as out-of-region on the strength of its
+  // own title. Measured on a 1,800-row scan ledger, this silently discarded
+  // in-region roles from tenants that use the title-only shape. The location
+  // shape always has the title AFTER it, so the hint segment being the LAST
+  // segment identifies the title-only shape.
+  if (jobIdx + 1 === segments.length - 1) return '';
   let segment = segments[jobIdx + 1];
   try {
     segment = decodeURIComponent(segment);

--- a/tests/location-filter-word-boundaries.test.mjs
+++ b/tests/location-filter-word-boundaries.test.mjs
@@ -1,0 +1,95 @@
+// tests/location-filter-word-boundaries.test.mjs — the location filter must not
+// anchor a keyword inside a word, and must not mistake a job title for a location.
+//
+// Both defects below drop IN-REGION postings silently: the scanner simply never
+// writes them, so there is no skipped_* row and no counter to notice. They were
+// found by re-running a 1,800-row scan-history ledger through the filters and
+// asking which surviving rows the filter would now refuse.
+//
+// 1. ASCII-ONLY WORD BOUNDARIES. compileLocationKeyword anchored with
+//    (?<![a-z0-9]) / (?![a-z0-9]). Those classes contain no accented letter, so
+//    every accented character reads as a word boundary and a keyword can match
+//    mid-word: "al," matches inside "montréal, quebec, can". The direction of
+//    the failure matters — a stray match on an `allow` keyword ADMITS a location
+//    the user blocks, which is the opposite of what an allow-list is for.
+//
+// 2. TITLE READ AS LOCATION. locationHintFromUrl recovers a location from the
+//    path segment after /job/, for providers that report a rolled-up "N
+//    Locations" display string. Workday has two URL shapes and only one carries
+//    a location there; on /job/{Title}_{ReqId} the hint became the job title.
+//    A title matches no `allow` keyword but IS non-empty, which defeats
+//    buildLocationFilter's "nothing to judge on either field → pass" escape, so
+//    a posting with an empty location field was rejected because of its title.
+
+import { pass, fail } from './helpers.mjs';
+import { buildLocationFilter, locationHintFromUrl } from '../scan.mjs';
+
+console.log('\nLocation filter — word boundaries and URL location hints');
+
+// The boundary hole is only observable when the ALLOW list is the thing
+// deciding. `block` is evaluated first, so a config that also blocks "Canada"
+// would reject "Montréal, Quebec, CAN" for the right reason and hide the bug —
+// which is exactly how it survived. So: no block entry here, and a non-empty
+// allow list, meaning anything that is not matched by a keyword must be
+// rejected. State abbreviations anchored on the comma that FOLLOWS them are a
+// real-world config shape ("Pittsburgh PA, 15222") and the one that reaches it.
+const allowOnly = buildLocationFilter({ allow: ['United States', 'al,', 'pa,'] });
+const check = (loc, want, why) => {
+  const got = allowOnly(String(loc).toLowerCase(), '', '');
+  if (got === want) pass(`${why}: ${JSON.stringify(loc)} → ${got}`);
+  else fail(`${why}: ${JSON.stringify(loc)} → ${got}, expected ${want}`);
+};
+
+// (1) The regression. In "montréal," the keyword "al," is preceded by "é",
+// which an ASCII-only lookbehind does not count as a word character — so the
+// keyword anchors mid-word and ADMITS a location nothing in the config allows.
+check('Montréal, Quebec, CAN', false, 'keyword must not anchor after an accented letter');
+// The same keyword preceded by an ASCII letter was always handled correctly.
+// Keeping both makes the asymmetry — the actual defect — explicit.
+check('Canal, Panama', false, 'keyword must not anchor after an ASCII letter');
+
+// …and the keywords still match the strings they were written for.
+check('Pittsburgh PA, 15222', true, 'comma-terminated state abbreviation still matches');
+check('Remote - United States', true, 'plain allow keyword still matches');
+
+// `block` precedence is unchanged — asserted on its own config so it cannot
+// mask the allow-list behaviour above.
+const withBlock = buildLocationFilter({
+  allow: ['United States', 'Remote'],
+  block: ['Colombia', 'Canada'],
+});
+if (withBlock('co - remote - colombia', '', '') === false) pass('block still beats allow');
+else fail('block no longer beats allow');
+
+// (2) The URL hint must be a location or nothing — never a job title.
+const hint = (url, want, why) => {
+  const got = locationHintFromUrl(url);
+  if (got === want) pass(`${why} → ${JSON.stringify(got)}`);
+  else fail(`${why} → ${JSON.stringify(got)}, expected ${JSON.stringify(want)}`);
+};
+
+hint(
+  'https://acme.wd12.myworkdayjobs.com/careers/job/Scrum-Master---Technical-Project-Manager_R0073509',
+  '',
+  'title-only /job/ shape yields no hint',
+);
+hint(
+  'https://acme.wd12.myworkdayjobs.com/careers/job/North-Carolina/Program-Manager_R0073884',
+  'north carolina',
+  'location shape still yields the location',
+);
+hint(
+  'https://acme.wd3.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Network-Engineer_R-65193-1',
+  'hyderabad telangana india',
+  'multi-word location still yields the location',
+);
+
+// The two combine: an empty location field plus a title-only URL must fall
+// through to "nothing to judge on → pass", not be judged on the title.
+const titleOnlyUrl =
+  'https://acme.wd12.myworkdayjobs.com/careers/job/Scrum-Master---Technical-Project-Manager_R0073509';
+if (allowOnly('', titleOnlyUrl, 'Scrum Master - Technical Project Manager') === true) {
+  pass('empty location + title-only URL passes (no data is not bad data)');
+} else {
+  fail('empty location + title-only URL was rejected on the strength of its job title');
+}


### PR DESCRIPTION
Fixes #3431.

Two independent defects in the location filter, both of which **silently discard in-region postings** — no `skipped_*` row is written, so the loss leaves no trace in `data/scan-history.tsv`.

### 1. ASCII-only word boundaries in `compileLocationKeyword`

`(?<![a-z0-9])` / `(?![a-z0-9])` contain no accented letter, so every accented character reads as a word boundary and a keyword can anchor mid-word — the allow keyword `"al,"` matches inside `"montréal, quebec, can"`. It fails in the dangerous direction: a stray match on an **`allow`** keyword admits a location the config does not allow. Exposed for every non-ASCII place name (Montréal, Bogotá, Málaga, München, São Paulo).

Fixed with `\p{L}\p{N}` and the `u` flag.

### 2. `locationHintFromUrl` reads a job title as a location

Workday has two URL shapes and only one carries a location after `/job/`:

- `/job/{Location}/{Title}_{ReqId}` → location
- `/job/{Title}_{ReqId}` → **title**

On the second, the hint became the job title. A title matches no `allow` keyword but **is** non-empty, defeating `buildLocationFilter`'s `if (lower === "" && hint === "") return true` escape — so a posting with an empty location field was rejected because of its own title.

Fixed by returning `""` when the segment after `/job/` is the last segment; the location shape always has the title after it.

### Testing

Adds `tests/location-filter-word-boundaries.test.mjs` (auto-discovered, no registration needed). It **fails on `main` in three places** and passes with this change:

```
❌ keyword must not anchor after an accented letter: "Montréal, Quebec, CAN" → true, expected false
❌ title-only /job/ shape yields no hint → "scrum master technical project manager r0073509", expected ""
❌ empty location + title-only URL was rejected on the strength of its job title
```

The accented case deliberately uses an **allow-only** config: `block` is evaluated first, so a config that also blocked the country would reject the string for the right reason and hide the bug — which is how it survived. The test also asserts the unchanged behaviours alongside it (comma-terminated abbreviations still match, plain allow keywords still match, `block` still beats `allow`, and both location-carrying URL shapes still yield their location).

Also ran the existing `scan-*`, `portal-*`, `title-filter-*`, `content-filter-*` and `validate-portals-*` suites against the change: 20 suites, 0 failures.

### Scope

Behaviour change is confined to the two functions. No config format change, no new option — an existing `portals.yml` keeps working, and the fix only makes the filter stricter about where a keyword may anchor and more conservative about what counts as a location hint.

Found by re-running an ~1,800-row `scan-history.tsv` ledger back through the filters and asking which surviving rows they would now refuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location keyword matching for names containing accented and other non-ASCII characters.
  * Prevented title-only Workday job URLs from being incorrectly interpreted as location hints.
  * Ensured location filters correctly handle empty location fields and prioritize blocked matches.

* **Tests**
  * Added coverage for Unicode word boundaries, location filtering, and Workday URL patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->