### PR TITLE
fix(portals): sweep and validate job_boards, not only tracked_companies

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -130,7 +130,7 @@ Processed TSVs are moved to `batch/tracker-additions/merged/`.
 
 Validates `portals.yml` before running the scanner. The validator is offline: it reads YAML, loads local provider IDs from `providers/*.mjs`, and checks common configuration mistakes without fetching any job boards.
 
-It reports errors for invalid YAML shape, unknown explicit providers, malformed URLs, empty filter keywords, and invalid local parser blocks. Duplicate enabled company names are warnings because they may be intentional during migrations, but they are worth reviewing.
+It reports errors for invalid YAML shape, unknown explicit providers, malformed URLs, empty filter keywords, and invalid local parser blocks. `tracked_companies` and `job_boards` entries are checked against the same schema, and their names share one namespace: a duplicate enabled name — within either list or across the two — is a warning (it may be intentional during a migration, but is worth reviewing).
 
 ```bash
 npm run validate:portals
@@ -798,10 +798,12 @@ node generate-cover-letter.mjs --payload payload.json --out output/slug-cover.pd
 
 ## verify:portals
 
-Online ATS-slug validator — complements the offline `validate:portals`. A
-wrong slug in `careers_url` 404s silently on every future scan, so this
-probes the public Greenhouse / Ashby / Lever endpoints to confirm each slug
-actually resolves.
+Online ATS-slug validator — complements the offline `validate:portals`. A wrong
+slug or a dead board 404s silently on every future scan, so this probes each
+portals entry to confirm it still resolves: Greenhouse / Ashby / Lever slugs
+directly, every other host through the same provider plugins the scanner uses.
+Both `tracked_companies` and `job_boards` entries are swept — a job board
+going dark is as invisible on the next scan as a company board 404ing.
 
 ```bash
 npm run verify:portals

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -803,7 +803,9 @@ slug or a dead board 404s silently on every future scan, so this probes each
 portals entry to confirm it still resolves: Greenhouse / Ashby / Lever slugs
 directly, every other host through the same provider plugins the scanner uses.
 Both `tracked_companies` and `job_boards` entries are swept — a job board
-going dark is as invisible on the next scan as a company board 404ing.
+going dark is as invisible on the next scan as a company board 404ing. An entry
+that no provider claims (no `provider:` field and no plugin `detect()` match) is
+reported `skipped`, not confirmed — those are a coverage gap, not a pass.
 
 ```bash
 npm run verify:portals

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -38,7 +38,7 @@ const VALUE_FLAGS = ['--target', '--cli'];
 const USAGE = `Usage:
   node doctor.mjs                    # run the setup diagnostic
   node doctor.mjs --json             # machine-readable onboarding state
-  node doctor.mjs --strict           # also probe portals.yml ATS slugs (network)
+  node doctor.mjs --strict           # also probe portals.yml entries (network)
   node doctor.mjs --target <path>    # diagnose another career-ops checkout
   node doctor.mjs --cli <name>       # check a specific CLI's integration
   node doctor.mjs --help             # show this message
@@ -57,8 +57,8 @@ const targetIdx = argv.indexOf('--target');
 const projectRoot =
   targetIdx !== -1 && argv[targetIdx + 1] ? argv[targetIdx + 1] : getCareerOpsRoot();
 const JSON_OUT = argv.includes('--json');
-// --strict adds a live ATS-slug probe of portals.yml (network). Opt-in so the
-// default `npm run doctor` stays fast and fully offline.
+// --strict adds a live reachability probe of every portals.yml entry (network).
+// Opt-in so the default `npm run doctor` stays fast and fully offline.
 const STRICT = argv.includes('--strict');
 
 const cliIdx = argv.indexOf('--cli');
@@ -492,13 +492,14 @@ function checkAutoDir(name) {
 }
 
 // --strict only: probe every portals.yml entry (tracked_companies and job_boards)
-// so a typo'd slug (which 404s silently on scans) surfaces here. Skipped
-// gracefully when portals.yml is absent. Delegates to verify-portals.mjs so there
-// is one slug-probing implementation. Network-bound, hence opt-in.
+// so a typo'd slug or a dead board — either of which 404s silently on scans —
+// surfaces here. Skipped gracefully when portals.yml is absent. Delegates to
+// verify-portals.mjs so there is one probing implementation. Network-bound,
+// hence opt-in.
 async function checkPortalSlugs(root) {
   const portalsPath = join(root, 'portals.yml');
   if (!existsSync(portalsPath)) {
-    return { pass: true, label: 'ATS slugs: no portals.yml yet (skipped)' };
+    return { pass: true, label: 'Portal entries: no portals.yml yet (skipped)' };
   }
   try {
     const { verifyPortalsFile } = await import('./verify-portals.mjs');
@@ -513,16 +514,22 @@ async function checkPortalSlugs(root) {
       providers,
       httpCtx: makeHttpCtx(),
     });
+    // Only 'missing' is a failure — a live probe that 404'd. 'skipped' (no
+    // provider claimed the entry) is left informational here, matching
+    // `verify-portals --strict`, which also fails only on 'missing'; an entry
+    // that resolves solely through a local parser is skipped by this path by
+    // design and must not fail the check.
     const unresolved = results.filter((r) => r.status === 'missing');
     if (unresolved.length === 0) {
-      return { pass: true, label: 'All ATS slugs in portals.yml resolve' };
+      return { pass: true, label: 'All portals.yml entries resolve' };
     }
     return {
       pass: false,
-      label: `${unresolved.length} ATS slug(s) in portals.yml do not resolve`,
+      label: `${unresolved.length} portals.yml entr${unresolved.length === 1 ? 'y' : 'ies'} do not resolve`,
       fix: [
         ...unresolved.map((r) => {
-          let line = `${r.name}: ${r.ats || '?'}/${r.slug || '?'} — ${r.reason || 'unresolved'}`;
+          const src = r.ats ? `${r.ats}/${r.slug}` : (r.provider || '?');
+          let line = `${r.name}: ${src} — ${r.reason || 'unresolved'}`;
           if (r.suggested) line += ` → try ${r.suggested.ats}/${r.suggested.slug}`;
           return line;
         }),
@@ -530,7 +537,7 @@ async function checkPortalSlugs(root) {
       ],
     };
   } catch (err) {
-    return { warn: true, label: `ATS slug check skipped: ${err.message}` };
+    return { warn: true, label: `Portal entry check skipped: ${err.message}` };
   }
 }
 
@@ -613,7 +620,7 @@ async function main() {
     checkPlugins(projectRoot),
   ].filter(Boolean);
 
-  // Network-bound ATS slug probe — only under --strict.
+  // Network-bound portals.yml reachability probe — only under --strict.
   if (STRICT) {
     checks.push(await checkPortalSlugs(projectRoot));
   }

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -502,7 +502,17 @@ async function checkPortalSlugs(root) {
   }
   try {
     const { verifyPortalsFile } = await import('./verify-portals.mjs');
-    const { results } = await verifyPortalsFile(portalsPath);
+    const { loadProviders } = await import('./providers/_registry.mjs');
+    const { makeHttpCtx } = await import('./providers/_http.mjs');
+    // Load the same provider plugins the scanner uses so tier 2 runs: without
+    // them every non-ATS entry (all job_boards, plus any Workday/Avature/…
+    // tracked_companies) resolves to an un-actionable "skipped" and a broken
+    // one would never reach "missing" — a false pass.
+    const providers = await loadProviders(join(__dirname, 'providers'));
+    const { results } = await verifyPortalsFile(portalsPath, {
+      providers,
+      httpCtx: makeHttpCtx(),
+    });
     const unresolved = results.filter((r) => r.status === 'missing');
     if (unresolved.length === 0) {
       return { pass: true, label: 'All ATS slugs in portals.yml resolve' };

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -491,10 +491,10 @@ function checkAutoDir(name) {
   }
 }
 
-// --strict only: probe the ATS slug of every tracked company in portals.yml so
-// a typo'd slug (which 404s silently on scans) surfaces here. Skipped gracefully
-// when portals.yml is absent. Delegates to verify-portals.mjs so there is one
-// slug-probing implementation. Network-bound, hence opt-in.
+// --strict only: probe every portals.yml entry (tracked_companies and job_boards)
+// so a typo'd slug (which 404s silently on scans) surfaces here. Skipped
+// gracefully when portals.yml is absent. Delegates to verify-portals.mjs so there
+// is one slug-probing implementation. Network-bound, hence opt-in.
 async function checkPortalSlugs(root) {
   const portalsPath = join(root, 'portals.yml');
   if (!existsSync(portalsPath)) {

--- a/fix-slugs.mjs
+++ b/fix-slugs.mjs
@@ -4,13 +4,17 @@
  * fix-slugs.mjs — write verify-portals.mjs's suggested ATS slug fixes back
  * into portals.yml.
  *
- * verify-portals.mjs already probes every tracked company's ATS slug and, for
- * a failing Greenhouse/Ashby/Lever entry, cross-probes slug variants across
- * all three ATSes and attaches `suggested: { ats, slug }` when one resolves
- * (see discoverAlternates() in verify-portals.mjs). That tool is read-only —
- * this script is the write side: it reuses the SAME probe/suggestion logic
- * (no re-implementation, no HTML scraping, no hardcoded company list) and
- * patches the matching `tracked_companies` entry in portals.yml.
+ * verify-portals.mjs already probes every tracked company's ATS slug. Its
+ * "tier 1" fast path is hardcoded to the three ATSes whose board URL carries a
+ * parseable slug — Greenhouse, Ashby, Lever — and for a failing entry it
+ * cross-probes slug variants across those three, attaching
+ * `suggested: { ats, slug }` when one resolves (see discoverAlternates() in
+ * verify-portals.mjs). Any other host is a provider-plugin (tier 2) entry and
+ * never gets a `suggested`, so this script only ever rewrites Greenhouse / Ashby
+ * / Lever slugs. That tool is read-only — this is the write side: it reuses the
+ * SAME probe/suggestion logic (no re-implementation, no HTML scraping, no
+ * hardcoded company list) and patches the matching `tracked_companies` entry in
+ * portals.yml.
  *
  * Only entries verify-portals classifies as `missing` AND carries a
  * `suggested` alternate for are touched. Live/empty entries and genuinely

--- a/providers/_registry.mjs
+++ b/providers/_registry.mjs
@@ -51,12 +51,12 @@ export async function loadProviders(dir) {
 }
 
 /**
- * Resolve which provider handles a tracked_companies entry.
+ * Resolve which provider handles a portals.yml entry (tracked_companies or job_boards).
  *   1. Explicit `provider:` field wins (skips detect()).
  *   2. local-parser when parser.command + script are configured (before API detect).
  *   3. Otherwise each provider's detect() runs in load order; first hit wins.
  *
- * @param {object} entry - tracked_companies entry.
+ * @param {object} entry - portals.yml entry (tracked_companies or job_boards).
  * @param {Map<string, object>} providers - id→provider Map from loadProviders().
  * @param {{skipIds?: string[]}} [opts] - Provider ids to skip (e.g. 'local-parser'
  *   so a network-only health check never execs a configured local command).

--- a/providers/_types.js
+++ b/providers/_types.js
@@ -49,7 +49,7 @@
  */
 
 /**
- * A single `tracked_companies` entry from `portals.yml`.
+ * A single portal entry from `portals.yml` — `tracked_companies` or `job_boards`.
  *
  * Provider-specific fields are opaque to scan.mjs and validated by the
  * provider itself. Examples in current providers: `api`, `careers_url`.

--- a/tests/validate-portals-job-boards.test.mjs
+++ b/tests/validate-portals-job-boards.test.mjs
@@ -1,0 +1,112 @@
+// tests/validate-portals-job-boards.test.mjs — validate-portals applies one
+// entry schema (name / careers_url / api / provider / parser) to both
+// `tracked_companies` and `job_boards`, and the two lists share an enabled-name
+// namespace. Diagnostics name the list they came from: `tracked_companies`
+// entries use the noun "company", `job_boards` entries use "job board".
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, run, NODE, rmSync } from './helpers.mjs';
+
+console.log('\nvalidate-portals — job_boards entry validation');
+
+const tmp = mkdtempSync(join(tmpdir(), 'co-vp-jb-'));
+const writeYml = (name, body) => {
+  const p = join(tmp, name);
+  writeFileSync(p, body, 'utf-8');
+  return p;
+};
+
+try {
+  // 1. An unknown provider under job_boards is an error.
+  const badProvider = writeYml('bad-provider.yml', `
+title_filter:
+  positive: ["QA"]
+job_boards:
+  - name: "Some Aggregator"
+    provider: "not-a-real-provider"
+`);
+  if (run(NODE, ['validate-portals.mjs', '--file', badProvider]) === null) {
+    pass('job_boards unknown provider → non-zero exit');
+  } else {
+    fail('job_boards unknown provider should fail validation');
+  }
+
+  // 2. job_boards present but not a list.
+  const notArray = writeYml('not-array.yml', `
+title_filter:
+  positive: ["QA"]
+job_boards:
+  name: oops
+`);
+  if (run(NODE, ['validate-portals.mjs', '--file', notArray]) === null) {
+    pass('job_boards non-array → non-zero exit');
+  } else {
+    fail('job_boards non-array should fail validation');
+  }
+
+  // 3. A well-formed job_boards list alongside tracked_companies validates clean.
+  const good = writeYml('good.yml', `
+title_filter:
+  positive: ["QA"]
+tracked_companies:
+  - name: "Acme"
+    careers_url: "https://jobs.lever.co/acme"
+job_boards:
+  - name: "Aggregator board A"
+    provider: hackernews
+  - name: "Aggregator board B"
+    provider: arbeitnow
+`);
+  const goodOut = run(NODE, ['validate-portals.mjs', '--file', good]);
+  if (goodOut !== null && goodOut.includes('0 errors')) {
+    pass('valid job_boards + tracked_companies → 0 errors');
+  } else {
+    fail(`a valid job_boards list should not raise errors — got:\n${goodOut}`);
+  }
+
+  // 4. A name shared by an enabled tracked_companies entry and an enabled
+  //    job_boards entry is flagged — they collide in the scanner's per-company
+  //    reporting — as a WARNING, not an error, and the job_boards side is
+  //    labelled "job board".
+  const dupName = writeYml('dup-name.yml', `
+title_filter:
+  positive: ["QA"]
+tracked_companies:
+  - name: "Twinco"
+    careers_url: "https://job-boards.greenhouse.io/twinco"
+job_boards:
+  - name: "Twinco"
+    provider: thehub
+`);
+  const dupOut = run(NODE, ['validate-portals.mjs', '--file', dupName]);
+  if (dupOut !== null
+    && dupOut.includes('0 errors')
+    && /warning: job_boards\[0\]\.name: duplicate enabled job board name/.test(dupOut)) {
+    pass('cross-list duplicate name → warning labelled "job board", exit 0');
+  } else {
+    fail(`cross-list duplicate name should warn (labelled "job board") and still exit 0 — got:\n${dupOut}`);
+  }
+
+  // 5. The tracked_companies duplicate-name warning uses the noun "company". (A
+  //    warning-only config is used so run() — which returns stdout only on a
+  //    zero exit — can capture the message text.)
+  const tcWord = writeYml('tc-word.yml', `
+title_filter:
+  positive: ["QA"]
+tracked_companies:
+  - name: "Dup Co"
+    careers_url: "https://jobs.lever.co/one"
+  - name: "Dup Co"
+    careers_url: "https://jobs.lever.co/two"
+`);
+  const tcWordOut = run(NODE, ['validate-portals.mjs', '--file', tcWord]);
+  if (tcWordOut !== null
+    && /duplicate enabled company name also seen at tracked_companies\[0\]\.name/.test(tcWordOut)) {
+    pass('tracked_companies duplicate warning uses the "company" noun');
+  } else {
+    fail(`tracked_companies duplicate warning wording — got:\n${tcWordOut}`);
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/tests/verify-portals-job-boards.test.mjs
+++ b/tests/verify-portals-job-boards.test.mjs
@@ -1,0 +1,149 @@
+// tests/verify-portals-job-boards.test.mjs — verifyPortalsFile() sweeps
+// `job_boards` entries together with `tracked_companies`: every enabled entry in
+// either list gets one health row.
+//
+// A `job_boards` entry is a multi-employer aggregator and comes in two shapes,
+// both resolved by the provider-plugin layer (verify-portals "tier 2"):
+//   - `provider:` only, no `careers_url` — arbeitnow, hackernews, himalayas,
+//     thehub, wttj, remotive …
+//   - `careers_url` on a non-ATS host + explicit `provider:` — the Getro VC
+//     boards (`careers.<vc>.com/jobs` + `provider: getro`), arbeitsagentur.
+// Neither carries an ATS slug, so tier 1 (the hardcoded Greenhouse/Ashby/Lever
+// fast probe) does not apply to a `job_boards` entry. The CLI's `main()` calls
+// verifyPortalsFile with the loaded provider registry, so each feed is probed
+// through its plugin.
+//
+// This test runs offline with stubs. Given no `providers` map a feed resolves to
+// `skipped` (it is still in the result); given a stub `providers` map it is
+// probed and classified. The per-ATS response shapes and the stub-provider
+// pattern match the tier-2 fixtures in test-all.mjs §10b. Entry names are
+// invented.
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { pass, fail, ROOT, rmSync } from './helpers.mjs';
+
+console.log('\nverify-portals — job_boards are swept alongside tracked_companies');
+
+const { verifyPortalsFile } = await import(
+  pathToFileURL(join(ROOT, 'verify-portals.mjs')).href
+);
+
+// tracked_companies control: a real ATS slug, probed via tier 1. Greenhouse/Ashby
+// wrap in `{ jobs: [...] }`, Lever returns a bare array.
+const fetchJson = async (url) =>
+  (url.includes('api.lever.co/') ? [{ id: 1 }] : { jobs: [{ id: 1, title: 'QA Engineer' }] });
+
+// Stand-in for the provider registry the CLI loads (loadProviders()). A bare
+// `provider:` field resolves straight to the matching stub — explicit provider
+// wins, no detect() needed — and its bounded `fetch` is called.
+const fakeCtx = { transport: 'http', fetchJson: async () => ({}), fetchText: async () => ['x'] };
+const boardPlugin = {
+  id: 'board-plugin',
+  fetch: async (_entry, ctx) => {
+    if (ctx.maxPages !== 1) throw new Error('health probe must bound pagination to maxPages=1');
+    return [{ title: 'one' }, { title: 'two' }];
+  },
+};
+const fakeProviders = new Map([[boardPlugin.id, boardPlugin]]);
+
+const tmp = mkdtempSync(join(tmpdir(), 'co-verify-jb-'));
+const writeYml = (name, body) => {
+  const p = join(tmp, name);
+  writeFileSync(p, body, 'utf-8');
+  return p;
+};
+const byName = (rows) => Object.fromEntries(rows.map((r) => [r.name, r]));
+
+// Both job_boards shapes + a tracked_companies control.
+const both = writeYml('both.yml', `
+tracked_companies:
+  - name: "Acme"
+    api: "https://boards-api.greenhouse.io/v1/boards/acme/jobs"
+job_boards:
+  - name: "VC portfolio board"
+    careers_url: "https://careers.example-vc.com/jobs"
+    provider: board-plugin
+  - name: "Remote-jobs feed"
+    provider: board-plugin
+`);
+
+try {
+  // 1. With no providers map, tier 2 is inert: each job_boards feed resolves to
+  //    `skipped`, and every entry from both lists is present in the result.
+  const noProv = await verifyPortalsFile(both, { fetchJson });
+  const npRows = byName(noProv.results);
+  if (noProv.results.length === 3 && npRows['Acme'] && npRows['VC portfolio board'] && npRows['Remote-jobs feed']) {
+    pass('every tracked_companies and job_boards entry gets a health row');
+  } else {
+    fail(`expected 3 rows (Acme + 2 job_boards) — got ${JSON.stringify(noProv.results.map((r) => r.name))}`);
+  }
+  if (npRows['VC portfolio board']?.status === 'skipped' && npRows['Remote-jobs feed']?.status === 'skipped') {
+    pass('with no provider layer, a job_boards feed resolves to skipped');
+  } else {
+    fail(`job_boards feeds should be "skipped" without providers — got ${JSON.stringify({
+      vc: npRows['VC portfolio board'], feed: npRows['Remote-jobs feed'],
+    })}`);
+  }
+
+  // 2. With the provider registry the CLI supplies, both job_boards shapes are
+  //    probed through their plugin and classified.
+  const withProv = await verifyPortalsFile(both, { fetchJson, providers: fakeProviders, httpCtx: fakeCtx });
+  const wpRows = byName(withProv.results);
+  if (wpRows['VC portfolio board']?.status === 'live' && wpRows['Remote-jobs feed']?.status === 'live'
+    && wpRows['Acme']?.status === 'live') {
+    pass('with the provider layer, job_boards feeds (url+provider and provider-only) are probed live');
+  } else {
+    fail(`job_boards feeds should probe live via the provider layer — got ${JSON.stringify(wpRows)}`);
+  }
+
+  // 3. A file with only a job_boards section is still swept.
+  const boardsOnly = writeYml('boards-only.yml', `
+job_boards:
+  - name: "Solo feed"
+    provider: board-plugin
+`);
+  const boardsOnlyRes = await verifyPortalsFile(boardsOnly, { fetchJson, providers: fakeProviders, httpCtx: fakeCtx });
+  if (boardsOnlyRes.found && boardsOnlyRes.results.length === 1
+    && boardsOnlyRes.results[0].name === 'Solo feed' && boardsOnlyRes.results[0].status === 'live') {
+    pass('a portals file with only a job_boards section is swept');
+  } else {
+    fail(`job_boards-only file should yield 1 probed row — got ${JSON.stringify(boardsOnlyRes)}`);
+  }
+
+  // 4. A file with only a tracked_companies section: the entry is probed via
+  //    tier 1.
+  const companiesOnly = writeYml('companies-only.yml', `
+tracked_companies:
+  - name: "Only Co"
+    api: "https://boards-api.greenhouse.io/v1/boards/onlyco/jobs"
+`);
+  const companiesOnlyRes = await verifyPortalsFile(companiesOnly, { fetchJson });
+  if (companiesOnlyRes.results.length === 1
+    && companiesOnlyRes.results[0].name === 'Only Co'
+    && companiesOnlyRes.results[0].status === 'live') {
+    pass('a portals file with only a tracked_companies section is swept');
+  } else {
+    fail(`tracked_companies-only file — got ${JSON.stringify(companiesOnlyRes)}`);
+  }
+
+  // 5. `enabled: false` excludes a job_boards entry from the sweep, as it does a
+  //    company.
+  const disabled = writeYml('disabled.yml', `
+job_boards:
+  - name: "Active feed"
+    provider: board-plugin
+  - name: "Retired feed"
+    provider: board-plugin
+    enabled: false
+`);
+  const disabledRes = await verifyPortalsFile(disabled, { fetchJson, providers: fakeProviders, httpCtx: fakeCtx });
+  if (disabledRes.results.length === 1 && disabledRes.results[0].name === 'Active feed') {
+    pass('an `enabled: false` job_boards entry is excluded from the sweep');
+  } else {
+    fail(`disabled job_boards entry should be excluded — got ${JSON.stringify(disabledRes.results.map((r) => r.name))}`);
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -224,46 +224,53 @@ export async function validatePortalsConfig(config, { providerIds = new Set() } 
     add(errors, 'search_queries', 'search_queries must be an array when set');
   }
 
-  const companies = config.tracked_companies;
-  if (companies !== undefined && !Array.isArray(companies)) {
-    add(errors, 'tracked_companies', 'tracked_companies must be an array when set');
-  }
-
+  // tracked_companies and job_boards share one entry schema (name / careers_url /
+  // api / provider / parser) and one dedup namespace downstream, so validate them
+  // in a single pass. seenEnabledNames spans both lists: a board and a company
+  // that share a name would still collide in the scanner's reporting.
   const seenEnabledNames = new Map();
-  if (Array.isArray(companies)) {
-    for (const [idx, company] of companies.entries()) {
-      const base = `tracked_companies[${idx}]`;
-      if (!isObject(company)) {
-        add(errors, base, 'company entry must be an object');
+  const validateEntryList = (list, key, noun) => {
+    if (list === undefined) return;
+    if (!Array.isArray(list)) {
+      add(errors, key, `${key} must be an array when set`);
+      return;
+    }
+    for (const [idx, entry] of list.entries()) {
+      const base = `${key}[${idx}]`;
+      if (!isObject(entry)) {
+        add(errors, base, `${noun} entry must be an object`);
         continue;
       }
-      if (company.enabled === false) continue;
+      if (entry.enabled === false) continue;
 
-      if (typeof company.name !== 'string' || company.name.trim() === '') {
-        add(errors, `${base}.name`, 'enabled company must have a non-empty string name');
+      if (typeof entry.name !== 'string' || entry.name.trim() === '') {
+        add(errors, `${base}.name`, `enabled ${noun} must have a non-empty string name`);
       } else {
-        const normalized = normalizeName(company.name);
+        const normalized = normalizeName(entry.name);
         if (seenEnabledNames.has(normalized)) {
-          add(warnings, `${base}.name`, `duplicate enabled company name also seen at ${seenEnabledNames.get(normalized)}`);
+          add(warnings, `${base}.name`, `duplicate enabled ${noun} name also seen at ${seenEnabledNames.get(normalized)}`);
         } else {
           seenEnabledNames.set(normalized, `${base}.name`);
         }
       }
 
-      validateUrl(company.careers_url, `${base}.careers_url`, errors);
-      validateUrl(company.api, `${base}.api`, errors);
+      validateUrl(entry.careers_url, `${base}.careers_url`, errors);
+      validateUrl(entry.api, `${base}.api`, errors);
 
-      if (company.provider !== undefined) {
-        if (typeof company.provider !== 'string' || company.provider.trim() === '') {
+      if (entry.provider !== undefined) {
+        if (typeof entry.provider !== 'string' || entry.provider.trim() === '') {
           add(errors, `${base}.provider`, 'provider must be a non-empty string when set');
-        } else if (!providerIds.has(company.provider)) {
-          add(errors, `${base}.provider`, `unknown provider "${company.provider}"`);
+        } else if (!providerIds.has(entry.provider)) {
+          add(errors, `${base}.provider`, `unknown provider "${entry.provider}"`);
         }
       }
 
-      validateParser(company.parser, `${base}.parser`, errors);
+      validateParser(entry.parser, `${base}.parser`, errors);
     }
-  }
+  };
+
+  validateEntryList(config.tracked_companies, 'tracked_companies', 'company');
+  validateEntryList(config.job_boards, 'job_boards', 'job board');
 
   return { errors, warnings };
 }

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -3,19 +3,22 @@
 /**
  * verify-portals.mjs — ATS slug validator for portals.yml.
  *
- * When a company is added to portals.yml, its ATS slug (the path segment in
+ * When an entry is added to portals.yml, its ATS slug (the path segment in
  * `careers_url`, e.g. `jobs.lever.co/<slug>`) is easy to guess wrong — and a
- * wrong slug 404s silently on every future scan, so the company never appears
- * in results and the mistake is invisible. This script probes the public
- * Greenhouse / Ashby / Lever endpoints for a company's slug (or for candidate
- * slugs derived from its name) and reports which resolve.
+ * wrong slug 404s silently on every future scan, so the entry never appears in
+ * results and the mistake is invisible. This script probes each entry and
+ * reports which resolve, in two tiers (see verifyCompanies() below):
+ *   1. Greenhouse / Ashby / Lever — the URL carries a parseable slug, hit
+ *      directly; `--add` also cross-probes candidate slugs derived from a name.
+ *   2. Every other host (Workday, SmartRecruiters, the aggregator feeds …) —
+ *      routed through the same provider plugins the scanner uses.
  *
  * A 200 that returns an empty job list is reported as 'live but empty' — a
  * legitimate state during between-hires periods — kept distinct from an
  * unresolved (404/wrong) slug so a quiet board isn't mistaken for a typo.
  *
  * Usage:
- *   node verify-portals.mjs                 # sweep tracked_companies in portals.yml
+ *   node verify-portals.mjs                 # sweep tracked_companies + job_boards in portals.yml
  *   node verify-portals.mjs --add cursor    # probe slug variants for one name
  *   node verify-portals.mjs --strict        # exit non-zero if any slug is unresolved
  *   node verify-portals.mjs --file <path>   # use a specific portals file
@@ -485,9 +488,9 @@ function boundedProbeCtx(base) {
 }
 
 /**
- * Probe one non-ATS company through the provider plugin the scanner would use.
+ * Probe one non-ATS entry through the provider plugin the scanner would use.
  *
- * @param {object} entry - tracked_companies entry.
+ * @param {object} entry - portals.yml entry (tracked_companies or job_boards).
  * @param {import('./providers/_types.js').Provider} provider
  * @param {import('./providers/_types.js').Context} baseCtx
  * @returns {Promise<{provider,status,jobCount?,partial?,httpStatus?,errorKind?,reason?}>}
@@ -527,7 +530,7 @@ export async function probeProvider(entry, provider, baseCtx) {
 }
 
 /**
- * Verify each enabled tracked company's board is reachable.
+ * Verify each enabled portals.yml entry's board is reachable.
  *
  * Two tiers, cheapest first:
  *   1. Greenhouse/Ashby/Lever slugs are probed directly (one JSON request each),
@@ -536,14 +539,14 @@ export async function probeProvider(entry, provider, baseCtx) {
  *      uses (Workday, SuccessFactors, SmartRecruiters, Avature, …), bounded to
  *      a few requests. This catches broken non-ATS boards that used to be
  *      reported as an un-actionable "skipped".
- * A company reaches `skipped` only when no provider claims it. Probing is
+ * An entry reaches `skipped` only when no provider claims it. Probing is
  * sequential to stay gentle on rate limits.
  *
- * @param {Array<object>} companies - tracked_companies entries.
+ * @param {Array<object>} companies - portals.yml entries (tracked_companies and/or job_boards).
  * @param {{fetchJson?: Function, providers?: Map, httpCtx?: object}} [deps]
  *   `providers`/`httpCtx` enable tier 2; omit them (as the ATS unit tests do) to
  *   get tier-1-only behavior where non-ATS entries stay `skipped`.
- * @returns {Promise<Array<object>>} One result row per company.
+ * @returns {Promise<Array<object>>} One result row per entry.
  */
 export async function verifyCompanies(
   companies,
@@ -597,7 +600,7 @@ export async function verifyCompanies(
 }
 
 /**
- * Read a portals file and verify its tracked companies' slugs.
+ * Read a portals file and verify its tracked_companies and job_boards slugs.
  *
  * @param {string} filePath - Path to a portals.yml.
  * @param {{fetchJson?: Function}} [deps]
@@ -610,10 +613,14 @@ export async function verifyPortalsFile(
 ) {
   if (!existsSync(filePath)) return { found: false, results: [] };
   const config = yaml.load(readFileSync(filePath, 'utf-8'));
-  const companies = Array.isArray(config?.tracked_companies)
-    ? config.tracked_companies
-    : [];
-  const results = await verifyCompanies(companies, { fetchJson, providers, httpCtx });
+  // tracked_companies and job_boards carry the same entry shape and both feed the
+  // scanner, so sweep both — a job board going dark is exactly as worth surfacing
+  // as a company board 404ing.
+  const entries = [
+    ...(Array.isArray(config?.tracked_companies) ? config.tracked_companies : []),
+    ...(Array.isArray(config?.job_boards) ? config.job_boards : []),
+  ];
+  const results = await verifyCompanies(entries, { fetchJson, providers, httpCtx });
   return { found: true, results };
 }
 


### PR DESCRIPTION
## What does this PR do?

`verify-portals.mjs` and `validate-portals.mjs` only ever read `config.tracked_companies`. `job_boards` — a first-class `portals.yml` section that `scan.mjs` scans and `detect-reposts.mjs` and `stats.mjs` already fold in — is invisible to both: a job board with a dead ATS slug gets no health sweep and no `--strict` failure, and a malformed `job_boards` entry passes schema validation silently.

`validate-portals` factors its `tracked_companies` loop into a `validateEntryList(list, key, noun)` helper and runs it for `job_boards` too. The enabled-name namespace is shared across the two lists, so a board and a company that share a name is still flagged. `tracked_companies` diagnostics are unchanged.

`verify-portals` concatenates the two lists before the sweep. `verifyCompanies` already keys off generic `name` / `careers_url` / `api` / `provider` fields, so no probe logic changes — a `job_boards` provider feed is probed through its plugin exactly as a `tracked_companies` entry is. `doctor.mjs --strict`, which delegates to `verifyPortalsFile`, now covers both lists too.

Comments that named only `tracked_companies` where the code already handles both — `resolveProvider`, the `PortalEntry` type, `verifyCompanies` — are corrected. The `fix-slugs.mjs` header comment is also clarified: its repair path is fed only by verify-portals's tier-1 (Greenhouse/Ashby/Lever slug) probe, so it rewrites `tracked_companies` ATS-slug entries only — a `job_boards` aggregator is a provider-layer entry and never carries a `suggested` alternate.

## Testing

`node test-all.mjs` passes. New: `tests/validate-portals-job-boards.test.mjs`, `tests/verify-portals-job-boards.test.mjs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portal validation now consistently covers tracked companies and job boards.
  * Duplicate enabled names are detected across both portal lists.
  * Verification checks all configured entries, including provider-based feeds.
  * Unclaimed entries are reported as skipped, while disabled entries are excluded.

* **Tests**
  * Added coverage for job board validation, verification, provider handling, and mixed configurations.

* **Documentation**
  * Updated portal scripts and guidance to reflect expanded coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->