### PR TITLE
fix(update-system): refuse to run when the install is not its own git toplevel

### DIFF
--- a/tests/updater-nested-checkout-guard.test.mjs
+++ b/tests/updater-nested-checkout-guard.test.mjs
@@ -1,0 +1,149 @@
+/**
+ * updater-nested-checkout-guard.test.mjs — nested .git-less install guard (#3334).
+ *
+ * A career-ops install with no `.git` of its own that sits inside another
+ * repository (a ZIP unpacked into an existing project) used to make every git
+ * call in update-system.mjs resolve to that OUTER repo: check() reported a
+ * phantom system-files-changed against a stranger's history, and apply()
+ * created its backup branch and fetched upstream into a repository that has
+ * nothing to do with career-ops, then failed on pathspecs prefixed by the
+ * install's subpath — `git checkout FETCH_HEAD -- update-system.mjs` is the
+ * failing path from the original report.
+ *
+ * The behavioral sections spawn the real CLI inside a throwaway outer repo.
+ * That is possible without staging the whole tree because update-system.mjs is
+ * self-loading by contract (#1706): copying just it and VERSION is a faithful
+ * model of the ZIP install that triggers the bug.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, existsSync, realpathSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, NODE, ROOT, rmSync, hermeticGitEnv } from './helpers.mjs';
+import { gitIn, gitToplevelMismatch } from '../update-system.mjs';
+
+console.log('\n🧪 Testing updater nested-checkout guard (#3334)...');
+
+const canonicalize = realpathSync.native ?? realpathSync;
+
+// An outer repo with a .git-less career-ops copy at tools/career-ops, committed
+// as vendored content — the layout the ZIP install produces.
+function makeNestedFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-nested-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  // Without these, a contributor's global gpg signer or hooksPath kills the
+  // fixture commits below (#2754) — same two lines as the sibling fixtures.
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
+  // The vendored copy is added with LF content; without this, Windows git
+  // prints a CRLF warning per file into every section's output.
+  g('config', 'core.autocrlf', 'false');
+  const nested = join(dir, 'tools', 'career-ops');
+  mkdirSync(nested, { recursive: true });
+  copyFileSync(join(ROOT, 'update-system.mjs'), join(nested, 'update-system.mjs'));
+  copyFileSync(join(ROOT, 'VERSION'), join(nested, 'VERSION'));
+  g('add', '-A');
+  g('commit', '-qm', 'vendored');
+  return { dir, g, nested };
+}
+
+function runUpdater(fixture, cmd) {
+  return spawnSync(NODE, ['update-system.mjs', cmd], {
+    cwd: fixture.nested,
+    encoding: 'utf-8',
+    timeout: 60000,
+    env: hermeticGitEnv(join(fixture.dir, 'hermetic-gitconfig')),
+  });
+}
+
+// ── 1. gitToplevelMismatch: the unit seam ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const foreign = gitToplevelMismatch(fixture.nested);
+    if (foreign && canonicalize(foreign) === canonicalize(fixture.dir)) {
+      pass('gitToplevelMismatch names the enclosing repo for a nested .git-less install');
+    } else {
+      fail(`gitToplevelMismatch returned ${JSON.stringify(foreign)} for a nested install (expected the outer repo)`);
+    }
+    if (gitToplevelMismatch(fixture.dir) === null) {
+      pass('gitToplevelMismatch is null for a repo that is its own toplevel');
+    } else {
+      fail('gitToplevelMismatch reported a mismatch for a healthy toplevel checkout');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 2. check: reports the layout as a status and touches nothing ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const res = runUpdater(fixture, 'check');
+    let status;
+    try { status = JSON.parse(res.stdout).status; } catch { status = undefined; }
+    if (res.status === 0 && status === 'not-a-git-toplevel') {
+      pass('check reports not-a-git-toplevel instead of diffing the outer repo');
+    } else {
+      fail(`check on a nested install exited ${res.status} with stdout ${JSON.stringify(res.stdout.slice(0, 200))}`);
+    }
+    if (!existsSync(join(fixture.dir, '.git', 'FETCH_HEAD'))) {
+      pass('check leaves the outer repo\'s FETCH_HEAD alone');
+    } else {
+      fail('check fetched into the outer repository');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 3. apply: refuses before the first side effect ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const res = runUpdater(fixture, 'apply');
+    if (res.status !== 0 && res.stderr.includes('enclosing repository')) {
+      pass('apply refuses a nested .git-less install with an actionable error');
+    } else {
+      fail(`apply on a nested install exited ${res.status} with stderr ${JSON.stringify(res.stderr.slice(0, 200))}`);
+    }
+    const branches = fixture.g('for-each-ref', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');
+    if (branches === '') {
+      pass('apply creates no backup branch in the outer repository');
+    } else {
+      fail(`apply left backup branches in the outer repository: ${branches}`);
+    }
+    if (!existsSync(join(fixture.dir, '.git', 'FETCH_HEAD'))) {
+      pass('apply never fetches into the outer repository');
+    } else {
+      fail('apply fetched upstream into the outer repository\'s FETCH_HEAD');
+    }
+    if (!existsSync(join(fixture.nested, '.update-lock'))) {
+      pass('apply refuses before taking the update lock');
+    } else {
+      fail('apply left .update-lock behind after refusing');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 4. rollback: same precondition ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const res = runUpdater(fixture, 'rollback');
+    if (res.status !== 0 && res.stderr.includes('enclosing repository')) {
+      pass('rollback refuses a nested .git-less install instead of reading the outer repo\'s branches');
+    } else {
+      fail(`rollback on a nested install exited ${res.status} with stderr ${JSON.stringify(res.stderr.slice(0, 200))}`);
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -732,6 +732,62 @@ function gitQuiet(...args) {
 }
 
 /**
+ * The enclosing repository's toplevel when ROOT is not a git toplevel itself,
+ * or null when ROOT is its own toplevel (or not inside any worktree at all).
+ *
+ * Every git call in this file runs with `cwd: ROOT` and assumes that resolves
+ * to the career-ops checkout. An install with no `.git` of its own that sits
+ * INSIDE another repository — a ZIP unpacked into an existing project — breaks
+ * that silently: git walks up, finds the outer repo, and every rev-parse,
+ * fetch, branch and checkout lands there, with pathspecs failing because at
+ * that root the files are prefixed by the install's subpath (#3334). Callers
+ * use this to refuse before the first side effect.
+ *
+ * A ROOT inside no worktree at all returns null: that layout has no foreign
+ * repo to damage, and each command already has its own handling for git
+ * being unavailable.
+ *
+ * @param {string} [root=ROOT] - Directory to test.
+ * @returns {string|null} The foreign toplevel path, or null.
+ */
+export function gitToplevelMismatch(root = ROOT) {
+  let toplevel;
+  try {
+    toplevel = gitIn(root, 'rev-parse', '--show-toplevel');
+  } catch {
+    return null;
+  }
+  if (!toplevel) return null;
+  // Realpath both sides: git resolves symlinks and reports on-disk casing
+  // (macOS /tmp -> /private/tmp; Windows 8.3 names), while `root` keeps
+  // whatever spelling the process was launched with. Same policy as the CLI
+  // guard at the bottom of this file. On a realpath failure fall back to
+  // resolve(): a false MISMATCH refuses an update, a false match fetches into
+  // a stranger's repo, so the fallback only ever errs toward refusing.
+  const canonicalize = realpathSync.native ?? realpathSync;
+  let same;
+  try {
+    same = canonicalize(toplevel) === canonicalize(root);
+  } catch {
+    same = resolve(toplevel) === resolve(root);
+  }
+  return same ? null : toplevel;
+}
+
+/**
+ * Throw when git operations from ROOT would land in an enclosing repository.
+ * First statement of apply() and rollback(); check() reports a status instead.
+ */
+function assertOwnGitToplevel() {
+  const foreignToplevel = gitToplevelMismatch();
+  if (foreignToplevel) {
+    throw new Error(
+      `career-ops at ${ROOT} is not a git checkout of its own, so git operations would land in the enclosing repository at ${foreignToplevel} — this happens when the install was unpacked from a ZIP or copied without its .git directory. Nothing was changed. To make updates work, clone career-ops fresh (git clone ${CANONICAL_REPO}) and move your user-layer files (cv.md, config/, data/, reports/ — see DATA_CONTRACT.md) into the new clone.`,
+    );
+  }
+}
+
+/**
  * Paths the target manifest ships that did not materialize on disk.
  *
  * apply() reports success without checking that the checkout loop actually
@@ -1336,6 +1392,18 @@ async function check() {
     return;
   }
 
+  // Before any git call: on an install nested inside a foreign repository the
+  // rev-parse below reads the OUTER repo's HEAD and the drift fetch writes the
+  // OUTER repo's FETCH_HEAD, so check reports a phantom system-files-changed
+  // forever on a byte-identical install (#3334). Report the layout as its own
+  // status instead; agents ignore unknown statuses by contract (AGENTS.md),
+  // and apply() refuses the same layout with the actionable message.
+  const foreignToplevel = gitToplevelMismatch();
+  if (foreignToplevel) {
+    console.log(JSON.stringify({ status: 'not-a-git-toplevel', local: localVersion(), toplevel: foreignToplevel }));
+    return;
+  }
+
   const local = localVersion();
   let remote = '';
   let releaseVersion = '';
@@ -1605,6 +1673,7 @@ export function reconcileGitignore(localText, upstreamText) {
 // ── APPLY ───────────────────────────────────────────────────────
 
 async function apply() {
+  assertOwnGitToplevel();
   const local = localVersion();
   // --force overwrites system files this install edited locally (#2337). The
   // env var carries the flag across the self-reexec, which re-invokes the
@@ -2099,6 +2168,9 @@ async function apply() {
 // ── ROLLBACK ────────────────────────────────────────────────────
 
 function rollback() {
+  // Same precondition as apply(): a nested .git-less install would look its
+  // backup branches up — and check files out — in the enclosing repo (#3334).
+  assertOwnGitToplevel();
   // Find most recent backup branch
   try {
     const branches = git('for-each-ref', '--sort=-committerdate', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');


### PR DESCRIPTION
## What does this PR do?

Fixes the surviving variant scoped in #3334: an install with no `.git` of its own sitting inside another repository (the ZIP-unpacked-into-an-existing-project layout) made every git call in `update-system.mjs` resolve to the outer repo — `check` reported phantom `system-files-changed` drift and fetched upstream into the outer repo's FETCH_HEAD, and `apply` created its backup branch there before failing on subpath-prefixed pathspecs. A new `gitToplevelMismatch()` helper realpath-compares `git rev-parse --show-toplevel` against ROOT; `check` now reports a `not-a-git-toplevel` status before touching git or the network (agents stay silent on unknown statuses per AGENTS.md), and `apply`/`rollback` refuse with an actionable message before their first side effect.

The new test spawns the real CLI inside a throwaway outer repo (possible because update-system.mjs is self-loading per #1706) and pins the failing path from the original report: no backup branch, no FETCH_HEAD, no `.update-lock` land in the enclosing repository. It fails on current main and passes here. Verified locally on Windows: full `node test-all.mjs --quick`, `go test ./...`, and `node upgrade-tests.mjs --pr-gate` (a real old-release-to-this-commit apply through the guarded updater) are green. Three unrelated suite failures on my machine are local-environment artifacts (Node 22 vs CI's Node 24 type stripping, `core.symlinks=false` symlink stubs, one load-induced timeout) and are byte-identical on unmodified main.

Deliberately left alone: an install inside no git worktree at all keeps its current behavior, and `doctor.mjs` still has no check for this layout — both would be follow-ups if wanted.

## Related issue

Fixes #3334

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented update operations from modifying an enclosing Git repository when the installation is nested inside another repository.
  * Added a clear error when applying or rolling back from an invalid Git location.
  * Updated checks to report `not-a-git-toplevel` without performing repository operations.
* **Tests**
  * Added coverage for nested installations, including check, apply, rollback, and repository-detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->