### PR TITLE
fix(agent-inbox): lock resolve rewrites

### DIFF
--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -9,6 +9,8 @@
  *   3. `list` shows pending only; `list --all` shows resolved items too.
  *   4. `resolve N` ticks the N-th *pending* item and appends a one-line result,
  *      so `list` then `resolve N` line up.
+ *   4b. resolve holds the same lock as add for its full read/modify/write, so a
+ *       request accepted concurrently cannot be overwritten by a stale view.
  *   5. An empty `add` fails loudly (exit 1) rather than queuing a blank line.
  *   6. On the default path, a first `add` self-heals .gitignore (idempotent) so
  *      the personal queue isn't accidentally tracked.
@@ -145,6 +147,38 @@ console.log('4. resolve ticks the N-th pending item + appends a one-line result'
   check('item marked done', /^- \[x\] .*gamma/m.test(md), md);
   check('result appended', /→ result: scored 4\.3 — report 012/.test(md));
   check('no pending left', (md.match(/^- \[ \]/gm) || []).length === 0);
+}
+
+// ---------------------------------------------------------------------------
+console.log('4b. resolve waits for the queue lock before rewriting');
+{
+  const dir = tmp('inbox-resolve-lock-');
+  const inbox = join(dir, 'agent-inbox.md');
+  writeFileSync(inbox, '# Agent Inbox\n\n- [ ] 2026-01-01 00:00 — alpha\n- [ ] 2026-01-01 00:01 — beta\n');
+  const held = await acquirePipelineLock(inbox, { timeoutMs: 10_000 });
+  const child = spawn(NODE, [CLI, 'resolve', '1', '--result', 'done alpha'], {
+    cwd: ROOT, env: { ...process.env, CAREER_OPS_INBOX: inbox }, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const closed = new Promise((res) => child.on('close', (code) => res(code)));
+  const whileHeld = await Promise.race([
+    closed.then(() => 'closed'),
+    // A fresh Node process starts in tens of milliseconds on the hosted
+    // runners. Half a second keeps the negative control decisive without
+    // making the suite inherit the lock's 30-second production timeout.
+    new Promise((res) => setTimeout(() => res('waiting'), 500)),
+  ]);
+  check('resolve stays blocked while another writer owns the queue lock', whileHeld === 'waiting', `state=${whileHeld}`);
+  held.release();
+  const exit = await closed;
+  check('resolve exits cleanly after the lock is released', exit === 0, `exit=${exit}, stderr=${stderr.trim()}`);
+  const md = readFileSync(inbox, 'utf8');
+  check('the selected item is resolved from the locked snapshot', /^- \[x\].*alpha.*→ result: done alpha/m.test(md), md);
+  check('the sibling pending item survives the rewrite', /^- \[ \].*beta/m.test(md), md);
+  check('resolve reports the selected item after committing', /Resolved #1: .*alpha/.test(stdout), stdout.trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -205,20 +205,30 @@ function list() {
   });
 }
 
-function resolve() {
+async function resolve() {
   const n = Number(process.argv[3]);
   if (!Number.isInteger(n) || n < 1) fail('resolve needs a 1-based item number (see `list`)');
-  // Number against the pending view, so `list` then `resolve N` line up.
-  const pending = parseItems().filter((it) => !it.done);
-  const target = pending[n - 1];
-  if (!target) fail(`no pending item #${n} (${pending.length} pending)`);
-  const result = oneLine(opt('result'));
-  const lines = readFileSync(PATH, 'utf8').split('\n');
-  let updated = lines[target.line].replace('[ ]', '[x]');
-  if (result && !/→ result:/.test(updated)) updated += ` → result: ${result}`;
-  lines[target.line] = updated;
-  writeFileSync(PATH, lines.join('\n'));
-  process.stdout.write(`Resolved #${n}: ${target.text}\n`);
+  const outcome = await withPipelineLock(PATH, () => {
+    // The pending snapshot, line lookup, and rewrite are one transaction. An
+    // add between the old read and write was acknowledged, then overwritten by
+    // this stale snapshot even though add itself correctly held this same lock.
+    // Number inside the critical section too, so the selected item and the
+    // rewritten line always come from one locked view.
+    const pending = parseItems().filter((it) => !it.done);
+    const target = pending[n - 1];
+    if (!target) return { error: `no pending item #${n} (${pending.length} pending)` };
+    const result = oneLine(opt('result'));
+    const lines = readFileSync(PATH, 'utf8').split('\n');
+    let updated = lines[target.line].replace('[ ]', '[x]');
+    if (result && !/→ result:/.test(updated)) updated += ` → result: ${result}`;
+    lines[target.line] = updated;
+    writeFileSync(PATH, lines.join('\n'));
+    return { target };
+  }, { timeoutMs: 30_000 });
+  // Fail only after withPipelineLock has released. process.exit() inside the
+  // callback would bypass the lock's finally block and strand the directory.
+  if (outcome.error) fail(outcome.error);
+  process.stdout.write(`Resolved #${n}: ${outcome.target.text}\n`);
 }
 
 function fail(msg) {
@@ -229,7 +239,7 @@ function fail(msg) {
 const cmd = process.argv[2];
 if (cmd === 'add') await add();
 else if (cmd === 'list') list();
-else if (cmd === 'resolve') resolve();
+else if (cmd === 'resolve') await resolve();
 else {
   process.stdout.write(
     'Usage:\n' +


### PR DESCRIPTION
Closes #3478.

## What changed

- serialize `resolve` through the same queue lock already used by `add`
- keep pending-item selection and the full read/modify/write in one critical section
- defer CLI failure until after lock release, avoiding a stranded lock on an invalid item number
- add a process-level regression that holds the lock, proves `resolve` waits, then verifies the selected and sibling rows

## Why

Previously, `resolve` could read an old queue, a concurrent `add` could append and report success, and `resolve` could then overwrite that accepted request with its stale snapshot. Holding the queue lock externally showed `resolve` still exiting 0 in 43 ms on current main.

## Verification

- `node agent-inbox-tests.mjs` — 42 passed, 0 failed
- `npm run lint` — 585 `.mjs` files passed
- `node test-all.mjs --quick` — 7288 passed, 0 failed, 11 pre-existing/environment warnings
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox resolution reliability when multiple actions occur at the same time.
  * Prevented newly added items from being overwritten during resolution.
  * Ensured resolution waits for ongoing inbox updates to finish.
  * Improved handling and reporting when the selected item is missing.

* **Tests**
  * Added regression coverage for concurrent inbox operations and preservation of pending items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->