### PR TITLE
fix(email): align fit points with tailored CV

### DIFF
--- a/modes/email.md
+++ b/modes/email.md
@@ -24,9 +24,12 @@ Supported inputs:
 1. `/career-ops email {report-number-or-slug}`
    - Load the matching `reports/{NNN}-*.md`.
    - Use the report header, score, archetype, PDF status, and evaluation content.
-   - If `data/pdf-index.tsv` contains a PDF for that report, mention it as the CV
-     attachment candidate. If no PDF is indexed, say that the CV should be
-     generated first via `/career-ops pdf {slug}` or attached manually.
+   - If `data/pdf-index.tsv` contains a row for that report, use that same row's
+     HTML companion to align the fit points with the tailored CV and mention its
+     PDF as the attachment candidate. If no usable tailored HTML is indexed,
+     select fit points from `cv.md`. If no PDF is indexed, say that the CV
+     should be generated first via `/career-ops pdf {slug}` or attached
+     manually.
 
 2. `/career-ops email {pasted JD}`
    - Use the pasted JD directly.
@@ -88,6 +91,27 @@ user's own rules.
 attachment checklist, subject/body structure, the draft-only rule — is set here
 and is not affected by it.
 
+### Tailored CV alignment source
+
+For an invocation resolved to a report, normalize the report number when
+matching `data/pdf-index.tsv` (`008` and `8` are the same report). Ignore blank
+and comment rows. The manifest writer keeps one current row per report; if a
+hand-edited manifest contains duplicates, use the last matching row.
+
+Resolve the row's workspace-relative `pdf` and `html` columns against the data
+root. Use the HTML companion, never the PDF, as the readable representation of
+the attached CV. It is usable only when the HTML path exists and is a file. Do
+not guess a similarly named file or silently use an artifact belonging to the
+same company but a different report.
+
+The tailored HTML is an **alignment guide, not a new source of truth**. It may
+control which supported bullets are selected and how they are ordered or
+framed, but every fact in the email must still be verified against the primary
+source-of-truth files above. If the row is absent, malformed, or its HTML file
+is unavailable, fall back explicitly to `cv.md` for fit-point selection. The
+PDF path may still be shown in the attachment checklist when that file exists,
+but never claim the body was aligned to it without a readable HTML companion.
+
 ### Profile fields
 
 Use these optional fields when present:
@@ -144,7 +168,11 @@ and follow the dedicated sections below instead of the Step 5 structures.
 
 ## Step 3 — Extract Fit Points
 
-From the report/JD and source-of-truth files, select 2-3 fit points:
+From the report/JD and source-of-truth files, select 2-3 fit points. When the
+Tailored CV alignment source resolved a usable HTML companion, prefer the
+proof points and emphasis present in that artifact so the body describes the
+CV being attached. Otherwise, use `cv.md` as the selection source and say that
+the tailored artifact was unavailable before presenting the draft.
 
 - One role-to-profile match: stack, domain, workflow, product type, or delivery
   style.
@@ -176,6 +204,9 @@ Attachments to include:
 Rules:
 - If `application_email.include_attachment_checklist` is `false`, omit this
   checklist.
+- For a report-based invocation, use the PDF from the same manifest row whose
+  HTML companion guided Step 3. Do not select the prose source and attachment
+  from different rows.
 - Mention only files that exist or are indexed. Do not claim a cover letter
   exists unless it does.
 - Do not attach files or send anything.

--- a/modes/email.md
+++ b/modes/email.md
@@ -98,11 +98,12 @@ matching `data/pdf-index.tsv` (`008` and `8` are the same report). Ignore blank
 and comment rows. The manifest writer keeps one current row per report; if a
 hand-edited manifest contains duplicates, use the last matching row.
 
-Resolve the row's workspace-relative `pdf` and `html` columns against the data
-root. Use the HTML companion, never the PDF, as the readable representation of
-the attached CV. It is usable only when the HTML path exists and is a file. Do
-not guess a similarly named file or silently use an artifact belonging to the
-same company but a different report.
+Resolve the row's workspace-relative `pdf` and `html` columns against the
+workspace root (the directory that contains `data/`), matching the base used by
+the manifest writer. Use the HTML companion, never the PDF, as the readable
+representation of the attached CV. It is usable only when the resolved HTML
+path exists and is a file. Do not guess a similarly named file or silently use
+an artifact belonging to the same company but a different report.
 
 The tailored HTML is an **alignment guide, not a new source of truth**. It may
 control which supported bullets are selected and how they are ordered or
@@ -172,7 +173,9 @@ From the report/JD and source-of-truth files, select 2-3 fit points. When the
 Tailored CV alignment source resolved a usable HTML companion, prefer the
 proof points and emphasis present in that artifact so the body describes the
 CV being attached. Otherwise, use `cv.md` as the selection source and say that
-the tailored artifact was unavailable before presenting the draft.
+HTML alignment was unavailable and `cv.md` was used before presenting the
+draft. A missing HTML alignment source does not by itself mean the tailored PDF
+is missing.
 
 - One role-to-profile match: stack, domain, workflow, product type, or delivery
   style.
@@ -204,9 +207,11 @@ Attachments to include:
 Rules:
 - If `application_email.include_attachment_checklist` is `false`, omit this
   checklist.
-- For a report-based invocation, use the PDF from the same manifest row whose
-  HTML companion guided Step 3. Do not select the prose source and attachment
-  from different rows.
+- For a report-based invocation, keep the PDF candidate from the selected
+  manifest row. When that row has a usable HTML companion, let it guide Step 3.
+  When it does not, use `cv.md` for Step 3 as described above, but still show
+  that row's PDF when the resolved PDF path exists. Do not select the prose
+  source and attachment from different rows.
 - Mention only files that exist or are indexed. Do not claim a cover letter
   exists unless it does.
 - Do not attach files or send anything.

--- a/tests/email-tailored-cv-source.test.mjs
+++ b/tests/email-tailored-cv-source.test.mjs
@@ -1,0 +1,25 @@
+// tests/email-tailored-cv-source.test.mjs — email copy and attachment stay aligned (#3460).
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+const emailMode = readFileSync(join(ROOT, 'modes', 'email.md'), 'utf8');
+const normalizedEmailMode = emailMode.replace(/\s+/g, ' ');
+
+const guarantees = [
+  ['normalizes padded report numbers', '`008` and `8` are the same report'],
+  ['reads the manifest HTML rather than parsing PDFs', 'Use the HTML companion, never the PDF'],
+  ['does not cross role boundaries by company name', 'the same company but a different report'],
+  ['keeps tailored output below primary factual sources', 'alignment guide, not a new source of truth'],
+  ['falls back to the master CV when tailored HTML is unavailable', 'fall back explicitly to `cv.md`'],
+  ['uses one manifest row for prose and attachment', 'Do not select the prose source and attachment from different rows'],
+];
+
+for (const [description, marker] of guarantees) {
+  if (normalizedEmailMode.includes(marker)) {
+    pass(`email mode ${description}`);
+  } else {
+    fail(`email mode no longer ${description}`);
+  }
+}

--- a/tests/email-tailored-cv-source.test.mjs
+++ b/tests/email-tailored-cv-source.test.mjs
@@ -13,6 +13,9 @@ const guarantees = [
   ['does not cross role boundaries by company name', 'the same company but a different report'],
   ['keeps tailored output below primary factual sources', 'alignment guide, not a new source of truth'],
   ['falls back to the master CV when tailored HTML is unavailable', 'fall back explicitly to `cv.md`'],
+  ['resolves manifest artifacts from the workspace root', 'workspace root (the directory that contains `data/`)'],
+  ['distinguishes unavailable HTML alignment from a missing tailored PDF', 'does not by itself mean the tailored PDF is missing'],
+  ['retains an existing PDF when its HTML companion is unavailable', "still show that row's PDF when the resolved PDF path exists"],
   ['uses one manifest row for prose and attachment', 'Do not select the prose source and attachment from different rows'],
 ];
 


### PR DESCRIPTION
Closes #3460.

## What changed

- resolves report-linked CV context through the existing five-column `data/pdf-index.tsv` contract
- uses the manifest HTML companion as the readable alignment guide while keeping primary profile files authoritative for every factual claim
- keeps `cv.md` as an explicit fallback when the row or HTML artifact is unavailable
- requires the prose source and attachment candidate to come from the same report row
- documents normalized report matching and avoids cross-role/company-name guessing

I kept the analogous `apply.md` boundary and any manifest-schema expansion out of this PR so this remains the narrow email slice claimed on the issue.

## Verification

- `node tests/email-tailored-cv-source.test.mjs` — 6 passed, 0 failed
- `node test-all.mjs` — 6604 passed, 0 failed, 11 existing environment/data warnings
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email drafts now select and order CV-aligned fit points using the matching report’s readable HTML companion.
  - Attachments are selected from the same report source used to guide the email content.
  - Existing `cv.md` fallback behavior is retained when HTML is unavailable.

- **Documentation**
  - Updated email-mode guidance to reflect content and attachment alignment behavior.

- **Tests**
  - Added coverage to verify the documented email drafting and attachment guarantees remain present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->