### PR TITLE
fix(providers/icims): fill a missing location from the posting's JSON-LD

### DIFF
--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -138,6 +138,14 @@ export default {
    * Fill in job.postedAt from the posting's detail page (JSON-LD JobPosting
    * `datePosted`) — the list pages carry no date at all. Any failure leaves
    * the job undated; the caller's undated policy then applies as usual.
+   *
+   * The same detail page also carries `jobLocation.address`, so an empty
+   * list-page location is filled here too. Several tenants render the search
+   * card without a location span at all; the empty string that produced then
+   * passes location_filter (an empty location can't match a block term), so a
+   * US-only board reaches the results with no country attached and the reader
+   * has to look each posting up by hand. Measured 2026-08-13: all six iCIMS
+   * matches in a 1,000-company sweep were US postings that arrived this way.
    */
   async enrichDate(job, ctx) {
     const sep = job.url.includes('?') ? '&' : '?';
@@ -158,8 +166,43 @@ export default {
     }
     const ts = Date.parse(pickDatePosted(nodes) || '');
     if (!Number.isNaN(ts)) job.postedAt = ts;
+    if (!String(job.location || '').trim() || /^n\/?a$/i.test(String(job.location).trim())) {
+      const loc = pickLocation(nodes);
+      if (loc) job.location = loc;
+    }
   },
 };
+
+// ISO country codes are what iCIMS emits, but location_filter matches on the
+// words a human wrote in portals.yml ("Canada", "United States"), so a bare
+// "US" would sail past a block list that spells the country out.
+const COUNTRY_NAMES = { US: 'United States', CA: 'Canada' };
+
+// From flattened JSON-LD nodes, build "Locality, Region, Country" out of the
+// first JobPosting's first jobLocation address. Partial addresses are kept:
+// the country alone is already enough for location_filter to decide.
+function pickLocation(nodes) {
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object' || !node.jobLocation) continue;
+    const place = Array.isArray(node.jobLocation) ? node.jobLocation[0] : node.jobLocation;
+    const addr = place?.address;
+    if (!addr || typeof addr !== 'object') continue;
+    const clean = v => {
+      const s = String(v ?? '').trim();
+      // iCIMS writes the literal string UNAVAILABLE into fields it has no value
+      // for, so an unchecked join yields "UNAVAILABLE, MD, United States".
+      return !s || /^unavailable$/i.test(s) ? '' : s;
+    };
+    const country = clean(addr.addressCountry);
+    const parts = [
+      clean(addr.addressLocality),
+      clean(addr.addressRegion),
+      COUNTRY_NAMES[country.toUpperCase()] || country,
+    ].filter(Boolean);
+    if (parts.length) return parts.join(', ');
+  }
+  return null;
+}
 
 // From flattened JSON-LD nodes, return the datePosted of the first JobPosting
 // node; if none carries a @type, fall back to the first node that has a

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -212,3 +212,52 @@ const mkCtx = (pages) => ({
     else fail(`JSON-LD with ${label}: postedAt ${job.postedAt}`);
   }
 }
+
+// Location enrichment. Several tenants render the search card with no location
+// span, so the list-page location arrives empty. An empty location cannot match
+// a location_filter block term, so a US-only board reaches the results with no
+// country attached — measured 2026-08-13, all six iCIMS matches in a sweep were
+// US postings that arrived that way. The detail page already being fetched for
+// the date also carries jobLocation.address.
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","datePosted":"2026-07-17","jobLocation":[{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"US","addressLocality":"Annapolis Junction","addressRegion":"MD","postalCode":"UNAVAILABLE"}}]}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: '' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  // Spelled out, not "US": location_filter matches the words written in
+  // portals.yml, where the block term is "United States".
+  if (job.location === 'Annapolis Junction, MD, United States') pass('enrichDate fills an empty location from jobLocation');
+  else fail(`location: ${job.location}`);
+}
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"CA","addressLocality":"Toronto","addressRegion":"ON"}}}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'N/A' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.location === 'Toronto, ON, Canada') pass('enrichDate replaces an N/A location, single jobLocation object');
+  else fail(`location: ${job.location}`);
+}
+// iCIMS writes the literal string UNAVAILABLE into address fields it has no
+// value for; joining it unchecked yields "UNAVAILABLE, MD, United States".
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","jobLocation":{"address":{"addressCountry":"US","addressLocality":"UNAVAILABLE","addressRegion":"MD"}}}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: '' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.location === 'MD, United States') pass('enrichDate drops UNAVAILABLE address parts');
+  else fail(`location: ${job.location}`);
+}
+// A location the list page did supply is authoritative: enrichment never
+// overwrites it.
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","jobLocation":{"address":{"addressCountry":"US","addressLocality":"Phoenix","addressRegion":"AZ"}}}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'Mississauga, ON' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.location === 'Mississauga, ON') pass('enrichDate leaves a populated location untouched');
+  else fail(`location overwritten: ${job.location}`);
+}
+// No jobLocation at all: the job keeps whatever it had, enrichment stays silent.
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","datePosted":"2026-07-17"}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: '' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.location === '') pass('enrichDate leaves location empty when jobLocation is absent');
+  else fail(`location: ${job.location}`);
+}


### PR DESCRIPTION
## The problem

iCIMS search results routinely carry no location, or the literal string `N/A`. A location-filtered scan cannot act on a blank field, so postings that *are* in the target area get dropped as unlocatable. The signal exists — the posting page publishes a structured `jobLocation` in JSON-LD — and the scan already fetches that page to read the date, so reading the address costs no extra request.

## The change

`enrichDate` now also fills the location when it is empty or `N/A`, and leaves a populated one untouched.

Address parts iCIMS renders as the literal `UNAVAILABLE` are dropped rather than concatenated, so a partial address degrades to `MD, United States` instead of `UNAVAILABLE, MD, United States`.

## Tests

Five cases added to `tests/providers/icims.test.mjs`: the fill from an empty field, the `N/A` replacement, `UNAVAILABLE` parts dropped, a populated location left untouched, and an absent `jobLocation`. Suite passes 36/36.

## Notes

No new dependency, no extra network call, no change to any other provider. Found while running location-filtered scans against Canadian iCIMS tenants, where the blank-location loss was large enough to be visible in the daily counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location details for job listings when list-page location data is empty or unavailable.
  * Locations can now be populated from posting details, with clearer locality, region, and country formatting.
  * Avoids displaying unavailable address components and preserves existing location information.

* **Tests**
  * Added coverage for location enrichment, missing address data, unavailable fields, and preservation of populated locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->