### PR TITLE
fix(tracker): reject malformed application IDs

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -705,7 +705,7 @@ node tracker.mjs export --out repaired.md # write to a file (existing file backe
 
 `query` and `history` auto-resync when the markdown changed since the last sync, so the index can never serve stale reads.
 
-`sync` detects and reports the corruption classes markdown accumulates — mojibake placeholder cells, scores stranded in the status column, non-canonical statuses (resolved via `templates/states.yml` aliases), missing/duplicate ids, stray pipes — and normalizes them **in the index only**; the markdown is never modified. Fix at the source with `normalize-statuses.mjs` / `dedup-tracker.mjs`, then re-sync. Status changes between syncs accumulate in a `status_events` table, which gives `analyze-patterns.mjs` a real funnel instead of only the current snapshot.
+`sync` detects and reports the corruption classes markdown accumulates — mojibake placeholder cells, scores stranded in the status column, non-canonical statuses (resolved via `templates/states.yml` aliases), missing/malformed/duplicate ids, stray pipes — and normalizes them **in the index only**; the markdown is never modified. Fix at the source with `normalize-statuses.mjs` / `dedup-tracker.mjs`, then re-sync. Status changes between syncs accumulate in a `status_events` table, which gives `analyze-patterns.mjs` a real funnel instead of only the current snapshot.
 
 `export` is the inverse of `sync` (round-trip `md → db → md` is lossless for clean input — enforced by `test-all.mjs`). It writes to stdout by default and never touches `applications.md` unless you explicitly pass it as `--out`. Phase 2 of #918 (DB becomes source of truth, markdown becomes a rendered view) is a separate, explicit per-user opt-in — not part of this script yet.
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12510,6 +12510,29 @@ if (!sqliteAvailable) {
         fail('sync modified the corrupted markdown (must only diagnose)');
       }
 
+      // A numeric prefix is not a valid application number. parseInt() used to
+      // accept `9junk` as 9, so --check reported the source as clean and the
+      // index could attach this row (and its status history) to the wrong ID.
+      const malformedId = clean +
+        '| 9junk | 2026-01-06 | Prefix Co | PM | 3.5/5 | Applied | ❌ | — | malformed id |\n';
+      writeFileSync(md, malformedId);
+      if (trackerRun(['sync', '--check']) === null) {
+        pass('sync --check rejects an application ID with a numeric prefix');
+      } else {
+        fail('sync --check accepted a numeric-prefix application ID');
+      }
+      const repairedId = JSON.parse(trackerRun(['query', '--company', 'Prefix Co', '--json']) || '[]');
+      if (repairedId.length === 1 && repairedId[0].id === 3) {
+        pass('malformed application ID is reassigned instead of coerced to its numeric prefix');
+      } else {
+        fail(`malformed application ID was not safely reassigned: ${JSON.stringify(repairedId)}`);
+      }
+      if (trackerRun(['query', '--id', '1junk', '--json']) === null && trackerRun(['history', '--id', '1junk']) === null) {
+        pass('query/history reject numeric-prefix --id values');
+      } else {
+        fail('query/history accepted a numeric-prefix --id value');
+      }
+
       // 3. Staleness: query after an md edit must auto-resync (no stale reads).
       writeFileSync(md, clean +
         '| 3 | 2026-01-07 | Delta | Analyst | 4.5/5 | Applied | ✅ | [3](../reports/003-delta-2026-01-07.md) | new |\n');

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -158,6 +158,13 @@ function normalizeStatus(raw, states) {
 const SCORE_RE = /^\*{0,2}(\d+(?:\.\d+)?\/5)\*{0,2}$/;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+function parseApplicationId(raw) {
+  const text = String(raw ?? '').trim();
+  if (!/^\d+$/.test(text)) return null;
+  const id = Number(text);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
 // Mojibake left by a UTF-8 → GBK → UTF-8 round trip: an em-dash cell becomes
 // "鈥?" / "鈥�" variants. Only short placeholder cells are repaired — free-text
 // notes are preserved as-is rather than risk corrupting real content.
@@ -262,8 +269,8 @@ function parseTracker(states) {
       status = canonical;
     }
 
-    let id = parseInt(idRaw, 10);
-    if (!Number.isInteger(id) || id <= 0 || usedIds.has(id)) {
+    let id = parseApplicationId(idRaw);
+    if (id === null || usedIds.has(id)) {
       id = 0; // assign after the pass, once maxId is known
       diag.badId++;
     } else {
@@ -296,7 +303,7 @@ function reportDiagnostics(diag) {
   if (diag.mojibake) console.error(`  ${diag.mojibake} mojibake placeholder cell(s)`);
   if (diag.scoreInStatus) console.error(`  ${diag.scoreInStatus} score(s) sitting in the status column`);
   if (diag.unknownStatus) console.error(`  ${diag.unknownStatus} non-canonical status(es), indexed as Evaluated (original kept in notes)`);
-  if (diag.badId) console.error(`  ${diag.badId} missing/duplicate id(s), reassigned in the index`);
+  if (diag.badId) console.error(`  ${diag.badId} missing/malformed/duplicate id(s), reassigned in the index`);
   if (diag.badDate) console.error(`  ${diag.badDate} malformed date(s), kept as-is`);
   if (diag.strayPipes) console.error(`  ${diag.strayPipes} row(s) with stray pipes, folded into notes`);
   console.error('Fix at the source with `node normalize-statuses.mjs` / `node dedup-tracker.mjs`, then re-sync.');
@@ -408,8 +415,12 @@ async function query(args) {
     if (!DATE_RE.test(since)) { console.error('Error: --since must be YYYY-MM-DD'); process.exit(1); }
     where.push('date >= ?'); params.push(since);
   }
-  const id = flagValue(args, '--id');
-  if (id) { where.push('id = ?'); params.push(parseInt(id, 10)); }
+  const idRaw = flagValue(args, '--id');
+  if (args.some(arg => arg === '--id' || arg.startsWith('--id='))) {
+    const id = parseApplicationId(idRaw);
+    if (id === null) { console.error('Error: --id must be a positive integer'); process.exit(1); }
+    where.push('id = ?'); params.push(id);
+  }
 
   let sql = 'SELECT id, date, company, role, score, status, pdf, report, notes FROM applications'
     + (where.length ? ' WHERE ' + where.join(' AND ') : '') + ' ORDER BY id DESC';
@@ -431,8 +442,8 @@ async function history(args) {
   const DatabaseSync = await loadSqlite();
   const db = openDb(DatabaseSync);
   ensureFresh(db, loadStates());
-  const id = parseInt(flagValue(args, '--id') || '', 10);
-  if (!Number.isInteger(id)) { console.error('Error: history requires --id N'); process.exit(1); }
+  const id = parseApplicationId(flagValue(args, '--id'));
+  if (id === null) { console.error('Error: history requires --id N (a positive integer)'); process.exit(1); }
   const app = db.prepare('SELECT * FROM applications WHERE id = ?').get(id);
   if (!app) { console.error(`Error: no application with id ${id}`); process.exit(1); }
   console.log(`#${app.id} ${app.company} — ${app.role}`);


### PR DESCRIPTION
Closes #3484.

## The bug

Application numbers were parsed with `parseInt(..., 10)`. A source row numbered `1junk` therefore became application `1`, while `sync --check` reported "No corruption detected." The same prefix coercion let `query --id 1junk` and `history --id 1junk` target application 1.

That is especially risky for the derived index because status history is keyed by the coerced ID.

## Fix

- Parse application IDs through one exact whole-value validator.
- Accept only positive, safe decimal integers after trimming.
- Route malformed source IDs through the existing repair/diagnostic path instead of accepting their numeric prefix.
- Reject malformed `query --id` and `history --id` inputs.
- Name malformed IDs in the diagnostic and script documentation.

## Regression coverage

The real tracker CLI fixture now verifies that:

- `sync --check` rejects `9junk`.
- The malformed row is reassigned rather than indexed as 9.
- Both read commands reject `1junk`.
- Existing round-trip, corruption repair, staleness, and history behavior remains intact.

## Verification

- `node --check tracker.mjs`
- `git diff --check`
- `node test-all.mjs --quick` — **7291 passed, 0 failed, 11 existing warnings**
