### PR TITLE
fix(web): reject malformed follow-up IDs

### DIFF
--- a/web/src/app/api/followups/log/route.ts
+++ b/web/src/app/api/followups/log/route.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { CHANNELS, isRealISODate, localISODate } from "@/lib/followups";
+import { parseFollowupId } from "@/lib/followup-id.mjs";
 import { followupsLogPath, withFollowupsWrite, followupsWriteError } from "@/lib/followups-server";
 
 export const runtime = "nodejs";
@@ -44,8 +45,8 @@ export async function POST(req: Request) {
     return Response.json({ error: "bad json" }, { status: 400 });
   }
 
-  const appNum = Number.parseInt(String(body.appNum ?? body.num ?? ""), 10);
-  if (!Number.isInteger(appNum) || appNum < 0) {
+  const appNum = parseFollowupId(body.appNum ?? body.num);
+  if (appNum === null) {
     return Response.json({ error: "appNum (application #) required" }, { status: 400 });
   }
   const company = cell(body.company, 80);
@@ -115,8 +116,8 @@ export async function DELETE(req: Request) {
   } catch {
     return Response.json({ error: "bad json" }, { status: 400 });
   }
-  const num = Number.parseInt(String(body.num ?? ""), 10);
-  if (!Number.isInteger(num) || num <= 0) return Response.json({ error: "num required" }, { status: 400 });
+  const num = parseFollowupId(body.num);
+  if (num === null) return Response.json({ error: "num required" }, { status: 400 });
 
   const file = followupsLogPath();
   if (!fs.existsSync(file)) return Response.json({ error: "no follow-up log" }, { status: 404 });

--- a/web/src/app/api/followups/override/route.ts
+++ b/web/src/app/api/followups/override/route.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { isRealISODate, localISODate } from "@/lib/followups";
+import { parseFollowupId } from "@/lib/followup-id.mjs";
 import { followupsLogPath, withFollowupsWrite, followupsWriteError } from "@/lib/followups-server";
 
 export const runtime = "nodejs";
@@ -23,8 +24,8 @@ export async function POST(req: Request) {
   } catch {
     return Response.json({ error: "bad json" }, { status: 400 });
   }
-  const appNum = Number.parseInt(String(body.appNum ?? ""), 10);
-  if (!Number.isInteger(appNum) || appNum < 0) {
+  const appNum = parseFollowupId(body.appNum);
+  if (appNum === null) {
     return Response.json({ error: "appNum (application #) required" }, { status: 400 });
   }
   const date = (body.date ?? "").trim();
@@ -59,8 +60,8 @@ export async function DELETE(req: Request) {
   } catch {
     return Response.json({ error: "bad json" }, { status: 400 });
   }
-  const appNum = Number.parseInt(String(body.appNum ?? ""), 10);
-  if (!Number.isInteger(appNum) || appNum < 0) {
+  const appNum = parseFollowupId(body.appNum);
+  if (appNum === null) {
     return Response.json({ error: "appNum (application #) required" }, { status: 400 });
   }
 

--- a/web/src/lib/followup-id.mjs
+++ b/web/src/lib/followup-id.mjs
@@ -1,0 +1,17 @@
+/**
+ * Parse an application or follow-up identifier without prefix coercion.
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+export function parseFollowupId(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return null;
+
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}

--- a/web/tests/lib/followup-id.test.mjs
+++ b/web/tests/lib/followup-id.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { parseFollowupId } from "../../src/lib/followup-id.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.resolve(here, "../..");
+
+test("parseFollowupId accepts positive safe integer numbers and canonical strings", () => {
+  for (const [input, expected] of [
+    [1, 1],
+    [42, 42],
+    [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+    ["1", 1],
+    [" 42 ", 42],
+    [String(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER],
+  ]) {
+    assert.equal(parseFollowupId(input), expected);
+  }
+});
+
+test("parseFollowupId rejects coercible prefixes and non-positive or unsafe values", () => {
+  for (const input of [
+    undefined,
+    null,
+    "",
+    "0",
+    0,
+    -1,
+    "-1",
+    1.5,
+    "1.5",
+    "1e2",
+    "42junk",
+    "01",
+    Number.MAX_SAFE_INTEGER + 1,
+    String(Number.MAX_SAFE_INTEGER + 1),
+    [],
+    {},
+  ]) {
+    assert.equal(parseFollowupId(input), null, `expected ${JSON.stringify(input)} to be rejected`);
+  }
+});
+
+test("all follow-up mutation routes use strict ID parsing", () => {
+  for (const [relative, expectedCalls] of [
+    ["src/app/api/followups/log/route.ts", 2],
+    ["src/app/api/followups/override/route.ts", 2],
+  ]) {
+    const source = fs.readFileSync(path.join(webRoot, relative), "utf8");
+    assert.equal(source.includes("Number.parseInt(String(body."), false, relative);
+    assert.equal((source.match(/parseFollowupId\(/g) ?? []).length, expectedCalls, relative);
+  }
+});


### PR DESCRIPTION
Closes #3480.

## What changed

- add one strict parser for follow-up and application identifiers
- use it in all four log/override mutation handlers
- reject coercible prefixes, zero/negative/decimal values, and unsafe integers
- cover accepted and rejected boundaries plus route wiring

## Why

`Number.parseInt` accepted a valid-looking prefix and discarded the rest. In the real routes, `42junk` could write application 42 and `1junk` could delete follow-up row 1; application `0` was also accepted by both POST handlers.

The shared parser now accepts only positive safe-integer numbers or canonical digit strings, so every mutation endpoint has the same contract as the core follow-up tooling.

## Verification

- `node --test web/tests/lib/followup-id.test.mjs` — 3 passed
- `cd web && npm test` — 388 passed, 0 failed
- `cd web && npm run typecheck` — passed
- `npm run lint` — 587 syntax checks passed
- `node test-all.mjs --quick` — 7290 passed, 0 failed, 11 existing warnings
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of follow-up application and log identifiers.
  * Invalid, unsafe, or incorrectly formatted identifiers are now rejected consistently.
  * Existing error handling and follow-up actions remain unchanged.

* **Tests**
  * Added coverage for valid and invalid identifier formats, including boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->