### PR TITLE
fix(gitignore): the tracker's derived SQLite index is unignored outside data/ (#3468)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,21 @@ reports/*-RESERVED.md
 # original sitting untracked in the repo root. Trailing `*` covers both.
 *.bak*
 
+# The tracker's derived SQLite index (tracker.mjs, #918). It sits beside the
+# tracker markdown, so on the standard layout it lands in data/ and is already
+# covered by the rules above — but resolveTrackerPath() falls back to
+# `<root>/applications.md` when data/applications.md is absent, and the index
+# follows it there. That is the legacy install layout, and it is also every
+# fresh clone: `node test-all.mjs` leaves a 36KB applications.db in the repo
+# root, which `git add .` then stages.
+#
+# Its content is the whole tracker — company, role, score, status, notes — so it
+# carries the same PII as the file it indexes, under a name none of the rules
+# above match. SQLite's -wal/-shm sidecars travel with it.
+*.db
+*.db-wal
+*.db-shm
+
 # OpenRouter runner — generated data (personal, never commit)
 data/model-blacklist.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,15 @@ reports/*-RESERVED.md
 # Its content is the whole tracker — company, role, score, status, notes — so it
 # carries the same PII as the file it indexes, under a name none of the rules
 # above match. SQLite's -wal/-shm sidecars travel with it.
+#
+# Deliberately not root-anchored. The index follows the tracker markdown, and
+# getCareerOpsRoot() resolves a relative CAREER_OPS_ROOT (or .career-ops-data
+# marker) against the codebase directory — so a data root configured as
+# `career-data` puts both inside the checkout, in neither of the two places an
+# anchored rule would cover. Nothing tracked in this repo ends in .db, and an
+# ignore rule cannot untrack a file that is already tracked, so the cost of the
+# wider glob is a `git add -f` on a .db fixture nobody has added yet; the cost
+# of the narrower one is this leak, for every non-default data root.
 *.db
 *.db-wal
 *.db-shm

--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -151,14 +151,21 @@ for (const path of timestampedBackupProbes) {
 // in a subdirectory of the checkout. `data/applications.db` cannot settle this
 // on its own: it is already covered by the blanket `data/*` rule at the top of
 // the file, so it passes either way.
-const derivedIndexProbes = [
-  'applications.db',
-  'applications.db-wal',
-  'applications.db-shm',
-  'data/applications.db',
-  'career-data/applications.db',
-  'career-data/applications.db-wal',
+//
+// Built as a cross-product rather than hand-listed. tracker.mjs derives every
+// one of these from a single path — DB_PATH is resolveTrackerPath() with .md
+// swapped for .db, and SQLite appends the sidecar suffixes to that — so any
+// directory that can hold the index can hold all three names. Enumerating them
+// by hand is how the -shm sidecar ended up covered in the repo root and missed
+// one directory down.
+const derivedIndexLocations = [
+  'applications',                // legacy layout: tracker markdown in the root
+  'data/applications',           // standard layout
+  'career-data/applications',    // a relative CAREER_OPS_ROOT / .career-ops-data root
 ];
+const derivedIndexProbes = derivedIndexLocations.flatMap(
+  (base) => ['.db', '.db-wal', '.db-shm'].map((suffix) => `${base}${suffix}`),
+);
 
 for (const path of derivedIndexProbes) {
   const { verdict, stderr } = checkIgnore(path);

--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -142,11 +142,22 @@ for (const path of timestampedBackupProbes) {
 // data/applications.md is absent, and the index follows the markdown, so on
 // the legacy layout it sits in the repo root instead. That is also every fresh
 // clone: `node test-all.mjs` leaves one there, 36KB, ready for `git add .`.
+//
+// The nested probes are the ones that decide the SHAPE of the rule. A
+// root-anchored `/*.db` covers the repo root and nothing else, and would still
+// pass every root probe below — but getCareerOpsRoot() resolves a RELATIVE
+// CAREER_OPS_ROOT (or .career-ops-data marker) against the codebase directory,
+// so a data root configured as `career-data` puts the tracker, and its index,
+// in a subdirectory of the checkout. `data/applications.db` cannot settle this
+// on its own: it is already covered by the blanket `data/*` rule at the top of
+// the file, so it passes either way.
 const derivedIndexProbes = [
   'applications.db',
   'applications.db-wal',
   'applications.db-shm',
   'data/applications.db',
+  'career-data/applications.db',
+  'career-data/applications.db-wal',
 ];
 
 for (const path of derivedIndexProbes) {

--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -133,6 +133,29 @@ for (const path of timestampedBackupProbes) {
   else fail(`${path}: git check-ignore could not answer — ${stderr}`);
 }
 
+// The tracker's DERIVED SQLite index (tracker.mjs, #918), which carries the
+// same content as the markdown it indexes — company, role, score, status,
+// notes.
+//
+// On the standard layout it lands in data/ and the rules above already cover
+// it. But resolveTrackerPath() falls back to `<root>/applications.md` when
+// data/applications.md is absent, and the index follows the markdown, so on
+// the legacy layout it sits in the repo root instead. That is also every fresh
+// clone: `node test-all.mjs` leaves one there, 36KB, ready for `git add .`.
+const derivedIndexProbes = [
+  'applications.db',
+  'applications.db-wal',
+  'applications.db-shm',
+  'data/applications.db',
+];
+
+for (const path of derivedIndexProbes) {
+  const { verdict, stderr } = checkIgnore(path);
+  if (verdict === 'ignored') pass(`${path} is git-ignored`);
+  else if (verdict === 'not-ignored') fail(`${path} is NOT git-ignored — the derived index holds the same PII as the tracker`);
+  else fail(`${path}: git check-ignore could not answer — ${stderr}`);
+}
+
 // Not user-layer data, but the same mechanism: this one is about what a
 // reflexive `git add .` can swallow. test-all.mjs builds its script-runner
 // sandbox with mkdtempSync under the repo ROOT, and a suite interrupted


### PR DESCRIPTION
Fixes #3468.

`applications.db` is `tracker.mjs`'s SQLite index of `data/applications.md` (#918) — company, role, score, status and notes for every application. It's not gitignored when it lands in the repo root:

```
data/applications.db     IGNORED          # covered by data/*
applications.db          NOT IGNORED      ←
applications.db-wal      NOT IGNORED      ←
applications.db-shm      NOT IGNORED      ←
```

The index sits beside the tracker markdown, and `resolveTrackerPath()` falls back to `<root>/applications.md` when `data/applications.md` is absent — so it lands in the root on the **legacy install layout**, and on **every fresh clone**:

```
$ rm -f applications.db && node test-all.mjs --quick >/dev/null 2>&1 && ls -la applications.db
-rw-r--r--  36864  applications.db
tables: applications, status_events, sqlite_sequence, meta
```

## Change

`*.db` and its `-wal`/`-shm` sidecars, beside the existing `*.bak*` rule whose comment already states this reasoning for the timestamped backups: a file holding the same PII as the original, under a name the other rules don't match. No tracked file matches (`git ls-files | grep '\.db$'` → empty).

Probes added to `tests/user-layer-gitignored.test.mjs` in the same block shape as the backup probes. Removing the rule:

```
❌ applications.db is NOT git-ignored — the derived index holds the same PII as the tracker
❌ applications.db-wal is NOT git-ignored — …
❌ applications.db-shm is NOT git-ignored — …
```

while `data/applications.db` stays ignored either way — which is exactly the gap: the existing rules only ever covered the standard layout.

## Scope, stated honestly

For an end user on the standard `data/` layout this never fires. What it actually costs is contributors — an untracked 36 KB binary after every test run that `git add .` will stage — and legacy-layout installs, where it is the user's real tracker. I wouldn't call it an active leak for most users; it's the same *class* as the backups, reached through a layout the rules never covered. Cheap to close either way.

`node test-all.mjs --quick` → green, and the `applications.db` the run itself leaves is now ignored.

## Note on ordering

This touches `.gitignore` a few lines from #3246's `*.tmp*` rule (still open). Different lines, so they should merge in either order — happy to rebase whichever lands second.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented derived tracker database and temporary sidecar files from appearing as untracked repository changes.

* **Tests**
  * Added coverage verifying that tracker index files in supported locations are correctly ignored by version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->