### PR TITLE
fix(web): build PDF HTML from canonical CV payload

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -63,16 +63,27 @@ const DEFAULT_SECTION_TITLES = {
   skills: 'Skills',
 };
 
+/**
+ * Return whether a parsed JSON value is an object record rather than an array.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
 function isPlainObject(value) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
 }
 
-// Identity and summary are the only required content shared by every supported
-// CV shape. The remaining sections are genuinely optional (see
-// cv-sections-core.mjs), so omitted section keys must keep behaving like empty
-// arrays for CLI users and custom template packs.
+/**
+ * Enforce the smallest payload contract shared by every supported CV shape.
+ *
+ * Identity and summary are required; the remaining sections are genuinely
+ * optional (see cv-sections-core.mjs), so omitted section keys keep behaving
+ * like empty arrays for CLI users and custom template packs.
+ *
+ * @param {unknown} payload
+ * @throws {Error} When candidate identity or summary is absent or malformed.
+ */
 function validatePayload(payload) {
   if (!isPlainObject(payload)) throw new Error('CV payload must be a JSON object.');
   if (!isPlainObject(payload.candidate)) throw new Error('CV payload candidate must be an object.');
@@ -731,6 +742,10 @@ async function writeAndReport(html, absOutput, payload, extra = {}) {
   console.log(JSON.stringify(report, null, 2));
 }
 
+/**
+ * Parse CLI arguments, validate the payload, and build or preview a CV.
+ * @returns {Promise<void>}
+ */
 async function main() {
   const args = process.argv.slice(2);
 

--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -2,14 +2,15 @@
 
 // Deterministic HTML CV renderer (#557 — the HTML twin of build-cv-latex.mjs).
 //
-// The agent reads cv.md + config/profile.yml, tailors the content, and writes a
-// compact JSON payload. This script merges that payload into the resolved CV
-// template (default templates/cv-template.html; pass a path resolved by
+// The agent reads cv.md + config/profile.yml and tailors the content into a
+// compact JSON payload. A CLI caller may save that payload directly; the web
+// backend saves the agent's parsed envelope. This script merges the payload into
+// the resolved CV template (default templates/cv-template.html; pass a path resolved by
 // cv-templates.mjs to honor config-selectable templates, #1691) — it owns every
 // tag, class, and the HTML escaping,
 // so the model never has to emit the full document. That moves the PDF step's
 // output tokens from full HTML markup down to the structured JSON payload while
-// producing byte-for-byte the same ATS-safe template the agent fills today.
+// producing the same ATS-safe template for every caller.
 //
 // The script does NOT parse cv.md / YAML: the authoritative read of the source
 // files stays in the agent (same contract as build-cv-latex.mjs / modes/latex.md).
@@ -61,6 +62,27 @@ const DEFAULT_SECTION_TITLES = {
   interests: 'Interests',
   skills: 'Skills',
 };
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+// Identity and summary are the only required content shared by every supported
+// CV shape. The remaining sections are genuinely optional (see
+// cv-sections-core.mjs), so omitted section keys must keep behaving like empty
+// arrays for CLI users and custom template packs.
+function validatePayload(payload) {
+  if (!isPlainObject(payload)) throw new Error('CV payload must be a JSON object.');
+  if (!isPlainObject(payload.candidate)) throw new Error('CV payload candidate must be an object.');
+  if (typeof payload.candidate.name !== 'string' || !payload.candidate.name.trim()) {
+    throw new Error('CV payload candidate.name is required and must be a non-empty string.');
+  }
+  if (typeof payload.summary !== 'string' || !payload.summary.trim()) {
+    throw new Error('CV payload summary is required and must be a non-empty string.');
+  }
+}
 
 // Escape user text for HTML text/attribute context. Covers the five characters
 // that change meaning in markup so tailored bullets containing &, <, >, quotes
@@ -760,6 +782,7 @@ async function main() {
   let payload;
   try {
     payload = JSON.parse(await readFile(absInput, 'utf-8'));
+    validatePayload(payload);
     payload.candidate = await prepareCandidatePhoto(payload.candidate);
   } catch (err) {
     console.error(`Failed to prepare CV input: ${err.message}`);

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -1143,9 +1143,9 @@ async function generatePDF() {
     console.error('<manifest>.results.json; it exits non-zero if any document fails.');
     console.error('');
     console.error('This script only converts an already-built HTML file to PDF.');
-    console.error('The input HTML is produced by the pdf mode: the agent fills cv-template.html');
-    console.error('with content tailored to the specific job (see modes/pdf.md) — there is no');
-    console.error('mechanical markdown-to-HTML step by design. Run `/career-ops pdf` in your AI');
+    console.error('The input HTML is produced deterministically by build-cv-html.mjs from the');
+    console.error('structured payload tailored in pdf mode (see modes/pdf.md). The builder owns');
+    console.error('the template markup and HTML escaping. Run `/career-ops pdf` in your AI');
     console.error('CLI to drive the full flow end to end.');
     process.exit(1);
   }

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -211,7 +211,12 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `awards[]` | object | `title` (award name), `org` (issuing body, optional), `year` (optional). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Use it for competitive or academic distinctions (olympiad medals, hackathon wins, dean's list) that carry more signal than a thin experience section. |
 | `skills[]` | object | `category` + `items` (comma-separated string or string array). |
 
-`build-cv-html.mjs` errors out (non-zero exit) if any template placeholder is left unresolved, so a malformed payload fails loudly instead of shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.
+The HTML builder requires a top-level object, a non-empty `candidate.name`, and
+a non-empty `summary`. All CV sections are optional at the builder boundary;
+when supplied, use the array shapes shown above. The builder errors out before
+writing HTML when required content is missing. It also errors if any template
+placeholder is left unresolved, so a malformed payload fails loudly instead of
+shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.
 
 ### Markdown bold
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -15260,7 +15260,7 @@ try {
 
   // 55.6 pdf mode must never hand the agent write access (#2185).
   // The web's "pdf" agent tailors content and nothing else: it emits the CV
-  // through a <<cv-html>> envelope and the BACKEND writes every file. A write
+  // through a <<cv-payload>> envelope and the BACKEND writes every file. A write
   // grant here would be unscoped, so a prompt injection in a posting or report
   // (both enter that agent's context) could redirect it at cv.md.
   //

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -15332,9 +15332,9 @@ try {
         pass('web pdf write-scope unit suites pass (#2185)');
       } else {
         // The signal distinguishes a timeout/kill from an assertion failure —
-        // run()'s default 30s is short for six suites in one child process.
+        // run()'s default 30s is short for every discovered suite in one child.
         const killed = lastRunFailure()?.signal;
-        fail(`web pdf write-scope unit suites failed${killed ? ` (killed: ${killed})` : ''} (run: node --test ${webUnits.join(' ')})`);
+        fail(`web pdf write-scope unit suites failed${killed ? ` (killed: ${killed})` : ''} (run: node --test ${webUnits.join(' ')})${formatRunFailure()}`);
       }
 
       if (invocation && prompts) {

--- a/tests/cv-payload-validation.test.mjs
+++ b/tests/cv-payload-validation.test.mjs
@@ -4,11 +4,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { pass, fail, ROOT, rmSync } from "./helpers.mjs";
 
+/** Record one root-harness assertion without aborting the remaining cases. */
 function check(condition, message) {
   if (condition) pass(message);
   else fail(message);
 }
 
+/** Run the real builder against one isolated payload fixture. */
 function run(payload) {
   const dir = mkdtempSync(join(tmpdir(), "co-cv-payload-"));
   const input = join(dir, "payload.json");

--- a/tests/cv-payload-validation.test.mjs
+++ b/tests/cv-payload-validation.test.mjs
@@ -1,11 +1,13 @@
-import test from "node:test";
-import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { pass, fail, ROOT, rmSync } from "./helpers.mjs";
 
-const ROOT = resolve(import.meta.dirname, "..");
+function check(condition, message) {
+  if (condition) pass(message);
+  else fail(message);
+}
 
 function run(payload) {
   const dir = mkdtempSync(join(tmpdir(), "co-cv-payload-"));
@@ -19,27 +21,23 @@ function run(payload) {
   return { dir, output, result };
 }
 
-test("build-cv-html rejects missing core fields before writing HTML", () => {
-  const cases = [
-    [{}, /candidate must be an object/i],
-    [{ candidate: {} }, /candidate\.name is required/i],
-    [{ candidate: { name: "Jane" } }, /summary is required/i],
-  ];
-
-  for (const [payload, message] of cases) {
+for (const [label, payload, message] of [
+  ["missing candidate", {}, /candidate must be an object/i],
+  ["missing candidate.name", { candidate: {} }, /candidate\.name is required/i],
+  ["missing summary", { candidate: { name: "Jane" } }, /summary is required/i],
+]) {
     const { dir, output, result } = run(payload);
     try {
-      assert.notEqual(result.status, 0, JSON.stringify(payload));
-      assert.match(result.stderr, message);
-      assert.equal(existsSync(output), false, "invalid payload must not leave HTML behind");
+      check(result.status !== 0, `build-cv-html rejects ${label}`);
+      check(message.test(result.stderr), `${label} reports the required field`);
+      check(!existsSync(output), `${label} leaves no HTML behind`);
     } finally { rmSync(dir, { recursive: true, force: true }); }
   }
-});
 
-test("build-cv-html accepts the minimal valid payload with optional sections omitted", () => {
+{
   const { dir, output, result } = run({ candidate: { name: "Jane" }, summary: "Builder" });
   try {
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(existsSync(output), true);
+    check(result.status === 0, `build-cv-html accepts a minimal valid payload${result.stderr ? `: ${result.stderr.trim()}` : ""}`);
+    check(existsSync(output), "minimal valid payload writes HTML");
   } finally { rmSync(dir, { recursive: true, force: true }); }
-});
+}

--- a/tests/cv-payload-validation.test.mjs
+++ b/tests/cv-payload-validation.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+function run(payload) {
+  const dir = mkdtempSync(join(tmpdir(), "co-cv-payload-"));
+  const input = join(dir, "payload.json");
+  const output = join(dir, "cv.html");
+  writeFileSync(input, JSON.stringify(payload));
+  const result = spawnSync(process.execPath, [join(ROOT, "build-cv-html.mjs"), input, output], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  return { dir, output, result };
+}
+
+test("build-cv-html rejects missing core fields before writing HTML", () => {
+  const cases = [
+    [{}, /candidate must be an object/i],
+    [{ candidate: {} }, /candidate\.name is required/i],
+    [{ candidate: { name: "Jane" } }, /summary is required/i],
+  ];
+
+  for (const [payload, message] of cases) {
+    const { dir, output, result } = run(payload);
+    try {
+      assert.notEqual(result.status, 0, JSON.stringify(payload));
+      assert.match(result.stderr, message);
+      assert.equal(existsSync(output), false, "invalid payload must not leave HTML behind");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  }
+});
+
+test("build-cv-html accepts the minimal valid payload with optional sections omitted", () => {
+  const { dir, output, result } = run({ candidate: { name: "Jane" }, summary: "Builder" });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(output), true);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/web/README.md
+++ b/web/README.md
@@ -40,15 +40,17 @@ Open http://localhost:3000. The app reads the career-ops checkout it lives in
 - **Never auto-submits:** the apply flow drafts and prefills; submitting is
   always a human action.
 - **CV generation never asks the agent to write:** the `pdf` worker tailors your
-  CV and emits it inline in a `<<cv-html>>` envelope; the backend parses that
-  envelope, writes the HTML, and renders the PDF itself. Job postings and
+  CV and emits only structured data in a `<<cv-payload>>` envelope; the backend
+  validates and saves that payload, then `build-cv-html.mjs` deterministically
+  generates the HTML before the backend renders the PDF. Job postings and
   evaluation reports are untrusted input that reaches this agent, so the safest
   thing is for it to hold no write tool at all — on Claude Code every write-capable
   tool is disallowed for this mode (`Write`, `Edit`, `MultiEdit`, `NotebookEdit`
   and `Bash`). Other CLIs are invoked with a bare prompt and keep their own default
   tool access, so on those the agent still *holds* write tools — what the pipeline
-  guarantees is that the CV which gets rendered is the one the backend parsed out of
-  the envelope, never a file an agent wrote behind it.
+  guarantees is that the CV which gets rendered is built from the payload the
+  backend parsed out of the envelope, never HTML or a file an agent wrote behind
+  it. The shared builder remains the sole owner of markup and HTML escaping.
 - **Additive:** the web is isolated from the core's packaging, CI and release
   automation. The CLI works exactly the same without it.
 

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -10,7 +10,7 @@ import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr, killMsFo
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
-import { renderAndMarkPdf, writeCvHtml, pdfRunOutcome } from "@/lib/pdf-render.mjs";
+import { renderAndMarkPdf, pdfRunOutcome } from "@/lib/pdf-render.mjs";
 import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
 import { buildPrompt, isShellSafeCompanyName } from "@/lib/run-prompts.mjs";
 import { claudeCliArgs } from "@/lib/claude-invocation.mjs";
@@ -42,12 +42,16 @@ export async function POST(req: Request) {
 
   // These run the REAL core (modes/scripts), not just data — fail clearly if the
   // root is incomplete instead of faking it.
-  const needsScript: Record<string, string> = { evaluate: "modes/oferta.md", "fix-portal": "verify-portals.mjs", pdf: "generate-pdf.mjs" };
-  const required = needsScript[kind];
-  if (required && !fs.existsSync(path.join(careerOpsRoot(), required))) {
+  const needsScripts: Record<string, string[]> = {
+    evaluate: ["modes/oferta.md"],
+    "fix-portal": ["verify-portals.mjs"],
+    pdf: ["build-cv-html.mjs", "generate-pdf.mjs"],
+  };
+  const missing = (needsScripts[kind] ?? []).find((required) => !fs.existsSync(path.join(careerOpsRoot(), required)));
+  if (missing) {
     return new Response(
       JSON.stringify({
-        error: `This needs a complete career-ops checkout (${required}). CAREER_OPS_ROOT has data only — point it at a full checkout.`,
+        error: `This needs a complete career-ops checkout (${missing}). CAREER_OPS_ROOT has data only — point it at a full checkout.`,
       }),
       { status: 400, headers: { "Content-Type": "application/json" } },
     );
@@ -77,8 +81,8 @@ export async function POST(req: Request) {
 
   // Precompute deterministic scratch + final paths so the agent never chooses
   // its own filenames — the backend owns naming, writing (#2185) and rendering
-  // (#2172). Nothing is cleared first: writeCvHtml rewrites the HTML
-  // from this run's freshly parsed envelope before any render, and the agent is
+  // (#2172). renderAndMarkPdf writes the parsed payload and has build-cv-html.mjs
+  // write fresh HTML before every render, and the agent is
   // no longer told these paths, so a stale file cannot survive into a render.
   let pdfPaths: PdfPaths | undefined;
   if (kind === "pdf") {
@@ -151,9 +155,9 @@ export async function POST(req: Request) {
   // Decode once on the stream, not per chunk. Buffer#toString() decodes each chunk
   // independently, so a chunk boundary falling inside a multi-byte UTF-8 sequence
   // yields a replacement character and mis-decodes the bytes after it. Those bytes
-  // are the CV now (#2185) — the agent's HTML flows through cvFilter to
-  // writeCvHtml and on to the renderer — and no structural check would catch it,
-  // because the envelope markers and </html> are ASCII and still match. Setting
+  // are the CV now (#2185) — the agent's JSON flows through cvFilter to the
+  // deterministic builder and on to the renderer — and no structural check would
+  // catch the corrupted string. Setting
   // the encoding makes Node hold partial sequences across chunks.
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
@@ -238,7 +242,7 @@ export async function POST(req: Request) {
       };
       // Time-based keepalive. The stream is silent whenever the agent is thinking
       // or inside a long tool call, and in pdf mode it is silent for the whole
-      // 15-25 KB <<cv-html>> envelope (cvFilter swallows every byte). Measured
+      // <<cv-payload>> envelope (cvFilter swallows every byte). Measured
       // idle gaps on a real pdf run reached 149s — long enough for the browser or
       // a proxy to drop the connection, after which the client reports
       // "Connection error" even though the agent finished and the PDF rendered.
@@ -255,12 +259,12 @@ export async function POST(req: Request) {
           try { controller.close(); } catch { /* */ }
         }
       };
-      // pdf's CV arrives inline in a <<cv-html>> envelope instead of being written
+      // pdf's CV arrives inline in a <<cv-payload>> envelope instead of being written
       // by the agent (#2185). The filter keeps every byte for the backend while
-      // holding the 15-25 KB body out of the run log, which is the agent's
+      // holding the payload body out of the run log, which is the agent's
       // narration — see cv-envelope.mjs.
       const cvFilter = kind === "pdf" ? createCvEnvelopeFilter() : null;
-      // While the agent emits the 15-25 KB <<cv-html>> envelope, cvFilter swallows
+      // While the agent emits the <<cv-payload>> envelope, cvFilter swallows
       // every byte, so the response stream goes completely silent for as long as
       // the model takes to write the CV — a minute or more. Nothing downstream can
       // tell that from a hung request, and the browser/proxy drops the connection;
@@ -276,13 +280,6 @@ export async function POST(req: Request) {
       const sendWarnings = (warnings: string[]) => {
         for (const w of warnings) send({ type: "text", text: `⚠️ ${w}\n` });
       };
-      /** Persist the emitted CV; streams the reason and returns false on failure. */
-      const saveCv = (paths: PdfPaths, envelope: CvEnvelope) => {
-        const written = writeCvHtml({ pdfPaths: paths, html: envelope.html });
-        if (!written.ok) send({ type: "error", msg: written.error.slice(0, 200) });
-        return written.ok;
-      };
-
       // One dispatch for every structured CLI: the per-CLI knowledge (which event
       // means text/tool/status/usage) lives in run-cli-support.mjs behind
       // spec.parseEvent, so adding the next such CLI needs no change here.
@@ -295,8 +292,8 @@ export async function POST(req: Request) {
         if (ev?.text) {
           emittedText = true;
           // sendAgentText, NEVER send: pdf's CV arrives inside the agent's text as a
-          // <<cv-html>> envelope, so parsed text has to reach cvFilter too or the
-          // backend has nothing to save and the 25 KB body floods the run log (#2185).
+          // <<cv-payload>> envelope, so parsed text has to reach cvFilter too or the
+          // backend has nothing to build and the body floods the run log (#2185).
           sendAgentText(ev.text);
         }
         if (ev?.tool) send({ type: "tool", name: ev.tool });
@@ -350,7 +347,7 @@ export async function POST(req: Request) {
       // triggered run (#2172). The tracker is marked ✅ only after a CONFIRMED
       // successful render, not optimistically — same honesty-gate discipline as
       // the evaluate path below.
-      const renderPdf = async (paths: PdfPaths, format: "letter" | "a4") => {
+      const renderPdf = async (paths: PdfPaths, envelope: CvEnvelope) => {
         send({ type: "status", label: "Rendering PDF…" });
         // renderAndMarkPdf is designed to resolve, never throw — but this is
         // the one place nothing else awaits or catches this promise (cancel()
@@ -363,10 +360,11 @@ export async function POST(req: Request) {
             execPath: process.execPath,
             root: careerOpsRoot(),
             pdfPaths: paths,
-            format,
+            payload: envelope.payload,
+            format: envelope.format,
             reportNum: input,
           });
-          if (result.kind === "render-failed") {
+          if (result.kind !== "rendered") {
             send({ type: "error", msg: result.error.slice(0, 200) });
             return;
           }
@@ -450,13 +448,10 @@ export async function POST(req: Request) {
             send({ type: "error", msg: "Internal error: the pdf run passed its gate with no CV to save — please report this." });
           } else {
             sendWarnings(envelope.warnings);
-            if (saveCv(pdfPaths, envelope)) {
-              // Tracked so cancel() can defer releasing writeToken until this
-              // settles; close() happens once rendering finishes, not here.
-              pdfRenderPromise = renderPdf(pdfPaths, envelope.format);
-              return;
-            }
-            // saveCv already streamed the specific reason.
+            // Tracked so cancel() can defer releasing writeToken until this
+            // settles; close() happens once rendering finishes, not here.
+            pdfRenderPromise = renderPdf(pdfPaths, envelope);
+            return;
           }
           return close();
         }

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -20,6 +20,14 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 800; // a real oferta evaluation / pdf-mode CV tailoring + render is heavy and multi-step
 
+/**
+ * Start a dashboard CLI run and stream structured status events to the client.
+ *
+ * Validates the request and checkout prerequisites, serializes tracker-writing
+ * runs, and delegates parsed PDF payloads to the deterministic render pipeline.
+ * @param req - Request containing kind, input, and cliId.
+ * @returns A stream of status, warning, error, and completion events.
+ */
 export async function POST(req: Request) {
   let body: { kind?: string; input?: string; cliId?: string };
   try {
@@ -347,6 +355,7 @@ export async function POST(req: Request) {
       // triggered run (#2172). The tracker is marked ✅ only after a CONFIRMED
       // successful render, not optimistically — same honesty-gate discipline as
       // the evaluate path below.
+      /** Build and render one parsed CV envelope, then always close the response. */
       const renderPdf = async (paths: PdfPaths, envelope: CvEnvelope) => {
         send({ type: "status", label: "Rendering PDF…" });
         // renderAndMarkPdf is designed to resolve, never throw — but this is

--- a/web/src/lib/claude-invocation.mjs
+++ b/web/src/lib/claude-invocation.mjs
@@ -72,7 +72,7 @@ function scopeFrom(allowed) {
  * canonical artifacts (reserve-report-num.mjs / merge-tracker.mjs /
  * verify-portals.mjs), so they need Write + Bash. `readOnly` kinds produce their
  * result through the response stream and need no write tool at all — pdf emits
- * its CV in a `<<cv-html>>` envelope the backend persists (#2185), and research
+ * its CV in a `<<cv-payload>>` envelope the backend persists (#2185), and research
  * only reports.
  *
  * @type {{persisting: ToolScope, readOnly: ToolScope}}

--- a/web/src/lib/cv-envelope.mjs
+++ b/web/src/lib/cv-envelope.mjs
@@ -6,9 +6,9 @@
  * injection in a job posting or an evaluation report — both of which enter that
  * agent's context — could redirect a write to cv.md, data/applications.md or
  * .env. Rather than fence those writes, pdf mode no longer grants them: the
- * agent emits the tailored HTML inline in a `<<cv-html …>>` envelope and the
- * BACKEND persists it. That completes the arc #2182 started, which moved
- * rendering out of the agent for the same reason.
+ * agent emits the canonical modes/pdf.md JSON payload inline in a
+ * `<<cv-payload>>` envelope and the BACKEND persists it. build-cv-html.mjs
+ * remains the sole HTML writer, so web and CLI share one rendering contract.
  *
  * Plain .mjs (same pattern as pdf-paths.mjs / pdf-render.mjs) so this can be
  * unit-tested with `node --test`, no TypeScript build step.
@@ -28,15 +28,15 @@ import { PAGE_FORMATS, DEFAULT_PAGE_FORMAT } from "./page-formats.mjs";
 // that reads them, and any guard that checks them all derive from one string.
 // Restating them by hand in the prompt is how you get a rename that breaks every
 // pdf run at runtime with the whole suite still green.
-export const OPEN_MARK = "<<cv-html";
-export const CLOSE_MARK = "<</cv-html>>";
+export const OPEN_MARK = "<<cv-payload>>";
+export const CLOSE_MARK = "<</cv-payload>>";
 
 // One pattern source per marker. The closer needs two compiled flavours because
 // `exec` on a global regex advances `lastIndex` between calls, so the single-shot
 // lookup and the scanning one must not share an object; the opener is only ever
 // scanned with `matchAll`, which clones and needs just the one.
-const OPENER_SRC = String.raw`^<<cv-html(?:[ \t]+format="([^"\n]*)")?>>[ \t]*$`;
-const CLOSER_SRC = String.raw`^<<\/cv-html>>[ \t]*$`;
+const OPENER_SRC = String.raw`^<<cv-payload>>[ \t]*$`;
+const CLOSER_SRC = String.raw`^<<\/cv-payload>>[ \t]*$`;
 const OPENER = new RegExp(OPENER_SRC, "gm");
 const CLOSER = new RegExp(CLOSER_SRC, "m");
 const CLOSER_ALL = new RegExp(CLOSER_SRC, "gm");
@@ -60,18 +60,18 @@ const CLOSER_ALL = new RegExp(CLOSER_SRC, "gm");
  * capabilities invites it to test the claim.
  */
 export const CV_ENVELOPE_INSTRUCTION =
-  `Do NOT save or edit any file — the platform persists your output for you. Instead OUTPUT the finished HTML inline, between two marker lines. The first line contains only the opening marker carrying your chosen page format — \`${OPEN_MARK} format="a4">>\` or \`${OPEN_MARK} format="letter">>\`, and nothing else on that line. Choose letter for a US/Canada company, otherwise a4. Then the complete HTML document, then a final line containing only \`${CLOSE_MARK}\`. Each marker appears exactly once. Emit the WHOLE document from <!DOCTYPE html> to </html> — never abbreviate, summarize, or write "unchanged"; the platform renders exactly these bytes and nothing else.`;
+  `Do NOT save or edit any file — the platform persists your output for you. Instead OUTPUT only the complete JSON payload described by modes/pdf.md, between two marker lines. The first line contains only \`${OPEN_MARK}\`, and nothing else on that line. Then one valid JSON object, then a final line containing only \`${CLOSE_MARK}\`. Each marker appears exactly once. Set page_format to "letter" for a US/Canada company and "a4" otherwise. Include the WHOLE payload — never abbreviate, summarize, use Markdown fences, or write "unchanged". The platform parses it and passes it to build-cv-html.mjs.`;
 
 /**
  * @typedef {Object} CvEnvelope
  * @property {true} ok
- * @property {string} html - The tailored CV HTML, byte-exact as emitted.
+ * @property {Record<string, unknown>} payload - Parsed canonical CV payload.
  * @property {"a4"|"letter"} format - Page format for generate-pdf.mjs.
  * @property {string[]} warnings - Non-fatal issues to surface in the run log.
  */
 
 /**
- * Extract the tailored CV HTML and page format from an agent's full output.
+ * Extract the tailored CV payload and page format from an agent's full output.
  *
  * Returns a result rather than throwing so the caller (the /api/run close
  * handler) can route the failure through the same honesty gate as every other
@@ -82,62 +82,67 @@ export const CV_ENVELOPE_INSTRUCTION =
  */
 export function parseCvEnvelope(text) {
   if (typeof text !== "string") {
-    return { ok: false, error: "No agent output to read a CV envelope from." };
+    return { ok: false, error: "No agent output to read a CV payload envelope from." };
   }
   // Normalize CRLF once so the line-anchored markers match on a Windows stream
-  // and no stray \r rides into the HTML handed to the renderer.
+  // and no stray \r rides into the JSON handed to the builder.
   const normalized = text.replace(/\r\n/g, "\n");
 
   const openers = [...normalized.matchAll(OPENER)];
   if (openers.length === 0) {
-    return { ok: false, error: "The agent emitted no <<cv-html>> envelope, so there is no CV to render." };
+    return { ok: false, error: "The agent emitted no <<cv-payload>> envelope, so there is no CV payload to render." };
   }
   if (openers.length > 1) {
     // Choosing one would be choosing blind — an injected envelope looks exactly
     // like the real one from here.
-    return { ok: false, error: `Found ${openers.length} <<cv-html>> envelopes; refusing to guess which is the real CV.` };
+    return { ok: false, error: `Found ${openers.length} <<cv-payload>> envelopes; refusing to guess which is the real CV payload.` };
   }
 
   const opener = openers[0];
   const afterOpener = normalized.slice(opener.index + opener[0].length);
   const closer = CLOSER.exec(afterOpener);
   if (!closer) {
-    return { ok: false, error: "The <<cv-html>> envelope was never closed — the CV output is incomplete." };
+    return { ok: false, error: "The <<cv-payload>> envelope was never closed — the CV payload is incomplete." };
   }
 
   // The opener match stops before its newline and the closer starts on its own
   // line, so exactly one delimiting newline sits on each side of the body.
-  const html = afterOpener.slice(0, closer.index).replace(/^\n/, "").replace(/\n$/, "");
-  if (!html.trim()) {
-    return { ok: false, error: "The <<cv-html>> envelope was empty — no CV was tailored." };
+  const body = afterOpener.slice(0, closer.index).replace(/^\n/, "").replace(/\n$/, "");
+  if (!body.trim()) {
+    return { ok: false, error: "The <<cv-payload>> envelope was empty — no CV was tailored." };
   }
-  // A closing </html> is what distinguishes a whole document from one the agent
-  // cut off mid-emission — the realistic failure when emitting 15-25 KB inline.
-  // This belongs here, not in the caller: the caller reports THIS error string, so
-  // splitting the rule out would leave the user with a generic message.
-  if (!/<\/html\s*>/i.test(html)) {
-    return { ok: false, error: "The CV was cut off before its closing </html> tag — the output is incomplete." };
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { ok: false, error: "The <<cv-payload>> envelope did not contain valid JSON — the CV payload is incomplete or malformed." };
+  }
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+    return { ok: false, error: "The <<cv-payload>> envelope must contain one JSON object — arrays and primitive values are not CV payloads." };
   }
 
   const warnings = [];
-  const declared = opener[1];
+  const declared = parsed.page_format;
   let format = DEFAULT_PAGE_FORMAT;
-  if (declared === undefined) {
+  if (declared === undefined || declared === null || declared === "") {
     warnings.push(`The agent declared no page format; defaulting to ${DEFAULT_PAGE_FORMAT}.`);
+  } else if (typeof declared !== "string") {
+    warnings.push(`The agent declared a non-text page format; defaulting to ${DEFAULT_PAGE_FORMAT}.`);
   } else {
     const lower = declared.trim().toLowerCase();
     if (PAGE_FORMATS.has(lower)) format = lower;
     else warnings.push(`Unrecognized page format "${declared}"; defaulting to ${DEFAULT_PAGE_FORMAT}.`);
   }
 
-  return { ok: true, html, format, warnings };
+  const payload = { ...parsed, page_format: format };
+  return { ok: true, payload, format, warnings };
 }
 
 /**
  * Could `line` still become a marker once more characters arrive?
  *
  * True both while the text is a prefix of a marker (`<`, `<<c`) and once it has
- * passed one (`<<cv-html format="a4"` is still growing towards `>>`).
+ * passed one (`<<cv-payload` is still growing towards `>>`).
  *
  * @param {string} line - The unterminated final line.
  * @returns {boolean}
@@ -175,7 +180,7 @@ function completeMarker(re, s) {
  * for parsing while keeping the envelope body out of the user's run log.
  *
  * Both halves are needed at once. The route must see every byte to reconstruct
- * the CV, but streaming 15-25 KB of raw HTML into the log would bury the agent's
+ * the CV, but streaming the raw payload into the log would bury the agent's
  * actual narration. Chunk boundaries fall wherever the transport likes, so the
  * markers are matched across pushes rather than per chunk.
  *

--- a/web/src/lib/pdf-paths.mjs
+++ b/web/src/lib/pdf-paths.mjs
@@ -21,7 +21,8 @@ export function slugify(s) {
 
 /**
  * @typedef {Object} PdfPaths
- * @property {string} html - Where the backend writes the tailored HTML it parsed out of the agent's envelope (#2185).
+ * @property {string} payload - Where the backend writes the parsed JSON payload.
+ * @property {string} html - Where build-cv-html.mjs writes the tailored HTML.
  * @property {string} finalPdf - Where the backend renders the final PDF (output/cv-{candidate}-{company}-{date}.pdf).
  */
 
@@ -81,6 +82,7 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   return {
     ok: true,
     paths: {
+      payload: path.join(scratchDir, `cv-web-${input}.payload.json`),
       html: path.join(scratchDir, `cv-web-${input}.html`),
       finalPdf: path.join(root, "output", `cv-${candidateSlug}-${companySlug}-${today}.pdf`),
     },

--- a/web/src/lib/pdf-paths.mjs
+++ b/web/src/lib/pdf-paths.mjs
@@ -19,6 +19,11 @@ export function slugify(s) {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
+/** Canonical prefix shared by scratch path creation and cleanup. */
+export function pdfScratchPrefix(input) {
+  return `cv-web-${input}.`;
+}
+
 /**
  * @typedef {Object} PdfPaths
  * @property {string} payload - Where the backend writes the parsed JSON payload.
@@ -27,7 +32,7 @@ export function slugify(s) {
  */
 
 /**
- * Precompute the scratch HTML and final PDF paths for a
+ * Precompute the scratch payload, HTML, and final PDF paths for a
  * "pdf" run, so the agent never chooses its own filenames — the backend owns
  * naming, writing (#2185) and rendering. Resolves the report (for the company slug)
  * and config/profile.yml (for the candidate slug) — same naming convention
@@ -37,7 +42,7 @@ export function slugify(s) {
  * the caller (a Next.js route today) decides how to surface `ok: false`.
  *
  * Side effect: creates `.career-ops-web/pdf-tmp/` under `root` if it doesn't
- * exist yet (the backend writes the parsed envelope there, #2185) — this is
+ * exist yet (the backend writes the parsed payload there, #2185) — this is
  * NOT a pure path computation, despite the name.
  *
  * @param {string} input - The report number (e.g. "018").
@@ -78,12 +83,13 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
     }
   }
   const scratchDir = path.join(root, ".career-ops-web", "pdf-tmp");
+  const scratchPrefix = pdfScratchPrefix(input);
   fs.mkdirSync(scratchDir, { recursive: true });
   return {
     ok: true,
     paths: {
-      payload: path.join(scratchDir, `cv-web-${input}.payload.json`),
-      html: path.join(scratchDir, `cv-web-${input}.html`),
+      payload: path.join(scratchDir, `${scratchPrefix}payload.json`),
+      html: path.join(scratchDir, `${scratchPrefix}html`),
       finalPdf: path.join(root, "output", `cv-${candidateSlug}-${companySlug}-${today}.pdf`),
     },
   };

--- a/web/src/lib/pdf-paths.mjs
+++ b/web/src/lib/pdf-paths.mjs
@@ -19,7 +19,11 @@ export function slugify(s) {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-/** Canonical prefix shared by scratch path creation and cleanup. */
+/**
+ * Return the run-scoped filename prefix shared by scratch creation and cleanup.
+ * @param {string} input - The validated report selector.
+ * @returns {string}
+ */
 export function pdfScratchPrefix(input) {
   return `cv-web-${input}.`;
 }

--- a/web/src/lib/pdf-render.mjs
+++ b/web/src/lib/pdf-render.mjs
@@ -19,6 +19,7 @@ import * as yaml from "js-yaml";
 import { pdfScratchPrefix } from "./pdf-paths.mjs";
 
 export const DEFAULT_PDF_CHILD_TIMEOUT_MS = 120_000;
+const PDF_CHILD_KILL_GRACE_MS = 1_000;
 
 /**
  * @typedef {Object} PdfRunSignals
@@ -160,11 +161,14 @@ function spawnResult({ spawnFn, execPath, args, cwd, startError, timeoutMs = DEF
   return new Promise((resolve) => {
     let settled = false;
     let timeoutId;
-    /** Settle the child-process result once and cancel its outstanding timeout. */
+    let killTimeoutId;
+    let timeoutResult;
+    /** Settle the child-process result once and cancel its outstanding timers. */
     const finish = (result) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeoutId);
+      clearTimeout(killTimeoutId);
       resolve(result);
     };
     let child;
@@ -178,11 +182,21 @@ function spawnResult({ spawnFn, execPath, args, cwd, startError, timeoutMs = DEF
     let stderr = "";
     child.stdout?.on("data", (d) => { stdout += d.toString(); });
     child.stderr?.on("data", (d) => { stderr += d.toString(); });
-    child.on("close", (code) => finish({ ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() }));
-    child.on("error", (e) => finish({ ok: false, stderr: `${startError}: ${e.message}` }));
+    child.on("close", (code) => finish(timeoutResult ?? { ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() }));
+    child.on("error", (e) => {
+      // A ChildProcess can emit error when signal delivery fails as well as
+      // when spawn fails. Once timed out, only close proves it is safe for the
+      // caller to clean scratch files; keep the SIGKILL escalation armed.
+      if (timeoutResult) return;
+      finish({ ok: false, stderr: `${startError}: ${e.message}` });
+    });
     timeoutId = setTimeout(() => {
-      finish({ ok: false, stderr: `${startError}: timed out after ${timeoutMs}ms` });
-      try { child.kill?.("SIGTERM"); } catch { /* already settled as a timeout */ }
+      timeoutResult = { ok: false, stderr: `${startError}: timed out after ${timeoutMs}ms` };
+      try { child.kill?.("SIGTERM"); } catch { /* escalate below */ }
+      if (settled) return;
+      killTimeoutId = setTimeout(() => {
+        try { child.kill?.("SIGKILL"); } catch { /* close still owns settlement */ }
+      }, Math.min(PDF_CHILD_KILL_GRACE_MS, timeoutMs));
     }, timeoutMs);
   });
 }

--- a/web/src/lib/pdf-render.mjs
+++ b/web/src/lib/pdf-render.mjs
@@ -110,7 +110,11 @@ export function writeCvPayload({ pdfPaths, payload, root }) {
   }
 }
 
-/** Spawn build-cv-html.mjs, the sole HTML writer for both CLI and web paths. */
+/**
+ * Spawn build-cv-html.mjs, the sole HTML writer for CLI and web paths.
+ * @param {{spawnFn: Function, execPath: string, root: string, payload: string, html: string, template?: string, timeoutMs?: number}} args
+ * @returns {Promise<{ok: boolean, stdout?: string, stderr: string}>}
+ */
 export function spawnBuildCvHtml({ spawnFn, execPath, root, payload, html, template, timeoutMs }) {
   return spawnResult({
     spawnFn,
@@ -122,7 +126,11 @@ export function spawnBuildCvHtml({ spawnFn, execPath, root, payload, html, templ
   });
 }
 
-/** Resolve the profile-selected template through the repository's canonical resolver. */
+/**
+ * Resolve the profile-selected template through the repository's canonical CLI.
+ * @param {{spawnFn: Function, execPath: string, root: string, timeoutMs?: number}} args
+ * @returns {Promise<{ok: boolean, template: string, stderr: string}>}
+ */
 export function resolveConfiguredCvTemplate({ spawnFn, execPath, root, timeoutMs }) {
   return spawnResult({
     spawnFn,
@@ -143,10 +151,16 @@ export function resolveConfiguredCvTemplate({ spawnFn, execPath, root, timeoutMs
   });
 }
 
+/**
+ * Run one bounded child process and normalize spawn, exit, and timeout failures.
+ * @param {{spawnFn: Function, execPath: string, args: string[], cwd: string, startError: string, timeoutMs?: number}} args
+ * @returns {Promise<{ok: boolean, stdout?: string, stderr: string}>}
+ */
 function spawnResult({ spawnFn, execPath, args, cwd, startError, timeoutMs = DEFAULT_PDF_CHILD_TIMEOUT_MS }) {
   return new Promise((resolve) => {
     let settled = false;
     let timeoutId;
+    /** Settle the child-process result once and cancel its outstanding timeout. */
     const finish = (result) => {
       if (settled) return;
       settled = true;

--- a/web/src/lib/pdf-render.mjs
+++ b/web/src/lib/pdf-render.mjs
@@ -15,6 +15,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import * as yaml from "js-yaml";
 
 /**
  * @typedef {Object} PdfRunSignals
@@ -58,32 +59,87 @@ export function pdfRunOutcome({ envelope, noOutputMessage, sawError, cleanExit, 
 }
 
 /**
- * Persist the CV the agent emitted through its <<cv-html>> envelope (#2185).
+ * Persist the parsed payload that build-cv-html.mjs will consume.
  *
- * The agent emits the tailored HTML inline and the backend saves it here. The
- * chosen page format is NOT written to disk: it is already in memory and goes
- * straight to renderAndMarkPdf. A sidecar written and re-read inside one request
- * bought only a fallback branch for a state that could not occur, plus an
- * undeclared ordering dependency between these two functions.
+ * The agent emits the canonical JSON object inline and the backend saves it
+ * here. page_format remains part of that payload, while the already-normalized
+ * in-memory value is also passed to generate-pdf.mjs.
  *
  * The scratch directory is created by resolvePdfPaths earlier in the same
  * request, so this deliberately does not mkdir — a missing directory here means
  * something is wrong upstream and should surface, not be papered over.
  *
- * @param {{pdfPaths: {html: string}, html: string}} args
+ * candidate.photo is special: the deterministic builder dereferences local
+ * paths, so trusting an agent-controlled value here would turn an untrusted job
+ * posting into a backend file-read capability. Source photo settings only from
+ * the user's local profile and discard whatever the agent emitted.
+ *
+ * @param {{pdfPaths: {payload: string}, payload: Record<string, unknown>, root: string}} args
  * @returns {{ok: true} | {ok: false, error: string}} Never throws: the caller
  *   routes the failure through the same honesty gate as every other pdf failure.
  */
-export function writeCvHtml({ pdfPaths, html }) {
+export function writeCvPayload({ pdfPaths, payload, root }) {
   try {
-    fs.writeFileSync(pdfPaths.html, html, "utf8");
+    const candidate = payload.candidate && typeof payload.candidate === "object" && !Array.isArray(payload.candidate)
+      ? { ...payload.candidate }
+      : payload.candidate;
+    if (candidate && typeof candidate === "object") {
+      delete candidate.photo;
+      delete candidate.photo_style;
+      delete candidate.photoStyle;
+      try {
+        const profile = yaml.load(fs.readFileSync(path.join(root, "config", "profile.yml"), "utf8"));
+        const trusted = profile?.candidate;
+        if (trusted?.photo) candidate.photo = trusted.photo;
+        if (trusted?.photo_style) candidate.photo_style = trusted.photo_style;
+      } catch (err) {
+        if (err?.code !== "ENOENT") throw new Error(`Could not read trusted photo settings from config/profile.yml: ${err.message}`);
+      }
+    }
+    const normalized = { ...payload, candidate };
+    fs.writeFileSync(pdfPaths.payload, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
     return { ok: true };
   } catch (err) {
     // err.path when the platform gives it: a non-fs throw (an oversized-content
     // RangeError, a bad argument type) carries none, and "could not save to
     // undefined" tells the user nothing.
-    return { ok: false, error: `Could not save the tailored CV to ${err.path ?? pdfPaths.html}: ${err.message}` };
+    return { ok: false, error: `Could not save the tailored CV payload to ${err.path ?? pdfPaths.payload}: ${err.message}` };
   }
+}
+
+/** Spawn build-cv-html.mjs, the sole HTML writer for both CLI and web paths. */
+export function spawnBuildCvHtml({ spawnFn, execPath, root, payload, html }) {
+  return spawnResult({
+    spawnFn,
+    execPath,
+    args: [path.join(root, "build-cv-html.mjs"), payload, html],
+    cwd: root,
+    startError: "CV builder failed to start",
+  });
+}
+
+function spawnResult({ spawnFn, execPath, args, cwd, startError }) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    let child;
+    try {
+      child = spawnFn(execPath, args, { cwd });
+    } catch (e) {
+      finish({ ok: false, stderr: `${startError}: ${e.message}` });
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d) => { stdout += d.toString(); });
+    child.stderr?.on("data", (d) => { stderr += d.toString(); });
+    child.on("close", (code) => finish({ ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() }));
+    child.on("error", (e) => finish({ ok: false, stderr: `${startError}: ${e.message}` }));
+  });
 }
 
 /**
@@ -92,21 +148,17 @@ export function writeCvHtml({ pdfPaths, html }) {
  * @returns {Promise<{ok: boolean, stderr: string}>}
  */
 export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, format, reportNum }) {
-  return new Promise((resolve) => {
-    const child = spawnFn(
-      execPath,
+  return spawnResult({
+    spawnFn,
+    execPath,
       // --allow-reorder: a real cv.md's section order can legitimately diverge
       // from the template's fixed markup order, so this guard would otherwise
       // hard-fail every web-triggered render — same bypass a human already
       // applies manually via the CLI when this diverges.
-      [path.join(root, "generate-pdf.mjs"), html, finalPdf, `--format=${format}`, `--report=${reportNum}`, "--allow-reorder"],
-      { cwd: root },
-    );
-    let stderr = "";
-    child.stderr.on("data", (d) => { stderr += d.toString(); });
-    child.on("close", (code) => resolve({ ok: code === 0, stderr: stderr.trim() }));
-    child.on("error", (e) => resolve({ ok: false, stderr: `PDF rendering failed to start: ${e.message}` }));
-  });
+    args: [path.join(root, "generate-pdf.mjs"), html, finalPdf, `--format=${format}`, `--report=${reportNum}`, "--allow-reorder"],
+    cwd: root,
+    startError: "PDF rendering failed to start",
+  }).then(({ ok, stderr }) => ({ ok, stderr }));
 }
 
 /**
@@ -118,18 +170,16 @@ export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, form
  * @returns {Promise<{ok: boolean, data: object | null, stderr: string}>}
  */
 export function markTrackerReady({ spawnFn, execPath, root, reportNum }) {
-  return new Promise((resolve) => {
-    const child = spawnFn(execPath, [path.join(root, "mark-pdf-ready.mjs"), reportNum, "--json"], { cwd: root });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => { stdout += d.toString(); });
-    child.stderr.on("data", (d) => { stderr += d.toString(); });
-    child.on("close", (code) => {
-      let data = null;
-      try { data = JSON.parse(stdout); } catch { /* not JSON, or exited before printing any */ }
-      resolve({ ok: code === 0, data, stderr: stderr.trim() });
-    });
-    child.on("error", (e) => resolve({ ok: false, data: null, stderr: `mark-pdf-ready.mjs failed to start: ${e.message}` }));
+  return spawnResult({
+    spawnFn,
+    execPath,
+    args: [path.join(root, "mark-pdf-ready.mjs"), reportNum, "--json"],
+    cwd: root,
+    startError: "mark-pdf-ready.mjs failed to start",
+  }).then(({ ok, stdout = "", stderr }) => {
+    let data = null;
+    try { data = JSON.parse(stdout); } catch { /* not JSON, or exited before printing any */ }
+    return { ok, data, stderr };
   });
 }
 
@@ -164,7 +214,7 @@ export function cleanupPdfScratch(scratchDir, prefix) {
 
 /**
  * @typedef {Object} RenderFailedResult
- * @property {"render-failed"} kind
+ * @property {"build-failed"|"render-failed"} kind
  * @property {string} error
  */
 /**
@@ -175,25 +225,38 @@ export function cleanupPdfScratch(scratchDir, prefix) {
 /** @typedef {RenderFailedResult | RenderedResult} RenderResult */
 
 /**
- * Render the tailored HTML to a PDF, then mark the tracker's PDF column
+ * Persist the tailored payload, build HTML deterministically, render it to a
+ * PDF, then mark the tracker's PDF column
  * ready — only after the render is CONFIRMED successful, never
  * optimistically. Always cleans up scratch files, whether the render
  * succeeds or fails.
  *
- * Call after writeCvHtml for the same pdfPaths — this reads the HTML that
- * function wrote. `format` is passed in rather than read back off disk, so the two
- * no longer share a file and the only coupling left is the HTML itself.
- * @param {{spawnFn: Function, execPath: string, root: string, pdfPaths: {html: string, finalPdf: string}, format: "letter"|"a4", reportNum: string}} args
+ * @param {{spawnFn: Function, execPath: string, root: string, pdfPaths: {payload: string, html: string, finalPdf: string}, payload: Record<string, unknown>, format: "letter"|"a4", reportNum: string}} args
  * @returns {Promise<RenderResult>}
  */
-export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, format, reportNum }) {
+export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, payload, format, reportNum }) {
   const warnings = [];
+  try {
+    const written = writeCvPayload({ pdfPaths, payload, root });
+    if (!written.ok) return { kind: "build-failed", error: written.error };
 
-  const render = await spawnGeneratePdf({ spawnFn, execPath, root, html: pdfPaths.html, finalPdf: pdfPaths.finalPdf, format, reportNum });
-  cleanupPdfScratch(path.dirname(pdfPaths.html), `cv-web-${reportNum}.`);
+    const build = await spawnBuildCvHtml({
+      spawnFn,
+      execPath,
+      root,
+      payload: pdfPaths.payload,
+      html: pdfPaths.html,
+    });
+    if (!build.ok) {
+      return { kind: "build-failed", error: build.stderr || "CV HTML build failed." };
+    }
 
-  if (!render.ok) {
-    return { kind: "render-failed", error: render.stderr || "PDF rendering failed." };
+    const render = await spawnGeneratePdf({ spawnFn, execPath, root, html: pdfPaths.html, finalPdf: pdfPaths.finalPdf, format, reportNum });
+    if (!render.ok) {
+      return { kind: "render-failed", error: render.stderr || "PDF rendering failed." };
+    }
+  } finally {
+    cleanupPdfScratch(path.dirname(pdfPaths.html), `cv-web-${reportNum}.`);
   }
 
   // The PDF is the real deliverable and it already rendered successfully — a

--- a/web/src/lib/pdf-render.mjs
+++ b/web/src/lib/pdf-render.mjs
@@ -7,7 +7,7 @@
  * or career-ops.ts directly, keeping this module free of TypeScript
  * dependencies and letting tests substitute a fake child process.
  *
- * Runs generate-pdf.mjs and mark-pdf-ready.mjs as plain Node child processes
+ * Runs build-cv-html.mjs, generate-pdf.mjs, and mark-pdf-ready.mjs as plain Node child processes
  * — no agent CLI or its sandbox involved — so a browser launch never depends
  * on an interactive sandbox-escalation approval nobody is present to grant in
  * a headless/web-triggered run. The tracker is marked ✅ only after a
@@ -16,6 +16,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
+import { pdfScratchPrefix } from "./pdf-paths.mjs";
+
+export const DEFAULT_PDF_CHILD_TIMEOUT_MS = 120_000;
 
 /**
  * @typedef {Object} PdfRunSignals
@@ -108,22 +111,46 @@ export function writeCvPayload({ pdfPaths, payload, root }) {
 }
 
 /** Spawn build-cv-html.mjs, the sole HTML writer for both CLI and web paths. */
-export function spawnBuildCvHtml({ spawnFn, execPath, root, payload, html }) {
+export function spawnBuildCvHtml({ spawnFn, execPath, root, payload, html, template, timeoutMs }) {
   return spawnResult({
     spawnFn,
     execPath,
-    args: [path.join(root, "build-cv-html.mjs"), payload, html],
+    args: [path.join(root, "build-cv-html.mjs"), payload, html, ...(template ? [template] : [])],
     cwd: root,
     startError: "CV builder failed to start",
+    timeoutMs,
   });
 }
 
-function spawnResult({ spawnFn, execPath, args, cwd, startError }) {
+/** Resolve the profile-selected template through the repository's canonical resolver. */
+export function resolveConfiguredCvTemplate({ spawnFn, execPath, root, timeoutMs }) {
+  return spawnResult({
+    spawnFn,
+    execPath,
+    args: [path.join(root, "cv-templates.mjs"), "resolve", "cv"],
+    cwd: root,
+    startError: "CV template resolver failed to start",
+    timeoutMs,
+  }).then(({ ok, stdout = "", stderr }) => {
+    const template = stdout.trim();
+    return {
+      ok: ok && Boolean(template),
+      template,
+      stderr: stderr || (!template
+        ? "CV template resolver returned no path."
+        : ok ? "" : "CV template resolution failed."),
+    };
+  });
+}
+
+function spawnResult({ spawnFn, execPath, args, cwd, startError, timeoutMs = DEFAULT_PDF_CHILD_TIMEOUT_MS }) {
   return new Promise((resolve) => {
     let settled = false;
+    let timeoutId;
     const finish = (result) => {
       if (settled) return;
       settled = true;
+      clearTimeout(timeoutId);
       resolve(result);
     };
     let child;
@@ -139,6 +166,10 @@ function spawnResult({ spawnFn, execPath, args, cwd, startError }) {
     child.stderr?.on("data", (d) => { stderr += d.toString(); });
     child.on("close", (code) => finish({ ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() }));
     child.on("error", (e) => finish({ ok: false, stderr: `${startError}: ${e.message}` }));
+    timeoutId = setTimeout(() => {
+      finish({ ok: false, stderr: `${startError}: timed out after ${timeoutMs}ms` });
+      try { child.kill?.("SIGTERM"); } catch { /* already settled as a timeout */ }
+    }, timeoutMs);
   });
 }
 
@@ -147,7 +178,7 @@ function spawnResult({ spawnFn, execPath, args, cwd, startError }) {
  * @param {{spawnFn: Function, execPath: string, root: string, html: string, finalPdf: string, format: "letter"|"a4", reportNum: string}} args
  * @returns {Promise<{ok: boolean, stderr: string}>}
  */
-export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, format, reportNum }) {
+export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, format, reportNum, timeoutMs }) {
   return spawnResult({
     spawnFn,
     execPath,
@@ -158,6 +189,7 @@ export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, form
     args: [path.join(root, "generate-pdf.mjs"), html, finalPdf, `--format=${format}`, `--report=${reportNum}`, "--allow-reorder"],
     cwd: root,
     startError: "PDF rendering failed to start",
+    timeoutMs,
   }).then(({ ok, stderr }) => ({ ok, stderr }));
 }
 
@@ -169,13 +201,14 @@ export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, form
  * @param {{spawnFn: Function, execPath: string, root: string, reportNum: string}} args
  * @returns {Promise<{ok: boolean, data: object | null, stderr: string}>}
  */
-export function markTrackerReady({ spawnFn, execPath, root, reportNum }) {
+export function markTrackerReady({ spawnFn, execPath, root, reportNum, timeoutMs }) {
   return spawnResult({
     spawnFn,
     execPath,
     args: [path.join(root, "mark-pdf-ready.mjs"), reportNum, "--json"],
     cwd: root,
     startError: "mark-pdf-ready.mjs failed to start",
+    timeoutMs,
   }).then(({ ok, stdout = "", stderr }) => {
     let data = null;
     try { data = JSON.parse(stdout); } catch { /* not JSON, or exited before printing any */ }
@@ -240,12 +273,18 @@ export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, payl
     const written = writeCvPayload({ pdfPaths, payload, root });
     if (!written.ok) return { kind: "build-failed", error: written.error };
 
+    const resolved = await resolveConfiguredCvTemplate({ spawnFn, execPath, root });
+    if (!resolved.ok) {
+      return { kind: "build-failed", error: `Could not resolve the configured CV template: ${resolved.stderr}` };
+    }
+
     const build = await spawnBuildCvHtml({
       spawnFn,
       execPath,
       root,
       payload: pdfPaths.payload,
       html: pdfPaths.html,
+      template: resolved.template,
     });
     if (!build.ok) {
       return { kind: "build-failed", error: build.stderr || "CV HTML build failed." };
@@ -256,7 +295,7 @@ export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, payl
       return { kind: "render-failed", error: render.stderr || "PDF rendering failed." };
     }
   } finally {
-    cleanupPdfScratch(path.dirname(pdfPaths.html), `cv-web-${reportNum}.`);
+    cleanupPdfScratch(path.dirname(pdfPaths.html), pdfScratchPrefix(reportNum));
   }
 
   // The PDF is the real deliverable and it already rendered successfully — a

--- a/web/src/lib/run-cli-support.mjs
+++ b/web/src/lib/run-cli-support.mjs
@@ -195,7 +195,7 @@ export function parseCodexEvent(line) {
     // Newline-terminate each message: Codex sends complete messages with NO
     // trailing newline ("hello", not "hello\n"), so consecutive messages would
     // otherwise concatenate mid-line downstream. That glued narration into one
-    // run-on log line AND broke pdf mode outright — the <<cv-html>> markers are
+    // run-on log line AND broke pdf mode outright — the <<cv-payload>> markers are
     // line-anchored by design (cv-envelope.mjs, fail-closed), so an envelope
     // message following unterminated narration parsed as "no envelope" and the
     // honesty gate failed a run whose CV was fully emitted.

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -61,22 +61,22 @@ End with EXACTLY one final line: VERDICT: {0-5 signal strength}/5 — {why it he
 Target: ${input}`;
   }
   if (kind === "pdf") {
-    // The agent tailors content only — it neither renders the PDF nor saves it.
+    // The agent tailors content only — it neither builds HTML, renders, nor saves.
     // Rendering moved to the backend because launching a real browser can hit a
     // sandbox escalation nobody is present to approve (#2172); SAVING moved for a
     // different reason (#2185): tool grants are tool-name-only, so the Write/Edit
     // this step used to need was unscoped, and a prompt injection in the posting
     // or the report — both of which land in this agent's context — could aim it at
     // cv.md or data/applications.md. The agent now emits the CV inline and the
-    // backend (a plain Node process, no CLI sandbox) writes and renders it, so
+    // backend (a plain Node process, no CLI sandbox) builds and renders it, so
     // pdf mode runs with no write tool at all.
-    return `You are tailoring the user's ATS-optimized CV for application #${input}, headless, on their machine. Run the REAL career-ops "pdf" mode's CONTENT step: follow modes/pdf.md's TAILORING rules exactly (do not improvise your own scoring or format). Apply its CONTENT rules — keyword injection, ordering, the competency grid, project selection, and its never-invent-a-skill rule. Its steps that shell out (the jd-skill-gap.mjs check, template resolution) and its build/save/render steps are NOT performed on web runs; the platform handles output itself.
+    return `You are tailoring the user's ATS-optimized CV for application #${input}, headless, on their machine. Run the REAL career-ops "pdf" mode's CONTENT step: follow modes/pdf.md's TAILORING rules and JSON payload schema exactly (do not improvise your own scoring or format). Apply its CONTENT rules — keyword injection, ordering, the competency grid, project selection, and its never-invent-a-skill rule. Its steps that shell out (the jd-skill-gap.mjs check, template resolution) and its build/save/render steps are NOT performed on web runs; the platform handles output itself.
 1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md (for the JD keywords + analysis).
 2. Tailor the CV per modes/pdf.md: inject the JD's keywords into the summary + first bullets, reorder experience by relevance, build the competency grid, pick the top 3–4 projects. NEVER invent skills — only reword REAL experience using the JD's vocabulary.
-3. Fill templates/cv-template.html's {{...}} placeholders with the tailored content. Use that template even though modes/pdf.md resolves one via cv-templates.mjs: web runs always use the base template. ${CV_ENVELOPE_INSTRUCTION}
-4. Emit the envelope EXACTLY ONCE. The platform writes the HTML, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
+3. Produce the complete structured JSON payload documented in modes/pdf.md. Do not produce HTML, template placeholders, or escaped HTML entities; build-cv-html.mjs owns all HTML generation and escaping. ${CV_ENVELOPE_INSTRUCTION}
+4. Emit the envelope EXACTLY ONCE. The platform writes the payload, builds HTML with the base template, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
 
-After the envelope, end with EXACTLY one final line: VERDICT: {5 if the complete HTML envelope was emitted, else 1}/5 — {a one-line summary, ≤12 words}`;
+After the envelope, end with EXACTLY one final line: VERDICT: {5 if the complete JSON payload envelope was emitted, else 1}/5 — {a one-line summary, ≤12 words}`;
   }
   if (kind === "fix-portal") {
     return `A company's job-portal ATS slug is BROKEN — career-ops can no longer scan it, so it silently disappears from every future scan. Repair it (headless, on the user's machine):
@@ -138,4 +138,3 @@ VERDICT: {score}/5 — {reason in 12 words or fewer}
 
 Posting URL: ${input}`;
 }
-

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -74,7 +74,7 @@ Target: ${input}`;
 1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md (for the JD keywords + analysis).
 2. Tailor the CV per modes/pdf.md: inject the JD's keywords into the summary + first bullets, reorder experience by relevance, build the competency grid, pick the top 3–4 projects. NEVER invent skills — only reword REAL experience using the JD's vocabulary.
 3. Produce the complete structured JSON payload documented in modes/pdf.md. Do not produce HTML, template placeholders, or escaped HTML entities; build-cv-html.mjs owns all HTML generation and escaping. ${CV_ENVELOPE_INSTRUCTION}
-4. Emit the envelope EXACTLY ONCE. The platform writes the payload, builds HTML with the base template, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
+4. Emit the envelope EXACTLY ONCE. The platform writes the payload, resolves the CV template configured in profile.yml, builds HTML, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
 
 After the envelope, end with EXACTLY one final line: VERDICT: {5 if the complete JSON payload envelope was emitted, else 1}/5 — {a one-line summary, ≤12 words}`;
   }

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -37,6 +37,9 @@ export function isShellSafeCompanyName(name) {
 
 const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
 
+/** ISO calendar date, the only form the dashboard's POSTED column parses. */
+const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
+
 /**
  * The exact prompt each worker kind is sent.
  *
@@ -45,12 +48,9 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
  * inline instead of writing it), and a guard that greps route.ts for the marker
  * text matched the route's own comments instead. See test-all.mjs §55.6.
  *
- * @param {{kind: string, input: string, memory: string, today: string}} args
+ * @param {{kind: string, input: string, memory: string, today: string, postedAt?: string}} args
  * @returns {string}
  */
-/** ISO calendar date, the only form the dashboard's POSTED column parses. */
-const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
-
 export function buildPrompt({ kind, input, memory, today, postedAt }) {
   const mem = memory.trim() ? `\n\nDurable notes about the user (from their profile):\n${memory.trim()}\n` : "";
   if (kind === "research") {

--- a/web/tests/lib/cv-envelope.test.mjs
+++ b/web/tests/lib/cv-envelope.test.mjs
@@ -1,215 +1,93 @@
-// Tests for the pdf-mode CV envelope parser (#2185). Imports directly from
-// cv-envelope.mjs (the single source of truth) so the test and production code
-// can never drift out of sync.
-//
-// The envelope exists so the pdf-mode agent needs NO write access at all: it
-// emits the tailored HTML inline and the backend persists it. Every case here is
-// therefore a security case as much as a parsing one — anything that lets
-// unintended bytes through, or lets a malformed run look successful, puts the
-// agent back in charge of what lands on disk.
-//
-// Run:  node --test tests/lib/cv-envelope.test.mjs
-
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseCvEnvelope, createCvEnvelopeFilter } from "../../src/lib/cv-envelope.mjs";
+import { OPEN_MARK, CLOSE_MARK, parseCvEnvelope, createCvEnvelopeFilter } from "../../src/lib/cv-envelope.mjs";
 
-/** Wrap `body` in a well-formed envelope; `format: null` omits the attribute. */
-function envelope(body, format = "a4") {
-  const open = format === null ? "<<cv-html>>" : `<<cv-html format="${format}">>`;
-  return `${open}\n${body}\n<</cv-html>>`;
+const PAYLOAD = {
+  lang: "en",
+  page_format: "a4",
+  candidate: { name: "Jane", email: "jane@example.com" },
+  summary: "Built <safe> systems — 你好 & reliable",
+  competencies: ["Agents", "Evaluation"],
+};
+
+function envelope(payload = PAYLOAD) {
+  const body = typeof payload === "string" ? payload : JSON.stringify(payload, null, 2);
+  return `${OPEN_MARK}\n${body}\n${CLOSE_MARK}`;
 }
 
-const DOC = "<!DOCTYPE html>\n<html><body><h1>Jane</h1></body></html>";
-
-test("parseCvEnvelope: extracts html and format from a well-formed envelope", () => {
-  // Given an agent reply with prose, an envelope, and a trailing VERDICT line
-  const text = `Tailoring done.\n\n${envelope(DOC, "a4")}\n\nVERDICT: 5/5 — tailored`;
-
-  // When parsing it
-  const result = parseCvEnvelope(text);
-
-  // Then the html is returned byte-exact, with the declared format
+test("parseCvEnvelope extracts a JSON object and canonicalizes page format", () => {
+  const result = parseCvEnvelope(`Tailoring.\n${envelope()}\nVERDICT: 5/5 — done`);
   assert.equal(result.ok, true);
-  assert.equal(result.html, DOC);
+  assert.deepEqual(result.payload, PAYLOAD);
   assert.equal(result.format, "a4");
   assert.deepEqual(result.warnings, []);
 });
 
-test("parseCvEnvelope: accepts letter as a format", () => {
-  // Given an envelope declaring the US page size
-  const result = parseCvEnvelope(envelope(DOC, "letter"));
+test("format lives only in the payload and is normalized for builder and renderer", () => {
+  const upper = parseCvEnvelope(envelope({ ...PAYLOAD, page_format: "LETTER" }));
+  assert.equal(upper.ok, true);
+  assert.equal(upper.format, "letter");
+  assert.equal(upper.payload.page_format, "letter");
 
-  // Then letter is preserved (a US/Canada role must not silently render A4)
-  assert.equal(result.ok, true);
-  assert.equal(result.format, "letter");
+  for (const page_format of [undefined, null, "", "legal", 42]) {
+    const result = parseCvEnvelope(envelope({ ...PAYLOAD, page_format }));
+    assert.equal(result.ok, true);
+    assert.equal(result.format, "letter");
+    assert.equal(result.payload.page_format, "letter");
+    assert.equal(result.warnings.length, 1);
+  }
 });
 
-test("parseCvEnvelope: normalizes format case", () => {
-  // Given an envelope shouting the format
-  const result = parseCvEnvelope(envelope(DOC, "A4"));
-
-  // Then it is lowercased to what generate-pdf.mjs expects
+test("JSON values preserve Unicode, braces, and HTML-significant text", () => {
+  const summary = 'José — <script> & {{SUMMARY}} "quoted"';
+  const result = parseCvEnvelope(envelope({ ...PAYLOAD, summary }));
   assert.equal(result.ok, true);
-  assert.equal(result.format, "a4");
-  assert.deepEqual(result.warnings, []);
+  assert.equal(result.payload.summary, summary);
 });
 
-test("parseCvEnvelope: missing format falls back to letter with a warning", () => {
-  // Given an envelope with no format attribute
-  const result = parseCvEnvelope(envelope(DOC, null));
-
-  // Then it still renders, defaulting to letter — the value modes/pdf.md:191
-  // documents for an absent page_format — but says so out loud
-  assert.equal(result.ok, true);
-  assert.equal(result.html, DOC);
-  assert.equal(result.format, "letter");
-  assert.equal(result.warnings.length, 1);
-  assert.match(result.warnings[0], /format/i);
+test("malformed, empty, and non-object bodies fail closed", () => {
+  for (const body of ["", "{", "null", "[]", '"text"', "42", "true"]) {
+    const result = parseCvEnvelope(envelope(body));
+    assert.equal(result.ok, false, body);
+  }
 });
 
-test("parseCvEnvelope: unrecognized format falls back to letter with a warning", () => {
-  // Given an envelope naming a page size generate-pdf.mjs does not support
-  const result = parseCvEnvelope(envelope(DOC, "legal"));
-
-  // Then it degrades to the documented default rather than passing junk on
-  assert.equal(result.ok, true);
-  assert.equal(result.format, "letter");
-  assert.equal(result.warnings.length, 1);
-  assert.match(result.warnings[0], /legal/);
-});
-
-test("parseCvEnvelope: no envelope at all is a failure", () => {
-  // Given a reply where the agent talked but never emitted an envelope
-  const result = parseCvEnvelope("I tailored the CV and saved it.\n\nVERDICT: 5/5 — done");
-
-  // Then the run must fail rather than render nothing and report success
+test("missing, unterminated, mid-line, and duplicate envelopes fail closed", () => {
+  assert.equal(parseCvEnvelope("no payload").ok, false);
+  assert.equal(parseCvEnvelope(`${OPEN_MARK}\n{`).ok, false);
+  assert.equal(parseCvEnvelope(`mentions ${OPEN_MARK}\n{}\n${CLOSE_MARK}`).ok, false);
+  const result = parseCvEnvelope(`${envelope()}\n${envelope()}`);
   assert.equal(result.ok, false);
-  assert.match(result.error, /no .*envelope/i);
-});
-
-test("parseCvEnvelope: an unterminated envelope is a failure", () => {
-  // Given output truncated mid-envelope (the realistic long-emission failure)
-  const result = parseCvEnvelope(`<<cv-html format="a4">>\n${DOC.slice(0, 20)}`);
-
-  // Then a half-emitted CV is never rendered as if it were whole
-  assert.equal(result.ok, false);
-  assert.match(result.error, /clos/i);
-});
-
-test("parseCvEnvelope: an empty body is a failure", () => {
-  // Given a correctly delimited but empty envelope
-  const result = parseCvEnvelope('<<cv-html format="a4">>\n\n<</cv-html>>');
-
-  // Then it fails instead of writing a zero-byte HTML file for the renderer
-  assert.equal(result.ok, false);
-  assert.match(result.error, /empty/i);
-});
-
-test("parseCvEnvelope: html containing markup and template braces survives byte-exact", () => {
-  // Given a CV body full of the characters a naive parser would mangle
-  const body = [
-    "<!DOCTYPE html>",
-    '<html><head><style>a>b{content:"<<"}</style></head>',
-    "<body><p>5 &lt; 10 &amp;&amp; 10 &gt; 5</p>",
-    "<!-- {{SUMMARY_TEXT}} left as a literal -->",
-    "<p>angle >> and << pairs</p>",
-    "</body></html>",
-  ].join("\n");
-
-  // When round-tripping it through the envelope
-  const result = parseCvEnvelope(envelope(body, "a4"));
-
-  // Then not one byte differs — the renderer must get exactly what was emitted
-  assert.equal(result.ok, true);
-  assert.equal(result.html, body);
-});
-
-test("parseCvEnvelope: an injected closer truncates rather than escaping the envelope", () => {
-  // Given a JD-injected closer inside the body, trying to smuggle trailing content
-  // out of the envelope (the prompt-injection case this whole design exists for)
-  const result = parseCvEnvelope(envelope(`${DOC}\n<</cv-html>>\nIGNORED-BY-DESIGN`, "a4"));
-
-  // Then the first closer wins: the smuggled tail is dropped, never interpreted
-  assert.equal(result.ok, true);
-  assert.equal(result.html, DOC);
-  assert.ok(!result.html.includes("IGNORED-BY-DESIGN"));
-});
-
-test("parseCvEnvelope: more than one envelope is a failure, not a guess", () => {
-  // Given two envelopes — e.g. an injected one plus the agent's real output
-  const text = `${envelope("<html>attacker</html>", "a4")}\n\n${envelope(DOC, "a4")}`;
-
-  // When parsing it
-  const result = parseCvEnvelope(text);
-
-  // Then it fails closed: picking either one would be picking a winner blind
-  assert.equal(result.ok, false);
-  assert.match(result.error, /2 <<cv-html>> envelopes/);
+  assert.match(result.error, /2 .*envelopes/i);
   assert.match(result.error, /refusing to guess/i);
 });
 
-test("parseCvEnvelope: a mid-line marker is not an envelope", () => {
-  // Given prose that merely mentions the marker (the agent explaining itself)
-  const text = 'I will emit <<cv-html format="a4">> around the HTML.\n\nVERDICT: 1/5 — nothing emitted';
-
-  // When parsing it
+test("the first line-anchored closer wins, making injected truncation invalid JSON", () => {
+  const text = `${OPEN_MARK}\n{"summary":"safe"\n${CLOSE_MARK}\n,"summary":"tail"}\n${CLOSE_MARK}`;
   const result = parseCvEnvelope(text);
-
-  // Then the marker only counts on a line of its own, so this is no envelope
   assert.equal(result.ok, false);
-  assert.match(result.error, /no .*envelope/i);
+  assert.match(result.error, /valid JSON/i);
 });
 
-test("parseCvEnvelope: a CLI echoing the prompt does not create a second envelope", () => {
-  // Given a CLI that echoes the prompt before the model replies (codex exec does).
-  // The prompt necessarily DESCRIBES the markers, so they must only ever count at
-  // line start — otherwise the echo parses as a rival envelope and every run on
-  // that CLI fails with "found 2 envelopes".
-  const promptEcho = [
-    "user",
-    'OUTPUT the HTML between two marker lines: first a line containing exactly `<<cv-html format="a4">>`,',
-    "then the document, then a final line containing exactly `<</cv-html>>`. Each marker alone on its line.",
-    "codex",
-  ].join("\n");
-
-  // When parsing the combined stream
-  const result = parseCvEnvelope(`${promptEcho}\n${envelope(DOC, "a4")}\nVERDICT: 5/5 — done`);
-
-  // Then only the real envelope counts, and its html is intact
+test("marker spellings inside JSON strings do not alter the envelope", () => {
+  const summary = `mentions ${OPEN_MARK} and ${CLOSE_MARK} mid-line`;
+  const result = parseCvEnvelope(envelope({ ...PAYLOAD, summary }));
   assert.equal(result.ok, true);
-  assert.equal(result.html, DOC);
-  assert.equal(result.format, "a4");
+  assert.equal(result.payload.summary, summary);
 });
 
-test("parseCvEnvelope: tolerates trailing whitespace and CRLF line endings", () => {
-  // Given a CRLF-terminated stream with trailing spaces after the markers
-  const text = `<<cv-html format="letter">>  \r\n${DOC}\r\n<</cv-html>>  \r\n`;
-
-  // When parsing it
+test("CRLF and trailing marker whitespace are accepted", () => {
+  const text = envelope().replace(/\n/g, "\r\n").replace(CLOSE_MARK, `${CLOSE_MARK}  `);
   const result = parseCvEnvelope(text);
-
-  // Then the markers still match and no stray \r rides into the html
   assert.equal(result.ok, true);
-  assert.equal(result.format, "letter");
-  assert.equal(result.html, DOC);
+  assert.equal(result.payload.summary, PAYLOAD.summary);
 });
 
-test("parseCvEnvelope: a non-string input fails closed", () => {
-  // Given no output at all (a CLI that produced nothing)
-  // Then it reports failure instead of throwing inside the route's close handler
+test("non-string input fails instead of throwing", () => {
   assert.equal(parseCvEnvelope(undefined).ok, false);
   assert.equal(parseCvEnvelope(null).ok, false);
 });
 
-// ── createCvEnvelopeFilter ──────────────────────────────────────────
-//
-// The filter exists for two reasons at once: the route needs the WHOLE text to
-// parse, and the user's run log must never receive the 15-25 KB HTML body. It
-// also has to survive arbitrary chunk boundaries, because the agent's output
-// arrives as stream deltas that split wherever the transport feels like it.
-
-/** Feed `text` through a fresh filter in `size`-char chunks. */
 function feed(text, size) {
   const filter = createCvEnvelopeFilter();
   let display = "";
@@ -218,217 +96,63 @@ function feed(text, size) {
   return { display, result: filter.result() };
 }
 
-const FULL = `Tailoring the CV now.\n<<cv-html format="letter">>\n${DOC}\n<</cv-html>>\nAll set.\nVERDICT: 5/5 — tailored`;
+const FULL = `Tailoring now.\n${envelope()}\nAll set.\nVERDICT: 5/5 — tailored`;
 
-test("createCvEnvelopeFilter: whole-text push parses and hides the body", () => {
-  // Given the complete agent output arriving as one chunk
-  const filter = createCvEnvelopeFilter();
-
-  // When pushed and finished
-  const display = filter.push(FULL) + filter.flush();
-  const result = filter.result();
-
-  // Then the envelope parses...
-  assert.equal(result.ok, true);
-  assert.equal(result.html, DOC);
-  assert.equal(result.format, "letter");
-  // ...and the log shows the prose and VERDICT but not one line of the CV
-  assert.match(display, /Tailoring the CV now\./);
-  assert.match(display, /All set\./);
-  assert.match(display, /VERDICT: 5\/5/);
-  assert.ok(!display.includes("<html>"), `body leaked into display: ${JSON.stringify(display)}`);
-  assert.ok(!display.includes("Jane"), `body leaked into display: ${JSON.stringify(display)}`);
-});
-
-test("createCvEnvelopeFilter: never emits a marker, at any chunk size", () => {
-  // Given every chunk size from 1 char up to past the whole message — this is
-  // the property that matters: a split can land inside either marker
-  for (const size of [1, 2, 3, 5, 7, 11, 13, 17, 29, 64, 512, FULL.length + 10]) {
-    // When the output is fed in that chunk size
+test("stream filter hides payload and markers at every chunk size", () => {
+  for (let size = 1; size <= FULL.length + 1; size += 1) {
     const { display, result } = feed(FULL, size);
-
-    // Then the body is reassembled byte-identically...
-    assert.equal(result.ok, true, `size ${size}: parse failed`);
-    assert.equal(result.html, DOC, `size ${size}: html differs`);
-    // ...and no partial or complete marker ever reaches the log
-    assert.ok(!display.includes("<<"), `size ${size}: marker fragment leaked: ${JSON.stringify(display)}`);
-    assert.ok(!display.includes("cv-html"), `size ${size}: marker text leaked: ${JSON.stringify(display)}`);
-    assert.ok(!display.includes("Jane"), `size ${size}: body leaked: ${JSON.stringify(display)}`);
-    assert.match(display, /VERDICT: 5\/5/, `size ${size}: VERDICT lost`);
+    assert.equal(result.ok, true, `size ${size}`);
+    assert.deepEqual(result.payload, PAYLOAD, `size ${size}`);
+    assert.match(display, /Tailoring now/);
+    assert.match(display, /VERDICT: 5\/5/);
+    assert.ok(!display.includes(PAYLOAD.summary), `size ${size}: payload leaked`);
+    assert.ok(!display.includes("cv-payload"), `size ${size}: marker leaked`);
   }
 });
 
-test("createCvEnvelopeFilter: a trailing partial opener is withheld, not shown", () => {
-  // Given a stream that stops mid-marker (the flicker bug act-envelope.mjs fixes)
-  const filter = createCvEnvelopeFilter();
-
-  // When only a fragment of the opener has arrived
-  const display = filter.push("Working.\n<<cv-h");
-
-  // Then the fragment is held back — a half-written marker must never render
-  assert.match(display, /Working\./);
-  assert.ok(!display.includes("<<"), `partial marker leaked: ${JSON.stringify(display)}`);
-});
-
-test("createCvEnvelopeFilter: prose mentioning the marker mid-line still displays", () => {
-  // Given the agent narrating rather than emitting (marker not at line start)
-  const { display, result } = feed('I will use <<cv-html format="a4">> markers.\nVERDICT: 1/5 — none\n', 3);
-
-  // Then the prose is shown intact and no envelope is claimed
-  assert.match(display, /I will use <<cv-html format="a4">> markers\./);
-  assert.equal(result.ok, false);
-});
-
-test("createCvEnvelopeFilter: flush releases held text that turned out to be prose", () => {
-  // Given a stream ending on an unterminated line that merely looks marker-ish
-  const filter = createCvEnvelopeFilter();
-  const pushed = filter.push("done\n<<not-a-marker");
-
-  // When the stream ends
-  const flushed = filter.flush();
-
-  // Then the held text is released rather than silently dropped from the log
-  assert.equal(pushed + flushed, "done\n<<not-a-marker");
-});
-
-test("createCvEnvelopeFilter: result() mirrors parseCvEnvelope on the raw text", () => {
-  // Given output whose envelope is unterminated
-  const truncated = `Tailoring.\n<<cv-html format="a4">>\n${DOC.slice(0, 30)}`;
-
-  // When streamed through the filter
-  const { result } = feed(truncated, 4);
-
-  // Then the filter reports the same failure the pure parser would — one gate,
-  // not two divergent notions of "did this run produce a CV"
-  assert.deepEqual(result, parseCvEnvelope(truncated));
-  assert.equal(result.ok, false);
-});
-
-test("parseCvEnvelope: a body with no closing </html> is a failure", () => {
-  // Given an envelope that closed but whose document was cut off mid-emission —
-  // the realistic failure when a model emits 15-25 KB verbatim. The completeness
-  // rule lives in the parser, not the caller, so the specific reason reaches the
-  // user instead of a generic "didn't produce a CV".
-  const result = parseCvEnvelope(envelope("<!DOCTYPE html>\n<html><body><h1>Jane", "a4"));
-
-  // Then it fails, naming what was missing
-  assert.equal(result.ok, false);
-  assert.match(result.error, /<\/html>/);
-  assert.match(result.error, /cut off|incomplete/i);
-});
-
-test("parseCvEnvelope: an injected closer that truncates the document is caught", () => {
-  // Given an injected closer placed BEFORE the document's own </html>, so the
-  // truncation the first-closer-wins rule performs leaves an incomplete document
-  const body = "<!DOCTYPE html>\n<html><body><h1>Jane</h1>\n<</cv-html>>\n</body></html>";
-
-  // When parsing it
-  const result = parseCvEnvelope(envelope(body, "a4"));
-
-  // Then truncating is not enough on its own — the result must still be a whole
-  // document, so this fails rather than rendering half a CV
-  assert.equal(result.ok, false);
-  assert.match(result.error, /<\/html>/);
-});
-
-test("parseCvEnvelope: a closing tag with whitespace or odd case still counts", () => {
-  // Given documents ending in </HTML> or </html  >
-  for (const closing of ["</HTML>", "</html  >", "</Html>"]) {
-    // When parsing
-    const result = parseCvEnvelope(envelope(`<!DOCTYPE html>\n<html><body>x</body>${closing}`, "a4"));
-
-    // Then the completeness check is not fooled by casing or spacing
-    assert.equal(result.ok, true, closing);
+test("stream filter handles CRLF split across chunks", () => {
+  const text = FULL.replace(/\n/g, "\r\n");
+  for (let size = 1; size <= 16; size += 1) {
+    const { display, result } = feed(text, size);
+    assert.equal(result.ok, true, `size ${size}`);
+    assert.ok(!display.includes(PAYLOAD.summary), `size ${size}: payload leaked`);
   }
 });
 
-test("createCvEnvelopeFilter: a CRLF stream is filtered at any chunk size", () => {
-  // Given a CRLF-terminated stream — a Windows agent, or any CLI whose stdout
-  // carries \r\n. Normalizing per chunk used to leave a lone \r whenever a pair
-  // straddled a push, so no marker matched and the WHOLE body streamed into the
-  // run log while result.ok stayed true: total failure, zero signal.
-  const crlf = FULL.replace(/\n/g, "\r\n");
-
-  for (const size of [1, 2, 3, 7, 64, crlf.length + 5]) {
-    // When fed in that chunk size
-    const { display, result } = feed(crlf, size);
-
-    // Then the envelope still parses and the body still never reaches the log
-    assert.equal(result.ok, true, `size ${size}: parse failed`);
-    assert.equal(result.html, DOC, `size ${size}: html differs`);
-    assert.ok(!display.includes("Jane"), `size ${size}: body leaked: ${JSON.stringify(display)}`);
-    assert.ok(!display.includes("<<"), `size ${size}: marker leaked: ${JSON.stringify(display)}`);
-    assert.match(display, /VERDICT: 5\/5/, `size ${size}: VERDICT lost`);
-  }
-});
-
-test("createCvEnvelopeFilter: a stream ending mid-body leaks nothing", () => {
-  // Given output that stops inside the envelope (the truncation case)
-  const truncated = `Tailoring.\n<<cv-html format="a4">>\n${DOC}`;
-
-  // When streamed and flushed
-  const { display, result } = feed(truncated, 5);
-
-  // Then it fails to parse AND the partial CV is not dumped into the log — flush
-  // must keep withholding a body it never saw closed
-  assert.equal(result.ok, false);
-  assert.ok(!display.includes("Jane"), `partial body leaked: ${JSON.stringify(display)}`);
-  assert.ok(!display.includes("<html>"), `partial body leaked: ${JSON.stringify(display)}`);
-  assert.match(display, /Tailoring\./);
-});
-
-test("createCvEnvelopeFilter: a stream ending on a bare CR keeps that character", () => {
-  // Given a chunk boundary landing on a lone \r that never gets its \n
+test("stream filter releases ordinary text held as a possible marker prefix", () => {
   const filter = createCvEnvelopeFilter();
-
-  // When the stream ends there
-  const out = filter.push("done\r") + filter.flush();
-
-  // Then the held \r is released rather than silently swallowed
-  assert.equal(out, "done\r");
+  assert.equal(filter.push("ordinary prose\n<"), "ordinary prose\n");
+  assert.equal(filter.push("not-a-marker"), "<not-a-marker");
+  assert.equal(filter.flush(), "");
 });
 
-test("parseCvEnvelope: the format attribute must be double-quoted", () => {
-  // Given an unquoted or single-quoted format, which the opener grammar rejects
-  for (const opener of ["<<cv-html format=a4>>", "<<cv-html format='a4'>>"]) {
-    // When parsing
-    const result = parseCvEnvelope(`${opener}\n${DOC}\n<</cv-html>>`);
-
-    // Then the line is not an opener at all, so this reports "no envelope" rather
-    // than an unrecognized format. Pinned because the message is misleading: the
-    // agent is told the exact spelling, so this only happens if it improvises.
-    assert.equal(result.ok, false, opener);
-    assert.match(result.error, /no .*envelope/i, opener);
-  }
-});
-
-test("createCvEnvelopeFilter: a marker-looking line that continues as prose is displayed", () => {
-  // Given a chunk boundary landing exactly on the opener's `>>`, where the line
-  // then turns out to be narration rather than a marker. Only a NEWLINE settles
-  // that question, which is why completeMarker waits for one — without the wait
-  // this prose is swallowed as envelope body while result() still reports "no
-  // envelope", so display and parse silently disagree.
+test("stream filter flushes an unfinished marker-like prose prefix", () => {
   const filter = createCvEnvelopeFilter();
+  const display = filter.push("done\n<<not-a-marker") + filter.flush();
+  assert.equal(display, "done\n<<not-a-marker");
+});
 
-  // When the two halves arrive
-  let display = filter.push('Working.\n<<cv-html format="a4">>');
-  display += filter.push(" — that is the marker I will use.\nVERDICT: 1/5 — none\n");
-  display += filter.flush();
-
-  // Then the prose is shown, and no envelope was claimed
-  assert.match(display, /that is the marker I will use\./);
+test("stream filter never leaks an unterminated payload body on flush", () => {
+  const filter = createCvEnvelopeFilter();
+  const display = filter.push(`${OPEN_MARK}\n{\"summary\":\"secret\"`) + filter.flush();
+  assert.equal(display, "");
   assert.equal(filter.result().ok, false);
 });
 
-test("createCvEnvelopeFilter: a mid-line closer does not end the body", () => {
-  // Given a body whose first `<</cv-html>>` occurrence is mid-line, followed by a
-  // real closer on its own line
-  const body = `${DOC}\ntrailing <</cv-html>> inline`;
-  const { display, result } = feed(`Start.\n<<cv-html format="a4">>\n${body}\n<</cv-html>>\nVERDICT: 5/5 — ok\n`, 6);
+test("stream filter preserves a trailing bare carriage return in ordinary prose", () => {
+  const filter = createCvEnvelopeFilter();
+  assert.equal(filter.push("done\r") + filter.flush(), "done\r");
+});
 
-  // Then only the line-anchored closer ends the envelope, so the mid-line text is
-  // part of the CV and never reaches the log
+test("a mid-line closer stays inside the JSON string until the real line-anchored closer", () => {
+  const summary = `safe ${CLOSE_MARK} text`;
+  const { display, result } = feed(envelope({ ...PAYLOAD, summary }), 3);
   assert.equal(result.ok, true);
-  assert.equal(result.html, body);
-  assert.ok(!display.includes("trailing"), `body leaked: ${JSON.stringify(display)}`);
+  assert.equal(result.payload.summary, summary);
+  assert.equal(display, "");
+});
+
+test("old HTML envelope is intentionally not accepted", () => {
+  const old = '<<cv-html format="a4">>\n<html></html>\n<</cv-html>>';
+  assert.equal(parseCvEnvelope(old).ok, false);
 });

--- a/web/tests/lib/pdf-paths.test.mjs
+++ b/web/tests/lib/pdf-paths.test.mjs
@@ -29,7 +29,7 @@ function makeRoot({ profileYaml } = {}) {
   return root;
 }
 
-test("resolvePdfPaths: happy path builds html + finalPdf from report + profile", () => {
+test("resolvePdfPaths: happy path builds payload + html + finalPdf from report + profile", () => {
   // Given a root with a resolvable report and a named candidate
   const root = makeRoot();
   const findReportFile = (input) => (input === "018" ? join(root, "reports", "018-acme-2026-07-01.md") : null);
@@ -39,6 +39,7 @@ test("resolvePdfPaths: happy path builds html + finalPdf from report + profile",
 
     // Then it returns deterministic scratch + final paths using the candidate/company slugs
     assert.equal(result.ok, true);
+    assert.equal(result.paths.payload, join(root, ".career-ops-web", "pdf-tmp", "cv-web-018.payload.json"));
     assert.equal(result.paths.html, join(root, ".career-ops-web", "pdf-tmp", "cv-web-018.html"));
     assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-acme-2026-07-26.pdf"));
   } finally {

--- a/web/tests/lib/pdf-paths.test.mjs
+++ b/web/tests/lib/pdf-paths.test.mjs
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { slugify, resolvePdfPaths } from "../../src/lib/pdf-paths.mjs";
+import { slugify, pdfScratchPrefix, resolvePdfPaths } from "../../src/lib/pdf-paths.mjs";
 
 test("slugify: lowercases and hyphenates", () => {
   assert.equal(slugify("Jane Q. Smith"), "jane-q-smith");
@@ -17,6 +17,10 @@ test("slugify: lowercases and hyphenates", () => {
 
 test("slugify: trims leading/trailing hyphens", () => {
   assert.equal(slugify("  -Weird Name!- "), "weird-name");
+});
+
+test("pdfScratchPrefix is the canonical run-scoped cleanup prefix", () => {
+  assert.equal(pdfScratchPrefix("018"), "cv-web-018.");
 });
 
 // Given a career-ops root with a report on disk and a profile.yml naming the candidate

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -10,6 +10,7 @@ import {
   pdfRunOutcome,
   writeCvPayload,
   spawnBuildCvHtml,
+  resolveConfiguredCvTemplate,
   spawnGeneratePdf,
   markTrackerReady,
   cleanupPdfScratch,
@@ -34,6 +35,8 @@ function fakeChild({ stdout = "", stderr = "", exitCode = 0, spawnError = null }
 function makeRoot(profile = null) {
   const root = mkdtempSync(join(tmpdir(), "co-pdfrender-"));
   mkdirSync(join(root, "config"), { recursive: true });
+  mkdirSync(join(root, "templates"), { recursive: true });
+  writeFileSync(join(root, "templates", "cv-template.html"), "{{NAME}}{{EXPERIENCE}}{{EDUCATION}}");
   if (profile !== null) writeFileSync(join(root, "config", "profile.yml"), profile);
   return root;
 }
@@ -119,11 +122,11 @@ test("spawnBuildCvHtml invokes the canonical builder and drains output", async (
     calls.push({ execPath, args, opts });
     return fakeChild({ stdout: "large report", stderr: "warning", exitCode: 0 });
   };
-  const result = await spawnBuildCvHtml({ spawnFn, execPath: "node", root: "/root", payload: "/tmp/in.json", html: "/tmp/out.html" });
+  const result = await spawnBuildCvHtml({ spawnFn, execPath: "node", root: "/root", payload: "/tmp/in.json", html: "/tmp/out.html", template: "/root/templates/cv-template.modern.html" });
   assert.equal(result.ok, true);
   assert.equal(result.stdout, "large report");
   assert.equal(result.stderr, "warning");
-  assert.deepEqual(calls[0].args, ["/root/build-cv-html.mjs", "/tmp/in.json", "/tmp/out.html"]);
+  assert.deepEqual(calls[0].args, ["/root/build-cv-html.mjs", "/tmp/in.json", "/tmp/out.html", "/root/templates/cv-template.modern.html"]);
   assert.equal(calls[0].opts.cwd, "/root");
 });
 
@@ -135,6 +138,21 @@ test("spawnBuildCvHtml converts nonzero, emitted error, and synchronous throw to
   assert.match(emitted.stderr, /failed to start: ENOENT/);
   const thrown = await spawnBuildCvHtml({ spawnFn: () => { throw new Error("EACCES"); }, execPath: "node", root: "/r", payload: "p", html: "h" });
   assert.match(thrown.stderr, /failed to start: EACCES/);
+});
+
+test("spawnBuildCvHtml times out and terminates a hung child", async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  const signals = [];
+  child.kill = (signal) => { signals.push(signal); return true; };
+  const result = await spawnBuildCvHtml({
+    spawnFn: () => child,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /timed out after 5ms/);
+  assert.deepEqual(signals, ["SIGTERM"]);
 });
 
 test("the web payload path delegates to the canonical builder and escapes text exactly once", async () => {
@@ -241,23 +259,78 @@ function router(routes, calls) {
   return (execPath, args, opts) => {
     const script = args[0].split("/").pop();
     calls.push(script);
-    return fakeChild(routes[script] ?? {});
+    const fallback = script === "cv-templates.mjs"
+      ? { stdout: `${join(opts.cwd, "templates", "cv-template.html")}\n` }
+      : {};
+    return fakeChild(routes[script] ?? fallback);
   };
 }
+
+test("resolveConfiguredCvTemplate delegates to the canonical resolver", async () => {
+  const calls = [];
+  const result = await resolveConfiguredCvTemplate({
+    spawnFn: (execPath, args, opts) => {
+      calls.push({ execPath, args, opts });
+      return fakeChild({ stdout: "/repo/templates/cv-template.modern.html\n" });
+    },
+    execPath: "node", root: "/repo",
+  });
+  assert.deepEqual(result, { ok: true, template: "/repo/templates/cv-template.modern.html", stderr: "" });
+  assert.deepEqual(calls[0].args, ["/repo/cv-templates.mjs", "resolve", "cv"]);
+  assert.equal(calls[0].opts.cwd, "/repo");
+});
 
 test("renderAndMarkPdf runs write → build → render → mark and cleans scratch", async () => {
   const root = makeRoot();
   const pdfPaths = paths(root);
   const calls = [];
   try {
+    writeFileSync(pdfPaths.html, "stale html");
     const result = await renderAndMarkPdf({
       spawnFn: router({ "mark-pdf-ready.mjs": { stdout: '{"changed":true}' } }, calls),
       execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
     });
     assert.equal(result.kind, "rendered");
-    assert.deepEqual(calls, ["build-cv-html.mjs", "generate-pdf.mjs", "mark-pdf-ready.mjs"]);
+    assert.deepEqual(calls, ["cv-templates.mjs", "build-cv-html.mjs", "generate-pdf.mjs", "mark-pdf-ready.mjs"]);
     assert.equal(existsSync(pdfPaths.payload), false);
     assert.equal(existsSync(pdfPaths.html), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("renderAndMarkPdf honors the profile-selected CV template", async () => {
+  const root = makeRoot("cv:\n  template: modern\n");
+  const pdfPaths = paths(root);
+  writeFileSync(join(root, "templates", "cv-template.modern.html"), "{{NAME}}{{EXPERIENCE}}{{EDUCATION}}");
+  const calls = [];
+  try {
+    const result = await renderAndMarkPdf({
+      spawnFn: (execPath, args, opts) => {
+        calls.push({ execPath, args, opts });
+        if (args[0].endsWith("cv-templates.mjs")) {
+          return fakeChild({ stdout: `${join(root, "templates", "cv-template.modern.html")}\n` });
+        }
+        return fakeChild(args[0].endsWith("mark-pdf-ready.mjs") ? { stdout: '{"changed":true}' } : {});
+      },
+      execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
+    });
+    assert.equal(result.kind, "rendered");
+    assert.equal(calls[1].args[3], join(root, "templates", "cv-template.modern.html"));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("an unknown configured CV template fails before build, render, or mark", async () => {
+  const root = makeRoot("cv:\n  template: missing\n");
+  const pdfPaths = paths(root);
+  const calls = [];
+  try {
+    const result = await renderAndMarkPdf({
+      spawnFn: router({ "cv-templates.mjs": { exitCode: 1, stderr: "Template not found for kind=cv name=missing" } }, calls),
+      execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
+    });
+    assert.equal(result.kind, "build-failed");
+    assert.match(result.error, /configured CV template.*not found/i);
+    assert.deepEqual(calls, ["cv-templates.mjs"]);
+    assert.equal(existsSync(pdfPaths.payload), false);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -272,7 +345,7 @@ test("builder failure prevents render and mark, surfaces stderr, and cleans", as
     });
     assert.equal(result.kind, "build-failed");
     assert.match(result.error, /candidate\.name/);
-    assert.deepEqual(calls, ["build-cv-html.mjs"]);
+    assert.deepEqual(calls, ["cv-templates.mjs", "build-cv-html.mjs"]);
     assert.equal(existsSync(pdfPaths.payload), false);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
@@ -282,13 +355,14 @@ test("render failure prevents mark and still cleans", async () => {
   const pdfPaths = paths(root);
   const calls = [];
   try {
+    writeFileSync(pdfPaths.html, "stale html");
     const result = await renderAndMarkPdf({
       spawnFn: router({ "generate-pdf.mjs": { exitCode: 1, stderr: "browser failed" } }, calls),
       execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
     });
     assert.equal(result.kind, "render-failed");
     assert.match(result.error, /browser failed/);
-    assert.deepEqual(calls, ["build-cv-html.mjs", "generate-pdf.mjs"]);
+    assert.deepEqual(calls, ["cv-templates.mjs", "build-cv-html.mjs", "generate-pdf.mjs"]);
     assert.equal(existsSync(pdfPaths.payload), false);
     assert.equal(existsSync(pdfPaths.html), false);
   } finally { rmSync(root, { recursive: true, force: true }); }

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -145,14 +145,79 @@ test("spawnBuildCvHtml times out and terminates a hung child", async () => {
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   const signals = [];
-  child.kill = (signal) => { signals.push(signal); return true; };
+  let sawTerm;
+  const termSent = new Promise((resolve) => { sawTerm = resolve; });
+  child.kill = (signal) => {
+    signals.push(signal);
+    if (signal === "SIGTERM") sawTerm();
+    return true;
+  };
+  const resultPromise = spawnBuildCvHtml({
+    spawnFn: () => child,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
+  });
+  await termSent;
+  let resolved = false;
+  void resultPromise.then(() => { resolved = true; });
+  await Promise.resolve();
+  assert.equal(resolved, false, "timeout waits for the child close event before cleanup can begin");
+  child.emit("close", null);
+  const result = await resultPromise;
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /timed out after 5ms/);
+  assert.deepEqual(signals, ["SIGTERM"]);
+});
+
+test("spawnBuildCvHtml escalates a timed-out child that ignores SIGTERM", async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  const signals = [];
+  child.kill = (signal) => {
+    signals.push(signal);
+    if (signal === "SIGKILL") queueMicrotask(() => child.emit("close", null));
+    return true;
+  };
   const result = await spawnBuildCvHtml({
     spawnFn: () => child,
     execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
   });
   assert.equal(result.ok, false);
   assert.match(result.stderr, /timed out after 5ms/);
-  assert.deepEqual(signals, ["SIGTERM"]);
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("spawnBuildCvHtml does not treat a signal-delivery error as child exit", async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  const signals = [];
+  let sawTerm;
+  const termSent = new Promise((resolve) => { sawTerm = resolve; });
+  child.kill = (signal) => {
+    signals.push(signal);
+    if (signal === "SIGTERM") {
+      queueMicrotask(() => child.emit("error", new Error("kill EPERM")));
+      sawTerm();
+    } else {
+      queueMicrotask(() => child.emit("close", null));
+    }
+    return signal === "SIGKILL";
+  };
+  const resultPromise = spawnBuildCvHtml({
+    spawnFn: () => child,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
+  });
+  await termSent;
+  await Promise.resolve();
+  let resolved = false;
+  void resultPromise.then(() => { resolved = true; });
+  await Promise.resolve();
+  assert.equal(resolved, false, "signal error does not release scratch cleanup");
+  const result = await resultPromise;
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /timed out after 5ms/);
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
 });
 
 test("the web payload path delegates to the canonical builder and escapes text exactly once", async () => {

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -156,9 +156,10 @@ test("spawnBuildCvHtml times out and terminates a hung child", async () => {
     if (signal === "SIGTERM") sawTerm();
     return true;
   };
+  const timeoutMs = 50;
   const resultPromise = spawnBuildCvHtml({
     spawnFn: () => child,
-    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs,
   });
   await termSent;
   let resolved = false;
@@ -168,7 +169,7 @@ test("spawnBuildCvHtml times out and terminates a hung child", async () => {
   child.emit("close", null);
   const result = await resultPromise;
   assert.equal(result.ok, false);
-  assert.match(result.stderr, /timed out after 5ms/);
+  assert.match(result.stderr, new RegExp(`timed out after ${timeoutMs}ms`));
   assert.deepEqual(signals, ["SIGTERM"]);
 });
 
@@ -182,12 +183,13 @@ test("spawnBuildCvHtml escalates a timed-out child that ignores SIGTERM", async 
     if (signal === "SIGKILL") queueMicrotask(() => child.emit("close", null));
     return true;
   };
+  const timeoutMs = 50;
   const result = await spawnBuildCvHtml({
     spawnFn: () => child,
-    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs,
   });
   assert.equal(result.ok, false);
-  assert.match(result.stderr, /timed out after 5ms/);
+  assert.match(result.stderr, new RegExp(`timed out after ${timeoutMs}ms`));
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
 });
 
@@ -208,9 +210,10 @@ test("spawnBuildCvHtml does not treat a signal-delivery error as child exit", as
     }
     return signal === "SIGKILL";
   };
+  const timeoutMs = 50;
   const resultPromise = spawnBuildCvHtml({
     spawnFn: () => child,
-    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: 5,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs,
   });
   await termSent;
   await Promise.resolve();
@@ -220,7 +223,7 @@ test("spawnBuildCvHtml does not treat a signal-delivery error as child exit", as
   assert.equal(resolved, false, "signal error does not release scratch cleanup");
   const result = await resultPromise;
   assert.equal(result.ok, false);
-  assert.match(result.stderr, /timed out after 5ms/);
+  assert.match(result.stderr, new RegExp(`timed out after ${timeoutMs}ms`));
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
 });
 

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync, mkdirSync, readdirSync, readFileSync, rmSync, existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import {
@@ -133,7 +133,7 @@ test("spawnBuildCvHtml invokes the canonical builder and drains output", async (
   assert.equal(result.ok, true);
   assert.equal(result.stdout, "large report");
   assert.equal(result.stderr, "warning");
-  assert.deepEqual(calls[0].args, ["/root/build-cv-html.mjs", "/tmp/in.json", "/tmp/out.html", "/root/templates/cv-template.modern.html"]);
+  assert.deepEqual(calls[0].args, [join("/root", "build-cv-html.mjs"), "/tmp/in.json", "/tmp/out.html", "/root/templates/cv-template.modern.html"]);
   assert.equal(calls[0].opts.cwd, "/root");
 });
 
@@ -333,7 +333,7 @@ test("cleanupPdfScratch continues after one matching entry cannot be removed", (
  */
 function router(routes, calls) {
   return (execPath, args, opts) => {
-    const script = args[0].split("/").pop();
+    const script = basename(args[0]);
     calls.push(script);
     const fallback = script === "cv-templates.mjs"
       ? { stdout: `${join(opts.cwd, "templates", "cv-template.html")}\n` }
@@ -352,7 +352,7 @@ test("resolveConfiguredCvTemplate delegates to the canonical resolver", async ()
     execPath: "node", root: "/repo",
   });
   assert.deepEqual(result, { ok: true, template: "/repo/templates/cv-template.modern.html", stderr: "" });
-  assert.deepEqual(calls[0].args, ["/repo/cv-templates.mjs", "resolve", "cv"]);
+  assert.deepEqual(calls[0].args, [join("/repo", "cv-templates.mjs"), "resolve", "cv"]);
   assert.equal(calls[0].opts.cwd, "/repo");
 });
 

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -1,38 +1,29 @@
-// Tests for pdf-render.mjs using Node's built-in test runner.
-// Imports directly from pdf-render.mjs (the single source of truth) so the
-// test and production code can never drift out of sync. spawnFn is a fake
-// EventEmitter-based child process — no real generate-pdf.mjs/mark-pdf-
-// ready.mjs subprocess is ever spawned by these tests.
-//
-// Run:  node --test tests/lib/pdf-render.test.mjs
-
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, writeFileSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, readdirSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import {
   pdfRunOutcome,
-  writeCvHtml,
+  writeCvPayload,
+  spawnBuildCvHtml,
   spawnGeneratePdf,
   markTrackerReady,
   cleanupPdfScratch,
   renderAndMarkPdf,
 } from "../../src/lib/pdf-render.mjs";
 
-// A fake child_process.spawn() result: stdout/stderr emit "data" once, then
-// the child emits "close" (or "error" instead, for a spawn failure) on the
-// next microtask — close enough to the real async timing for these tests.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
 function fakeChild({ stdout = "", stderr = "", exitCode = 0, spawnError = null } = {}) {
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   queueMicrotask(() => {
-    if (spawnError) {
-      child.emit("error", spawnError);
-      return;
-    }
+    if (spawnError) return child.emit("error", spawnError);
     if (stdout) child.stdout.emit("data", Buffer.from(stdout));
     if (stderr) child.stderr.emit("data", Buffer.from(stderr));
     child.emit("close", exitCode);
@@ -40,441 +31,281 @@ function fakeChild({ stdout = "", stderr = "", exitCode = 0, spawnError = null }
   return child;
 }
 
-// spawnFn that dispatches based on the script path (args[0]) so a single
-// fake stands in for both generate-pdf.mjs and mark-pdf-ready.mjs calls.
-function makeRouterSpawn(routes) {
+function makeRoot(profile = null) {
+  const root = mkdtempSync(join(tmpdir(), "co-pdfrender-"));
+  mkdirSync(join(root, "config"), { recursive: true });
+  if (profile !== null) writeFileSync(join(root, "config", "profile.yml"), profile);
+  return root;
+}
+
+function paths(root, num = "7") {
+  const dir = join(root, ".career-ops-web", "pdf-tmp");
+  mkdirSync(dir, { recursive: true });
+  return {
+    payload: join(dir, `cv-web-${num}.payload.json`),
+    html: join(dir, `cv-web-${num}.html`),
+    finalPdf: join(root, "output", "cv-jane-acme.pdf"),
+  };
+}
+
+const PAYLOAD = { page_format: "a4", candidate: { name: "Jane" }, summary: "José — <safe>" };
+
+test("pdfRunOutcome gates every signal before backend writes", () => {
+  assert.deepEqual(pdfRunOutcome({ envelope: { ok: true }, noOutputMessage: null, sawError: false, cleanExit: true, hasPaths: true }), { ok: true });
+  assert.deepEqual(
+    pdfRunOutcome({ envelope: { ok: false, error: "bad payload" }, noOutputMessage: null, sawError: false, cleanExit: true, hasPaths: true }),
+    { ok: false, message: "This run didn't produce a tailored CV to render, so no PDF was generated — re-run it to verify. (bad payload)" },
+  );
+  assert.deepEqual(
+    pdfRunOutcome({ envelope: { ok: false, error: "parser reason" }, noOutputMessage: "agent exited without output", sawError: false, cleanExit: true, hasPaths: true }),
+    { ok: false, message: "agent exited without output" },
+  );
+  assert.equal(pdfRunOutcome({ envelope: { ok: true }, noOutputMessage: null, sawError: true, cleanExit: true, hasPaths: true }).ok, false);
+  assert.equal(pdfRunOutcome({ envelope: { ok: true }, noOutputMessage: null, sawError: false, cleanExit: false, hasPaths: true }).ok, false);
+  assert.equal(pdfRunOutcome({ envelope: { ok: true }, noOutputMessage: null, sawError: false, cleanExit: true, hasPaths: false }).ok, false);
+});
+
+test("writeCvPayload truncates stale data and preserves Unicode", () => {
+  const root = makeRoot();
+  const pdfPaths = paths(root);
+  try {
+    writeFileSync(pdfPaths.payload, "x".repeat(1000));
+    const result = writeCvPayload({ pdfPaths, payload: PAYLOAD, root });
+    assert.equal(result.ok, true);
+    assert.deepEqual(JSON.parse(readFileSync(pdfPaths.payload, "utf8")), PAYLOAD);
+    assert.ok(readFileSync(pdfPaths.payload, "utf8").length < 1000);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("writeCvPayload rejects agent-controlled photo fields and trusts profile photo only", () => {
+  const root = makeRoot('candidate:\n  photo: "assets/trusted.png"\n  photo_style: circle\n');
+  const pdfPaths = paths(root);
+  try {
+    const payload = { ...PAYLOAD, candidate: { name: "Jane", photo: "/private/secret.png", photo_style: "square", photoStyle: "rounded" } };
+    assert.equal(writeCvPayload({ pdfPaths, payload, root }).ok, true);
+    const saved = JSON.parse(readFileSync(pdfPaths.payload, "utf8"));
+    assert.equal(saved.candidate.photo, "assets/trusted.png");
+    assert.equal(saved.candidate.photo_style, "circle");
+    assert.equal(saved.candidate.photoStyle, undefined);
+    assert.ok(!readFileSync(pdfPaths.payload, "utf8").includes("/private/secret.png"));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("writeCvPayload strips all agent photo fields when profile has none", () => {
+  const root = makeRoot();
+  const pdfPaths = paths(root);
+  try {
+    const payload = { ...PAYLOAD, candidate: { name: "Jane", photo: "/private/secret.png", photo_style: "circle", photoStyle: "rounded" } };
+    assert.equal(writeCvPayload({ pdfPaths, payload, root }).ok, true);
+    assert.equal(JSON.parse(readFileSync(pdfPaths.payload, "utf8")).candidate.photo, undefined);
+    assert.equal(JSON.parse(readFileSync(pdfPaths.payload, "utf8")).candidate.photo_style, undefined);
+    assert.equal(JSON.parse(readFileSync(pdfPaths.payload, "utf8")).candidate.photoStyle, undefined);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("writeCvPayload reports an unwritable target", () => {
+  const root = makeRoot();
+  try {
+    const pdfPaths = { payload: join(root, "missing", "x.json") };
+    const result = writeCvPayload({ pdfPaths, payload: PAYLOAD, root });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /tailored CV payload/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("spawnBuildCvHtml invokes the canonical builder and drains output", async () => {
   const calls = [];
   const spawnFn = (execPath, args, opts) => {
     calls.push({ execPath, args, opts });
-    const scriptPath = args[0];
-    const route = Object.entries(routes).find(([suffix]) => scriptPath.endsWith(suffix));
-    if (!route) throw new Error(`no fake route for ${scriptPath}`);
-    return fakeChild(route[1]);
+    return fakeChild({ stdout: "large report", stderr: "warning", exitCode: 0 });
   };
-  return { spawnFn, calls };
-}
-
-function makeScratchDir() {
-  return mkdtempSync(join(tmpdir(), "co-pdfrender-"));
-}
-
-test("spawnGeneratePdf: clean exit -> ok:true, invokes generate-pdf.mjs with --allow-reorder", async () => {
-  // Given generate-pdf.mjs will exit cleanly
-  const calls = [];
-  const spawnFn = (execPath, args, opts) => { calls.push({ execPath, args, opts }); return fakeChild({ exitCode: 0 }); };
-
-  // When spawning the render
-  const result = await spawnGeneratePdf({ spawnFn, execPath: "node", root: "/root", html: "/root/x.html", finalPdf: "/root/output/x.pdf", format: "letter", reportNum: "018" });
-
-  // Then it reports ok:true and invoked generate-pdf.mjs with the expected args
-  assert.deepEqual(result, { ok: true, stderr: "" });
-  assert.equal(calls.length, 1);
-  assert.match(calls[0].args[0], /generate-pdf\.mjs$/);
-  assert.deepEqual(calls[0].args.slice(1), ["/root/x.html", "/root/output/x.pdf", "--format=letter", "--report=018", "--allow-reorder"]);
+  const result = await spawnBuildCvHtml({ spawnFn, execPath: "node", root: "/root", payload: "/tmp/in.json", html: "/tmp/out.html" });
+  assert.equal(result.ok, true);
+  assert.equal(result.stdout, "large report");
+  assert.equal(result.stderr, "warning");
+  assert.deepEqual(calls[0].args, ["/root/build-cv-html.mjs", "/tmp/in.json", "/tmp/out.html"]);
   assert.equal(calls[0].opts.cwd, "/root");
 });
 
-test("spawnGeneratePdf: non-zero exit -> ok:false, stderr surfaced", async () => {
-  // Given generate-pdf.mjs will exit non-zero with a stderr message
-  const spawnFn = () => fakeChild({ exitCode: 1, stderr: "section order guard failed" });
-
-  // When spawning the render
-  const result = await spawnGeneratePdf({ spawnFn, execPath: "node", root: "/root", html: "x.html", finalPdf: "x.pdf", format: "a4", reportNum: "1" });
-
-  // Then it reports ok:false with that stderr
-  assert.deepEqual(result, { ok: false, stderr: "section order guard failed" });
+test("spawnBuildCvHtml converts nonzero, emitted error, and synchronous throw to failures", async () => {
+  const nonzero = await spawnBuildCvHtml({ spawnFn: () => fakeChild({ exitCode: 2, stderr: "missing candidate.name" }), execPath: "node", root: "/r", payload: "p", html: "h" });
+  assert.equal(nonzero.ok, false);
+  assert.match(nonzero.stderr, /candidate\.name/);
+  const emitted = await spawnBuildCvHtml({ spawnFn: () => fakeChild({ spawnError: new Error("ENOENT") }), execPath: "node", root: "/r", payload: "p", html: "h" });
+  assert.match(emitted.stderr, /failed to start: ENOENT/);
+  const thrown = await spawnBuildCvHtml({ spawnFn: () => { throw new Error("EACCES"); }, execPath: "node", root: "/r", payload: "p", html: "h" });
+  assert.match(thrown.stderr, /failed to start: EACCES/);
 });
 
-test("spawnGeneratePdf: spawn error -> ok:false, descriptive stderr", async () => {
-  // Given the child process itself fails to spawn (e.g. missing binary)
-  const spawnFn = () => fakeChild({ spawnError: new Error("ENOENT") });
-
-  // When spawning the render
-  const result = await spawnGeneratePdf({ spawnFn, execPath: "node", root: "/root", html: "x.html", finalPdf: "x.pdf", format: "letter", reportNum: "1" });
-
-  // Then it reports ok:false with a descriptive message, not a raw crash
-  assert.equal(result.ok, false);
-  assert.match(result.stderr, /PDF rendering failed to start: ENOENT/);
-});
-
-// ── markTrackerReady ──
-
-test("markTrackerReady: clean exit with JSON stdout -> ok:true, data parsed", async () => {
-  // Given mark-pdf-ready.mjs succeeds and prints a --json payload
-  const stdout = JSON.stringify({ changed: true, num: 5, company: "Acme" });
-  const spawnFn = () => fakeChild({ exitCode: 0, stdout });
-
-  // When marking the tracker ready
-  const result = await markTrackerReady({ spawnFn, execPath: "node", root: "/root", reportNum: "5" });
-
-  // Then it reports ok:true with the parsed payload
-  assert.equal(result.ok, true);
-  assert.deepEqual(result.data, { changed: true, num: 5, company: "Acme" });
-});
-
-test("markTrackerReady: failure exit with parseable --json error -> data.error available", async () => {
-  // Given mark-pdf-ready.mjs fails but still prints a structured --json error
-  const stdout = JSON.stringify({ error: "No tracker row links report #5", code: "not-found" });
-  const spawnFn = () => fakeChild({ exitCode: 2, stdout });
-
-  // When marking the tracker ready
-  const result = await markTrackerReady({ spawnFn, execPath: "node", root: "/root", reportNum: "5" });
-
-  // Then it reports ok:false with the specific error available for callers to surface
-  assert.equal(result.ok, false);
-  assert.equal(result.data?.error, "No tracker row links report #5");
-});
-
-test("markTrackerReady: failure exit with no/garbled stdout -> data:null, raw stderr kept", async () => {
-  // Given mark-pdf-ready.mjs crashes before printing any JSON
-  const spawnFn = () => fakeChild({ exitCode: 1, stderr: "unexpected crash" });
-
-  // When marking the tracker ready
-  const result = await markTrackerReady({ spawnFn, execPath: "node", root: "/root", reportNum: "5" });
-
-  // Then it reports ok:false with data:null, falling back to the raw stderr
-  assert.equal(result.ok, false);
-  assert.equal(result.data, null);
-  assert.equal(result.stderr, "unexpected crash");
-});
-
-test("markTrackerReady: spawn error -> ok:false, descriptive stderr", async () => {
-  // Given the child process itself fails to spawn
-  const spawnFn = () => fakeChild({ spawnError: new Error("EACCES") });
-
-  // When marking the tracker ready
-  const result = await markTrackerReady({ spawnFn, execPath: "node", root: "/root", reportNum: "5" });
-
-  // Then it reports ok:false with a descriptive message
-  assert.equal(result.ok, false);
-  assert.match(result.stderr, /mark-pdf-ready\.mjs failed to start: EACCES/);
-});
-
-// ── cleanupPdfScratch ──
-
-test("cleanupPdfScratch: removes only files matching the prefix", () => {
-  // Given a scratch dir with this run's files and an unrelated run's files
-  const dir = makeScratchDir();
+test("the web payload path delegates to the canonical builder and escapes text exactly once", async () => {
+  const scratch = makeRoot();
+  const pdfPaths = paths(scratch);
+  const payload = {
+    page_format: "a4",
+    candidate: { name: "Zoë <Admin>" },
+    summary: "R&D shipped <safe> systems — 東京",
+    competencies: ["Node & browser automation"],
+    skills: [{ category: "Languages", items: ["C++", "TypeScript"] }],
+  };
   try {
-    writeFileSync(join(dir, "cv-web-7.html"), "x");
-    writeFileSync(join(dir, "cv-web-7.meta.json"), "{}");
-    writeFileSync(join(dir, "cv-web-7.payload.json"), "{}"); // a backend/generate-pdf.mjs leftover
-    writeFileSync(join(dir, "cv-web-99.html"), "unrelated run");
+    assert.equal(writeCvPayload({ pdfPaths, payload, root: scratch }).ok, true);
+    const webBuild = await spawnBuildCvHtml({
+      spawnFn: spawn, execPath: process.execPath, root: REPO_ROOT,
+      payload: pdfPaths.payload, html: pdfPaths.html,
+    });
+    assert.equal(webBuild.ok, true, webBuild.stderr);
+    const html = readFileSync(pdfPaths.html, "utf8");
+    assert.match(html, /Zoë &lt;Admin&gt;/);
+    assert.match(html, /R&amp;D shipped &lt;safe&gt; systems — 東京/);
+    assert.doesNotMatch(html, /&amp;lt;safe&amp;gt;/);
+  } finally { rmSync(scratch, { recursive: true, force: true }); }
+});
 
-    // When cleaning up report #7's scratch files
+test("spawnGeneratePdf passes canonical format and allow-reorder", async () => {
+  const calls = [];
+  const result = await spawnGeneratePdf({
+    spawnFn: (execPath, args, opts) => { calls.push({ execPath, args, opts }); return fakeChild(); },
+    execPath: "node", root: "/root", html: "/tmp/x.html", finalPdf: "/tmp/x.pdf", format: "letter", reportNum: "7",
+  });
+  assert.deepEqual(result, { ok: true, stderr: "" });
+  assert.deepEqual(calls[0].args.slice(1), ["/tmp/x.html", "/tmp/x.pdf", "--format=letter", "--report=7", "--allow-reorder"]);
+});
+
+test("spawnGeneratePdf converts nonzero, emitted error, and synchronous throw to failures", async () => {
+  const nonzero = await spawnGeneratePdf({ spawnFn: () => fakeChild({ exitCode: 1, stderr: "browser failed" }), execPath: "node", root: "/r", html: "h", finalPdf: "p", format: "a4", reportNum: "7" });
+  assert.deepEqual(nonzero, { ok: false, stderr: "browser failed" });
+  const emitted = await spawnGeneratePdf({ spawnFn: () => fakeChild({ spawnError: new Error("ENOENT") }), execPath: "node", root: "/r", html: "h", finalPdf: "p", format: "a4", reportNum: "7" });
+  assert.match(emitted.stderr, /failed to start: ENOENT/);
+  const thrown = await spawnGeneratePdf({ spawnFn: () => { throw new Error("EACCES"); }, execPath: "node", root: "/r", html: "h", finalPdf: "p", format: "a4", reportNum: "7" });
+  assert.match(thrown.stderr, /failed to start: EACCES/);
+});
+
+test("markTrackerReady parses structured success and error output", async () => {
+  const good = await markTrackerReady({ spawnFn: () => fakeChild({ stdout: '{"changed":true}' }), execPath: "node", root: "/r", reportNum: "7" });
+  assert.equal(good.ok, true);
+  assert.deepEqual(good.data, { changed: true });
+  const bad = await markTrackerReady({ spawnFn: () => fakeChild({ stdout: '{"error":"row missing"}', exitCode: 2 }), execPath: "node", root: "/r", reportNum: "7" });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.data.error, "row missing");
+});
+
+test("markTrackerReady preserves garbled output and converts child start failures", async () => {
+  const garbled = await markTrackerReady({ spawnFn: () => fakeChild({ stdout: "not json", stderr: "crash", exitCode: 1 }), execPath: "node", root: "/r", reportNum: "7" });
+  assert.deepEqual(garbled, { ok: false, data: null, stderr: "crash" });
+  const emitted = await markTrackerReady({ spawnFn: () => fakeChild({ spawnError: new Error("ENOENT") }), execPath: "node", root: "/r", reportNum: "7" });
+  assert.match(emitted.stderr, /failed to start: ENOENT/);
+  const thrown = await markTrackerReady({ spawnFn: () => { throw new Error("EACCES"); }, execPath: "node", root: "/r", reportNum: "7" });
+  assert.match(thrown.stderr, /failed to start: EACCES/);
+});
+
+test("cleanupPdfScratch removes only the current report prefix", () => {
+  const root = makeRoot();
+  const dir = join(root, "scratch");
+  mkdirSync(dir);
+  try {
+    for (const name of ["cv-web-7.payload.json", "cv-web-7.html", "cv-web-8.html"]) writeFileSync(join(dir, name), "x");
     cleanupPdfScratch(dir, "cv-web-7.");
-
-    // Then only the #7-prefixed files are gone
-    assert.deepEqual(readdirSync(dir).sort(), ["cv-web-99.html"]);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    assert.deepEqual(readdirSync(dir), ["cv-web-8.html"]);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test("cleanupPdfScratch: missing directory logs but does not throw", () => {
-  // Given the scratch directory itself doesn't exist
-  const parent = makeScratchDir();
-  const dir = join(parent, "does-not-exist");
-  const originalError = console.error;
+test("cleanupPdfScratch logs a missing directory instead of throwing", () => {
+  const root = makeRoot();
   const logged = [];
-  console.error = (msg) => logged.push(msg);
+  const original = console.error;
+  console.error = (message) => logged.push(message);
   try {
-    // When cleaning up
-    // Then it logs the failure instead of throwing, so a caller can't crash on cleanup
-    assert.doesNotThrow(() => cleanupPdfScratch(dir, "cv-web-1."));
+    assert.doesNotThrow(() => cleanupPdfScratch(join(root, "missing"), "cv-web-7."));
     assert.equal(logged.length, 1);
-    assert.match(logged[0], /pdf scratch cleanup: could not list/);
-  } finally {
-    console.error = originalError;
-    // The mkdtemp parent is real even though the child isn't — without this the
-    // suite leaves a co-pdfrender-* directory behind on every run.
-    rmSync(parent, { recursive: true, force: true });
-  }
+    assert.match(logged[0], /could not list/);
+  } finally { console.error = original; rmSync(root, { recursive: true, force: true }); }
 });
 
-test("cleanupPdfScratch: a single file's removal failure logs but does not throw or stop cleanup", () => {
-  // Given one prefixed entry that can't be removed as a plain file (a
-  // subdirectory, which fs.rmSync without `recursive` refuses) alongside a
-  // normal prefixed file that CAN be removed
-  const dir = makeScratchDir();
-  const originalError = console.error;
+test("cleanupPdfScratch continues after one matching entry cannot be removed", () => {
+  const root = makeRoot();
+  const dir = join(root, "scratch");
+  mkdirSync(dir);
+  mkdirSync(join(dir, "cv-web-7.stuck"));
+  writeFileSync(join(dir, "cv-web-7.html"), "x");
   const logged = [];
-  console.error = (msg) => logged.push(msg);
+  const original = console.error;
+  console.error = (message) => logged.push(message);
   try {
-    mkdirSync(join(dir, "cv-web-3.stuck-dir"));
-    writeFileSync(join(dir, "cv-web-3.html"), "x");
-
-    // When cleaning up report #3's scratch files
-    assert.doesNotThrow(() => cleanupPdfScratch(dir, "cv-web-3."));
-
-    // Then the failure is logged, the removable file is still gone, and the
-    // unremovable directory is left behind rather than crashing the caller
-    assert.equal(logged.length, 1);
-    assert.match(logged[0], /pdf scratch cleanup: could not remove cv-web-3\.stuck-dir/);
-    assert.deepEqual(readdirSync(dir), ["cv-web-3.stuck-dir"]);
-  } finally {
-    console.error = originalError;
-    rmSync(dir, { recursive: true, force: true });
-  }
+    assert.doesNotThrow(() => cleanupPdfScratch(dir, "cv-web-7."));
+    assert.deepEqual(readdirSync(dir), ["cv-web-7.stuck"]);
+    assert.match(logged[0], /could not remove cv-web-7\.stuck/);
+  } finally { console.error = original; rmSync(root, { recursive: true, force: true }); }
 });
 
-// ── renderAndMarkPdf ──
-
-function makePdfPaths(dir, reportNum) {
-  return {
-    html: join(dir, `cv-web-${reportNum}.html`),
-    finalPdf: join(dir, "output", `cv-jane-acme-2026-07-26.pdf`),
+function router(routes, calls) {
+  return (execPath, args, opts) => {
+    const script = args[0].split("/").pop();
+    calls.push(script);
+    return fakeChild(routes[script] ?? {});
   };
 }
 
-test("renderAndMarkPdf: happy path -> rendered with no warnings, scratch cleaned up", async () => {
-  // Given both scripts succeeding
-  const dir = makeScratchDir();
-  const pdfPaths = makePdfPaths(dir, "1");
-  writeFileSync(pdfPaths.html, "<html></html>");
-  const { spawnFn, calls } = makeRouterSpawn({
-    "generate-pdf.mjs": { exitCode: 0 },
-    "mark-pdf-ready.mjs": { exitCode: 0, stdout: JSON.stringify({ changed: true }) },
-  });
+test("renderAndMarkPdf runs write → build → render → mark and cleans scratch", async () => {
+  const root = makeRoot();
+  const pdfPaths = paths(root);
+  const calls = [];
   try {
-    // When rendering and marking
-    const result = await renderAndMarkPdf({ spawnFn, execPath: "node", root: "/root", pdfPaths, format: "a4", reportNum: "1" });
-
-    // Then it reports rendered with no warnings, and scratch is cleaned up
-    assert.deepEqual(result, { kind: "rendered", warnings: [] });
-    assert.deepEqual(readdirSync(dir).filter((f) => f.startsWith("cv-web-1.")), []);
-    // ...and the format actually reached generate-pdf.mjs. The argv was only
-    // inspected on the failure path, so a hardcoded or defaulted format would pass
-    // while every US/Canada CV rendered on the wrong page size.
-    const renderCall = calls.find((c) => c.args.some((a) => String(a).includes("generate-pdf.mjs")));
-    assert.ok(renderCall, "generate-pdf.mjs was never spawned");
-    assert.ok(renderCall.args.includes("--format=a4"), `expected --format=a4, got ${renderCall.args.join(" ")}`);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("renderAndMarkPdf: generate-pdf.mjs fails -> render-failed, mark-pdf-ready never invoked, scratch still cleaned up", async () => {
-  // Given generate-pdf.mjs exits non-zero
-  const dir = makeScratchDir();
-  const pdfPaths = makePdfPaths(dir, "3");
-  writeFileSync(pdfPaths.html, "<html></html>");
-  const { spawnFn, calls } = makeRouterSpawn({
-    "generate-pdf.mjs": { exitCode: 1, stderr: "Refusing to write the PDF outside the project directory" },
-    "mark-pdf-ready.mjs": { exitCode: 0 },
-  });
-  try {
-    // When rendering
-    const result = await renderAndMarkPdf({ spawnFn, execPath: "node", root: "/root", pdfPaths, format: "letter", reportNum: "3" });
-
-    // Then it reports render-failed with the render's stderr, never calls mark-pdf-ready, and still cleans scratch
-    assert.deepEqual(result, { kind: "render-failed", error: "Refusing to write the PDF outside the project directory" });
-    assert.equal(calls.length, 1);
-    assert.deepEqual(readdirSync(dir).filter((f) => f.startsWith("cv-web-3.")), []);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("renderAndMarkPdf: render succeeds but mark-pdf-ready fails with a parseable error -> rendered with a specific warning", async () => {
-  // Given generate-pdf.mjs succeeds but mark-pdf-ready.mjs fails with a --json error
-  const dir = makeScratchDir();
-  const pdfPaths = makePdfPaths(dir, "4");
-  writeFileSync(pdfPaths.html, "<html></html>");
-  const { spawnFn } = makeRouterSpawn({
-    "generate-pdf.mjs": { exitCode: 0 },
-    "mark-pdf-ready.mjs": { exitCode: 2, stdout: JSON.stringify({ error: "No tracker row links report #4", code: "not-found" }) },
-  });
-  try {
-    // When rendering and marking
-    const result = await renderAndMarkPdf({ spawnFn, execPath: "node", root: "/root", pdfPaths, format: "letter", reportNum: "4" });
-
-    // Then the PDF is still reported rendered, but the warning carries mark-pdf-ready's specific error
+    const result = await renderAndMarkPdf({
+      spawnFn: router({ "mark-pdf-ready.mjs": { stdout: '{"changed":true}' } }, calls),
+      execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
+    });
     assert.equal(result.kind, "rendered");
-    assert.equal(result.warnings.length, 1);
-    assert.match(result.warnings[0], /No tracker row links report #4/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    assert.deepEqual(calls, ["build-cv-html.mjs", "generate-pdf.mjs", "mark-pdf-ready.mjs"]);
+    assert.equal(existsSync(pdfPaths.payload), false);
+    assert.equal(existsSync(pdfPaths.html), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test("renderAndMarkPdf: render succeeds but mark-pdf-ready fails with no parseable stdout -> rendered with the generic fallback warning", async () => {
-  // Given generate-pdf.mjs succeeds but mark-pdf-ready.mjs crashes before printing any JSON
-  const dir = makeScratchDir();
-  const pdfPaths = makePdfPaths(dir, "5");
-  writeFileSync(pdfPaths.html, "<html></html>");
-  const { spawnFn } = makeRouterSpawn({
-    "generate-pdf.mjs": { exitCode: 0 },
-    "mark-pdf-ready.mjs": { exitCode: 1, stderr: "unexpected crash" },
-  });
+test("builder failure prevents render and mark, surfaces stderr, and cleans", async () => {
+  const root = makeRoot();
+  const pdfPaths = paths(root);
+  const calls = [];
   try {
-    // When rendering and marking
-    const result = await renderAndMarkPdf({ spawnFn, execPath: "node", root: "/root", pdfPaths, format: "letter", reportNum: "5" });
+    const result = await renderAndMarkPdf({
+      spawnFn: router({ "build-cv-html.mjs": { exitCode: 1, stderr: "candidate.name is required" } }, calls),
+      execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
+    });
+    assert.equal(result.kind, "build-failed");
+    assert.match(result.error, /candidate\.name/);
+    assert.deepEqual(calls, ["build-cv-html.mjs"]);
+    assert.equal(existsSync(pdfPaths.payload), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
 
-    // Then the PDF is still reported rendered, with the generic fallback
-    // warning (no mark.data.error to quote) rather than the crash text
+test("render failure prevents mark and still cleans", async () => {
+  const root = makeRoot();
+  const pdfPaths = paths(root);
+  const calls = [];
+  try {
+    const result = await renderAndMarkPdf({
+      spawnFn: router({ "generate-pdf.mjs": { exitCode: 1, stderr: "browser failed" } }, calls),
+      execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
+    });
+    assert.equal(result.kind, "render-failed");
+    assert.match(result.error, /browser failed/);
+    assert.deepEqual(calls, ["build-cv-html.mjs", "generate-pdf.mjs"]);
+    assert.equal(existsSync(pdfPaths.payload), false);
+    assert.equal(existsSync(pdfPaths.html), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("mark failure keeps successful PDF result but returns a warning", async () => {
+  const root = makeRoot();
+  const pdfPaths = paths(root);
+  const calls = [];
+  const original = console.error;
+  console.error = () => {};
+  try {
+    const result = await renderAndMarkPdf({
+      spawnFn: router({ "mark-pdf-ready.mjs": { exitCode: 2, stdout: '{"error":"row missing"}' } }, calls),
+      execPath: "node", root, pdfPaths, payload: PAYLOAD, format: "a4", reportNum: "7",
+    });
     assert.equal(result.kind, "rendered");
-    assert.equal(result.warnings.length, 1);
-    assert.match(result.warnings[0], /tracker's PDF column wasn't updated automatically/);
-    assert.match(result.warnings[0], /node mark-pdf-ready\.mjs 5/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-// ── writeCvHtml (#2185) ──
-//
-// The agent no longer writes the tailored CV — it emits it through the
-// <<cv-html>> envelope and the backend persists it here. These cases guard the
-// handover: the bytes must land verbatim, and a failed write must be reported
-// rather than swallowed — a silent failure would render a stale or missing file.
-
-test("writeCvHtml: writes the html verbatim", () => {
-  // Given a tailored document with characters a re-encode would mangle
-  const dir = makeScratchDir();
-  const html = '<!DOCTYPE html>\n<html><head><style>a>b{content:"<<"}</style></head><body>José — 5 &lt; 10</body></html>';
-  const paths = { html: join(dir, "cv-web-018.html"), finalPdf: join(dir, "out.pdf") };
-  try {
-    // When persisting the parsed envelope
-    const result = writeCvHtml({ pdfPaths: paths, html });
-
-    // Then the file lands byte-exact. The page format is NOT written here — it
-    // goes straight to renderAndMarkPdf, so there is no sidecar to keep in sync.
-    assert.equal(result.ok, true);
-    assert.equal(readFileSync(paths.html, "utf8"), html);
-    assert.deepEqual(readdirSync(dir), ["cv-web-018.html"]);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("writeCvHtml: an unwritable target reports failure instead of continuing", () => {
-  // Given an html path whose parent directory does not exist
-  const dir = makeScratchDir();
-  const paths = {
-    html: join(dir, "no-such-dir", "cv.html"),
-    finalPdf: join(dir, "out.pdf"),
-  };
-  try {
-    // When persisting
-    const result = writeCvHtml({ pdfPaths: paths, html: "<html></html>" });
-
-    // Then it fails fast and says why — the caller must not go on to render
-    assert.equal(result.ok, false);
-    assert.match(result.error, /cv\.html/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("writeCvHtml: an error carrying no path still names a file", () => {
-  // Given a write that fails with a non-fs error — no `.path` property (e.g. an
-  // oversized-content RangeError). Without the fallback the user is told the CV
-  // could not be saved to "undefined".
-  const dir = makeScratchDir();
-  const paths = { html: join(dir, "cv.html"), finalPdf: join(dir, "out.pdf") };
-  try {
-    // When persisting a value writeFileSync refuses to serialize
-    const result = writeCvHtml({ pdfPaths: paths, html: { not: "a string" } });
-
-    // Then it fails naming the intended file rather than `undefined`
-    assert.equal(result.ok, false);
-    assert.ok(!result.error.includes("undefined"), `error names no file: ${result.error}`);
-    assert.match(result.error, /cv\.html/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-// ── pdfRunOutcome (#2185) ──
-//
-// The honesty gate. It decides both whether anything is written and whether the
-// run is reported as success, so it must never call a run good on thin evidence.
-
-const OK_ENVELOPE = { ok: true, html: "<html></html>", format: "a4", warnings: [] };
-const GOOD = { envelope: OK_ENVELOPE, noOutputMessage: null, sawError: false, cleanExit: true, hasPaths: true };
-
-test("pdfRunOutcome: a clean run with a parsed envelope is the only success", () => {
-  // Given every signal healthy
-  // Then the run proceeds to write and render
-  assert.deepEqual(pdfRunOutcome(GOOD), { ok: true });
-});
-
-test("pdfRunOutcome: each degraded signal on its own blocks the render", () => {
-  // Given one thing wrong at a time — no single failure may be shrugged off
-  const degraded = {
-    "unparsed envelope": { envelope: { ok: false, error: "never closed" } },
-    "missing envelope": { envelope: undefined },
-    "dirty exit": { cleanExit: false },
-    "stderr error": { sawError: true },
-    "no scratch paths": { hasPaths: false },
-  };
-  for (const [label, override] of Object.entries(degraded)) {
-    // When deciding the outcome
-    const outcome = pdfRunOutcome({ ...GOOD, ...override });
-
-    // Then it fails with a message, never silently
-    assert.equal(outcome.ok, false, `${label} must block the render`);
-    assert.ok(outcome.message.length > 0, `${label} must explain itself`);
-  }
-});
-
-test("pdfRunOutcome: the parser's reason is surfaced, not swallowed", () => {
-  // Given the envelope failed for a specific, actionable reason
-  const outcome = pdfRunOutcome({ ...GOOD, envelope: { ok: false, error: "the envelope was never closed" } });
-
-  // Then that reason reaches the user — "never closed" and "no envelope at all"
-  // are different bugs and the difference is what tells them what to do
-  assert.equal(outcome.ok, false);
-  assert.match(outcome.message, /never closed/);
-});
-
-test("pdfRunOutcome: the route's no-output verdict wins over the generic message", () => {
-  // Given the caller already decided the CLI produced nothing usable. That is a
-  // transport question, so the route owns the wording and passes it in — this
-  // module must not carry a second copy of those strings.
-  const outcome = pdfRunOutcome({
-    ...GOOD,
-    envelope: undefined,
-    noOutputMessage: "The CLI produced no output — is it installed and authenticated?",
-  });
-
-  // Then that message is surfaced verbatim, not replaced by "didn't produce a CV",
-  // because "nothing ran" and "ran but fell short" need different advice
-  assert.equal(outcome.ok, false);
-  assert.match(outcome.message, /installed and authenticated/);
-});
-
-test("pdfRunOutcome: a no-output verdict outranks an otherwise healthy envelope", () => {
-  // Given contradictory signals — a parsed envelope but the route saw no output
-  const outcome = pdfRunOutcome({ ...GOOD, noOutputMessage: "nothing came back" });
-
-  // Then it fails closed rather than rendering on the strength of the envelope
-  assert.equal(outcome.ok, false);
-  assert.equal(outcome.message, "nothing came back");
-});
-
-test("writeCvHtml: a shorter re-render leaves no trailing bytes", () => {
-  // Given the same report rendered twice, the second CV shorter than the first.
-  // route.ts clears no stale scratch file because this function is documented to
-  // rewrite the HTML before any render — a claim that rests entirely on
-  // writeFileSync truncating. Switch to an append flag, or to a write-then-rename
-  // helper, and every other test here stays green while the renderer reads the tail
-  // of a previous run's CV.
-  const dir = makeScratchDir();
-  const paths = { html: join(dir, "cv-web-018.html"), finalPdf: join(dir, "out.pdf") };
-  const long = `<!DOCTYPE html><html><body>${"X".repeat(4000)}</body></html>`;
-  const short = "<!DOCTYPE html><html><body>short</body></html>";
-  try {
-    // When the long document is written and then the short one to the same path
-    assert.equal(writeCvHtml({ pdfPaths: paths, html: long }).ok, true);
-    assert.equal(writeCvHtml({ pdfPaths: paths, html: short }).ok, true);
-
-    // Then the file is exactly the short document, with nothing left over
-    const onDisk = readFileSync(paths.html, "utf8");
-    assert.equal(onDisk, short);
-    assert.ok(!onDisk.includes("XXXX"), "trailing bytes from the earlier write survived");
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    assert.match(result.warnings[0], /row missing/);
+  } finally { console.error = original; rmSync(root, { recursive: true, force: true }); }
 });

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -18,6 +18,9 @@ import {
 } from "../../src/lib/pdf-render.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+// Real timers keep these integration-style child fixtures honest; leave enough
+// headroom for coarse or loaded CI event loops without slowing the suite much.
+const SYNTHETIC_TIMEOUT_MS = 50;
 
 /**
  * Model a spawned child whose output and terminal event arrive asynchronously,
@@ -156,10 +159,9 @@ test("spawnBuildCvHtml times out and terminates a hung child", async () => {
     if (signal === "SIGTERM") sawTerm();
     return true;
   };
-  const timeoutMs = 50;
   const resultPromise = spawnBuildCvHtml({
     spawnFn: () => child,
-    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: SYNTHETIC_TIMEOUT_MS,
   });
   await termSent;
   let resolved = false;
@@ -169,7 +171,7 @@ test("spawnBuildCvHtml times out and terminates a hung child", async () => {
   child.emit("close", null);
   const result = await resultPromise;
   assert.equal(result.ok, false);
-  assert.match(result.stderr, new RegExp(`timed out after ${timeoutMs}ms`));
+  assert.match(result.stderr, new RegExp(`timed out after ${SYNTHETIC_TIMEOUT_MS}ms`));
   assert.deepEqual(signals, ["SIGTERM"]);
 });
 
@@ -183,13 +185,12 @@ test("spawnBuildCvHtml escalates a timed-out child that ignores SIGTERM", async 
     if (signal === "SIGKILL") queueMicrotask(() => child.emit("close", null));
     return true;
   };
-  const timeoutMs = 50;
   const result = await spawnBuildCvHtml({
     spawnFn: () => child,
-    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: SYNTHETIC_TIMEOUT_MS,
   });
   assert.equal(result.ok, false);
-  assert.match(result.stderr, new RegExp(`timed out after ${timeoutMs}ms`));
+  assert.match(result.stderr, new RegExp(`timed out after ${SYNTHETIC_TIMEOUT_MS}ms`));
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
 });
 
@@ -210,10 +211,9 @@ test("spawnBuildCvHtml does not treat a signal-delivery error as child exit", as
     }
     return signal === "SIGKILL";
   };
-  const timeoutMs = 50;
   const resultPromise = spawnBuildCvHtml({
     spawnFn: () => child,
-    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs,
+    execPath: "node", root: "/r", payload: "p", html: "h", timeoutMs: SYNTHETIC_TIMEOUT_MS,
   });
   await termSent;
   await Promise.resolve();
@@ -223,7 +223,7 @@ test("spawnBuildCvHtml does not treat a signal-delivery error as child exit", as
   assert.equal(resolved, false, "signal error does not release scratch cleanup");
   const result = await resultPromise;
   assert.equal(result.ok, false);
-  assert.match(result.stderr, new RegExp(`timed out after ${timeoutMs}ms`));
+  assert.match(result.stderr, new RegExp(`timed out after ${SYNTHETIC_TIMEOUT_MS}ms`));
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
 });
 

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -19,6 +19,10 @@ import {
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
+/**
+ * Model a spawned child whose output and terminal event arrive asynchronously,
+ * preserving the event order the production wrapper must handle.
+ */
 function fakeChild({ stdout = "", stderr = "", exitCode = 0, spawnError = null } = {}) {
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
@@ -320,6 +324,10 @@ test("cleanupPdfScratch continues after one matching entry cannot be removed", (
   } finally { console.error = original; rmSync(root, { recursive: true, force: true }); }
 });
 
+/**
+ * Route script launches to configured fake results while recording their order;
+ * template resolution gets the normal fixture path when no override is supplied.
+ */
 function router(routes, calls) {
   return (execPath, args, opts) => {
     const script = args[0].split("/").pop();

--- a/web/tests/lib/run-cli-support.test.mjs
+++ b/web/tests/lib/run-cli-support.test.mjs
@@ -26,7 +26,7 @@ test("Codex agent message becomes dashboard text, newline-terminated", () => {
   // Given: Codex sends complete messages with NO trailing newline ("hello", not
   // "hello\n"), so without termination consecutive messages glue mid-line —
   // which runs narration together in the log and breaks the line-anchored
-  // <<cv-html>> markers in pdf mode.
+  // <<cv-payload>> markers in pdf mode.
   const event = parseCodexEvent(JSON.stringify({
     type: "item.completed",
     item: { type: "agent_message", text: "VERDICT: 4.2/5 — strong fit" },
@@ -53,7 +53,10 @@ test("a cv envelope in its own Codex message survives preceding narration", () =
   }));
   const envelope = parseCodexEvent(JSON.stringify({
     type: "item.completed",
-    item: { type: "agent_message", text: '<<cv-html format="a4">>\n<!DOCTYPE html><html><body>CV</body></html>\n<</cv-html>>' },
+    item: {
+      type: "agent_message",
+      text: '<<cv-payload>>\n{"page_format":"a4","candidate":{"name":"Test"},"summary":"Summary","competencies":[],"skills":[]}\n<</cv-payload>>',
+    },
   }));
 
   // When: both flow through the same filter the route feeds via sendAgentText.
@@ -66,7 +69,7 @@ test("a cv envelope in its own Codex message survives preceding narration", () =
   const result = filter.result();
   assert.equal(result.ok, true);
   assert.equal(result.format, "a4");
-  assert.match(result.html, /<\/html>/);
+  assert.equal(result.payload.candidate.name, "Test");
 });
 
 test("Codex turn.started maps to a kind-agnostic working status", () => {

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -50,16 +50,22 @@ test("buildPrompt: the pdf prompt never tells the agent to save a file", () => {
   assert.ok(!/\.meta\.json/.test(prompt), "pdf prompt must not name the sidecar path");
 });
 
-test("buildPrompt: the pdf prompt offers both page formats", () => {
-  // Given the marker example once interpolated the parser's FALLBACK, which made
-  // the prompt read "choose letter for a US/Canada company, otherwise letter" —
-  // biasing every CV to one size. The tailoring rule and the fallback are separate.
+test("buildPrompt: the JSON payload offers both page formats", () => {
   const prompt = buildPrompt({ kind: "pdf", ...ARGS });
 
   // Then both spellings are shown, and the rule distinguishes them
-  assert.match(prompt, /format="a4"/);
-  assert.match(prompt, /format="letter"/);
-  assert.match(prompt, /letter for a US\/Canada company, otherwise a4/i);
+  assert.match(prompt, /page_format to "letter"/);
+  assert.match(prompt, /"a4" otherwise/);
+  assert.match(prompt, /"letter" for a US\/Canada company and "a4" otherwise/i);
+});
+
+test("buildPrompt: the agent emits payload data, never agent-authored HTML", () => {
+  const prompt = buildPrompt({ kind: "pdf", ...ARGS });
+  assert.match(prompt, /complete structured JSON payload/i);
+  assert.match(prompt, /Do not produce HTML/i);
+  assert.match(prompt, /never .*Markdown fences/i);
+  assert.ok(!prompt.includes("cv-template.html"));
+  assert.ok(!prompt.includes("<!DOCTYPE html>"));
 });
 
 test("buildPrompt: the pdf prompt still pins tailoring to the real mode", () => {


### PR DESCRIPTION
Closes #2505.

## Problem

Web PDF mode asked the model to author the complete CV HTML document. That duplicated `build-cv-html.mjs`, made the model output substantially larger than the underlying CV data, and allowed the web path to drift from the deterministic CLI builder.

## Change

- replace the `<<cv-html>>` response with a canonical `<<cv-payload>>` JSON envelope
- validate and persist that payload before invoking `build-cv-html.mjs`
- make the deterministic builder the HTML writer in the normal web PDF backend pipeline
- preserve the trusted local profile photo instead of accepting an agent-supplied path
- render and mark the application tracker only after the builder succeeds
- clean scratch payload/HTML files on success, renderer failure, builder failure, and synchronous spawn failure
- wait for timed-out builder/renderer children to actually exit before cleanup, with escalation to `SIGKILL`
- centralize the scratch-file prefix so creation and cleanup cannot silently drift
- honor the configured CV template throughout the web pipeline
- update the Claude/Codex prompt contracts, help text, docs, and regression coverage

## Acceptance evidence

| Criterion | Evidence |
|---|---|
| Same-report PDF equivalence | A controlled replay held the canonical payload and generated HTML constant across the legacy persistence/render path and the new build/render path. Both produced the exact hashes below. |
| Builder owns web HTML | The normal web backend sequence is now payload write → `build-cv-html.mjs` → `generate-pdf.mjs` → tracker mark; the route no longer writes HTML. The lifecycle test asserts that order. |
| Missing required fields fail loudly | Real builder subprocess tests cover missing `candidate`, `candidate.name`, and `summary`; each exits non-zero and leaves no HTML file. |
| Before/after output-token cost | One paired real Codex observation used the same candidate/job fixture and production prompt path; results are below. |
| Claude agent still has no write tool | The existing `web/tests/lib/claude-invocation.test.mjs` coverage and required `test-all.mjs` §55.6 argv freeze remain in place and pass. Other CLIs retain their pre-existing native capabilities. |

### Controlled output equivalence

For a controlled transport replay, I first generated HTML from one frozen canonical payload, then fed that exact HTML through the legacy persistence/render path and fed the payload through the new build/render path. The resulting artifacts were byte-identical:

- HTML: 22,510 bytes, SHA-256 `06df8ed044fac20458d63a7d08e6897c0f5b4df309aaba27d075fc5298469541`
- PDF: 106,139 bytes, SHA-256 `a3d1810e7e37c23fed78525f7ac6105942d255e8d7685dee0a8a4fe4ac09d040`

This satisfies byte equivalence with authored CV content held constant and isolates persistence/rendering from stochastic model-content differences. If the criterion instead requires two independent model generations to match byte-for-byte, that remains unproven; separate model samples are not deterministic.

### Observed output cost

In one paired Codex observation on the same report fixture and model, using each revision's production prompt:

- model output tokens: 10,565 before -> 3,252 after (69.2% reduction)
- emitted response text: 19,965 bytes before -> 4,533 bytes after (77.3% reduction)

The observed reduction is a paired observation, not a benchmark.

The full production `/api/run` path also completed with HTTP 200, generated the PDF, updated the tracker, and removed its scratch payload/HTML files.

## Verification

- `cd web && npm test` — 358 passed, 0 failed
- `cd web && node --test tests/lib/pdf-render.test.mjs` — 25 passed, 0 failed
- `node test-all.mjs --quick` — 6,568 passed, 0 failed
- `cd web && npx tsc --noEmit`
- `cd web && npm run build`
- focused canonical-payload validation — 11 assertions passed
- local changed-function docstring audit — 24/29 (82.76%), matching CodeRabbit's reported function total and threshold scope

The live model acceptance measurement used Codex. Claude's no-write-tool contract remains covered by `web/tests/lib/claude-invocation.test.mjs` and the required `test-all.mjs` §55.6 argv freeze; shared prompt/parser tests cover the no-HTML payload contract. A live Claude run was unavailable because the local OAuth session had expired.

I also simulated integration with open PR #2941. Its only textual conflict is the `<<cv-html>>`/`<<cv-payload>>` marker comment in `claude-invocation.mjs`; retaining the payload wording produced a combined tree with 6,558 passing checks and no failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PDF generation now uses structured CV data to create consistent, ATS-safe documents.
  - Profile photos follow configured profile settings.
  - PDF page format is derived from the CV data.
  - HTML is generated consistently before PDF rendering.

- **Bug Fixes**
  - Invalid or incomplete CV data is rejected before document creation.
  - Improved handling of build and rendering failures, malformed responses, timeouts, and temporary-file cleanup.

- **Documentation**
  - Updated PDF-generation guidance with structured output and validation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
