### PR TITLE
fix(dashboard): read job URLs from tracker

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -131,6 +131,7 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 			Date:    at("date"),
 			Company: at("company"),
 			Role:    at("role"),
+			JobURL:  at("url"),
 			Status:  at("status"),
 			HasPDF:  strings.Contains(at("pdf"), "\u2705"),
 		}
@@ -161,7 +162,9 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 		apps = append(apps, app)
 	}
 
-	// Enrich with job URLs using 5-tier strategy:
+	// Enrich with job URLs using the tracker URL as tier zero, followed by the
+	// legacy 5-tier strategy for trackers that predate the URL column:
+	// 0. URL column in the tracker
 	// 1. **URL:** field in report header (newest reports)
 	// 2. **Batch ID:** in report -> batch-input.tsv URL lookup
 	// 3. report_num -> batch-state completed mapping (legacy)
@@ -171,6 +174,9 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 	reportNumURLs := loadJobURLs(careerOpsPath)
 
 	for i := range apps {
+		if apps[i].JobURL != "" {
+			continue
+		}
 		if apps[i].ReportPath == "" {
 			continue
 		}
@@ -629,7 +635,7 @@ var trackerHeaderAliases = map[string]string{
 	"company": "company", "empresa": "company",
 	"via": "via", "role": "role", "puesto": "role",
 	"location": "location", "score": "score", "status": "status",
-	"pdf": "pdf", "report": "report", "notes": "notes",
+	"pdf": "pdf", "report": "report", "notes": "notes", "url": "url",
 }
 
 // legacyTrackerColumns is the original fixed layout in splitTrackerRow field

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -295,6 +295,39 @@ func TestParseApplicationsMapsColumnsByHeader(t *testing.T) {
 	}
 }
 
+func TestParseApplicationsUsesTrackerURLBeforeLegacyEnrichment(t *testing.T) {
+	tempDir, _ := writeTracker(t, `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL |
+|---|------|---------|------|-------|--------|-----|--------|-------|-----|
+| 1 | 2026-08-28 | Acme | Triage Engineer | 4.0/5 | Evaluated | — | — | triage only | https://jobs.example.com/triage |
+| 2 | 2026-08-28 | Globex | Platform Engineer | 4.2/5 | Evaluated | — | [2](../reports/002-globex.md) | has report | https://jobs.example.com/tracker |
+`)
+
+	reportsDir := filepath.Join(tempDir, "reports")
+	if err := os.MkdirAll(reportsDir, 0o755); err != nil {
+		t.Fatalf("mkdir reports: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(reportsDir, "002-globex.md"),
+		[]byte("**URL:** https://jobs.example.com/report\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+
+	apps := ParseApplications(tempDir)
+	if len(apps) != 2 {
+		t.Fatalf("expected 2 applications, got %d", len(apps))
+	}
+	if got := apps[0].JobURL; got != "https://jobs.example.com/triage" {
+		t.Errorf("triage-only JobURL = %q, want tracker URL", got)
+	}
+	if got := apps[1].JobURL; got != "https://jobs.example.com/tracker" {
+		t.Errorf("report-backed JobURL = %q, want tracker URL to take precedence", got)
+	}
+}
+
 // End-to-end status update on the inserted-column layout: parse, update, and
 // re-parse. Only the Status cell may change; every other cell stays intact.
 func TestUpdateApplicationStatusInsertedColumn(t *testing.T) {
@@ -355,10 +388,10 @@ func TestResolveTrackerColumns(t *testing.T) {
 
 func TestParseApplicationsRespectsCareerOpsTracker(t *testing.T) {
 	tempDir := t.TempDir()
-	
+
 	// Create a tracker file outside the tempDir's default search paths
 	customTrackerPath := filepath.Join(tempDir, "custom-tracker.md")
-	
+
 	applications := `# Applications Tracker
 
 | # | Date | Company | Role | Score | Status | PDF | Report | Notes |

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -302,6 +302,7 @@ func TestParseApplicationsUsesTrackerURLBeforeLegacyEnrichment(t *testing.T) {
 |---|------|---------|------|-------|--------|-----|--------|-------|-----|
 | 1 | 2026-08-28 | Acme | Triage Engineer | 4.0/5 | Evaluated | — | — | triage only | https://jobs.example.com/triage |
 | 2 | 2026-08-28 | Globex | Platform Engineer | 4.2/5 | Evaluated | — | [2](../reports/002-globex.md) | has report | https://jobs.example.com/tracker |
+| 3 | 2026-08-28 | Initech | Legacy Engineer | 3.9/5 | Evaluated | — | [3](../reports/003-initech.md) | legacy fallback | |
 `)
 
 	reportsDir := filepath.Join(tempDir, "reports")
@@ -315,16 +316,26 @@ func TestParseApplicationsUsesTrackerURLBeforeLegacyEnrichment(t *testing.T) {
 	); err != nil {
 		t.Fatalf("write report: %v", err)
 	}
+	if err := os.WriteFile(
+		filepath.Join(reportsDir, "003-initech.md"),
+		[]byte("**URL:** https://jobs.example.com/legacy\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write legacy report: %v", err)
+	}
 
 	apps := ParseApplications(tempDir)
-	if len(apps) != 2 {
-		t.Fatalf("expected 2 applications, got %d", len(apps))
+	if len(apps) != 3 {
+		t.Fatalf("expected 3 applications, got %d", len(apps))
 	}
 	if got := apps[0].JobURL; got != "https://jobs.example.com/triage" {
 		t.Errorf("triage-only JobURL = %q, want tracker URL", got)
 	}
 	if got := apps[1].JobURL; got != "https://jobs.example.com/tracker" {
 		t.Errorf("report-backed JobURL = %q, want tracker URL to take precedence", got)
+	}
+	if got := apps[2].JobURL; got != "https://jobs.example.com/legacy" {
+		t.Errorf("legacy JobURL = %q, want report URL fallback", got)
 	}
 }
 

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -603,7 +603,11 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 		}
 
 	case "o":
-		if app, ok := m.CurrentApp(); ok && app.JobURL != "" {
+		if app, ok := m.CurrentApp(); ok {
+			if app.JobURL == "" {
+				m.flash = "No URL found for this application"
+				break
+			}
 			return m, func() tea.Msg {
 				return PipelineOpenURLMsg{URL: app.JobURL}
 			}

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -186,6 +186,45 @@ func TestSearchIsCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestOpenURLKeyFlashesWhenApplicationHasNoURL(t *testing.T) {
+	apps := []model.CareerApplication{
+		{Company: "Acme", Role: "Triage Engineer", Status: "Evaluated", Score: 4.0},
+	}
+	pm := NewPipelineModel(theme.NewTheme("catppuccin-mocha"), apps, model.PipelineMetrics{Total: 1}, "..", 120, 40)
+	pm.viewMode = "flat"
+	pm.applyFilterAndSort()
+
+	updated, cmd := pm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd != nil {
+		t.Fatal("expected no open command when the application has no URL")
+	}
+	if updated.flash != "No URL found for this application" {
+		t.Fatalf("flash = %q, want missing-URL notice", updated.flash)
+	}
+}
+
+func TestOpenURLKeyEmitsTrackerURL(t *testing.T) {
+	const jobURL = "https://jobs.example.com/triage"
+	apps := []model.CareerApplication{
+		{Company: "Acme", Role: "Triage Engineer", Status: "Evaluated", Score: 4.0, JobURL: jobURL},
+	}
+	pm := NewPipelineModel(theme.NewTheme("catppuccin-mocha"), apps, model.PipelineMetrics{Total: 1}, "..", 120, 40)
+	pm.viewMode = "flat"
+	pm.applyFilterAndSort()
+
+	_, cmd := pm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd == nil {
+		t.Fatal("expected an open command for the tracker URL")
+	}
+	msg, ok := cmd().(PipelineOpenURLMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want PipelineOpenURLMsg", cmd())
+	}
+	if msg.URL != jobURL {
+		t.Fatalf("opened URL = %q, want %q", msg.URL, jobURL)
+	}
+}
+
 func TestSearchEnterCommitsAndEscClearsCommittedQuery(t *testing.T) {
 	apps := []model.CareerApplication{
 		{Company: "Stripe", Role: "Backend Engineer", Status: "Evaluated", Score: 4.6},


### PR DESCRIPTION
Closes #3379.

## What changed
- Reads the canonical tracker `URL` column into `JobURL` as tier zero.
- Preserves all five legacy enrichment paths as fallbacks for older trackers.
- Shows an explicit notice when `o` has no URL to open instead of silently doing nothing.
- Covers triage-only rows, tracker-over-report precedence, successful open messages, and the missing-URL notice.

## Verification
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/data ./internal/ui/screens`
- `node test-all.mjs --quick` — 6,591 passed, 0 failed, 11 warnings
- `node test-all.mjs` — 6,592 passed, 0 failed, 11 warnings

The 11 harness warnings are unchanged repository warnings; both runs completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application URLs are now read directly from the tracker when available.
  * Pressing `o` opens the application’s tracker URL.

* **Bug Fixes**
  * Tracker URLs now take precedence over URLs extracted from reports.
  * A clear notification appears when an application has no URL to open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->