### PR TITLE
docs(portals): point aggregator provider examples at job_boards

### DIFF
--- a/providers/remotli.mjs
+++ b/providers/remotli.mjs
@@ -14,7 +14,8 @@
 // Note the doubly-nested shape: each element of the top-level `jobs` array is a
 // join row `{ jobs, companies }`, and the posting itself lives under `.jobs`.
 //
-// Wire in as a tracked_companies entry:
+// Configure via a `job_boards` (or `tracked_companies`) entry with
+// `provider: remotli`:
 //
 //   - name: Remotli (Swiss remote board)
 //     provider: remotli

--- a/providers/yourator.mjs
+++ b/providers/yourator.mjs
@@ -9,7 +9,8 @@
 //       salary, lastActiveAt, location, companyId, tags, company: { brand, … },
 //       thirdPartyUrl, externalSource } ], recommendedJobs, trendingKeywords } }
 //
-// Wire in as a tracked_companies entry:
+// Configure via a `job_boards` (or `tracked_companies`) entry with
+// `provider: yourator`:
 //
 //   - name: Yourator (Taiwan startup board)
 //     provider: yourator

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -922,13 +922,13 @@ search_queries:
 
 # ── Built-in provider examples ────────────────────────────────────
 # One commented stanza per provider in providers/. Uncomment one and adjust.
-# Auto-detected providers only need careers_url; the rest need provider: plus
-# any fields shown.
+# A provider whose host is auto-detected (company ATS or job board) only needs
+# careers_url; the rest need provider: plus any fields shown.
 #
 # Grouped by which list the stanza belongs in: the "Company ATS" group goes
 # under tracked_companies: (one entry = one employer); the "Job boards /
 # aggregators" and "Remote-job feeds" groups go under job_boards: (one entry =
-# many employers, in a single API call).
+# many employers).
 #
 # -- Company ATS  (→ tracked_companies:; careers_url is enough unless noted) --
 #
@@ -1123,7 +1123,7 @@ search_queries:
 #   provider: beesite
 #   enabled: true
 #
-# -- Job boards / aggregators  (→ job_boards:; set provider: explicitly) --
+# -- Job boards / aggregators  (→ job_boards:; set provider: explicitly unless the host auto-detects) --
 #
 # - name: Amazon / AWS                    # global amazon.jobs board
 #   provider: amazon

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -921,12 +921,16 @@ search_queries:
 # manfred, thehub, vdab, weworkremotely, workingnomads, wttj, a16z-speedrun-talent. Examples for every built-in provider are below.
 
 # ── Built-in provider examples ────────────────────────────────────
-# Commented config for each provider in providers/. Copy a stanza into
-# tracked_companies (or into job_boards for the multi-employer aggregators
-# grouped at the end), uncomment, and adjust. Auto-detected providers only
-# need careers_url; the rest need provider: plus any fields shown.
+# One commented stanza per provider in providers/. Uncomment one and adjust.
+# Auto-detected providers only need careers_url; the rest need provider: plus
+# any fields shown.
 #
-# -- Auto-detected company ATS (careers_url is enough) --
+# Grouped by which list the stanza belongs in: the "Company ATS" group goes
+# under tracked_companies: (one entry = one employer); the "Job boards /
+# aggregators" and "Remote-job feeds" groups go under job_boards: (one entry =
+# many employers, in a single API call).
+#
+# -- Company ATS  (→ tracked_companies:; careers_url is enough unless noted) --
 #
 # - name: Example BambooHR Co
 #   careers_url: https://exampleco.bamboohr.com/careers   # any *.bamboohr.com host
@@ -1070,12 +1074,6 @@ search_queries:
 #   api: https://jobs.exampleco.com                  # RMK board origin
 #   enabled: true
 #
-# - name: SolidJobs — Engineering
-#   # division path is required; one of:
-#   # it, engineering, marketing, sales, hr, logistics, finances, other
-#   careers_url: https://solid.jobs/public-api/offers/engineering
-#   enabled: true
-#
 # - name: Example join.com Co
 #   # join.com career page. Auto-detects any join.com/companies/<slug> URL and
 #   # parses the __NEXT_DATA__ JSON embedded in the server-rendered HTML — no
@@ -1086,7 +1084,46 @@ search_queries:
 #                            # is logged if the cap truncates real results)
 #   enabled: true
 #
-# -- Job boards / aggregators (put under job_boards:; no careers_url; set provider: explicitly) --
+# Single-employer career sites on their own dedicated provider. Most auto-detect
+# from the company's own host (provider: optional, shown for clarity); a few need
+# it named. All still go under tracked_companies:.
+#
+# - name: Dassault Systèmes              # single-company; Exalead card_search_api
+#   careers_url: https://www.3ds.com/careers/jobs   # auto-detects on *.3ds.com
+#   provider: dassault                    # optional — 3ds.com host also auto-detects
+#   enabled: true                         # ~445 English postings (zero-token XML)
+#
+# - name: Deutsche Bahn                   # single-company; db.jobs Avature front
+#   careers_url: https://db.jobs          # auto-detects; SSR search, paginated over HTTP
+#   provider: deutschebahn                # optional — db.jobs host also auto-detects
+#   enabled: true
+#
+# - name: Heckler & Koch                  # single-company; SSR Nuxt vacancy list
+#   careers_url: https://www.heckler-koch.com/de/Karriere/Stellenangebote
+#   provider: hecklerkoch                 # optional — heckler-koch.com host also auto-detects
+#   enabled: true
+#
+# - name: Rheinmetall                     # single-company; SSR Nuxt vacancy list
+#   careers_url: https://www.rheinmetall.com/en/career/vacancies
+#   provider: rheinmetall                 # optional — rheinmetall.com host also auto-detects
+#   enabled: true
+#
+# - name: OHB                             # Cornerstone OnDemand (csod) branded site
+#   careers_url: https://career-ohb.csod.com/ux/ats/careersite/4/home?c=career-ohb
+#   provider: csod                        # anonymous-JWT bootstrap, then public search API
+#   enabled: true
+#
+# - name: RENK                            # softgarden hosted job widget
+#   careers_url: https://renk-group.softgarden.io/de/widgets/jobs
+#   provider: softgarden
+#   enabled: true
+#
+# - name: Mercedes-Benz                   # BeeSite (milch & zucker) search backend
+#   careers_url: https://mercedes-benz-beesite-production-gjb.app.beesite.de   # the *.app.beesite.de host, not the branded front (jobs.mercedes-benz.com)
+#   provider: beesite
+#   enabled: true
+#
+# -- Job boards / aggregators  (→ job_boards:; set provider: explicitly) --
 #
 # - name: Amazon / AWS                    # global amazon.jobs board
 #   provider: amazon
@@ -1197,42 +1234,14 @@ search_queries:
 #     categories: ["Software Engineering"]  # optional facet filter
 #   enabled: true
 #
-# - name: Dassault Systèmes              # single-company; Exalead card_search_api
-#   careers_url: https://www.3ds.com/careers/jobs   # auto-detects on *.3ds.com
-#   provider: dassault                    # optional — 3ds.com host also auto-detects
-#   enabled: true                         # ~445 English postings (zero-token XML)
-#
-# - name: Deutsche Bahn                   # single-company; db.jobs Avature front
-#   careers_url: https://db.jobs          # auto-detects; SSR search, paginated over HTTP
-#   provider: deutschebahn                # optional — db.jobs host also auto-detects
+# - name: SolidJobs — Engineering        # Polish multi-division job board
+#   # provider: solidjobs is optional — the solid.jobs host auto-detects.
+#   # Division path is required; one of:
+#   # it, engineering, marketing, sales, hr, logistics, finances, other
+#   careers_url: https://solid.jobs/public-api/offers/engineering
 #   enabled: true
 #
-# - name: Heckler & Koch                  # single-company; SSR Nuxt vacancy list
-#   careers_url: https://www.heckler-koch.com/de/Karriere/Stellenangebote
-#   provider: hecklerkoch                 # optional — heckler-koch.com host also auto-detects
-#   enabled: true
-#
-# - name: Rheinmetall                     # single-company; SSR Nuxt vacancy list
-#   careers_url: https://www.rheinmetall.com/en/career/vacancies
-#   provider: rheinmetall                 # optional — rheinmetall.com host also auto-detects
-#   enabled: true
-#
-# - name: OHB                             # Cornerstone OnDemand (csod) branded site
-#   careers_url: https://career-ohb.csod.com/ux/ats/careersite/4/home?c=career-ohb
-#   provider: csod                        # anonymous-JWT bootstrap, then public search API
-#   enabled: true
-#
-# - name: RENK                            # softgarden hosted job widget
-#   careers_url: https://renk-group.softgarden.io/de/widgets/jobs
-#   provider: softgarden
-#   enabled: true
-#
-# - name: Mercedes-Benz                   # BeeSite (milch & zucker) search backend
-#   careers_url: https://mercedes-benz-beesite-production-gjb.app.beesite.de   # the *.app.beesite.de host, not the branded front (jobs.mercedes-benz.com)
-#   provider: beesite
-#   enabled: true
-#
-# -- Remote-job feeds (no careers_url, no extra fields) --
+# -- Remote-job feeds  (→ job_boards:; set provider:, no extra fields) --
 # title_filter / location_filter defined above still apply.
 #
 # - name: Himalayas

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1241,7 +1241,7 @@ search_queries:
 #   careers_url: https://solid.jobs/public-api/offers/engineering
 #   enabled: true
 #
-# -- Remote-job feeds  (→ job_boards:; set provider:, no extra fields) --
+# -- Remote-job feeds  (→ job_boards:; set provider: plus any provider-specific fields) --
 # title_filter / location_filter defined above still apply.
 #
 # - name: Himalayas

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -922,7 +922,8 @@ search_queries:
 
 # ── Built-in provider examples ────────────────────────────────────
 # Commented config for each provider in providers/. Copy a stanza into
-# tracked_companies, uncomment, and adjust. Auto-detected providers only
+# tracked_companies (or into job_boards for the multi-employer aggregators
+# grouped at the end), uncomment, and adjust. Auto-detected providers only
 # need careers_url; the rest need provider: plus any fields shown.
 #
 # -- Auto-detected company ATS (careers_url is enough) --
@@ -1085,7 +1086,7 @@ search_queries:
 #                            # is logged if the cap truncates real results)
 #   enabled: true
 #
-# -- Job boards / aggregators (no careers_url; set provider: explicitly) --
+# -- Job boards / aggregators (put under job_boards:; no careers_url; set provider: explicitly) --
 #
 # - name: Amazon / AWS                    # global amazon.jobs board
 #   provider: amazon


### PR DESCRIPTION
## What does this PR do?

`portals.yml` has two entry lists: `tracked_companies` (one entry = one employer) and `job_boards` (one entry = a multi-employer aggregator feed). Three doc comments tell the reader to wire a multi-employer aggregator into `tracked_companies`, which is where the misplacement that miscounts the companies-vs-boards split in `scan-runs.tsv` starts.

`templates/portals.example.yml`: the "Built-in provider examples" block said "Copy a stanza into `tracked_companies`" for every stanza, including the group explicitly headed "Job boards / aggregators". That instruction now points the aggregator group at `job_boards`, and the group's own subsection header says so too.

`providers/remotli.mjs` and `providers/yourator.mjs`: both are multi-employer boards (remotli.ch — remote roles at Swiss companies; yourator.co — a Taiwanese startup job board), but their headers said "Wire in as a tracked_companies entry". They now use the same "Configure via a `job_boards` (or `tracked_companies`) entry with `provider: X`" phrasing that `arbeitsagentur.mjs`, `ibm.mjs`, and `vdab.mjs` already use.

Comment-only. No code paths change — `scan.mjs` reads both lists identically.

## Testing

`node test-all.mjs` passes. `validate-portals` still accepts `templates/portals.example.yml` (comment-only edit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified configuration guidance for Remotli and Yourator.
  - Reorganized example configuration comments by provider type.
  - Clarified placement of company providers, single-employer providers, job boards, aggregators, and remote job feeds under `tracked_companies` or `job_boards`.
  - Moved the SolidJobs example to the job-board section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->