### PR TITLE
test(harness): the syntax gate read one directory and called it the repo

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -222,14 +222,49 @@ console.log('\n🧪 career-ops test suite\n');
 
 console.log('1. Syntax checks');
 
-const mjsFiles = readdirSync(ROOT).filter(f => f.endsWith('.mjs'));
+// This gate presented itself as the suite's syntax check while reading ONE
+// directory: readdirSync does not recurse, so it saw 125 of the repo's 582
+// tracked .mjs files and never opened tests/, providers/, web/, lib/, plugins/,
+// scripts/ or scaffolder/ (#3419). Nothing announced the gap, because a gate
+// that covers less looks exactly like a gate that found nothing wrong.
+//
+// git decides the set instead. It recurses, it excludes node_modules and every
+// untracked scratch file without a denylist to maintain, and it is the same
+// source the coverage guards further down this file already trust. A file that
+// is not tracked does not ship, so it is not this gate's business.
+//
+// -z, and split on NUL: git C-quotes any path containing a quote, a backslash or
+// a non-ASCII byte, and a quoted name would be handed to `node --check` as a
+// literal filename that does not exist — the trap 79152e7 fixed for git status.
+//
+// An empty list is a FAILURE, never a quiet narrowing. That is this repo's
+// settled reading (#2240, and the comment on the coverage-guard probe below): a
+// guard that cannot look must never pass. Running from a tree git cannot see is
+// exactly how a sibling guard printed "OK: 0 tracked files covered" while five
+// unregistered files shipped.
+const NUL = String.fromCharCode(0);
+let mjsFiles = [];
+try {
+  mjsFiles = execSync(`git ls-files -z -- "*.mjs"`, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 16 * 1024 * 1024,
+  })
+    .split(NUL)
+    .filter(Boolean);
+} catch (err) {
+  fail(`syntax gate: git ls-files failed (${String(err.message).split('\n')[0]}) — it inspected nothing`);
+}
+if (mjsFiles.length === 0) {
+  fail('syntax gate: git ls-files returned no .mjs files — this gate could not inspect anything');
+}
 
 // `node --check` parses a file and exits; it runs no user code, touches no
 // shared state, and its result depends on nothing but that one file. Spawning
 // the 100+ root scripts one at a time was pure process-startup latency, so they
 // go through a bounded pool instead (#2387). Results are collected by index and
-// reported afterwards in the original readdir order, so the log stays
-// byte-identical to the sequential version regardless of completion order.
+// reported afterwards in git's own order, so the log stays byte-identical to the
+// sequential version regardless of completion order.
 const SYNTAX_POOL_SIZE = 8;
 const execFileAsync = promisify(execFile);
 const syntaxOk = new Array(mjsFiles.length);


### PR DESCRIPTION
Closes #3419.

## The gap, on today's `main`

```
tracked .mjs in the repo    582
seen by section 1           125     ← readdirSync(ROOT), which does not recurse
never opened                457     tests/ 263 · providers/ 90 · web/ 67
                                    plugins/ · lib/ · scripts/ · scaffolder/ · batch/
```

A gate covering a fifth of the tree prints exactly what a gate covering all of it prints, which is why this sat.

## What replaces it

`git ls-files -z -- "*.mjs"`. It recurses, it drops `node_modules` and every untracked scratch file with no denylist to maintain, and it is the same source the coverage guards further down this file already trust. A file git does not track does not ship, so it is not this gate's business.

**`-z` is load-bearing.** git C-quotes any path containing a quote, a backslash or a non-ASCII byte, and a quoted name would reach `node --check` as a filename that does not exist — the trap `79152e7` fixed for `git status` three days ago.

**An empty list fails.** That is the repo's settled reading, and the comment on the coverage-guard probe in this same file records what the other answer cost:

> the guard printed "OK: 0 tracked files covered" and exited 0 while the real tree had an unregistered top-level file… That class has landed five times with this check green throughout.

So both the throw and the empty result are reported rather than silently shrinking the gate back to nothing. Verified by running the query from a directory git cannot see:

```
fatal: not a git repository → the catch branch reports, it does not pass
```

## Verified by mutation, not by the count

A wider list proves nothing on its own. A syntax error planted in `batch/aggregate-tokens.mjs` — a file the old gate never saw:

```
❌ batch/aggregate-tokens.mjs has syntax errors
   ...\batch\aggregate-tokens.mjs:248

old gate saw batch/aggregate-tokens.mjs:  false
```

## Two things worth saying plainly

**Nothing was hiding.** All 457 newly covered files parse today — I checked before writing the fix. The gate had been finding nothing because there was nothing to find, not because it was looking. That is the honest framing, and it is the argument for doing this before the day a file in `providers/` does not parse rather than after.

**The assertion count rises by ~457**, since section 1 reports one line per file and there are now 4.6× as many. That is coverage becoming visible rather than a change in what passes, but it does make the headline number discontinuous across this commit, so it is better said here than discovered in a diff.

## Cost

```
125 files   1.01s
582 files   4.53s
```

Measured on this tree with the existing 8-way pool (#2387) unchanged.

## Verification

```
node test-all.mjs   7040 passed, 1 failed, 15 warnings
                    (6581 passed, 1 failed on main, same box)
582 files through the gate
```

That one failure is #3364 — the skill-entrypoint symlinks a default Windows clone materializes as pointer text — and it reproduces on unmodified `main`. @gowrishacv's #3456 fixes it; I validated that branch on the box this morning.

Run on Windows 11, non-elevated, Developer Mode off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax validation to reliably discover tracked `.mjs` files in nested directories.
  * Added clear failures when file discovery encounters errors or finds no files.
  * Preserved consistent result ordering based on the repository’s file list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->