### PR TITLE
fix(update-system): prioritize nested layout check

### DIFF
--- a/tests/updater-nested-checkout-guard.test.mjs
+++ b/tests/updater-nested-checkout-guard.test.mjs
@@ -1,0 +1,149 @@
+/**
+ * updater-nested-checkout-guard.test.mjs — nested .git-less install guard (#3334).
+ *
+ * A career-ops install with no `.git` of its own that sits inside another
+ * repository (a ZIP unpacked into an existing project) used to make every git
+ * call in update-system.mjs resolve to that OUTER repo: check() reported a
+ * phantom system-files-changed against a stranger's history, and apply()
+ * created its backup branch and fetched upstream into a repository that has
+ * nothing to do with career-ops, then failed on pathspecs prefixed by the
+ * install's subpath — `git checkout FETCH_HEAD -- update-system.mjs` is the
+ * failing path from the original report.
+ *
+ * The behavioral sections spawn the real CLI inside a throwaway outer repo.
+ * That is possible without staging the whole tree because update-system.mjs is
+ * self-loading by contract (#1706): copying just it and VERSION is a faithful
+ * model of the ZIP install that triggers the bug.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, existsSync, realpathSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, NODE, ROOT, rmSync, hermeticGitEnv } from './helpers.mjs';
+import { gitIn, gitToplevelMismatch } from '../update-system.mjs';
+
+console.log('\n🧪 Testing updater nested-checkout guard (#3334)...');
+
+const canonicalize = realpathSync.native ?? realpathSync;
+
+// An outer repo with a .git-less career-ops copy at tools/career-ops, committed
+// as vendored content — the layout the ZIP install produces.
+function makeNestedFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-nested-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  // Without these, a contributor's global gpg signer or hooksPath kills the
+  // fixture commits below (#2754) — same two lines as the sibling fixtures.
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
+  // The vendored copy is added with LF content; without this, Windows git
+  // prints a CRLF warning per file into every section's output.
+  g('config', 'core.autocrlf', 'false');
+  const nested = join(dir, 'tools', 'career-ops');
+  mkdirSync(nested, { recursive: true });
+  copyFileSync(join(ROOT, 'update-system.mjs'), join(nested, 'update-system.mjs'));
+  copyFileSync(join(ROOT, 'VERSION'), join(nested, 'VERSION'));
+  g('add', '-A');
+  g('commit', '-qm', 'vendored');
+  return { dir, g, nested };
+}
+
+function runUpdater(fixture, cmd) {
+  return spawnSync(NODE, ['update-system.mjs', cmd], {
+    cwd: fixture.nested,
+    encoding: 'utf-8',
+    timeout: 60000,
+    env: hermeticGitEnv(join(fixture.dir, 'hermetic-gitconfig')),
+  });
+}
+
+// ── 1. gitToplevelMismatch: the unit seam ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const foreign = gitToplevelMismatch(fixture.nested);
+    if (foreign && canonicalize(foreign) === canonicalize(fixture.dir)) {
+      pass('gitToplevelMismatch names the enclosing repo for a nested .git-less install');
+    } else {
+      fail(`gitToplevelMismatch returned ${JSON.stringify(foreign)} for a nested install (expected the outer repo)`);
+    }
+    if (gitToplevelMismatch(fixture.dir) === null) {
+      pass('gitToplevelMismatch is null for a repo that is its own toplevel');
+    } else {
+      fail('gitToplevelMismatch reported a mismatch for a healthy toplevel checkout');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 2. check: reports the layout as a status and touches nothing ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const res = runUpdater(fixture, 'check');
+    let status;
+    try { status = JSON.parse(res.stdout).status; } catch { status = undefined; }
+    if (res.status === 0 && status === 'not-a-git-toplevel') {
+      pass('check reports not-a-git-toplevel instead of diffing the outer repo');
+    } else {
+      fail(`check on a nested install exited ${res.status} with stdout ${JSON.stringify(res.stdout.slice(0, 200))}`);
+    }
+    if (!existsSync(join(fixture.dir, '.git', 'FETCH_HEAD'))) {
+      pass('check leaves the outer repo\'s FETCH_HEAD alone');
+    } else {
+      fail('check fetched into the outer repository');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 3. apply: refuses before the first side effect ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const res = runUpdater(fixture, 'apply');
+    if (res.status !== 0 && res.stderr.includes('enclosing repository')) {
+      pass('apply refuses a nested .git-less install with an actionable error');
+    } else {
+      fail(`apply on a nested install exited ${res.status} with stderr ${JSON.stringify(res.stderr.slice(0, 200))}`);
+    }
+    const branches = fixture.g('for-each-ref', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');
+    if (branches === '') {
+      pass('apply creates no backup branch in the outer repository');
+    } else {
+      fail(`apply left backup branches in the outer repository: ${branches}`);
+    }
+    if (!existsSync(join(fixture.dir, '.git', 'FETCH_HEAD'))) {
+      pass('apply never fetches into the outer repository');
+    } else {
+      fail('apply fetched upstream into the outer repository\'s FETCH_HEAD');
+    }
+    if (!existsSync(join(fixture.nested, '.update-lock'))) {
+      pass('apply refuses before taking the update lock');
+    } else {
+      fail('apply left .update-lock behind after refusing');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 4. rollback: same precondition ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    const res = runUpdater(fixture, 'rollback');
+    if (res.status !== 0 && res.stderr.includes('enclosing repository')) {
+      pass('rollback refuses a nested .git-less install instead of reading the outer repo\'s branches');
+    } else {
+      fail(`rollback on a nested install exited ${res.status} with stderr ${JSON.stringify(res.stderr.slice(0, 200))}`);
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}

--- a/tests/updater-nested-checkout-guard.test.mjs
+++ b/tests/updater-nested-checkout-guard.test.mjs
@@ -102,7 +102,30 @@ function runUpdater(fixture, cmd) {
   }
 }
 
-// ── 3. apply: refuses before the first side effect ──
+// ── 3. check: nested layout beats a dismissed local update flag ──
+{
+  const fixture = makeNestedFixture();
+  try {
+    writeFileSync(join(fixture.nested, '.update-dismissed'), 'dismissed by operator\n');
+    const res = runUpdater(fixture, 'check');
+    let body;
+    try { body = JSON.parse(res.stdout); } catch { body = {}; }
+    if (res.status === 0 && body.status === 'not-a-git-toplevel' && body.local && body.toplevel) {
+      pass('check reports not-a-git-toplevel before honoring .update-dismissed in a nested install');
+    } else {
+      fail(`check on a dismissed nested install exited ${res.status} with stdout ${JSON.stringify(res.stdout.slice(0, 200))}`);
+    }
+    if (!existsSync(join(fixture.dir, '.git', 'FETCH_HEAD'))) {
+      pass('dismissed nested check still leaves the outer repo\'s FETCH_HEAD alone');
+    } else {
+      fail('dismissed nested check fetched into the outer repository');
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 4. apply: refuses before the first side effect ──
 {
   const fixture = makeNestedFixture();
   try {
@@ -133,7 +156,7 @@ function runUpdater(fixture, cmd) {
   }
 }
 
-// ── 4. rollback: same precondition ──
+// ── 5. rollback: same precondition ──
 {
   const fixture = makeNestedFixture();
   try {

--- a/tests/updater-nested-checkout-guard.test.mjs
+++ b/tests/updater-nested-checkout-guard.test.mjs
@@ -27,8 +27,15 @@ console.log('\n🧪 Testing updater nested-checkout guard (#3334)...');
 
 const canonicalize = realpathSync.native ?? realpathSync;
 
-// An outer repo with a .git-less career-ops copy at tools/career-ops, committed
-// as vendored content — the layout the ZIP install produces.
+/**
+ * Create an outer repo with a .git-less career-ops copy at tools/career-ops.
+ *
+ * The committed vendored content mirrors the ZIP-install layout that makes git
+ * resolve to the enclosing repository instead of the career-ops directory.
+ *
+ * @returns {{dir: string, g: (...args: string[]) => string, nested: string}}
+ * Fixture paths and a git helper rooted at the outer repository.
+ */
 function makeNestedFixture() {
   const dir = mkdtempSync(join(tmpdir(), 'co-nested-'));
   const g = (...args) => gitIn(dir, ...args);
@@ -51,6 +58,14 @@ function makeNestedFixture() {
   return { dir, g, nested };
 }
 
+/**
+ * Run the real updater command inside the nested fixture.
+ *
+ * @param {{dir: string, nested: string}} fixture - Nested install fixture.
+ * @param {string} cmd - Updater subcommand to execute.
+ * @returns {import('child_process').SpawnSyncReturns<string>}
+ * Spawn result with captured stdout/stderr.
+ */
 function runUpdater(fixture, cmd) {
   return spawnSync(NODE, ['update-system.mjs', cmd], {
     cwd: fixture.nested,

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -732,6 +732,62 @@ function gitQuiet(...args) {
 }
 
 /**
+ * The enclosing repository's toplevel when ROOT is not a git toplevel itself,
+ * or null when ROOT is its own toplevel (or not inside any worktree at all).
+ *
+ * Every git call in this file runs with `cwd: ROOT` and assumes that resolves
+ * to the career-ops checkout. An install with no `.git` of its own that sits
+ * INSIDE another repository — a ZIP unpacked into an existing project — breaks
+ * that silently: git walks up, finds the outer repo, and every rev-parse,
+ * fetch, branch and checkout lands there, with pathspecs failing because at
+ * that root the files are prefixed by the install's subpath (#3334). Callers
+ * use this to refuse before the first side effect.
+ *
+ * A ROOT inside no worktree at all returns null: that layout has no foreign
+ * repo to damage, and each command already has its own handling for git
+ * being unavailable.
+ *
+ * @param {string} [root=ROOT] - Directory to test.
+ * @returns {string|null} The foreign toplevel path, or null.
+ */
+export function gitToplevelMismatch(root = ROOT) {
+  let toplevel;
+  try {
+    toplevel = gitIn(root, 'rev-parse', '--show-toplevel');
+  } catch {
+    return null;
+  }
+  if (!toplevel) return null;
+  // Realpath both sides: git resolves symlinks and reports on-disk casing
+  // (macOS /tmp -> /private/tmp; Windows 8.3 names), while `root` keeps
+  // whatever spelling the process was launched with. Same policy as the CLI
+  // guard at the bottom of this file. On a realpath failure fall back to
+  // resolve(): a false MISMATCH refuses an update, a false match fetches into
+  // a stranger's repo, so the fallback only ever errs toward refusing.
+  const canonicalize = realpathSync.native ?? realpathSync;
+  let same;
+  try {
+    same = canonicalize(toplevel) === canonicalize(root);
+  } catch {
+    same = resolve(toplevel) === resolve(root);
+  }
+  return same ? null : toplevel;
+}
+
+/**
+ * Throw when git operations from ROOT would land in an enclosing repository.
+ * First statement of apply() and rollback(); check() reports a status instead.
+ */
+function assertOwnGitToplevel() {
+  const foreignToplevel = gitToplevelMismatch();
+  if (foreignToplevel) {
+    throw new Error(
+      `career-ops at ${ROOT} is not a git checkout of its own, so git operations would land in the enclosing repository at ${foreignToplevel} — this happens when the install was unpacked from a ZIP or copied without its .git directory. Nothing was changed. To make updates work, clone career-ops fresh (git clone ${CANONICAL_REPO}) and move your user-layer files (cv.md, config/, data/, reports/ — see DATA_CONTRACT.md) into the new clone.`,
+    );
+  }
+}
+
+/**
  * Paths the target manifest ships that did not materialize on disk.
  *
  * apply() reports success without checking that the checkout loop actually
@@ -1336,6 +1392,18 @@ async function check() {
     return;
   }
 
+  // Before any git call: on an install nested inside a foreign repository the
+  // rev-parse below reads the OUTER repo's HEAD and the drift fetch writes the
+  // OUTER repo's FETCH_HEAD, so check reports a phantom system-files-changed
+  // forever on a byte-identical install (#3334). Report the layout as its own
+  // status instead; agents ignore unknown statuses by contract (AGENTS.md),
+  // and apply() refuses the same layout with the actionable message.
+  const foreignToplevel = gitToplevelMismatch();
+  if (foreignToplevel) {
+    console.log(JSON.stringify({ status: 'not-a-git-toplevel', local: localVersion(), toplevel: foreignToplevel }));
+    return;
+  }
+
   const local = localVersion();
   let remote = '';
   let releaseVersion = '';
@@ -1605,6 +1673,7 @@ export function reconcileGitignore(localText, upstreamText) {
 // ── APPLY ───────────────────────────────────────────────────────
 
 async function apply() {
+  assertOwnGitToplevel();
   const local = localVersion();
   // --force overwrites system files this install edited locally (#2337). The
   // env var carries the flag across the self-reexec, which re-invokes the
@@ -2099,6 +2168,9 @@ async function apply() {
 // ── ROLLBACK ────────────────────────────────────────────────────
 
 function rollback() {
+  // Same precondition as apply(): a nested .git-less install would look its
+  // backup branches up — and check files out — in the enclosing repo (#3334).
+  assertOwnGitToplevel();
   // Find most recent backup branch
   try {
     const branches = git('for-each-ref', '--sort=-committerdate', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1386,21 +1386,22 @@ function curlGet(url, extraArgs = []) {
 }
 
 async function check() {
-  // Respect dismiss flag
-  if (existsSync(join(ROOT, '.update-dismissed'))) {
-    console.log(JSON.stringify({ status: 'dismissed' }));
-    return;
-  }
-
-  // Before any git call: on an install nested inside a foreign repository the
-  // rev-parse below reads the OUTER repo's HEAD and the drift fetch writes the
-  // OUTER repo's FETCH_HEAD, so check reports a phantom system-files-changed
-  // forever on a byte-identical install (#3334). Report the layout as its own
-  // status instead; agents ignore unknown statuses by contract (AGENTS.md),
-  // and apply() refuses the same layout with the actionable message.
+  // Before any git call or local-state shortcut: on an install nested inside a
+  // foreign repository the rev-parse below reads the OUTER repo's HEAD and the
+  // drift fetch writes the OUTER repo's FETCH_HEAD, so check reports a phantom
+  // system-files-changed forever on a byte-identical install (#3334). Report the
+  // layout as its own status even when the install also has .update-dismissed;
+  // agents ignore unknown statuses by contract (AGENTS.md), and apply() refuses
+  // the same layout with the actionable message.
   const foreignToplevel = gitToplevelMismatch();
   if (foreignToplevel) {
     console.log(JSON.stringify({ status: 'not-a-git-toplevel', local: localVersion(), toplevel: foreignToplevel }));
+    return;
+  }
+
+  // Respect dismiss flag only after layout safety is established.
+  if (existsSync(join(ROOT, '.update-dismissed'))) {
+    console.log(JSON.stringify({ status: 'dismissed' }));
     return;
   }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -641,15 +641,34 @@ function newestBackupBranch(branches) {
   return timestamped[0]?.branch || branchList[0];
 }
 
+/**
+ * Parse a positive integer environment override with a safe fallback.
+ *
+ * @param {unknown} value - Candidate integer value.
+ * @param {number} fallback - Value returned when parsing fails or is <= 0.
+ * @returns {number} Positive parsed integer or the fallback.
+ */
 export function parsePositiveInt(value, fallback) {
   const parsed = Number.parseInt(String(value || ''), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+/**
+ * Select the timeout budget for a git command.
+ *
+ * @param {string[]} args - Git argv without the leading `git`.
+ * @returns {number} Timeout in milliseconds for the command.
+ */
 export function gitTimeoutMs(args) {
   return args[0] === 'fetch' ? DEFAULT_GIT_FETCH_TIMEOUT_MS : DEFAULT_GIT_TIMEOUT_MS;
 }
 
+/**
+ * Compute the upper bound for the self-reexec update phase.
+ *
+ * @param {number} [updatePathCount] - Count of paths the target checkout may materialize.
+ * @returns {number} Timeout in milliseconds for the reexec buffer.
+ */
 export function reexecTimeoutMs(updatePathCount = SYSTEM_PATHS.length + BOOTSTRAP_PATHS.length) {
   return Math.max(
     120000,
@@ -699,6 +718,13 @@ export function gitRawIn(root, ...args) {
   }
 }
 
+/**
+ * Run git in a target directory and trim stdout for ordinary line output.
+ *
+ * @param {string} root - Directory to use as git cwd.
+ * @param {...string} args - Git argv without the leading `git`.
+ * @returns {string} Trimmed stdout from git.
+ */
 export function gitIn(root, ...args) {
   return gitRawIn(root, ...args).trim();
 }


### PR DESCRIPTION
## Summary
- Addresses the CodeRabbit review note on #3434 without touching the contributor branch.
- Makes nested .git-less installs report not-a-git-toplevel before honoring .update-dismissed.
- Adds a regression fixture covering nested install + .update-dismissed precedence and FETCH_HEAD safety.

## Test Plan
- git diff --check
- npm run lint
- node --test tests/updater-nested-checkout-guard.test.mjs
- npm install --no-package-lock --ignore-scripts, then node test-all.mjs --quick (6568 passed / 0 failed / 11 warnings)

Context: bridge for santifer/career-ops PR #3434 because direct push to fix/updater-toplevel-guard was denied to chipoto69.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented update operations from running in checkouts nested inside another Git repository.
  - Update checks now clearly report when a checkout is not a standalone Git root.
  - Apply and rollback actions stop safely before making changes in this situation.
  - Dismissed update notices no longer bypass this repository safety check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->