### PR TITLE
fix(cv-sync-check): use CODE_ROOT instead of undefined projectRoot

### DIFF
--- a/cv-sync-check.mjs
+++ b/cv-sync-check.mjs
@@ -51,9 +51,9 @@ if (!existsSync(profilePath)) {
 
 // 3. Check for hardcoded metrics in prompt files
 const filesToCheck = [
-  { path: join(projectRoot, 'modes', '_shared.md'), name: '_shared.md' },
-  { path: join(projectRoot, 'modes', '_writing.md'), name: '_writing.md' },
-  { path: join(projectRoot, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
+  { path: join(CODE_ROOT, 'modes', '_shared.md'), name: '_shared.md' },
+  { path: join(CODE_ROOT, 'modes', '_writing.md'), name: '_writing.md' },
+  { path: join(CODE_ROOT, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
 ];
 
 // Pattern: numbers that look like hardcoded metrics (e.g., "170+ hours", "90% self-service")

--- a/cv-sync-check.mjs
+++ b/cv-sync-check.mjs
@@ -16,8 +16,7 @@ import { fileURLToPath } from 'url';
 
 import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const CODE_ROOT = __dirname;
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
 
 const warnings = [];

--- a/tests/cv-sync-check-runs.test.mjs
+++ b/tests/cv-sync-check-runs.test.mjs
@@ -1,0 +1,58 @@
+// tests/cv-sync-check-runs.test.mjs — regression coverage for cv-sync-check.mjs starting up.
+//
+// Why this exists: cv-sync-check.mjs referenced an undefined `projectRoot`, so it
+// crashed with a ReferenceError before running a single check. test-all.mjs asserts
+// `expectExit: 1` for this script ("fails without cv.md (normal in repo)"), and an
+// uncaught ReferenceError ALSO exits 1 — so the crash was indistinguishable from the
+// expected missing-cv.md failure and CI stayed green. Exit code alone cannot cover
+// this script; assert on the output instead.
+
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\ncv-sync-check.mjs — starts up and reports instead of crashing');
+
+const work = mkdtempSync(join(tmpdir(), 'cops-cvsync-'));
+try {
+  // Empty data root: no cv.md, no config/profile.yml. The script is EXPECTED to
+  // exit 1 here — that is a clean, reported failure, not a crash.
+  const res = spawnSync(NODE, [join(ROOT, 'cv-sync-check.mjs')], {
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: { ...process.env, CAREER_OPS_ROOT: work },
+  });
+
+  const stdout = res.stdout || '';
+  const stderr = res.stderr || '';
+
+  if (/ReferenceError/.test(stderr)) {
+    fail(`cv-sync-check.mjs crashed with a ReferenceError: ${stderr.split('\n').find(l => l.includes('ReferenceError'))}`);
+  } else {
+    pass('no ReferenceError on startup');
+  }
+
+  if (stdout.includes('=== career-ops sync check ===')) {
+    pass('emits its own report header (proof it ran, not just exited)');
+  } else {
+    fail(`expected the sync-check header in stdout, got: ${JSON.stringify(stdout.slice(0, 200))}`);
+  }
+
+  if (/cv\.md not found/.test(stdout)) {
+    pass('reports the missing cv.md as a structured error');
+  } else {
+    fail(`expected a missing-cv.md error in stdout, got: ${JSON.stringify(stdout.slice(0, 200))}`);
+  }
+
+  // Guard the whole file, not just the three lines that were broken: any future
+  // undefined identifier at module scope surfaces here as a non-1 exit or a trace.
+  if (res.status === 1) {
+    pass('exits 1 for the expected reason (missing user files), not from a throw');
+  } else {
+    fail(`expected exit 1, got ${res.status}${stderr ? ` — stderr: ${stderr.slice(0, 200)}` : ''}`);
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
Fixes #3440.

## The bug

`cv-sync-check.mjs` throws `ReferenceError: projectRoot is not defined` at line 54 and exits before running a single check. `modes/_shared.md` makes it mandatory ("First evaluation of each session: Run `node cv-sync-check.mjs`"), so the hardcoded-metric guard and the `article-digest.md` check have not been running.

## The fix (3 lines)

The file already defines both roots:

```js
const CODE_ROOT = __dirname;
const DATA_ROOT = getCareerOpsRoot();
```

`DATA_ROOT` is used for the user-layer reads (`cv.md`, `config/profile.yml`, `article-digest.md`); `CODE_ROOT` was defined and then never referenced. Lines 54-56 still used the pre-refactor `projectRoot`. Those three paths point at `modes/` and `batch/` — code assets — so `CODE_ROOT` is the intended target and this completes the rename rather than changing behaviour.

## Why a test was needed too

The existing coverage is one line in `test-all.mjs`:

```js
{ name: 'cv-sync-check.mjs', expectExit: 1, allowFail: true }, // fails without cv.md (normal in repo)
```

The repo ships no `cv.md`, so exit 1 is legitimately expected — and an uncaught `ReferenceError` also exits 1. Both states satisfy the check, so a crash is indistinguishable from the intended failure. I verified this directly: broken and fixed versions both return exit 1 against an empty data root.

> **Corrected 2026-08-28:** this paragraph originally said the bug "survived at least v1.29.0 and v1.30.0 with CI green". That is false — both tags are clean. The break is `7f7cad1f` (2026-08-27 16:33Z), a take-both merge; `career-ops-v1.30.0` targets `e1c1339b`, published nine hours earlier, and runs fine. Only `main` after that merge is affected. Full evidence: https://github.com/santifer/career-ops/pull/3441#issuecomment-5452516846

`tests/cv-sync-check-runs.test.mjs` therefore asserts on **output**, not exit code:

- no `ReferenceError` in stderr
- `=== career-ops sync check ===` present in stdout (proof it ran rather than just exited)
- the missing-`cv.md` error reported as structured text
- exit 1 for the expected reason

Confirmed red on the old code:

```
  ❌ cv-sync-check.mjs crashed with a ReferenceError: ReferenceError: projectRoot is not defined
  ❌ expected the sync-check header in stdout, got: ""
  ❌ expected a missing-cv.md error in stdout, got: ""
  ✅ exits 1 for the expected reason (missing user files), not from a throw
```

and green after the fix. Note the fourth assertion passes in both cases — that is the exit-code blind spot this PR closes.

## Test run

`node test-all.mjs` → 6571 passed, 1 failed. The single failure is **pre-existing and unrelated**: `SYSTEM_PATHS coverage gap`, listing legacy `test/` files and some root-level `*.test.mjs`. I re-ran with this change fully removed and it still fails (6567 passed, 1 failed) — the delta from this PR is +4 passing assertions and no change to the failure. Happy to open a separate issue for that if it is not already tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync checks so referenced files are located reliably relative to the check tool.

* **Tests**
  * Added coverage for startup behavior with an empty data directory.
  * Verified clear reporting of missing CV content, correct failure status, and absence of startup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
