### PR TITLE
fix(cv-sync-check): ReferenceError at module scope, and the allowFail entry that hid it (#3440)

### DIFF
--- a/cv-sync-check.mjs
+++ b/cv-sync-check.mjs
@@ -51,9 +51,9 @@ if (!existsSync(profilePath)) {
 
 // 3. Check for hardcoded metrics in prompt files
 const filesToCheck = [
-  { path: join(projectRoot, 'modes', '_shared.md'), name: '_shared.md' },
-  { path: join(projectRoot, 'modes', '_writing.md'), name: '_writing.md' },
-  { path: join(projectRoot, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
+  { path: join(CODE_ROOT, 'modes', '_shared.md'), name: '_shared.md' },
+  { path: join(CODE_ROOT, 'modes', '_writing.md'), name: '_writing.md' },
+  { path: join(CODE_ROOT, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
 ];
 
 // Pattern: numbers that look like hardcoded metrics (e.g., "170+ hours", "90% self-service")

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -283,6 +283,23 @@ console.log('\n2. Script execution (graceful on empty data)');
 // headroom.
 const SLOW_SCRIPT_WARN_FRACTION = 0.75;
 
+/**
+ * Whether a failed run died with an UNCAUGHT exception rather than exiting.
+ *
+ * The two are not the same outcome and only one of them is ever "expected".
+ * Node prints an uncaught error as `SomeError: message` at the start of a line
+ * followed by a stack; a script reporting its own problem and exiting non-zero
+ * prints neither. Both parts are required, so a script whose own diagnostic
+ * happens to start with "Error: " is not mistaken for a crash.
+ *
+ * @param {{stderr?: string}|null} failure
+ * @returns {boolean}
+ */
+function crashedBeforeRunning(failure) {
+  const stderr = String(failure?.stderr ?? '');
+  return /^[A-Za-z]*Error(?: \[[^\]]+\])?: /m.test(stderr) && /\n\s+at /.test(stderr);
+}
+
 const scripts = [
   { name: 'cv-sync-check.mjs', expectExit: 1, allowFail: true }, // fails without cv.md (normal in repo)
   { name: 'verify-pipeline.mjs', expectExit: 0 },
@@ -479,8 +496,16 @@ try {
     }
     if (result !== null) {
       pass(`${name} runs OK`);
-    } else if (allowFail) {
+    } else if (allowFail && !crashedBeforeRunning(lastRunFailure())) {
       warn(`${name} exited with error (expected without user data)`);
+    } else if (allowFail) {
+      // allowFail says "a non-zero exit is expected here", never "any outcome
+      // is fine". A script that dies with an uncaught exception did not run at
+      // all, and reporting that as the expected failure is how #3440 sat in
+      // main: cv-sync-check.mjs threw a ReferenceError at module scope, exited
+      // 1 like a missing cv.md, and the suite printed the reassuring warning
+      // for a script that never reached a single check.
+      fail(`${name} crashed before running — allowFail covers an expected exit, not an uncaught error${formatRunFailure()}`);
     } else {
       // Include the child's exit status and streams. Without them a CI-only
       // failure arrives as a bare `<name> crashed`: no stack, no assertion

--- a/tests/cv-sync-check.test.mjs
+++ b/tests/cv-sync-check.test.mjs
@@ -1,0 +1,105 @@
+// tests/cv-sync-check.test.mjs — the setup validator has to reach its checks.
+//
+// cv-sync-check.mjs threw a ReferenceError at module scope (#3440): the
+// CODE_ROOT/DATA_ROOT split left three `join(projectRoot, …)` call sites naming
+// an identifier that no longer existed, so `npm run sync-check` died before the
+// first check and printed a stack instead of a report.
+//
+// It sat because a crash and a correct run look identical from outside. The
+// script exits 1 when cv.md is missing — which is normal in this repo — and
+// exits 1 on a ReferenceError too. test-all.mjs's own entry says as much:
+//
+//   { name: 'cv-sync-check.mjs', expectExit: 1, allowFail: true }
+//
+// (`expectExit` is not read by the runner at all; `allowFail` was doing the
+// work, and it excused everything.) So this asserts what an exit code cannot:
+// that the run produced the validator's REPORT rather than a stack trace.
+//
+// Run:  node --test tests/cv-sync-check.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Run the validator against a throwaway DATA root, leaving the repo alone. */
+function runAgainst(dataRoot) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'cv-sync-check.mjs')], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CAREER_OPS_ROOT: dataRoot },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+/** Node prints an uncaught error as `SomeError: …` plus a stack. */
+function looksLikeCrash(text) {
+  return /^[A-Za-z]*Error(?: \[[^\]]+\])?: /m.test(text) && /\n\s+at /.test(text);
+}
+
+test('it reaches its checks instead of throwing at module scope', () => {
+  // The regression itself. Nothing here is about WHAT it reports — only that it
+  // got far enough to report anything.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-sync-check-'));
+  try {
+    const r = runAgainst(dir);
+    assert.ok(!looksLikeCrash(r.all), `crashed instead of running:\n${r.all.slice(0, 400)}`);
+    assert.match(r.stdout, /career-ops sync check/, 'no report header — the run never reached its checks');
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('a missing cv.md is reported as an error, not a crash', () => {
+  // The legitimate non-zero exit, which is what makes the crash invisible: both
+  // leave status 1. The difference is that this one says something useful.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-sync-check-'));
+  try {
+    const r = runAgainst(dir);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /cv\.md not found/);
+    assert.ok(!looksLikeCrash(r.all));
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('a complete setup passes', () => {
+  // The other side, so "always errors" cannot satisfy the tests above.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-sync-check-'));
+  try {
+    mkdirSync(join(dir, 'config'), { recursive: true });
+    writeFileSync(join(dir, 'cv.md'), `# Jane Roe\n\n## Experience\n\n${'Backend engineer. '.repeat(12)}\n`);
+    writeFileSync(join(dir, 'config', 'profile.yml'),
+      'candidate:\n  full_name: "Jane Roe"\n  email: jane@example.com\n  location: Lisbon\n');
+    const r = runAgainst(dir);
+    assert.ok(!looksLikeCrash(r.all), r.all.slice(0, 400));
+    assert.equal(r.status, 0, `expected a clean pass, got ${r.status}:\n${r.all.slice(0, 400)}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('the prompt-file checks read the CODE root, not the data root', () => {
+  // What the three broken call sites were for. modes/ and batch/ ship with the
+  // code, so an externalized data root (the whole point of CAREER_OPS_ROOT)
+  // must not make them unreadable — pointing DATA_ROOT at an empty directory
+  // must not produce "file not found" warnings for them.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-sync-check-'));
+  try {
+    const r = runAgainst(dir);
+    for (const name of ['_shared.md', '_writing.md', 'batch-prompt.md']) {
+      assert.doesNotMatch(r.all, new RegExp(`${name.replace('.', '\\.')} not found`),
+        `${name} was looked for under the DATA root instead of the code root`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});


### PR DESCRIPTION
Fixes #3440.

`node cv-sync-check.mjs` throws before its first check:

```
ReferenceError: projectRoot is not defined
    at cv-sync-check.mjs:54
```

The CODE_ROOT/DATA_ROOT split gave the user-layer reads a `DATA_ROOT` and left three call sites naming the identifier it replaced. Those three are `modes/_shared.md`, `modes/_writing.md` and `batch/batch-prompt.md` — code assets, so `CODE_ROOT` is the intended root, and pointing them at the data root would break the externalized layout the split exists to support. `npm run sync-check` has been dead since.

## The half that let it sit

@kitecloud213's title says CI cannot see it, and the mechanism turns out to be sharper than "expects exit 1". `cv-sync-check.mjs` exits 1 when `cv.md` is missing — normal in this repo — and exits 1 on a ReferenceError too, so the two are the same outcome from outside. The suite printed

```
⚠ cv-sync-check.mjs exited with error (expected without user data)
```

for a script that had not reached a single check, and stayed green.

**`expectExit` is declared on sixteen entries and read by nothing** — `allowFail` was doing all the work, and it excused everything.

I did *not* wire up `expectExit`: that would change how sixteen entries are judged to fix one bug. Instead `allowFail` is narrowed to what it says. A non-zero exit is still expected; an **uncaught exception** is not, because a script that died at module scope did not run. Detected by requiring both halves of Node's uncaught-error shape (a `SomeError: ` at line start *and* a stack frame), so a script whose own diagnostic happens to start with `Error: ` isn't mistaken for a crash. `cv-sync-check.mjs` is the only `allowFail` entry, so this changes the judgment of exactly one script.

## Verification

The harness change, both directions:

```
fix in place  ->  ⚠ cv-sync-check.mjs exited with error (expected without user data)   [suite green]
crash back    ->  ❌ cv-sync-check.mjs crashed before running — allowFail covers an
                     expected exit, not an uncaught error (exit 1)                      [suite red]
```

Three of the four new tests fail on the pre-fix file:

```
✖ it reaches its checks instead of throwing at module scope
✖ a missing cv.md is reported as an error, not a crash
✖ a complete setup passes
ℹ pass 1  ℹ fail 3
```

The fourth is what the three broken call sites were *for*: running against an externalized `CAREER_OPS_ROOT` must not report `modes/` and `batch/` missing. Naming `CODE_ROOT` isn't interchangeable with naming `DATA_ROOT`, and that's the part a bare "does it crash" test wouldn't have kept. Each case runs against its own mkdtemp data root, so the repo's own `cv.md` state can't change the result.

`node test-all.mjs --quick` → green.

## Unrelated, noticed while here

Running the suite leaves an untracked **`applications.db`** (36 KB) in the repo root — a SQLite index of `data/applications.md`, which is user layer — and it is **not** gitignored. Same shape as the atomic-write temp files in #3245. Not touched here; happy to open it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed validation failures caused by prompt files being resolved from the wrong location.
  - Improved test-runner reporting to distinguish unexpected crashes from expected script errors.
  - Validation now provides clearer results when required career documents are missing.

- **Tests**
  - Added coverage confirming validation completes successfully, reports missing files clearly, and reads prompt files from the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->