### PR TITLE
fix(calibrate): resolve the tracker colmap from the line array, not the header line

### DIFF
--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -212,10 +212,18 @@ export function computeCalibration(rows, journals, opts = {}) {
 
 // --- Filesystem assembly --------------------------------------------------
 
-function loadTrackerRows(appsFile) {
+export function loadTrackerRows(appsFile) {
   const lines = readFileSync(appsFile, 'utf-8').split(/\r?\n/);
-  const headerLine = lines.find((l) => isHeaderRow(l));
-  const colmap = headerLine ? resolveColumns(headerLine) : undefined;
+  // resolveColumns() takes the LINE ARRAY and locates the header itself.
+  // Passing it a single header string made detectColumns() iterate that
+  // string character by character, find no header, and fall back to
+  // LEGACY_COLMAP — the 9-column order with no Via column. On a tracker that
+  // HAS Via (#1596), where the column sits between Company and Role, every
+  // field from `role` onward then reads one column to the left: `status`
+  // reads the score cell ("4.5/5"), no status matches, and every row silently
+  // drops out of the population. The report renders 0 resolved / 0 in-flight
+  // and a false "insufficient data" verdict on a tracker full of outcomes.
+  const colmap = resolveColumns(lines);
   const rows = [];
   for (const line of lines) {
     if (!line.trim().startsWith('|') || isHeaderRow(line) || isSeparatorRow(line)) continue;

--- a/tests/calibrate-tracker-colmap.test.mjs
+++ b/tests/calibrate-tracker-colmap.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * calibrate-tracker-colmap.test.mjs — regression suite for calibrate.mjs's
+ * tracker loader.
+ *
+ * calibrate.mjs's `--self-test` covers computeCalibration() against in-memory
+ * rows, so it never exercises the step that turns applications.md into those
+ * rows. That gap hid a column-map bug: loadTrackerRows() called
+ * `resolveColumns(headerLine)` with a single string, but resolveColumns()
+ * takes the LINE ARRAY and finds the header itself. detectColumns() iterated
+ * the string character by character, matched no header, and fell back to
+ * LEGACY_COLMAP — the 9-column order with no Via column.
+ *
+ * On a tracker carrying the optional Via column (#1596), which sits between
+ * Company and Role, every field from `role` onward then reads one column to
+ * the left: `status` reads the score cell ("4.5/5"), no canonical status
+ * matches, and every row drops out of the population. The failure is silent —
+ * the report renders "0 resolved / 0 in-flight" and an "insufficient data"
+ * verdict rather than an error, so a user reads it as "not enough history yet"
+ * on a tracker full of recorded outcomes.
+ *
+ * Every other resolveColumns() caller in the repo passes `lines`.
+ *
+ * Run: node tests/calibrate-tracker-colmap.test.mjs
+ */
+
+import { loadTrackerRows } from '../calibrate.mjs';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail } from './helpers.mjs';
+
+console.log('\ncalibrate.mjs — tracker column mapping');
+
+function ok(label, cond) {
+  if (cond) pass(label);
+  else fail(label);
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'calibrate-colmap-'));
+
+// A tracker WITH the Via column, in its documented position: between Company
+// and Role (see AGENTS.md, "Optional Via field").
+const withVia = `# Applications Tracker
+
+| # | Date | Company | Via | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|-----|------|-------|--------|-----|--------|-------|
+| 1 | 2026-01-02 | Acme | Hays | Backend Dev | 4.5/5 | Applied | ✅ | [1](reports/1.md) | note |
+| 2 | 2026-01-03 | Globex | — | Eng Lead | 2.2/5 | Rejected | ❌ | [2](reports/2.md) | note |
+`;
+const viaFile = join(dir, 'applications-via.md');
+writeFileSync(viaFile, withVia, 'utf-8');
+const viaRows = loadTrackerRows(viaFile);
+
+ok('Via tracker: both rows load', viaRows.length === 2);
+ok('Via tracker: status reads the Status column, not the score cell',
+  viaRows[0].status === 'Applied' && viaRows[1].status === 'Rejected');
+ok('Via tracker: score reads the Score column',
+  viaRows[0].score === 4.5 && viaRows[1].score === 2.2);
+ok('Via tracker: company is not shifted into Via',
+  viaRows[0].company === 'Acme' && viaRows[1].company === 'Globex');
+
+// The legacy 9-column tracker (no Via) must keep loading identically.
+const legacy = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-01-02 | Acme | Backend Dev | 4.5/5 | Applied | ✅ | [1](reports/1.md) | note |
+`;
+const legacyFile = join(dir, 'applications-legacy.md');
+writeFileSync(legacyFile, legacy, 'utf-8');
+const legacyRows = loadTrackerRows(legacyFile);
+
+ok('legacy tracker: row loads', legacyRows.length === 1);
+ok('legacy tracker: status still correct', legacyRows[0].status === 'Applied');
+ok('legacy tracker: score still correct', legacyRows[0].score === 4.5);
+ok('legacy tracker: company still correct', legacyRows[0].company === 'Acme');


### PR DESCRIPTION
Fixes #3495.

## The bug

`loadTrackerRows()` in `calibrate.mjs` built its column map from a single header string:

```js
const headerLine = lines.find((l) => isHeaderRow(l));
const colmap = headerLine ? resolveColumns(headerLine) : undefined;
```

`resolveColumns()` takes the **line array** — it locates the header itself. Given a string, `detectColumns()` iterates it character by character, matches no header, and falls back to `LEGACY_COLMAP`, the 9-column order with no `Via` column.

`Via` sits between `Company` and `Role`, so on a tracker carrying it (#1596) every field from `role` onward reads one column to the left: `status` lands on the score cell (`"4.5/5"`), no canonical status matches, and the row is dropped from the population.

Result on a real tracker with 19 tracked applications:

```
Resolved outcomes: 0 · in flight (not counted): 0 · unscored: 0
Verdict: Not enough resolved outcomes to compare score bands yet (0 resolved, floor 5 per band).
```

After the fix, same tracker: `10 resolved · 9 in flight`.

The failure mode is what makes it worth fixing rather than documenting: it does not error. It reports "not enough history yet", which is indistinguishable from the normal state of a young search — so the user has no signal that the tool read nothing.

## The fix

One line: pass `lines`, as all 25 other `resolveColumns()` callers in the repo do (`stats.mjs`, `set-status.mjs`, `analyze-patterns.mjs`, `outcome.mjs`, `funnel-velocity.mjs`, `tracker.mjs`, …). `calibrate.mjs` was the only caller passing a string.

## Test coverage

`calibrate.mjs --self-test` exercises `computeCalibration()` against in-memory rows, so nothing covered the step that turns `applications.md` into those rows — which is why this survived.

`tests/calibrate-tracker-colmap.test.mjs` covers both tracker shapes: with `Via` (status, score and company each read from their own column) and the legacy 9-column layout (unchanged). `loadTrackerRows` is exported so the external suite can reach it, following the `company-history.mjs` precedent. The suite is auto-discovered, uses `pass`/`fail` from `tests/helpers.mjs`, and calls neither `process.exit()` nor `finish()`.

Verified: **fails before the fix** (the two column-position assertions go red), **passes after**.

## Suite

`node test-all.mjs --quick` → `7297 passed, 0 failed, 11 warnings` (baseline on `main`: `7288 passed, 0 failed, 11 warnings`).

One note in case it is useful: on the first run the LaTeX assertion `localized section titles validate` went red with `null`, and passed on re-run. `latexValidate()` returns `null` whenever the `generate-latex.mjs` child exceeds its 30 s timeout, so under load the assertion reports as a validation failure rather than as a timeout. Unrelated to this change, and I have not touched it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tracker calibration so records with an optional Via column are read correctly.
  * Prevented valid tracker rows from being silently excluded from calibration.

* **Tests**
  * Added regression coverage for trackers both with and without the Via column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->