### PR TITLE
fix(dashboard): bound company fallback matches

### DIFF
--- a/dashboard/internal/data/pdf.go
+++ b/dashboard/internal/data/pdf.go
@@ -172,7 +172,8 @@ var rePDFDate = regexp.MustCompile(`(\d{4}-\d{2}-\d{2})\.pdf$`)
 //  1. Manifest entry for the application's report number, when the file
 //     still exists. This is exact — generate-pdf.mjs recorded the linkage.
 //  2. Filename match: output/cv-*.pdf whose name contains the kebab-cased
-//     company. This covers every PDF generated before the manifest existed.
+//     company at hyphen boundaries. This covers every PDF generated before
+//     the manifest existed without matching a longer company's slug.
 //     Multiple matches are all returned (newest first) so the caller can
 //     offer a picker instead of guessing — one company can have several
 //     role-variant CVs from the same day.
@@ -207,16 +208,12 @@ func ResolvePDFs(careerOpsPath string, app model.CareerApplication, manifest PDF
 	return matches
 }
 
-// matchesCompanySlug reports whether a generated CV filename refers to the
-// company. Short slugs (< 3 runes) require a full "-slug-" segment so a
-// company like "X" can't match every file; longer slugs use substring
-// containment, which tolerates role-variant suffixes (cv-…-anthropic-staff-
-// ui-….pdf matches "anthropic").
+// matchesCompanySlug reports whether a generated CV filename contains the
+// company as a complete hyphen-delimited segment. This still permits role
+// variants (cv-…-anthropic-staff-ui-….pdf matches "anthropic") without letting
+// a company prefix match a different company ("meta" must not match "metabase").
 func matchesCompanySlug(base, slug string) bool {
-	if len([]rune(slug)) < 3 {
-		return strings.Contains(base, "-"+slug+"-")
-	}
-	return strings.Contains(base, slug)
+	return strings.Contains(base, "-"+slug+"-")
 }
 
 // sortPDFsNewestFirst orders candidate paths by the date stamp embedded in

--- a/dashboard/internal/data/pdf_test.go
+++ b/dashboard/internal/data/pdf_test.go
@@ -148,6 +148,16 @@ func TestResolvePDFsMultiWordCompany(t *testing.T) {
 	}
 }
 
+func TestResolvePDFsDoesNotMatchCompanyPrefix(t *testing.T) {
+	root := t.TempDir()
+	writeFixture(t, root, "output/cv-jane-doe-metabase-2026-06-05.pdf", "pdf")
+
+	app := model.CareerApplication{Company: "Meta"}
+	if got := ResolvePDFs(root, app, LoadPDFManifest(root)); len(got) != 0 {
+		t.Fatalf("expected Meta not to match Metabase's PDF, got %v", got)
+	}
+}
+
 func TestResolvePDFsNoMatch(t *testing.T) {
 	root := t.TempDir()
 	writeFixture(t, root, "output/cv-jane-doe-acme-2026-06-05.pdf", "pdf")

--- a/dashboard/internal/ui/screens/pipeline_pdf_test.go
+++ b/dashboard/internal/ui/screens/pipeline_pdf_test.go
@@ -115,6 +115,24 @@ func TestPDFKeyOpensNewestForMultipleMatches(t *testing.T) {
 	}
 }
 
+func TestPDFKeyDoesNotOpenCompanyPrefixMatch(t *testing.T) {
+	root := t.TempDir()
+	writePDFFixture(t, root, "output/cv-jane-doe-metabase-2026-06-05.pdf")
+	apps := []model.CareerApplication{
+		{Company: "Meta", Role: "Engineer", Status: "Evaluated", Score: 4.0},
+	}
+
+	pm := newPDFTestModel(t, root, apps)
+	updated, cmd := pm.Update(keyMsg("d"))
+
+	if cmd != nil {
+		t.Fatalf("expected no open command for Metabase's PDF, got %#v", cmd())
+	}
+	if updated.flash == "" {
+		t.Fatal("expected a no-PDF flash for the Meta application")
+	}
+}
+
 func TestRegenerateKeyFlashesWithoutManifestEntry(t *testing.T) {
 	root := t.TempDir()
 	apps := []model.CareerApplication{
@@ -129,6 +147,32 @@ func TestRegenerateKeyFlashesWithoutManifestEntry(t *testing.T) {
 	}
 	if updated.flash == "" {
 		t.Fatal("expected a flash notice without a manifest entry")
+	}
+}
+
+func TestRegenerateKeyDoesNotUseCompanyPrefixMatch(t *testing.T) {
+	root := t.TempDir()
+	pdfPath := "output/cv-jane-doe-metabase-2026-06-05.pdf"
+	htmlPath := "output/cv-jane-doe-metabase-2026-06-05.html"
+	writePDFFixture(t, root, pdfPath)
+	writePDFFixture(t, root, htmlPath)
+	writePDFFixture(t, root, "data/pdf-index.tsv")
+	manifest := "\t" + pdfPath + "\t" + htmlPath + "\tletter\t2026-06-05\n"
+	if err := os.WriteFile(filepath.Join(root, "data", "pdf-index.tsv"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	apps := []model.CareerApplication{
+		{Company: "Meta", Role: "Engineer", Status: "Evaluated", Score: 4.0},
+	}
+
+	pm := newPDFTestModel(t, root, apps)
+	updated, cmd := pm.Update(keyMsg("D"))
+
+	if cmd != nil {
+		t.Fatalf("expected no regeneration command for Metabase's artifacts, got %#v", cmd())
+	}
+	if updated.flash == "" {
+		t.Fatal("expected a no-source flash for the Meta application")
 	}
 }
 


### PR DESCRIPTION
Closes #3481.

## What changed

- require the company slug to occupy a complete hyphen-delimited filename segment
- preserve legacy role-variant and multiword-company fallback matches
- add resolver coverage for the `Meta` / `Metabase` prefix collision
- add dashboard regressions for both `d` (open PDF) and `D` (regenerate from manifest source)

## Why

The pre-manifest fallback used raw substring matching for company slugs of three or more characters. That made a selected `Meta` application resolve `Metabase` artifacts, so `d` could open the wrong CV and `D` could regenerate from the wrong HTML when a manifest entry was unkeyed.

Generated CV names already delimit company slugs with hyphens. Matching `-<slug>-` keeps intended files such as `-anthropic-staff-ui-...` and multiword slugs while preventing one company from matching a longer company name.

## Verification

- `cd dashboard && go test ./... -count=1` — all packages passed
- focused resolver, `d`, and `D` regressions — passed
- `gofmt` — clean
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CV PDF matching to prevent company-name prefixes from being treated as valid matches.
  * Prevented incorrect PDFs from opening when company names are similar, such as “Meta” and “Metabase.”
  * Prevented regeneration attempts when no exact matching source document is available.
  * Added clearer feedback when a matching PDF or source document cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->