### PR TITLE
fix(updater): back up self-bootstrap edits before checkout

### DIFF
--- a/tests/updater-self-bootstrap-backup.test.mjs
+++ b/tests/updater-self-bootstrap-backup.test.mjs
@@ -1,0 +1,46 @@
+// tests/updater-self-bootstrap-backup.test.mjs — #3207 recovery guarantee.
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { backupSystemFiles } from '../update-system.mjs';
+import { pass, fail } from './helpers.mjs';
+
+const dir = mkdtempSync(join(tmpdir(), 'co-bootstrap-backup-'));
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+try {
+  const updater = join(dir, 'update-system.mjs');
+  writeFileSync(updater, 'local fork fix\n');
+
+  const [saved] = backupSystemFiles(['update-system.mjs'], { root: dir });
+  writeFileSync(updater, 'fetched upstream updater\n');
+
+  if (saved.backup === 'update-system.mjs.bak'
+      && readFileSync(`${updater}.bak`, 'utf8') === 'local fork fix\n'
+      && readFileSync(updater, 'utf8') === 'fetched upstream updater\n') {
+    pass('self-bootstrap preserves the local updater before loading upstream');
+  } else {
+    fail('self-bootstrap backup did not preserve the pre-checkout bytes');
+  }
+
+  const failure = backupSystemFiles(['missing-import.mjs'], { root: dir })[0];
+  if (failure.error && failure.backup === 'missing-import.mjs.bak') {
+    pass('a backup failure is reportable without hiding the affected path');
+  } else {
+    fail('backup failures must retain both the path and error');
+  }
+
+  const source = readFileSync(join(root, 'update-system.mjs'), 'utf8');
+  const detectAt = source.indexOf("locallyModifiedSystemFiles(reexecFiles, 'FETCH_HEAD')");
+  const backUpAt = source.indexOf('backupSystemFiles(bootstrapAtRisk)', detectAt);
+  const checkoutAt = source.indexOf("git('checkout', 'FETCH_HEAD', '--', ...reexecFiles)", detectAt);
+  if (detectAt !== -1 && backUpAt > detectAt && checkoutAt > backUpAt) {
+    pass('apply detects and backs up bootstrap edits before checkout');
+  } else {
+    fail('apply must preserve bootstrap edits before the destructive checkout');
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/tests/updater-self-bootstrap-backup.test.mjs
+++ b/tests/updater-self-bootstrap-backup.test.mjs
@@ -41,6 +41,14 @@ try {
   } else {
     fail('apply must preserve bootstrap edits before the destructive checkout');
   }
+
+  const recordAt = source.indexOf('generatedBackupPaths.add(result.backup)');
+  const validationAt = source.indexOf('!generatedBackupPaths.has(file)');
+  if (recordAt > backUpAt && validationAt > recordAt) {
+    pass('apply excludes only its successfully generated backups from user-layer validation');
+  } else {
+    fail('updater-created backups must not be mistaken for user-layer changes');
+  }
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1717,6 +1717,10 @@ async function apply() {
   // TARGET updater as `update-system.mjs apply` with a fixed argv.
   const updateForce = process.argv.includes('--force') || process.env.CAREER_OPS_UPDATE_FORCE === '1';
   const initialStatusPaths = new Set(gitStatusEntries().map(entry => entry.path));
+  // Backups created by this apply run are expected updater output, not user
+  // files the checkout modified. Record only successful copies so an unrelated
+  // pre-existing .bak can never receive this exemption.
+  const generatedBackupPaths = new Set();
   const isReexec = process.env.CAREER_OPS_UPDATE_REEXEC === '1';
 
   // Check for lock
@@ -1833,6 +1837,7 @@ async function apply() {
           // abort the update — the file itself is still listed either way.
           console.log(`  ${result.file}  (could not write ${result.backup}: ${result.error})`);
         } else {
+          generatedBackupPaths.add(result.backup);
           console.log(`  ${result.file}  (local copy saved: ${result.backup})`);
         }
       }
@@ -2024,7 +2029,7 @@ async function apply() {
       // (e.g. writing-samples/README.md is system-owned doc inside a user dir).
       const changed = gitStatusEntries()
         .map((entry) => entry.path)
-        .filter((file) => !initialStatusPaths.has(file));
+        .filter((file) => !initialStatusPaths.has(file) && !generatedBackupPaths.has(file));
       for (const file of userLayerViolations(changed, updatePaths, effectiveUserPaths())) {
         console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
         violatedUserPaths.add(file);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1190,6 +1190,31 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
     .sort();
 }
 
+/**
+ * Preserve byte-for-byte copies of system files before an unavoidable
+ * overwrite. The self-bootstrap stage cannot use the normal "keep local"
+ * path: it must load the fetched updater to remain forward-compatible. A
+ * sibling .bak makes that exceptional overwrite recoverable instead.
+ *
+ * @param {string[]} files - Repo-relative files already proven at risk.
+ * @param {{root?: string, copyFile?: Function}} [ctx] - Test seams.
+ * @returns {{file: string, backup: string, error?: string}[]}
+ */
+export function backupSystemFiles(files, ctx = {}) {
+  const root = ctx.root || ROOT;
+  const copyFile = ctx.copyFile || copyFileSync;
+  return files.map((file) => {
+    const source = join(root, ...file.split('/'));
+    const backup = `${source}.bak`;
+    try {
+      copyFile(source, backup);
+      return { file, backup: `${file}.bak` };
+    } catch (err) {
+      return { file, backup: `${file}.bak`, error: err.message };
+    }
+  });
+}
+
 export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {
   const runGit = ctx.git || git;
   const root = ctx.root || ROOT;
@@ -1739,6 +1764,20 @@ async function apply() {
         // relative-import closure and check out exactly those files, so a future
         // new top-level import can't reintroduce the self-reexec crash (#1245).
         const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
+        const bootstrapAtRisk = locallyModifiedSystemFiles(reexecFiles, 'FETCH_HEAD');
+        if (bootstrapAtRisk.length > 0) {
+          console.log('');
+          console.log(`${bootstrapAtRisk.length} self-bootstrap file(s) differ from upstream because THIS install changed them:`);
+          for (const result of backupSystemFiles(bootstrapAtRisk)) {
+            if (result.error) {
+              console.log(`  ${result.file}  (could not write ${result.backup}: ${result.error})`);
+            } else {
+              console.log(`  ${result.file}  (local copy saved: ${result.backup})`);
+            }
+          }
+          console.log('Self-bootstrap must load the upstream versions; the local versions remain in the backups above.');
+          console.log('');
+        }
         git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
@@ -1788,15 +1827,13 @@ async function apply() {
     if (atRisk.length > 0) {
       console.log('');
       console.log(`${atRisk.length} system file(s) differ from upstream because THIS install changed them:`);
-      for (const file of atRisk) {
-        const backup = `${join(ROOT, ...file.split('/'))}.bak`;
-        try {
-          copyFileSync(join(ROOT, ...file.split('/')), backup);
-          console.log(`  ${file}  (local copy saved: ${file}.bak)`);
-        } catch (err) {
+      for (const result of backupSystemFiles(atRisk)) {
+        if (result.error) {
           // A .bak we could not write is worth saying out loud, but it must not
           // abort the update — the file itself is still listed either way.
-          console.log(`  ${file}  (could not write ${file}.bak: ${err.message})`);
+          console.log(`  ${result.file}  (could not write ${result.backup}: ${result.error})`);
+        } else {
+          console.log(`  ${result.file}  (local copy saved: ${result.backup})`);
         }
       }
       if (updateForce) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -209,7 +209,9 @@ const twoPassManifestChecks = [
   },
   {
     name: 'the local copy is saved as .bak before any overwrite (#2337)',
-    pattern: /copyFileSync\([\s\S]{0,80}?backup\)/,
+    // backupSystemFiles owns the byte copy for both the normal update and the
+    // earlier self-bootstrap overwrite (#3207); pin the normal call site here.
+    pattern: /backupSystemFiles\(atRisk\)/,
   },
   {
     name: 'overwriting a locally edited system file requires --force (#2337)',


### PR DESCRIPTION
Closes #3207.

## What changed

- detect locally modified files in the fetched updater's self-reexec closure before the bootstrap checkout
- save each at-risk local version to a sibling `.bak` and name both successes and failures before loading upstream
- share the byte-copy helper with the existing post-bootstrap backup path so both overwrite paths use the same behavior
- add regression coverage for byte preservation, failure reporting, and detect → backup → checkout ordering

The self-bootstrap remains unconditional, as required for forward compatibility; this makes its exceptional overwrite visible and recoverable.

## Verification

- `node test-all.mjs`: 6601 passed, 0 failed, 11 existing warnings
- post-rebase: `node tests/updater-self-bootstrap-backup.test.mjs`
- post-rebase: `node updater-migration-tests.mjs`: 372 passed, 0 failed
- `git diff --check`

The branch was rebased onto current `main`; the intervening upstream change only registered the shared syntax-walk helper in `SYSTEM_PATHS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved updater recovery by preserving local system files before potentially destructive updates.
  * Backup failures now report affected file paths and errors without stopping the update process.
  * Ensured backup and recovery actions occur in the correct order during self-bootstrap updates.
  * Prevented generated backup files from being incorrectly reported as update safety violations.

* **Tests**
  * Added coverage for file preservation, backup failure reporting, operation ordering, safety validation, and temporary fixture cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->