### PR TITLE
docs(setup): add Claude Code web quick start

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -39,7 +39,8 @@ browser storage:
 | `data/` | Tracker and other private workflow state |
 | `reports/` | Job evaluations and generated reports |
 
-These paths are intentionally git-ignored because they contain personal data.
+`cv.md`, runtime content under `data/`, and Markdown files directly under
+`reports/` are intentionally git-ignored because they contain personal data.
 That also means a normal web-session branch push does **not** persist them to
 GitHub: a new cloud session starts from the repository again, without the
 ignored files from the previous VM. Keep a personal workflow in one session

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -8,6 +8,45 @@
 
 ## Quick Start
 
+### Browser-only — Claude Code on the web
+
+[Claude Code on the web](https://code.claude.com/docs/en/web-quickstart) can run
+career-ops without a local checkout. It is currently a research preview for
+eligible Claude plans. A web session clones a GitHub repository into an
+isolated cloud VM; it does not have your machine's files or local configuration.
+
+1. Put career-ops in a **private GitHub repository** that your account can
+   access. You can use [GitHub Importer](https://docs.github.com/en/migrations/importing-source-code/using-github-importer/importing-a-repository-with-github-importer)
+   with `https://github.com/santifer/career-ops.git` as the source. A normal
+   fork of this public repository is public, so do not use one for personal
+   career data.
+2. Open [claude.ai/code](https://claude.ai/code), connect GitHub, and select the
+   private repository and branch. The Default cloud environment is enough for
+   the first run; Anthropic's quick start explains plan-specific onboarding.
+3. Submit this first task:
+
+   ```text
+   Set up career-ops in this checkout. Run npm install, then start the first-run
+   onboarding. Keep cv.md, data/, and reports/ out of Git.
+   ```
+
+career-ops still uses ordinary workspace files in the cloud checkout, not
+browser storage:
+
+| Path (from the repository root) | What it holds |
+|---|---|
+| `cv.md` | Your master CV |
+| `data/` | Tracker and other private workflow state |
+| `reports/` | Job evaluations and generated reports |
+
+These paths are intentionally git-ignored because they contain personal data.
+That also means a normal web-session branch push does **not** persist them to
+GitHub: a new cloud session starts from the repository again, without the
+ignored files from the previous VM. Keep a personal workflow in one session
+and move any output you need to secure storage before its environment expires.
+Never force-add these paths. For a durable workspace shared across many
+sessions, use the local quick start below.
+
 ### Recommended — one command
 
 ```bash

--- a/tests/claude-web-setup-docs.test.mjs
+++ b/tests/claude-web-setup-docs.test.mjs
@@ -1,0 +1,22 @@
+// tests/claude-web-setup-docs.test.mjs — browser-only setup keeps the privacy boundary explicit (#1978).
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+const setup = readFileSync(join(ROOT, 'docs', 'SETUP.md'), 'utf8').replace(/\s+/g, ' ');
+
+const guarantees = [
+  ['links the official Claude Code web quick start', 'https://code.claude.com/docs/en/web-quickstart'],
+  ['requires a private repository for personal career data', 'private GitHub repository'],
+  ['locates the master CV at the cloud checkout root', '| `cv.md` | Your master CV |'],
+  ['locates private workflow state under data', '| `data/` | Tracker and other private workflow state |'],
+  ['locates evaluations under reports', '| `reports/` | Job evaluations and generated reports |'],
+  ['explains that ignored user data does not cross cloud sessions', 'a new cloud session starts from the repository again'],
+  ['forbids force-adding private paths', 'Never force-add these paths'],
+];
+
+for (const [description, marker] of guarantees) {
+  if (setup.includes(marker)) pass(`Claude Code web setup ${description}`);
+  else fail(`Claude Code web setup no longer ${description}`);
+}


### PR DESCRIPTION
Closes #1978.

## What changed

- add a browser-only quick start for Claude Code on the web, linked to Anthropic's current documentation
- explain the private-repository requirement and warn that a normal fork of this public repository is public
- locate `cv.md`, `data/`, and `reports/` inside the cloud checkout
- make the persistence boundary explicit: those private, gitignored files do not follow a branch into a fresh cloud session
- add a focused documentation contract test for those privacy and path guarantees

## Verification

- `node tests/claude-web-setup-docs.test.mjs` — 7 passed, 0 failed
- `npm run lint` — 586 `.mjs` files passed
- `node test-all.mjs --quick` — 7296 passed, 0 failed, 11 existing warnings
- `git diff --check origin/main...HEAD`

The setup guidance was checked against the current official Claude Code web quick start and GitHub Importer documentation on 2026-08-29.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added browser-based setup instructions for Claude Code on the web.
  - Documented private repository requirements, GitHub connection, onboarding, cloud workspace locations, ignored data behavior, and session persistence limits.
  - Included a local quick-start alternative.

- **Tests**
  - Added checks to ensure the setup documentation clearly explains privacy boundaries, private data locations, cloud session behavior, and restrictions on force-adding ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->