### PR TITLE
fix(verify-cv-facts): greedy modifier window binds a count to the farthest noun (#3414)

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -82,7 +82,26 @@ const MODIFIER_WINDOW = 4;
 // handled by the modifier window) and "50kg users" (k not at a boundary) both keep
 // their existing behaviour and still normalize to "50".
 const COUNT_CLAIM_RE = new RegExp(
-  String.raw`\b(\d[\d,.]*(?:[kKmMbB]\b)?)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}(${METRIC_NOUNS.join('|')})\b`,
+  // LAZY (`{0,N}?`), so the number binds to the NEAREST noun in the window
+  // rather than the farthest. Greedy, the quantifier consumed as many filler
+  // words as the window allowed before looking for a noun, and only backtracked
+  // if that failed — so whenever two METRIC_NOUNS sat within the window it
+  // reported the wrong one (#3414):
+  //
+  //   "15+ years scaling teams and platforms"        -> 15 platforms, not 15 years
+  //   "20+ years leading engineering organizations"  -> 20 organizations, not 20 years
+  //
+  // The same sentence's plainer paraphrase ("15+ years of experience") produced
+  // "15 years", so a truthful line copied verbatim out of cv.md could be flagged
+  // as invented: the CV and the source stated the same fact and the extractor
+  // read two different claims out of them.
+  //
+  // Lazy cannot LOSE a claim. Both directions match exactly when some noun sits
+  // inside the window; only WHICH one is bound differs, and the nearest is the
+  // one a human reads. #2279's wide-window cases are unaffected — "~5 live
+  // Cloud Run deployments" still yields "5 deployments", because there is only
+  // one noun to bind to.
+  String.raw`\b(\d[\d,.]*(?:[kKmMbB]\b)?)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}?(${METRIC_NOUNS.join('|')})\b`,
   'gi'
 );
 const NOUN_SYNONYMS = new Map([
@@ -608,6 +627,24 @@ function runSelfTest() {
   equal('truthful multiplier', auditClaims('Partners earned 2x more', source).invented, []);
   equal('noun synonym', auditClaims('Authored 80 articles', source).invented, []);
   equal('ordinary year is ignored', auditClaims('Joined the team in 2013', source).invented, []);
+
+  // The number binds to the NEAREST noun in the window, not the farthest (#3414).
+  // Greedy, each of these bound the wrong noun while the SAME fact worded plainly
+  // bound the right one — so a truthful line copied verbatim out of cv.md read as
+  // a different claim from its own source, and the gate flagged it as invented.
+  const claimsOf = (text) => [...metricClaims(text)].sort().join(' | ');
+  equal('nearest noun wins over a farther one', claimsOf('15+ years scaling teams and platforms'), '15 years');
+  equal('nearest noun wins across three modifiers', claimsOf('20+ years leading engineering organizations'), '20 years');
+  equal('the plain phrasing of the same fact agrees', claimsOf('I have 15+ years of experience.'), '15 years');
+  // …and the whole point of a truthful restatement passing the gate:
+  equal('a verbatim experience line is not invented',
+    auditClaims('15+ years scaling teams and platforms', '15+ years of experience.').invented, []);
+  // #2279 is why the window is wide: one noun, several modifiers. Lazy must not
+  // shrink the reach, only decide which noun wins when there are two.
+  equal('a 3-modifier single-noun phrase still resolves', claimsOf('~5 live Cloud Run deployments'), '5 deployments');
+  equal('and its 2-modifier paraphrase agrees', claimsOf('~5 Cloud Run deployments'), '5 deployments');
+  // A number is a hard barrier for the chain, so two counts stay separate.
+  equal('two counts in one sentence stay distinct', claimsOf('8 years supporting 40 engineers'), '40 engineers | 8 years');
   equal(
     'allow_metrics override',
     auditClaims('Reached 94,772 users', source, { allow_metrics: ['94,772 users'] }).invented,


### PR DESCRIPTION
Fixes #3414.

`COUNT_CLAIM_RE`'s modifier window was **greedy**, so it consumed as many filler words as the window allowed before looking for a noun, and only backtracked if that failed. Whenever two `METRIC_NOUNS` sat inside the window it bound the number to the farthest:

| sentence | before | after |
|---|---|---|
| `15+ years scaling teams and platforms` | **`15 platforms`** | `15 years` |
| `20+ years leading engineering organizations` | **`20 organizations`** | `20 years` |
| `I have 15+ years of experience.` | `15 years` | `15 years` |

The third line is what makes it a bug rather than an oddity: the *same fact* worded plainly binds the right noun. So a truthful sentence copied verbatim out of `cv.md` reads as a different claim from its own source, and the gate flags an unedited line as invented.

That is the expensive direction for this particular script. A fabrication gate that cries wolf on the user's real CV is one they learn to override, and then it has stopped working for the case it exists for.

## The fix is one character

The quantifier becomes lazy — `{0,4}?` — so the number binds to the nearest noun, which is the one a human reads.

**It cannot lose a claim.** Both directions match exactly when *some* noun sits inside the window; only which one is bound differs. And #2279's reason for widening the window to 4 is a single noun behind several modifiers, which is untouched:

```
~5 live Cloud Run deployments   ->  5 deployments   (unchanged)
~5 Cloud Run deployments        ->  5 deployments   (unchanged)
50k users                       ->  50k users       (unchanged)
8 years supporting 40 engineers ->  8 years, 40 engineers   (a number is still a hard barrier)
```

## Verification

Self-test goes 63 → 70. Reverting just the quantifier, assertions kept:

```
FAIL: nearest noun wins over a farther one
FAIL: nearest noun wins across three modifiers
FAIL: a verbatim experience line is not invented
verify-cv-facts self-test: 67 passed, 3 failed
```

The seven new assertions are the two reported phrasings, the plain paraphrase they must now agree with, an end-to-end `auditClaims` case (a verbatim experience line is not reported as invented), both #2279 phrasings so the window's reach is pinned, and the two-counts-in-one-sentence case.

`node test-all.mjs --quick` → green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of numerical claims so counts are associated with the nearest relevant metric noun.
  * Corrected cases where multiple metrics appear in the same phrase, such as experience duration and platform counts.
  * Preserved accurate extraction for single-metric and multiple-count sentences.

* **Tests**
  * Added coverage for nearest-noun matching, equivalent phrasing, broad matching windows, and multiple counts in one sentence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->