### PR TITLE
docs(scan): correct the scan-history column count and stop hand-writing rows in step 8b

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -260,7 +260,7 @@ Levels are additive — they are executed in order, and results are merged and d
 
 8. **For each new verified offer that passes filters**:
    a. Add to the `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
-   b. Record in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+   b. Record in `scan-history.tsv` with status `added`. Write the row with `formatScanHistoryRow` / `appendToScanHistory` from `scan.mjs` rather than composing the tab-separated line by hand — the column set has grown and will grow again, and a hand-written row is silently short.
 
 9. **Offers filtered by title**: record in `scan-history.tsv` with status `skipped_title`.
 10. **Duplicate offers**: record with status `skipped_dup`.
@@ -286,7 +286,7 @@ If a non-publicly accessible URL is found:
 
 ## Scan History
 
-`data/scan-history.tsv` tracks ALL seen URLs. Each row has nine tab-separated columns:
+`data/scan-history.tsv` tracks ALL seen URLs. Each row has twelve tab-separated columns, in the order `formatScanHistoryRow` emits them (`scan.mjs`):
 
 | # | Column | Example | Notes |
 |---|--------|---------|-------|
@@ -297,18 +297,23 @@ If a non-publicly accessible URL is found:
 | 5 | `company` | `Acme` | Company name |
 | 6 | `status` | `added` | `added`, `skipped_dup`, `skipped_title`, `skipped_expired` |
 | 7 | `location` | `Remote — Europe` | Location string (may be empty); persisted for later auditing |
-| 8 | `jd_fingerprint` | `a3f1c8d2e4b70592` | 64-bit SimHash of the JD text (16 hex chars); empty when no usable body was available |
-| 9 | `postedAt` | `2026-02-08` | ISO date the role was originally posted (as reported by the ATS); empty when not available |
+| 8 | `fingerprint` | `a3f1c8d2e4b70592` | 64-bit SimHash of the JD text (16 hex chars); empty when no usable body was available |
+| 9 | `posted_at` | `2026-02-08` | ISO date the role was originally posted (as reported by the ATS); empty when not available |
+| 10 | `trust_score` | `70` | Trust/legitimacy score, written only when the scanner flagged the posting (score < 100); empty otherwise |
+| 11 | `trust_flags` | `no_company_site,vague_jd` | Comma-joined trust flags, written under the same condition as col 10; empty otherwise |
+| 12 | `normalized_company` | `acme` | Canonical company key (`normalizeCompanyName`) so `Acme Inc.`, `Acme, Inc.` and `ACME  Inc` all match; col 5 stays faithful to what the provider returned |
+
+Columns are append-only: readers index by position, so new columns arrive at the end and older files keep their shorter rows. Never renumber or reorder. The header is written only when the file is created, so an existing file may still carry a shorter header than the rows being appended to it — that is expected, not corruption.
 
 ```tsv
-url	first_seen	portal	title	company	status	location	jd_fingerprint	postedAt
-https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added	Remote	a3f1c8d2e4b70592	2026-02-08
+url	first_seen	portal	title	company	status	location	fingerprint	posted_at	trust_score	trust_flags	normalized_company
+https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added	Remote	a3f1c8d2e4b70592	2026-02-08			acme
 ```
 
 ### Filtering by posted date
 
 `first_seen` (column 2) is when **our scanner** spotted the URL — not when the
-employer actually posted it. That real posting date is column 9 (`postedAt`).
+employer actually posted it. That real posting date is column 9 (`posted_at`).
 To scope a scan to an absolute posting-date window (e.g. "only postings from
 the 17th to the 20th"), pass `--posted-after`/`--posted-before` on the CLI —
 both optional, both `YYYY-MM-DD`, both inclusive:
@@ -385,7 +390,7 @@ weekly, `--since 10` keeps a margin for a skipped run.
 
 ### Cross-listing detection
 
-The `jd_fingerprint` column exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.
+The `fingerprint` column exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.
 
 How it works:
 


### PR DESCRIPTION
## What does this PR do?

Corrects `modes/scan.md`, which documented **nine** `scan-history.tsv` columns and instructed step 8b to write **six**, while `formatScanHistoryRow` emits **twelve**. Since `modes/*.md` are agent instruction files rather than prose docs, an agent following 8b literally writes a short row into real data.

Also replaces the hand-written row literal in 8b with a pointer to `formatScanHistoryRow` / `appendToScanHistory`, so the next column added doesn't silently invalidate this file again.

## Related issue

Closes #3458

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### Detail

Four things were stale, all from the same commit series that appended the trailing columns. `DATA_CONTRACT.md:35` and `docs/SCRIPTS.md:612-614` were updated then; this file was missed.

1. **The column table** now lists all twelve in writer order, documenting `trust_score`, `trust_flags` and `normalized_company`.
2. **Two column names were also wrong.** The header literal says `fingerprint` and `posted_at`, not `jd_fingerprint` and `postedAt`. I left the `offer.postedAt` references alone — that one really is camelCase, because it's the provider field rather than the column.
3. **The example TSV block** carried the same nine-column header, so it now shows a real twelve-column row.
4. **Step 8b** no longer spells out a tab-separated literal.

I also added a short note that the columns are append-only and that an existing file keeps its shorter header by design. That behaviour is documented in `scan.mjs` but not where someone looking at a real file would find it, and a seven-column header above twelve-column rows reads like corruption if you don't know it's intentional.

**Test run:** `node test-all.mjs --quick` → 6591 passed, 0 failed, 11 warnings. The warnings are pre-existing and unrelated to this change (I did not run the dashboard build, hence `--quick`).

One thing I deliberately did **not** do, because it's your call: nothing ties this doc to the writer, so it can drift again. A test asserting the documented column list matches the emitted header would prevent that — the same shape as the parity test guarding `web/src/lib/core/url-key.mjs` against its root mirror. But it puts a doc under test in `test-all.mjs`, which may be more coupling than you want. Say the word and I'll add it here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated scan-history documentation to reflect the expanded 12-column TSV format.
  - Renamed fingerprint and posting-date fields for consistency.
  - Documented new trust and normalized-company fields.
  - Added guidance for safely appending scan-history entries and clarified append-only behavior.
  - Updated examples and date-filtering instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->