### PR TITLE
fix(scan-ats-full): send the progress counter to stderr under --json

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -640,7 +640,12 @@ async function main() {
   // In --json mode, stdout is reserved for the single machine-readable result,
   // so every human-facing line goes to stderr instead.
   const log = opts.json ? (...a) => console.error(...a) : (...a) => console.log(...a);
-  const progress = (s) => { if (!opts.json) process.stdout.write(s); };
+  // Same rule as `log` above: under --json the counter goes to stderr rather
+  // than being dropped. Suppressing it left a sweep with no progress signal on
+  // either stream, and `--dry-run --json` has no checkpoint to fall back on
+  // (dry runs write no state), so a long run was indistinguishable from a hung
+  // one.
+  const progress = (s) => { if (opts.json) process.stderr.write(s); else process.stdout.write(s); };
 
   if (!existsSync(PORTALS_PATH)) {
     console.error('Error: portals.yml not found. Run onboarding first — the reverse scan reuses its title_filter/location_filter.');


### PR DESCRIPTION
The block that builds the two output helpers states the rule in its own comment: "In --json mode, stdout is reserved for the single machine-readable result, so every human-facing line goes to stderr instead." `log` follows it; `progress` did not — it wrote to stdout and was therefore suppressed entirely whenever `--json` was set.

So a `--json` sweep reports no progress on either stream. Combined with `--dry-run`, which writes no checkpoint, a long run has no external progress signal at all and cannot be told apart from a hung one.

This routes it to stderr like `log`, leaving stdout as the single JSON payload. Non-json runs are byte-for-byte unchanged.

## What does this PR do?

Routes `scan-ats-full`'s progress counter to stderr under `--json`, matching the rule the surrounding comment already states for `log`.

## Related issue

None — bug fix, sent straight in per CONTRIBUTING.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass — see the note below
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156) — not claimed either way; I have not read the roadmap discussion

### Note on the test run

`node test-all.mjs --quick` on this branch: **7275 passed, 1 failed**. The failure is `tests/skill-project-root.test.mjs` ("missing cwd-independent routing rule" for all seven `*/skills/career-ops/SKILL.md`), and it is not from this change — I checked out the parent commit (current `main`, `8af93cd`) and it fails there identically. It may be Windows-specific; the paths in the failure message are backslash-separated. Flagging it in case it is news rather than known.

The suites that actually cover this change pass: `scan-json-stdout` (including "stdout of a --json run parses as a single JSON object"), `scan-ats-full-resume`, `scan-ats-full-outage-checkpoint`, `scan-ats-full-title-filter-full`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Progress updates are now visible during JSON-mode scans, including long-running and dry-run scans.
  * Machine-readable scan results remain available on standard output for reliable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->