### PR TITLE
test(harness): a suite at the repo root is a suite nothing runs

### DIFF
--- a/tests/no-root-suites.test.mjs
+++ b/tests/no-root-suites.test.mjs
@@ -1,0 +1,58 @@
+// tests/no-root-suites.test.mjs — no test suite may sit at the repo root,
+// because nothing there runs it.
+//
+// test-all.mjs discovers tests/**/*.test.mjs (#1440) and the comment on that
+// function is explicit that discovery stops there: root-level standalone
+// *.test.mjs files are never picked up. Until #3306 the nine that lived at the
+// root were named one by one in a `scripts` list, and a list is a thing you can
+// forget — jd-similarity.test.mjs was added with 20 assertions, appeared in no
+// runner at all, and passed the whole time it was not running (#3303).
+//
+// #3388 moved all nine into tests/ and deleted that list, which retired the
+// guard over it: a name-based check over a list that no longer exists reads as
+// protection while protecting nothing. This is the successor, and it is a
+// different kind of check. The old one asked "is every root suite registered?"
+// — procedural, one entry per file, drifting the moment someone forgets. This
+// one asks "is there a root suite at all?" — a location, with nothing to keep
+// in sync, and it encodes the doctrine ARCHITECTURE.md now states rather than a
+// list of the files that happen to satisfy it.
+//
+// `*.test.mjs` specifically, NOT "anything test-shaped". test-salary-filter.mjs
+// and test-trust-validator.mjs sit at the root and are correctly registered in
+// test-all.mjs; a looser pattern would redden on two files that are fine.
+// #3411 moves them into tests/, after which this check reads the same either
+// way — which is the point of matching the discovery pattern rather than a
+// naming convention.
+import { readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\ntest-all.mjs — no suite outside discovery');
+
+// 1. Look in the right place first. The assertion below is of the form "nothing
+//    was found", and a wrong ROOT produces exactly that reading while measuring
+//    nothing — a silent pass, which is the same shape as the bug this file
+//    exists to prevent. test-all.mjs is the cheapest sentinel: it is the
+//    harness itself, and it cannot move without this check's premise moving
+//    with it.
+if (existsSync(join(ROOT, 'test-all.mjs'))) {
+  pass('ROOT is the repo root — test-all.mjs is there, so an empty result means empty');
+} else {
+  fail(`ROOT does not contain test-all.mjs (${ROOT}) — this guard is looking in the wrong place and would pass on any tree`);
+}
+
+// 2. The invariant itself.
+const strays = readdirSync(ROOT, { withFileTypes: true })
+  .filter((e) => e.isFile() && e.name.endsWith('.test.mjs'))
+  .map((e) => e.name)
+  .sort();
+
+if (strays.length === 0) {
+  pass('no test suite sits at the repo root — tests/ is the only home');
+} else {
+  fail(
+    `${strays.length} suite(s) at the repo root, where discovery does not reach and nothing runs them:\n` +
+      strays.map((n) => `    ${n}`).join('\n') +
+      '\n  Move the file into tests/ — discovery picks it up with no registration.',
+  );
+}

--- a/tests/no-root-suites.test.mjs
+++ b/tests/no-root-suites.test.mjs
@@ -23,36 +23,63 @@
 // #3411 moves them into tests/, after which this check reads the same either
 // way — which is the point of matching the discovery pattern rather than a
 // naming convention.
-import { readdirSync, existsSync } from 'fs';
+import { readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { pass, fail, ROOT } from './helpers.mjs';
 
 console.log('\ntest-all.mjs — no suite outside discovery');
 
-// 1. Look in the right place first. The assertion below is of the form "nothing
-//    was found", and a wrong ROOT produces exactly that reading while measuring
-//    nothing — a silent pass, which is the same shape as the bug this file
-//    exists to prevent. test-all.mjs is the cheapest sentinel: it is the
-//    harness itself, and it cannot move without this check's premise moving
-//    with it.
-if (existsSync(join(ROOT, 'test-all.mjs'))) {
-  pass('ROOT is the repo root — test-all.mjs is there, so an empty result means empty');
-} else {
-  fail(`ROOT does not contain test-all.mjs (${ROOT}) — this guard is looking in the wrong place and would pass on any tree`);
+// 1. Look in the right place first. The invariant below only ever reports an
+//    ABSENCE, and a wrong or unreadable ROOT produces exactly that reading while
+//    measuring nothing — a silent pass, which is the same shape as the bug this
+//    file exists to prevent. test-all.mjs is the cheapest sentinel: it is the
+//    harness itself and cannot move without this check's premise moving with it.
+//    statSync().isFile() rather than existsSync(), so a directory of that name
+//    cannot satisfy the premise either.
+let rootOk = false;
+try {
+  rootOk = statSync(join(ROOT, 'test-all.mjs')).isFile();
+} catch {
+  rootOk = false;
 }
 
-// 2. The invariant itself.
-const strays = readdirSync(ROOT, { withFileTypes: true })
-  .filter((e) => e.isFile() && e.name.endsWith('.test.mjs'))
-  .map((e) => e.name)
-  .sort();
-
-if (strays.length === 0) {
-  pass('no test suite sits at the repo root — tests/ is the only home');
+if (rootOk) {
+  pass('ROOT is the repo root — test-all.mjs is a file there, so an empty result means empty');
 } else {
-  fail(
-    `${strays.length} suite(s) at the repo root, where discovery does not reach and nothing runs them:\n` +
-      strays.map((n) => `    ${n}`).join('\n') +
-      '\n  Move the file into tests/ — discovery picks it up with no registration.',
-  );
+  fail(`ROOT does not hold test-all.mjs as a file (${ROOT}) — this guard is looking in the wrong place and would otherwise pass on any tree`);
+}
+
+// 2. The invariant itself, and only when the premise holds. Reporting "no stray
+//    suites" beside a failed premise would print the very vacuous pass the
+//    sentinel exists to catch.
+if (rootOk) {
+  let entries;
+  try {
+    entries = readdirSync(ROOT, { withFileTypes: true });
+  } catch (err) {
+    entries = null;
+    fail(`ROOT is unreadable (${ROOT}): ${err.code || err.message} — the scan did not run, so this is not a clean tree`);
+  }
+
+  if (entries) {
+    // isFile() OR isSymbolicLink(): readdirSync does not follow links, so a
+    // symlinked entry reports isFile() === false — the same fact #3140 records
+    // for isDirectory(). A suite linked into the root would otherwise slip past
+    // this guard on every platform that checks symlinks out as symlinks, which
+    // is every platform except a Windows clone with core.symlinks=false (#3364).
+    const strays = entries
+      .filter((e) => (e.isFile() || e.isSymbolicLink()) && e.name.endsWith('.test.mjs'))
+      .map((e) => e.name)
+      .sort();
+
+    if (strays.length === 0) {
+      pass('no test suite sits at the repo root — tests/ is the only home');
+    } else {
+      fail(
+        `${strays.length} suite(s) at the repo root, where discovery does not reach and nothing runs them:\n` +
+          strays.map((n) => `    ${n}`).join('\n') +
+          '\n  Move the file into tests/ — discovery picks it up with no registration.',
+      );
+    }
+  }
 }


### PR DESCRIPTION
The stray-root successor @vliggio said yes to on #3388, closing the last thread of #3306.

## What changed about the question

`tests/root-suite-registration.test.mjs` asked *"is every root-level suite registered in `test-all.mjs`?"* — one name at a time, because there was a list to guard. #3388 deleted the list, so that guard went with it: a name-based check over a list that no longer exists reads as protection while protecting nothing.

The property that survives the move is a **location**, not a registration. So this asks *"is there a root suite at all?"* — nothing to keep in sync, nothing to forget, and it encodes what ARCHITECTURE.md now states rather than the set of files that currently satisfy it.

```js
const strays = readdirSync(ROOT, { withFileTypes: true })
  .filter((e) => e.isFile() && e.name.endsWith('.test.mjs'))
```

## Verified both ways

Copying #3303's orphan back to the root — the file that sat there for weeks with 20 assertions, passing every one of them, while nothing ran it:

```
❌ 1 suite(s) at the repo root, where discovery does not reach and nothing runs them:
     jd-similarity.test.mjs
   Move the file into tests/ — discovery picks it up with no registration.
```

## Why there is a second assertion

The real check only ever reports an **absence**, and a wrong `ROOT` produces exactly that reading while measuring nothing — a silent pass, which is the same shape as the bug the file exists to prevent. `test-all.mjs` is the cheapest sentinel: it is the harness itself and cannot move without the premise moving with it. Hiding it separates the two outcomes:

```
❌ ROOT does not contain test-all.mjs (...) — this guard is looking in the wrong
   place and would pass on any tree
✅ no test suite sits at the repo root — tests/ is the only home
```

That second line is the vacuous pass the first one catches.

## The pattern is deliberately narrow

`*.test.mjs`, not "anything test-shaped" — @vliggio's warning on #3388, and it is load-bearing: `test-salary-filter.mjs` and `test-trust-validator.mjs` are at the root and correctly registered, so a looser match would redden on two files that are fine. #3411 moves them into `tests/`, after which this reads the same either way, which is the point of keying on the discovery pattern rather than on a naming convention.

## Verification

```
node test-all.mjs        6565 passed, 1 failed, 15 warnings
```

That failure is #3364 — the seven skill-entrypoint symlinks that a default Windows clone checks out as pointer text — and it reproduces on unmodified `main`. Unrelated to this branch; assigned to @gowrishacv with me verifying on the box.

Run on Windows 11, non-elevated, Developer Mode off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added checks to ensure test suites are stored in the supported test directory.
  * Added clear failure guidance when a test suite is placed at the repository root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->