### PR TITLE
fix(web): remove unsupported followup JSON flag

### DIFF
--- a/web/src/app/api/followups/route.ts
+++ b/web/src/app/api/followups/route.ts
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // The DEMAND loop: surface follow-ups due, via the core's own
-// followup-cadence.mjs --json (the SAME calculator the CLI uses) — we never
+// followup-cadence.mjs (the SAME calculator the CLI uses) — we never
 // reimplement the cadence logic, we read its verdict (mirrors /api/doctor).
 // Default: capped list for the home card. `?full=1`: the complete cadence
 // (entries + metadata + cadenceConfig) for the /followups tracker page.
@@ -16,7 +16,7 @@ export async function GET(req: Request) {
   const script = rootScript("followup-cadence");
   if (!fs.existsSync(script)) return Response.json({ available: false, metadata: null, entries: [], nextUpcoming: null });
   const stdout = await new Promise<string>((resolve) => {
-    execFile("node", [script, "--json"], { cwd: careerOpsRoot(), timeout: 12_000 }, (err, out) => resolve(err ? "" : out || ""));
+    execFile("node", [script], { cwd: careerOpsRoot(), timeout: 12_000 }, (err, out) => resolve(err ? "" : out || ""));
   });
   try {
     const start = stdout.indexOf("{");


### PR DESCRIPTION
## Summary

Remove the obsolete `--json` argument from the web follow-ups route. `followup-cadence.mjs` emits JSON by default, while its current flag validator rejects `--json`, causing the route to silently report follow-ups as unavailable.

Also update the nearby comment so it reflects the actual invocation.

Closes part of #2369.

## Verification

- `npm --prefix web run typecheck`
- `npm --prefix web test` (385 tests passed)
- `git diff --check`

The standalone core command was also exercised after installing root dependencies. In this fresh checkout it returned the expected structured `No applications found in tracker` response because no user-layer tracker data is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved follow-up processing by correctly handling the cadence script’s JSON output.
  * Follow-up results now continue to be processed reliably without requiring an additional output option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->