### PR TITLE
fix(cv-sync-check): resolve prompt files from CODE_ROOT, not an undefined projectRoot

### DIFF
--- a/cv-sync-check.mjs
+++ b/cv-sync-check.mjs
@@ -51,9 +51,9 @@ if (!existsSync(profilePath)) {
 
 // 3. Check for hardcoded metrics in prompt files
 const filesToCheck = [
-  { path: join(projectRoot, 'modes', '_shared.md'), name: '_shared.md' },
-  { path: join(projectRoot, 'modes', '_writing.md'), name: '_writing.md' },
-  { path: join(projectRoot, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
+  { path: join(CODE_ROOT, 'modes', '_shared.md'), name: '_shared.md' },
+  { path: join(CODE_ROOT, 'modes', '_writing.md'), name: '_writing.md' },
+  { path: join(CODE_ROOT, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
 ];
 
 // Pattern: numbers that look like hardcoded metrics (e.g., "170+ hours", "90% self-service")

--- a/tests/cv-sync-check-code-root.test.mjs
+++ b/tests/cv-sync-check-code-root.test.mjs
@@ -1,0 +1,43 @@
+// tests/cv-sync-check-code-root.test.mjs — cv-sync-check.mjs must resolve the
+// system prompt files it scans for hardcoded metrics (_shared.md, _writing.md,
+// batch-prompt.md) from the code root, not from an undeclared identifier.
+//
+// The script defined CODE_ROOT and DATA_ROOT but built `filesToCheck` from a
+// `projectRoot` that no longer existed, so every invocation died at module
+// load with `ReferenceError: projectRoot is not defined` — before a single
+// check ran. `_shared.md` tells the agent to run this on the first evaluation
+// of every session, so the crash fired on every session that honoured it.
+//
+// Run:  node --test tests/cv-sync-check-code-root.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CODE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function runWithDataRoot() {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'cv-sync-check-'));
+  mkdirSync(join(dataRoot, 'config'));
+  writeFileSync(join(dataRoot, 'cv.md'), '# Test Candidate\n');
+  writeFileSync(
+    join(dataRoot, 'config', 'profile.yml'),
+    'candidate:\n  full_name: "Test Candidate"\n  email: "test@example.com"\n  location: "Nowhere"\n',
+  );
+  return spawnSync(process.execPath, [join(CODE_ROOT, 'cv-sync-check.mjs')], {
+    env: { ...process.env, CAREER_OPS_ROOT: dataRoot },
+    encoding: 'utf-8',
+  });
+}
+
+test('cv-sync-check.mjs loads and runs its checks instead of throwing at module load', () => {
+  const result = runWithDataRoot();
+  assert.doesNotMatch(result.stderr, /ReferenceError/, result.stderr);
+  assert.doesNotMatch(result.stderr, /projectRoot/, result.stderr);
+  assert.match(result.stdout, /=== career-ops sync check ===/);
+  assert.equal(result.status, 0, `exit ${result.status}\n${result.stdout}\n${result.stderr}`);
+});


### PR DESCRIPTION
## Problem

`node cv-sync-check.mjs` crashes on every invocation, before running a single check:

```
ReferenceError: projectRoot is not defined
    at file:///.../cv-sync-check.mjs:54:16
```

`filesToCheck` (lines 54–56) still builds its paths from `projectRoot`, which stopped existing when the script gained `CODE_ROOT` / `DATA_ROOT` for the `CAREER_OPS_ROOT` override (02daaf1c). Reproduces on current `main` (bb46c66) and on the v1.30.0 release.

`modes/_shared.md` → ALWAYS rule 1b tells the agent to run this on the first evaluation of every session, so the crash surfaces every session that honours it.

## Fix

Use `CODE_ROOT` for the three files scanned for hardcoded metrics (`modes/_shared.md`, `modes/_writing.md`, `batch/batch-prompt.md`). They're system-layer prompt files that ship with the code, so `CODE_ROOT` is correct: `DATA_ROOT` would silently skip the check for anyone with an external data directory, since those files wouldn't exist there.

3-line change, no behaviour change beyond "runs at all".

## Test

`tests/cv-sync-check-code-root.test.mjs` spawns the script against a minimal temp `CAREER_OPS_ROOT` (cv.md + profile.yml) and asserts it reaches its own `=== career-ops sync check ===` banner and exits 0, with no `ReferenceError` on stderr. Fails on `main`, passes with the fix. Auto-discovered by `test-all.mjs` via `tests/**/*.test.mjs`, no registration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the CV sync check that prevented it from loading successfully.
  * Ensured system prompt files are resolved from the correct code location.
  * Confirmed the sync check completes successfully and reports its results as expected.

* **Tests**
  * Added coverage to verify correct path resolution and successful execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->