### PR TITLE
fix(verify-cv-facts): nearest-noun precedence in COUNT_CLAIM_RE

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -82,7 +82,7 @@ const MODIFIER_WINDOW = 4;
 // handled by the modifier window) and "50kg users" (k not at a boundary) both keep
 // their existing behaviour and still normalize to "50".
 const COUNT_CLAIM_RE = new RegExp(
-  String.raw`\b(\d[\d,.]*(?:[kKmMbB]\b)?)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}(${METRIC_NOUNS.join('|')})\b`,
+  String.raw`\b(\d[\d,.]*(?:[kKmMbB]\b)?)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}?(${METRIC_NOUNS.join('|')})\b`,
   'gi'
 );
 const NOUN_SYNONYMS = new Map([
@@ -823,6 +823,29 @@ function runSelfTest() {
     'a unit beginning with a suffix letter is unaffected',
     [...metricClaims('Shipped 50kg servers')],
     ['50 servers']
+  );
+  // Nearest-noun precedence (not farthest): COUNT_CLAIM_RE's modifier-window
+  // quantifier must be lazy. When two METRIC_NOUNS both sit within the
+  // window, a greedy quantifier binds the number to the FARTHEST one it can
+  // still reach — "15+ years scaling teams and platforms" extracted as
+  // "15 teams" instead of "15 years", purely because "teams" also happens
+  // to be in range. Same true "15 years" claim, worded two different ways,
+  // extracting to two different results — exactly the shape that makes a
+  // fabrication gate block a truthful, unedited CV line.
+  equal(
+    'two METRIC_NOUNS in the window: binds to the nearer noun, not the farther one',
+    [...metricClaims('15+ years scaling teams and platforms')],
+    ['15 years']
+  );
+  equal(
+    'nearest-noun precedence holds for a second real-shaped sentence',
+    [...metricClaims('20+ years leading engineering organizations')],
+    ['20 years']
+  );
+  equal(
+    'two genuine claims in one sentence are both still extracted correctly',
+    [...metricClaims('led 12 engineers across 3 teams')],
+    ['12 engineers', '3 teams']
   );
 
   console.log(`verify-cv-facts self-test: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Closes #3414.

## Summary

`COUNT_CLAIM_RE`'s modifier-window quantifier was greedy, so when two `METRIC_NOUNS` both sat within `MODIFIER_WINDOW` of a number, it bound to the **farthest** one it could reach instead of the nearest:

```js
metricClaims('15+ years scaling teams and platforms')   // → ['15 teams']  (wrong)
metricClaims('I have 15+ years of experience.')          // → ['15 years'] (correct)
```

Same true "15 years" claim, worded two different ways, extracting to two different results — the exact shape that makes a fabrication gate block a truthful, unedited CV line instead of the actual fabrication it's meant to catch.

**Fix:** made the quantifier lazy (`{0,${MODIFIER_WINDOW}}` → `{0,${MODIFIER_WINDOW}}?`) — a one-character change. Scoped to just this: `MODIFIER_WINDOW`'s size is #2279's separate, still-open discussion and is untouched here; `GENERIC_COUNT_RE` (the other regex using that constant, for the language-agnostic "was there a count claim this gate couldn't read" check) has no lexicon so the nearest/farthest-noun bug doesn't apply to it and it's untouched too.

Verified against all cases discussed on the issue:
- `15+ years scaling teams and platforms` → `15 years`
- `I have 15+ years of experience.` → `15 years`
- `20+ years leading engineering organizations` → `20 years`
- `led 12 engineers across 3 teams` → `['12 engineers', '3 teams']` (both genuine claims still extracted)

## Test plan

- [x] `node verify-cv-facts.mjs --self-test` (66/66 passing, was 63/63 — 3 new assertions pin nearest-noun precedence)
- [x] `node test-all.mjs` (full suite passing on top of `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CV fact verification when multiple metric nouns appear close together.
  * Numbers now associate with the nearest relevant metric, reducing incorrect claim interpretations.

* **Tests**
  * Added validation for nearest-metric matching in ambiguous statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->