### PR TITLE
fix(openrouter): write scan-history and pipeline through the shared locked writers

### DIFF
--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -30,6 +30,8 @@ import {
 import { TokenAccumulator, formatBreakdown, normalizeOpenAIUsage } from './utils/token-tracker.mjs';
 import { DEFAULT_USER_AGENT } from './user-agent.mjs';
 import { buildTitleFilter } from './title-keywords.mjs';
+import { appendToPipeline, appendToScanHistory } from './scan.mjs';
+import { localToday } from './lib/local-today.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -506,7 +508,24 @@ function markPipelineDone(url) {
   writeFile('data/pipeline.md', content);
 }
 
-function addToPipeline(entries) {
+// Both writes go through the shared writers in scan.mjs rather than this
+// module's own read-modify-write. Those writers hold pipeline-lock.mjs on the
+// file they touch, so this stops being a fourth, unlocked writer racing the
+// three appendToPipeline already names. The previous version read each file
+// whole, appended in memory, and wrote the whole thing back with a truncating
+// writeFileSync — so any row another scanner appended in between was erased,
+// silently, because every reader skips a malformed or missing row quietly.
+//
+// Delegating fixes three things at once that were all symptoms of hand-rolling
+// the write: the lock, the row format (formatScanHistoryRow emits all twelve
+// columns; this module wrote seven and created a seven-column header), and the
+// date (the shared path stamps the local day, this one stamped the UTC day —
+// the defect #3240/#3241 fixed in the other scanners, which this module escaped
+// because that census finds scanners by looking for appendToScanHistory calls).
+//
+// It also picks up CAREER_OPS_DATA_DIR support for free: the shared paths are
+// DATA_ROOT-anchored, while the __dirname-relative paths here ignored it.
+async function addToPipeline(entries) {
   const history = readFile('data/scan-history.tsv') ?? 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n';
   const seenUrls = new Set(history.split('\n').slice(1).map(l => l.split('\t')[0]).filter(Boolean));
 
@@ -529,17 +548,18 @@ function addToPipeline(entries) {
 
   if (newEntries.length === 0) return 0;
 
-  const today = new Date().toISOString().split('T')[0];
-  let pipeline = existingPipeline;
-  let hist = history;
+  // The shared writers take {url, company, title, location}; this module calls
+  // the title `role`.
+  const offers = newEntries.map(e => ({
+    url: e.url,
+    company: e.company,
+    title: e.role,
+    location: typeof e.location === 'string' ? e.location : '',
+    source: 'openrouter scan',
+  }));
 
-  for (const e of newEntries) {
-    pipeline += `- [ ] ${e.url} | ${e.company} | ${e.role}\n`;
-    hist     += `${e.url}\t${today}\tscan\t${e.role}\t${e.company}\tadded\t${e.location ?? ''}\n`;
-  }
-
-  writeFile('data/pipeline.md', pipeline);
-  writeFile('data/scan-history.tsv', hist);
+  await appendToPipeline(offers);
+  await appendToScanHistory(offers, localToday());
   return newEntries.length;
 }
 
@@ -598,7 +618,7 @@ async function cmdScan() {
     }
   }
 
-  const added = addToPipeline(found);
+  const added = await addToPipeline(found);
   console.log(`\n✅ Scan complete. ${found.length} matches, ${added} new entries added to pipeline.md.`);
   if (added > 0) {
     console.log('\n→  node openrouter-runner.mjs pipeline\n   to evaluate pending listings.\n');

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -685,7 +685,7 @@ async function cmdEvaluate(input, ctx) {
 
   try {
     // Save report
-    const today   = new Date().toISOString().split('T')[0];
+    const today   = localToday();
     const num     = reservedNumbers[0];
     const slug    = extractCompanySlug(jdText, typeof input === 'string' ? input : null);
     const numStr  = formatReportNumber(num);

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -32,6 +32,7 @@ import { DEFAULT_USER_AGENT } from './user-agent.mjs';
 import { buildTitleFilter } from './title-keywords.mjs';
 import { appendToPipeline, appendToScanHistory } from './scan.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -162,19 +163,30 @@ async function cmdModels() {
 // ---------------------------------------------------------------------------
 // File helpers
 // ---------------------------------------------------------------------------
+// Anchored to the career-ops data root, not to __dirname. scan.mjs resolves
+// every path it touches through getCareerOpsRoot(), so with CAREER_OPS_DATA_DIR
+// set this module was reading a DIFFERENT data/scan-history.tsv than the shared
+// writers it now delegates to — dedup would clear a URL the writer then found
+// present, or skip one it had never seen. The default is unchanged: with no
+// env and no .career-ops-data marker, getCareerOpsRoot() returns the same
+// directory __dirname did.
+const DATA_ROOT = getCareerOpsRoot();
+
 function readFile(relPath) {
-  try { return fs.readFileSync(path.join(__dirname, relPath), 'utf-8'); }
+  try { return fs.readFileSync(path.join(DATA_ROOT, relPath), 'utf-8'); }
   catch { return null; }
 }
 
 function writeFile(relPath, content) {
-  const full = path.join(__dirname, relPath);
+  const full = path.join(DATA_ROOT, relPath);
   fs.mkdirSync(path.dirname(full), { recursive: true });
   fs.writeFileSync(full, content, 'utf-8');
 }
 
 function fileExists(relPath) {
-  return fs.existsSync(path.join(__dirname, relPath));
+  // Same root as readFile() above: a fileExists that disagrees with the reader
+  // is a split-brain waiting to happen under CAREER_OPS_DATA_DIR.
+  return fs.existsSync(path.join(DATA_ROOT, relPath));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Routes `openrouter-runner.mjs`'s `data/scan-history.tsv` and `data/pipeline.md` writes through the shared `appendToScanHistory` / `appendToPipeline` in `scan.mjs`, instead of its own unlocked read-modify-write.

It was a fourth writer of both files that neither took `pipeline-lock` nor used the shared appenders. `appendToPipeline`'s own comment names *"scan.mjs, scan-ats-full.mjs, and plugins.mjs — the three current callers"*; this module was not among them.

## Related issue

Closes #3457

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### The bug

`addToPipeline` read each file whole, appended in memory, and wrote the whole thing back with a truncating `writeFileSync`. Any row another scanner appended between the read and the write was erased — silently, because every reader skips a malformed or missing row quietly.

**Reproduced before fixing**, rather than argued from the code. A second *process* appends one row mid-flight:

```
BEFORE:  url, https://example.com/pre
AFTER:   url, https://example.com/pre, https://example.com/new
RESULT:  concurrent row LOST
```

Timing-dependent as a race should be: lost at 20ms and 40ms appender delays, survives at 60ms and 80ms. Worth noting that a *same-process* timer proves nothing here — `addToPipeline` was fully synchronous, so nothing could interleave, and my first attempt showed no loss for exactly that reason.

### Why delegate rather than add a lock in place

Three symptoms were all consequences of hand-rolling the write, and delegating fixes them together:

1. **The lock** — the data-loss bug above.
2. **The row format** — `formatScanHistoryRow` emits twelve columns; this module wrote seven, and created a seven-column header on a fresh file.
3. **The day stamp** — the shared path uses `localToday()`; this module used the UTC day, the defect #3240/#3241 fixed in the other scanners.

Two things come along for free: `CAREER_OPS_DATA_DIR` support, because the shared paths are `DATA_ROOT`-anchored while the `__dirname`-relative ones here ignored it; and correct placement, because `appendToPipeline` inserts into the Pending section rather than appending past the end of the file.

**You offered no such choice and I don't want to assume** — I said on the issue that if you'd rather keep this module self-contained and just add `withPipelineLock` in place, I'll rewrite it that way. This version removes a writer instead of adding a second locked one, which seemed closer to the direction #2901 and #2639 were already going.

### On the missing test

I did not add one, deliberately. The census in `tests/local-today-gates.test.mjs` is *derived* from files that call `appendToScanHistory`, so this module is covered by it the moment it starts calling one — which is also precisely why it escaped #3241. That suite passes 18/18 with this change.

If you'd rather have an explicit regression test for the lock itself, say so and I'll add one.

### Second commit is separable

`fix(openrouter): stamp the report filename with the local day` is a one-line fix to a *different* site in the same file — the report path is built as `reports/{num}-{slug}-{today}.md` from the UTC day, so west of Greenwich an evening run names the file with tomorrow's date. Same defect class, not on the scan-history path. **Drop that commit if you consider it out of scope for this issue**; the first commit stands alone.

**Test run:** `node test-all.mjs --quick` → 6591 passed, 0 failed, 11 warnings. Warnings are pre-existing and unrelated (`--quick` skips the dashboard build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving scan results and pipeline updates.
  * Prevented potential data loss or conflicts during concurrent writes.
  * Corrected report dates to use the local calendar day.
  * Ensured scan processing waits for updates to finish before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->