### PR TITLE
fix(scan): Level 1 runs Playwright sequentially, not in batches of 3-5

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -179,7 +179,8 @@ Levels are additive — they are executed in order, and results are merged and d
    f. If the parser fails, log the error, attempt fallback via the ATS API if it exists, and continue with the other companies (**do not** add to `local_parser_ok`).
    g. If the parser completes successfully (steps c–e without fatal error), add the current company name to `local_parser_ok` and accumulate jobs in candidates.
 
-4. **Level 1 — Playwright Scan** (parallel in batches of 3-5):
+4. **Level 1 — Playwright Scan** (sequential — NEVER parallel Playwright):
+   Browser-backed workers share one browser session, so concurrent `browser_navigate`/`browser_snapshot` calls cross-contaminate and a snapshot can return another company's page (#2551). Batching stays correct for the fetch-based levels below (Level 2 APIs/feeds, Level 3 queries), which open no shared session.
    For each company in `tracked_companies` with `enabled: true`, a defined `careers_url`, and a **name not listed in `local_parser_ok`**:
    a. `browser_navigate` to `careers_url`.
    b. `browser_snapshot` to read all job listings.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4599,6 +4599,19 @@ if (
   fail('scan.md missing local_parser_ok skip rules for agent scan');
 }
 
+// #2551's fix landed in modes/pipeline.md only, so modes/scan.md kept ordering parallel
+// Playwright batches at Level 1 — the highest-volume browser-backed step (#3366). The
+// marker assertion is per-file for that reason: a rule that holds in one mode file and
+// not in another is exactly what went unnoticed.
+if (
+  scanMode.includes('**Level 1 — Playwright Scan** (sequential — NEVER parallel Playwright)') &&
+  !scanMode.includes('**Level 1 — Playwright Scan** (parallel')
+) {
+  pass('scan.md Level 1 runs Playwright sequentially, matching the shared-session rule (#3366)');
+} else {
+  fail('scan.md Level 1 still orders parallel Playwright batches, contradicting pipeline.md and _shared.md (#3366)');
+}
+
 // Guard against scan.md's manual-parse conventions drifting from what providers/*.mjs
 // emit and scan.mjs's filters consume (location/salary/description). We assert the two
 // most specific, consumed-field tokens: Ashby `secondaryLocations` (location_filter) and


### PR DESCRIPTION
## What does this PR do?

`modes/scan.md` ordered parallel Playwright batches at Level 1, while [line 246 of the same file](https://github.com/santifer/career-ops/blob/316906e64cc779d7580122b1d345c4c06f503a4b/modes/scan.md#L246) and the [Tools table in `modes/_shared.md`](https://github.com/santifer/career-ops/blob/316906e64cc779d7580122b1d345c4c06f503a4b/modes/_shared.md#L200) forbid exactly that. This makes Level 1 sequential, records why, and extends the regression assertion to `scan.md` so the rule cannot hold in one mode file and lapse in another.

## Related issue

Fixes #3366

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

The bytes are instruction text, but `modes/*.md` is the program the agent executes, so, this is a behavior fix rather than a docs edit.

## How it got here

1. **#2551 diagnosed the pattern**: parallel workers each calling the interactive Playwright/MCP tools share one browser session, so, concurrent navigations race and a worker's `browser_snapshot` can return another worker's page.
2. **The fix was scoped to one file**: `3bc0053` added the "Concurrency is conditional on the extraction tool" paragraph to [`modes/pipeline.md`](https://github.com/santifer/career-ops/blob/316906e64cc779d7580122b1d345c4c06f503a4b/modes/pipeline.md#L43). `modes/scan.md` was never touched.
3. **The regression test inherited that scope**: the marker assertion ran against `pipelineMode` only, so, nothing caught the `scan.md` case.

## Blast radius

Level 1 runs against every company in `tracked_companies` with `enabled: true` and a `careers_url` not listed in `local_parser_ok`, which makes it the highest-volume browser-backed step in the project. The failure it invites is the silent kind: #2545 reports an earlier run where several URLs were incorrectly deemed duplicates of one another and the evaluations had to be redone from scratch. The `scan` equivalent is a candidate accumulated under the wrong company.

## What changed

1. **`modes/scan.md`**: Level 1 reads `(sequential — NEVER parallel Playwright)`, matching Level 3's phrasing 64 lines down, plus one line carrying the reason and stating that batching stays correct for the fetch-based levels. The second half earns its place: on its own the change reads as a blanket ban on batching, which invites a later editor to re-widen it for being over-broad.
2. **`test-all.mjs`**: the marker assertion now runs against `scanMode`, not only `pipelineMode`. #2551's fix was file-scoped and its test inherited that scope, which is **_why_** this survived for as long as it did, so, the per-file assertion is the part that keeps it from coming back.

I took the smaller of the two alternatives offered in #3366, i.e., the sequential default rather than a conditional gated on `scan.extractor: cli`, following @santifer's answer there. A conditional adds a branch to the instruction that only one extractor path can currently honour; it stays available later if the isolated CLI extractor is ever wired into Level 1.

## Verification

`node test-all.mjs`: **6592 passed, 0 failed, 12 warnings**. The warnings are pre-existing and unrelated.

The new assertion is load-bearing rather than decorative: reverting only the `modes/scan.md` hunk and re-running flips it to `❌ scan.md Level 1 still orders parallel Playwright batches, contradicting pipeline.md and _shared.md (#3366)`.

## Follow-up, not in this PR

Because #2551's fix was file-scoped, any other mode that spawns browser-backed workers wants the same audit. I have not done that sweep.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (#3366, though bug fixes are exempt either way)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — both files are system layer
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that Level 1 browser-based scans run sequentially to prevent results from being mixed between pages.
  - Documented that batch processing remains available for API, feed, and query-based scan levels.

- **Tests**
  - Added regression coverage to verify sequential execution for Level 1 Playwright scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->