### PR TITLE
test: relax dashboard lock wait on Windows runners

### DIFF
--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -79,7 +79,7 @@ func TestUpdateApplicationStatusWaitsForSharedLock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("update after lock release: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("dashboard update did not resume after lock release")
 	}
 


### PR DESCRIPTION
## Summary
- Raises the dashboard shared-lock test post-release wait from 2s to 10s.
- Targets the Windows CI flake seen on PR #3463 where TestUpdateApplicationStatusWaitsForSharedLock timed out at 2.16s after lock release.
- Keeps the lock-bypass assertion intact; this only gives slow Windows runners enough time to observe the released lock.

## Test Plan
- git diff --check
- npm run lint
- cd dashboard && go test ./internal/data
- cd dashboard && go test ./...

Related: #3463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the wait time allowed for a dashboard update test to complete after a shared lock is released, reducing potential failures caused by timing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->