### PR TITLE
fix(discard): harden analytics summary

### DIFF
--- a/discard-analytics.mjs
+++ b/discard-analytics.mjs
@@ -20,10 +20,9 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join, dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
-
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+import { join } from 'path';
+import { getCareerOpsRoot } from './path-resolver.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 /**
  * Parse a discard log's contents into entries.
@@ -142,7 +141,7 @@ export function renderSummary(agg, topN, firstDate, lastDate) {
 
 // ── CLI entry point ────────────────────────────────────────────────────────
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+if (isMainModule(import.meta.url)) {
   if (process.argv.includes('-h') || process.argv.includes('--help')) {
     console.log('Usage: node discard-analytics.mjs [--log <path>] [--reason <pattern>] [--top N] [--since YYYY-MM-DD]');
     console.log('  Analyzes the discard log for filter tuning insights.');
@@ -159,7 +158,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1
   const sinceDate = argValue('--since');
   const customLog = argValue('--log');
 
-  const logFile = customLog || join(CAREER_OPS, 'data/discard.log');
+  const logFile = customLog || join(getCareerOpsRoot(), 'data/discard.log');
   if (!existsSync(logFile)) {
     console.log(`No discard log found at ${logFile}`);
     process.exit(0);

--- a/discard-analytics.mjs
+++ b/discard-analytics.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * discard-analytics.mjs — Analyze the discard log for filter tuning
+ *
+ * The discard log (data/discard.log, or batch/logs/discard.log for batch runs)
+ * is the only record of what the filters threw away and why. This script reads
+ * it and produces a summary of rejection reasons, domains, and daily volume,
+ * plus the most frequent title_mismatch URLs for the candidate to review.
+ *
+ * Read-only: never modifies the log.
+ *
+ * The top title_mismatch section is deliberately dumb — it lists the URLs and
+ * lets the candidate judge whether a keyword is costing them real roles. It
+ * never infers which keyword to add; that is a guess wearing a number.
+ *
+ * Run: node discard-analytics.mjs [--log <path>] [--reason <pattern>] [--top N] [--since YYYY-MM-DD]
+ *
+ * --log defaults to data/discard.log. Pass batch/logs/discard.log to analyze
+ * the batch variant (same shape, one extra id field per row).
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Parse a discard log's contents into entries.
+ *
+ * Interactive rows are 3 fields:  {timestamp}\t{url}\t{reason}
+ * Batch rows are 4 fields:        {timestamp}\t{id}\t{url}\t{reason}
+ * The URL is always the field before the reason; detected by field count.
+ *
+ * @param {string} text - Raw log contents.
+ * @returns {Array<{timestamp:string, url:string, reason:string}>}
+ */
+export function parseDiscardLog(text) {
+  const out = [];
+  for (const line of String(text).replace(/^\uFEFF/, '').split(/\r?\n/)) {
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    let timestamp, url, reason;
+    if (parts.length >= 4) {
+      [timestamp, , url, reason] = parts;
+    } else {
+      [timestamp, url, reason] = parts;
+    }
+    if (!timestamp || !url || !reason) continue;
+    out.push({ timestamp, url, reason: reason.trim() });
+  }
+  return out;
+}
+
+/**
+ * Aggregate parsed entries into sorted reason/domain/day counts.
+ *
+ * @param {Array<{timestamp:string, url:string, reason:string}>} entries
+ * @returns {{
+ *   total: number,
+ *   byReason: Array<[string, number]>,
+ *   byDomain: Array<[string, number]>,
+ *   byDay: Array<[string, number]>,
+ *   titleMismatch: string[]
+ * }}
+ */
+export function aggregateDiscards(entries) {
+  const reasonCounts = {};
+  const domainCounts = {};
+  const dayCounts = {};
+  const titleMismatch = [];
+
+  for (const e of entries) {
+    reasonCounts[e.reason] = (reasonCounts[e.reason] || 0) + 1;
+    try {
+      const u = new URL(e.url);
+      domainCounts[u.hostname] = (domainCounts[u.hostname] || 0) + 1;
+    } catch { /* malformed URL */ }
+    const day = e.timestamp.slice(0, 10);
+    dayCounts[day] = (dayCounts[day] || 0) + 1;
+    if (e.reason.includes('title_mismatch')) titleMismatch.push(e.url);
+  }
+
+  const byReason = Object.entries(reasonCounts).sort((a, b) => b[1] - a[1]);
+  const byDomain = Object.entries(domainCounts).sort((a, b) => b[1] - a[1]);
+  const byDay = Object.entries(dayCounts).sort((a, b) => a[0].localeCompare(b[0]));
+
+  return { total: entries.length, byReason, byDomain, byDay, titleMismatch };
+}
+
+/**
+ * Render the summary to a string (the CLI prints it).
+ * @param {ReturnType<typeof aggregateDiscards>} agg
+ * @param {number} topN - Number of domains/URLs to show.
+ * @param {string} firstDate - Earliest timestamp in the filtered set.
+ * @param {string} lastDate - Latest timestamp in the filtered set.
+ * @returns {string}
+ */
+export function renderSummary(agg, topN, firstDate, lastDate) {
+  const pct = (n) => ((n / agg.total) * 100).toFixed(1);
+  const pad = (s, n) => String(s).padEnd(n);
+
+  const lines = [];
+  lines.push('=== Discard Log Analytics ===');
+  lines.push(`Period: ${firstDate} to ${lastDate}`);
+  lines.push(`Total discards: ${agg.total}`);
+  lines.push('');
+
+  lines.push('By reason:');
+  for (const [reason, count] of agg.byReason) {
+    lines.push(`  ${pad(reason, 30)} ${pad(count, 5)}  (${pct(count)}%)`);
+  }
+  lines.push('');
+
+  lines.push(`By domain (top ${topN}):`);
+  for (const [domain, count] of agg.byDomain.slice(0, topN)) {
+    lines.push(`  ${pad(domain, 35)} ${pad(count, 5)}  (${pct(count)}%)`);
+  }
+  lines.push('');
+
+  lines.push('By day:');
+  for (const [day, count] of agg.byDay) {
+    lines.push(`  ${day}  ${pad(count, 5)}  ${'#'.repeat(Math.min(count, 50))}`);
+  }
+  lines.push('');
+
+  if (agg.titleMismatch.length > 0) {
+    lines.push(`Top title_mismatch URLs (review for keyword tuning):`);
+    for (const url of agg.titleMismatch.slice(0, topN)) {
+      lines.push(`  1. ${url}`);
+    }
+    lines.push('');
+  }
+
+  lines.push(`Summary: ${agg.byReason.length} unique reasons, ${agg.byDomain.length} domains, ${agg.byDay.length} active days`);
+  if (agg.byReason.length > 0) {
+    const [topReason, count] = agg.byReason[0];
+    lines.push(`Top rejection: "${topReason}" (${count} occurrences, ${pct(count)}%)`);
+  }
+  return lines.join('\n');
+}
+
+// ── CLI entry point ────────────────────────────────────────────────────────
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  if (process.argv.includes('-h') || process.argv.includes('--help')) {
+    console.log('Usage: node discard-analytics.mjs [--log <path>] [--reason <pattern>] [--top N] [--since YYYY-MM-DD]');
+    console.log('  Analyzes the discard log for filter tuning insights.');
+    process.exit(0);
+  }
+
+  function argValue(flag) {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+  }
+
+  const filterReason = argValue('--reason');
+  const topN = parseInt(argValue('--top') || '10', 10);
+  const sinceDate = argValue('--since');
+  const customLog = argValue('--log');
+
+  const logFile = customLog || join(CAREER_OPS, 'data/discard.log');
+  if (!existsSync(logFile)) {
+    console.log(`No discard log found at ${logFile}`);
+    process.exit(0);
+  }
+
+  let entries = parseDiscardLog(readFileSync(logFile, 'utf-8'));
+  if (sinceDate) entries = entries.filter((e) => e.timestamp >= sinceDate);
+  if (filterReason) entries = entries.filter((e) => e.reason.toLowerCase().includes(filterReason.toLowerCase()));
+
+  if (entries.length === 0) {
+    console.log('No matching entries in discard log.');
+    process.exit(0);
+  }
+
+  const agg = aggregateDiscards(entries);
+  const firstDate = entries[0].timestamp.slice(0, 10);
+  const lastDate = entries[entries.length - 1].timestamp.slice(0, 10);
+
+  console.log(renderSummary(agg, topN, firstDate, lastDate));
+}

--- a/discard-analytics.mjs
+++ b/discard-analytics.mjs
@@ -19,7 +19,7 @@
  * the batch variant (same shape, one extra id field per row).
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
@@ -60,14 +60,14 @@ export function parseDiscardLog(text) {
  *   byReason: Array<[string, number]>,
  *   byDomain: Array<[string, number]>,
  *   byDay: Array<[string, number]>,
- *   titleMismatch: string[]
+ *   titleMismatch: Array<[string, number]>
  * }}
  */
 export function aggregateDiscards(entries) {
   const reasonCounts = {};
   const domainCounts = {};
   const dayCounts = {};
-  const titleMismatch = [];
+  const titleMismatchCounts = {};
 
   for (const e of entries) {
     reasonCounts[e.reason] = (reasonCounts[e.reason] || 0) + 1;
@@ -77,12 +77,15 @@ export function aggregateDiscards(entries) {
     } catch { /* malformed URL */ }
     const day = e.timestamp.slice(0, 10);
     dayCounts[day] = (dayCounts[day] || 0) + 1;
-    if (e.reason.includes('title_mismatch')) titleMismatch.push(e.url);
+    if (e.reason.includes('title_mismatch')) {
+      titleMismatchCounts[e.url] = (titleMismatchCounts[e.url] || 0) + 1;
+    }
   }
 
   const byReason = Object.entries(reasonCounts).sort((a, b) => b[1] - a[1]);
   const byDomain = Object.entries(domainCounts).sort((a, b) => b[1] - a[1]);
   const byDay = Object.entries(dayCounts).sort((a, b) => a[0].localeCompare(b[0]));
+  const titleMismatch = Object.entries(titleMismatchCounts).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 
   return { total: entries.length, byReason, byDomain, byDay, titleMismatch };
 }
@@ -125,8 +128,8 @@ export function renderSummary(agg, topN, firstDate, lastDate) {
 
   if (agg.titleMismatch.length > 0) {
     lines.push(`Top title_mismatch URLs (review for keyword tuning):`);
-    for (const url of agg.titleMismatch.slice(0, topN)) {
-      lines.push(`  1. ${url}`);
+    for (const [url, count] of agg.titleMismatch.slice(0, topN)) {
+      lines.push(`  ${count}. ${url}`);
     }
     lines.push('');
   }
@@ -154,12 +157,19 @@ if (isMainModule(import.meta.url)) {
   }
 
   const filterReason = argValue('--reason');
-  const topN = parseInt(argValue('--top') || '10', 10);
+  const parsedTopN = Number(argValue('--top') || '10');
+  const topN = Number.isInteger(parsedTopN) && parsedTopN > 0 ? parsedTopN : 10;
   const sinceDate = argValue('--since');
   const customLog = argValue('--log');
 
   const logFile = customLog || join(getCareerOpsRoot(), 'data/discard.log');
-  if (!existsSync(logFile)) {
+  let logStat = null;
+  try {
+    logStat = existsSync(logFile) ? statSync(logFile) : null;
+  } catch {
+    logStat = null;
+  }
+  if (!logStat?.isFile()) {
     console.log(`No discard log found at ${logFile}`);
     process.exit(0);
   }
@@ -174,8 +184,8 @@ if (isMainModule(import.meta.url)) {
   }
 
   const agg = aggregateDiscards(entries);
-  const firstDate = entries[0].timestamp.slice(0, 10);
-  const lastDate = entries[entries.length - 1].timestamp.slice(0, 10);
+  const firstDate = agg.byDay[0][0];
+  const lastDate = agg.byDay[agg.byDay.length - 1][0];
 
   console.log(renderSummary(agg, topN, firstDate, lastDate));
 }

--- a/tests/discard-analytics.test.mjs
+++ b/tests/discard-analytics.test.mjs
@@ -1,0 +1,71 @@
+// tests/discard-analytics.test.mjs — discard log analytics (#3392).
+//
+// Covers the parsing of both discard-log shapes (interactive 3-field, batch
+// 4-field), the aggregation, the --since/--reason filters, and the "dumb"
+// title_mismatch URL list (URLs only, no keyword inference).
+//
+// Imported directly (like rank-pipeline.test.mjs) so the pure functions are
+// exercised without spawning the CLI.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\ndiscard-analytics — discard log parsing + aggregation');
+
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'discard-analytics.mjs')).href);
+  const { parseDiscardLog, aggregateDiscards, renderSummary } = mod;
+  const check = (label, cond) => (cond ? pass(label) : fail(label));
+
+  // ── parsing: interactive 3-field rows ──
+  const interactive = parseDiscardLog([
+    '2026-08-25T10:00:00Z\thttps://example.com/job1\ttitle_mismatch: program manager not in filter',
+    '2026-08-25T11:00:00Z\thttps://boards.greenhouse.io/co/job2\tnot_tech: marketing role',
+    '2026-08-26T09:00:00Z\thttps://jobs.ashbyhq.com/co/job3\tlocation_mismatch: requires on-site',
+    '',
+    'this is a malformed line',
+  ].join('\n'));
+  check('interactive 3-field rows parse', interactive.length === 3);
+  check('reason is trimmed', interactive[0].reason === 'title_mismatch: program manager not in filter');
+  check('blank and malformed lines are skipped', interactive.length === 3);
+  check('no spurious fields on a 3-field row', interactive[0].timestamp.startsWith('2026-08-25'));
+
+  // ── parsing: batch 4-field rows (url before reason, id skipped) ──
+  const batchLog = parseDiscardLog([
+    '2026-08-25T10:00:00Z\tjob-001\thttps://example.com/job1\ttitle_mismatch: foo',
+    '2026-08-25T12:00:00Z\tjob-002\thttps://x.test/job2\tnot_tech: bar',
+  ].join('\n'));
+  check('batch 4-field rows parse', batchLog.length === 2);
+  check('url is the third field, reason the fourth', batchLog[0].url === 'https://example.com/job1' && batchLog[0].reason === 'title_mismatch: foo');
+
+  // ── aggregation ──
+  const entries = parseDiscardLog([
+    '2026-08-25T10:00:00Z\thttps://example.com/job1\ttitle_mismatch: a',
+    '2026-08-25T11:00:00Z\thttps://example.com/job2\ttitle_mismatch: b',
+    '2026-08-25T12:00:00Z\thttps://boards.greenhouse.io/co/job3\tnot_tech: c',
+    '2026-08-26T09:00:00Z\thttps://jobs.ashbyhq.com/co/job4\tlocation_mismatch: d',
+    '2026-08-25T13:00:00Z\thttps://example.com/job5\ttitle_mismatch: b',
+  ].join('\n'));
+  const agg = aggregateDiscards(entries);
+  check('total counts every parsed entry', agg.total === 5);
+  check('duplicate reasons are merged', agg.byReason.length === 4);
+  check('reasons are counted and sorted descending', agg.byReason[0][1] === 2);
+  check('domains are extracted from URLs', agg.byDomain.some(([d]) => d === 'boards.greenhouse.io'));
+  check('days are bucketed and sorted ascending', agg.byDay[0][0] === '2026-08-25' && agg.byDay[1][0] === '2026-08-26');
+  check('title_mismatch URLs are collected (URLs only)', agg.titleMismatch.length === 3);
+
+  // ── "dumb" list: URLs only, no keyword inference ──
+  const summary = renderSummary(agg, 10, '2026-08-25', '2026-08-26');
+  check('summary includes total', summary.includes('Total discards: 5'));
+  check('summary lists title_mismatch URLs', summary.includes('Top title_mismatch URLs'));
+  check('summary lists raw URLs, not a suggested keyword', summary.includes('https://example.com/job1'));
+  check('summary does not infer a keyword', !/add keyword/i.test(summary));
+
+  // ── filters (mirror the CLI's --since / --reason behaviour) ──
+  const filteredDate = entries.filter((e) => e.timestamp >= '2026-08-26');
+  check('--since keeps only later entries', filteredDate.length === 1);
+  const filteredReason = entries.filter((e) => e.reason.toLowerCase().includes('title_mismatch'));
+  check('--reason keeps only matches', filteredReason.length === 3);
+} catch (err) {
+  fail(`discard-analytics test suite threw: ${err?.message ?? err}`);
+}

--- a/tests/discard-analytics.test.mjs
+++ b/tests/discard-analytics.test.mjs
@@ -52,14 +52,28 @@ try {
   check('reasons are counted and sorted descending', agg.byReason[0][1] === 2);
   check('domains are extracted from URLs', agg.byDomain.some(([d]) => d === 'boards.greenhouse.io'));
   check('days are bucketed and sorted ascending', agg.byDay[0][0] === '2026-08-25' && agg.byDay[1][0] === '2026-08-26');
-  check('title_mismatch URLs are collected (URLs only)', agg.titleMismatch.length === 3);
+  check('title_mismatch URLs are aggregated (URLs only)', agg.titleMismatch.length === 3);
 
   // ── "dumb" list: URLs only, no keyword inference ──
   const summary = renderSummary(agg, 10, '2026-08-25', '2026-08-26');
   check('summary includes total', summary.includes('Total discards: 5'));
   check('summary lists title_mismatch URLs', summary.includes('Top title_mismatch URLs'));
-  check('summary lists raw URLs, not a suggested keyword', summary.includes('https://example.com/job1'));
+  check('summary lists raw URLs, not a suggested keyword', summary.split('\n').some((line) => line.trim() === '1. https://example.com/job1'));
   check('summary does not infer a keyword', !/add keyword/i.test(summary));
+
+  const repeated = aggregateDiscards(parseDiscardLog([
+    '2026-08-25T10:00:00Z\thttps://example.com/job1\ttitle_mismatch: a',
+    '2026-08-25T11:00:00Z\thttps://example.com/job2\ttitle_mismatch: b',
+    '2026-08-25T12:00:00Z\thttps://example.com/job1\ttitle_mismatch: c',
+  ].join('\n')));
+  check('title_mismatch URLs are ranked by frequency', repeated.titleMismatch[0][0] === 'https://example.com/job1' && repeated.titleMismatch[0][1] === 2);
+
+  const nonMonotonic = aggregateDiscards(parseDiscardLog([
+    '2026-08-27T10:00:00Z\thttps://example.com/job3\tnot_tech: c',
+    '2026-08-25T10:00:00Z\thttps://example.com/job1\ttitle_mismatch: a',
+    '2026-08-26T10:00:00Z\thttps://example.com/job2\tlocation_mismatch: b',
+  ].join('\n')));
+  check('summary period can use chronological bounds', renderSummary(nonMonotonic, 10, nonMonotonic.byDay[0][0], nonMonotonic.byDay[nonMonotonic.byDay.length - 1][0]).includes('Period: 2026-08-25 to 2026-08-27'));
 
   // ── filters (mirror the CLI's --since / --reason behaviour) ──
   const filteredDate = entries.filter((e) => e.timestamp >= '2026-08-26');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -186,6 +186,7 @@ const SYSTEM_PATHS = [
   'tracker.mjs',
   'find.mjs',
   'verify-pipeline.mjs',
+  'discard-analytics.mjs',
   'reconcile-pipeline.mjs',
   'dedup-tracker.mjs',
   'add-entry.mjs',


### PR DESCRIPTION
## Summary
- Opens a safe steward bridge for external PR #3443 after its Tests matrix turned green but CodeQL stayed red.
- Applies the already-pushed `chipoto69:steward/pr3443-codeql-fix-20260828` fix instead of touching BigBrown10's contributor branch.
- Hardens discard analytics output/tests to avoid incomplete URL substring sanitization and keeps aggregation deterministic.

## Test Plan
- `node --check discard-analytics.mjs`
- `node tests/main-guard-convention.test.mjs`
- `node tests/discard-analytics.test.mjs`
- `npm run lint`
- `git diff --check origin/main...HEAD`

## Steward Notes
- Original PR: https://github.com/santifer/career-ops/pull/3443
- Original blocker: CodeQL `Incomplete URL substring sanitization` on `tests/discard-analytics.test.mjs`.
- No dirty primary worktree touched: `/Users/rudlord/ORGANIZED/JOBSEARCH/career-ops` remains under the existing owner gate.
- No force-push and no overwrite of `BigBrown10:feat/discard-log-analytics`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only command-line tool for analyzing discard logs.
  - View discard totals grouped by reason, domain, date, and title-mismatch URLs.
  - Filter results by reason or date and limit output to the most frequent entries.
  - Handles missing logs, malformed URLs, empty results, and both interactive and batch log formats.

- **Maintenance**
  - The analytics tool is now included in system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->