### PR TITLE
fix(web): identify the verdict block by its heading, not by the letter F (#3416)

### DIFF
--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -148,8 +148,8 @@ export function ReportView({
             //
             // Identified by the heading, never by the letter: reading "whatever is
             // lettered F" as the verdict rendered the Interview Plan table into a
-            // callout built for one sentence, in every mode and every language
-            // (#3416). No mode writes a Verdict block today, so today there is
+            // callout built for one sentence — in the canonical mode and in all
+            // eight localized `oferta.md` files alike (#3416). No mode writes a Verdict block today, so today there is
             // simply no callout and every block renders below.
             const verdict = sections.find((s) => isVerdictHeading(s.heading));
             const rest = sections.filter((s) => s !== verdict);

--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 import type { Application } from "@/lib/career-ops";
 import { Badge } from "@/components/ui/badge";
 import { scoreTone, scoreNum, legitimacyTone, parseReport } from "@/lib/format";
-import { cleanHeading, splitSections } from "@/lib/report-sections.mjs";
+import { cleanHeading, isVerdictHeading, splitSections } from "@/lib/report-sections.mjs";
 import { StatusSelect } from "@/components/status-select";
 import { CompanyLogo } from "@/components/company-logo";
 import { ScoreMethodology } from "@/components/score-methodology";
@@ -15,7 +15,7 @@ import { DeleteFromTracker } from "@/components/delete-from-tracker";
 import { companyPresentation } from "@/lib/company-presentation.mjs";
 
 // Progressive disclosure of the report. The core writes prose blocks
-// "## F) Verdict (lead)", "## A) Role Summary", "## B) Match with CV", then
+// "## A) Role Summary", "## B) Match with CV", then
 // the remaining lettered blocks + machine artifacts (Machine Summary YAML,
 // Application Answers, submit log). A mainstream user deciding "should I
 // apply?" needs the verdict + fit; the rest is depth-on-demand. We lead with
@@ -140,11 +140,18 @@ export function ReportView({
                 </article>
               );
             }
-            // Verdict (F) leads as a highlighted callout with no competing heading —
-            // it's THE answer. A/B stay expanded (fit detail); C–G collapse as
-            // content (with a 1-line preview); machine artifacts drop to a dimmer
-            // "Technical" tier so the CLI-DNA is present-but-clearly-secondary.
-            const verdict = sections.find((s) => s.letter === "F");
+            // A verdict block leads as a highlighted callout with no competing
+            // heading — it's THE answer. A/B stay expanded (fit detail); the rest
+            // collapse as content (with a 1-line preview); machine artifacts drop
+            // to a dimmer "Technical" tier so the CLI-DNA is present-but-clearly-
+            // secondary.
+            //
+            // Identified by the heading, never by the letter: reading "whatever is
+            // lettered F" as the verdict rendered the Interview Plan table into a
+            // callout built for one sentence, in every mode and every language
+            // (#3416). No mode writes a Verdict block today, so today there is
+            // simply no callout and every block renders below.
+            const verdict = sections.find((s) => isVerdictHeading(s.heading));
             const rest = sections.filter((s) => s !== verdict);
             const machine = rest.filter((s) => isMachine(s.heading));
             const mainSections = rest.filter((s) => !isMachine(s.heading));

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -82,8 +82,9 @@ export function authorLetter(heading) {
  * lettered F" as the verdict, but no mode has ever written a Verdict block:
  * the callout landed in #1535 when `modes/oferta.md` already read
  * `## F) Interview Plan`, so every report has rendered the Interview Plan
- * table into a callout built for one sentence (#3416). All 19 localized modes
- * write Interview Plan at F too, so this was never an English-only slip.
+ * table into a callout built for one sentence (#3416). All eight localized
+ * `oferta.md` files write Interview Plan at F too, so this was never an
+ * English-only slip.
  *
  * The marker is what the core actually promises: `cleanHeading` has always
  * stripped a trailing `(lead)` / `(verdict)`, which is a deliberate authoring

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -75,6 +75,33 @@ export function authorLetter(heading) {
 }
 
 /**
+ * Whether a heading marks the block the viewer should lead with as a Verdict
+ * callout.
+ *
+ * The letter is NOT the signal. `report-view.tsx` used to read "whatever is
+ * lettered F" as the verdict, but no mode has ever written a Verdict block:
+ * the callout landed in #1535 when `modes/oferta.md` already read
+ * `## F) Interview Plan`, so every report has rendered the Interview Plan
+ * table into a callout built for one sentence (#3416). All 19 localized modes
+ * write Interview Plan at F too, so this was never an English-only slip.
+ *
+ * The marker is what the core actually promises: `cleanHeading` has always
+ * stripped a trailing `(lead)` / `(verdict)`, which is a deliberate authoring
+ * signal and is language-independent — a Spanish `## F) Veredicto (lead)`
+ * reads the same as an English one. The bare English word is accepted as well
+ * so a block titled plainly `## Verdict` is not missed.
+ *
+ * When nothing matches, there is no callout and every block renders through
+ * the normal progressive disclosure — which is the correct outcome today.
+ * @param {string} heading
+ * @returns {boolean}
+ */
+export function isVerdictHeading(heading) {
+  if (/\((?:lead|verdict)\)\s*$/i.test(heading.trim())) return true;
+  return /^verdict$/i.test(cleanHeading(heading));
+}
+
+/**
  * Split a report body on `## ` headings. Everything before the first one is
  * the intro.
  * @param {string} body

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -139,8 +139,8 @@ test("the Interview Plan at F is not a verdict", () => {
 });
 
 test("no localized mode heading is mistaken for a verdict", () => {
-  // All 19 localized modes write Interview Plan at F, so this was never an
-  // English-only slip. A letter-based rule is wrong in every language at once.
+  // All eight localized `oferta.md` files write Interview Plan at F, so this was
+  // never an English-only slip. A letter-based rule is wrong in every language at once.
   for (const heading of [
     "F) Plan rozmów kwalifikacyjnych",
     "F) План співбесід",

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -6,7 +6,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { cleanHeading, authorLetter, splitSections } from "../../src/lib/report-sections.mjs";
+import { cleanHeading, authorLetter, isVerdictHeading, splitSections } from "../../src/lib/report-sections.mjs";
 
 test("strips the author letter from the blocks the core has always written", () => {
   assert.equal(cleanHeading("A) Role Summary"), "Role Summary");
@@ -126,4 +126,43 @@ test("the ASCII double-hyphen Block form is stripped whole", () => {
   // A heading whose text legitimately starts with a hyphen keeps it: only the
   // separator run is consumed, and it must be attached to the letter.
   assert.equal(cleanHeading("Block A) -- keep this"), "-- keep this");
+});
+
+test("the Interview Plan at F is not a verdict", () => {
+  // report-view.tsx read "whatever is lettered F" as the verdict and promoted it
+  // into a callout built for a single sentence. F has been the Interview Plan
+  // since before that callout existed (#1535 landed against a modes/oferta.md
+  // that already read "## F) Interview Plan"), so every report rendered a table
+  // into it (#3416).
+  assert.equal(isVerdictHeading("F) Interview Plan"), false);
+  assert.equal(isVerdictHeading("Block F -- Interview Plan"), false);
+});
+
+test("no localized mode heading is mistaken for a verdict", () => {
+  // All 19 localized modes write Interview Plan at F, so this was never an
+  // English-only slip. A letter-based rule is wrong in every language at once.
+  for (const heading of [
+    "F) Plan rozmów kwalifikacyjnych",
+    "F) План співбесід",
+    "F) 面試準備計畫",
+    "F) 면접 준비 계획",
+    "F) Vorstellungsgesprächs-Plan",
+    "F) Plan d'entretiens",
+  ]) {
+    assert.equal(isVerdictHeading(heading), false, heading);
+  }
+});
+
+test("the authoring marker names the verdict, in any language", () => {
+  // cleanHeading has always stripped a trailing "(lead)" / "(verdict)": that
+  // marker is the core's deliberate signal, and it does not depend on the
+  // letter or on English.
+  assert.equal(isVerdictHeading("F) Verdict (lead)"), true);
+  assert.equal(isVerdictHeading("C) Veredicto (lead)"), true);
+  assert.equal(isVerdictHeading("A) 判定 (verdict)"), true);
+  // A plainly titled block is caught too, with the letter stripped first.
+  assert.equal(isVerdictHeading("Verdict"), true);
+  assert.equal(isVerdictHeading("B) Verdict"), true);
+  // ...but a heading that merely mentions the word is not the verdict block.
+  assert.equal(isVerdictHeading("D) Verdict rationale and caveats"), false);
 });


### PR DESCRIPTION
## What does this PR do?

Stops the report viewer from treating "whatever block is lettered F" as the Verdict. The callout is now selected by the heading itself, so the Interview Plan table is no longer rendered into a box built for one sentence.

## Related issue

Fixes #3416

## Two things worth adding to the issue's account

**The callout has been wrong since the day it landed, not since a later schema change.** #3416 describes the current schema as having no Verdict block. It is stronger than that: `30fa1d1` (#1535), the commit that introduced the callout, changed only `web/src/components/report-view.tsx`, and `git show 30fa1d1:modes/oferta.md` already read `## F) Interview Plan`. There was never a Verdict block for it to find.

**It was never English-only.** All 19 localized modes that write lettered blocks put Interview Plan at F — `## F) Plan rozmów kwalifikacyjnych`, `## F) План співбесід`, `## F) 面試準備計畫`, `## F) 면접 준비 계획`, and so on. A letter-based rule is wrong in every language simultaneously, which is what makes the letter the wrong key rather than the mapping being out of date.

## How it is identified now

Not by the word, and not by the letter — by the authoring marker `cleanHeading` has always stripped: a trailing `(lead)` / `(verdict)`. That is the signal the core actually promises, and it is language-independent, so a Spanish `## F) Veredicto (lead)` reads the same as an English one. A block plainly titled `Verdict` is accepted too, with its letter stripped first, while a heading that merely mentions the word (`D) Verdict rationale and caveats`) is not.

Since no mode writes a verdict block today, the practical result is that there is no callout and every block renders through the normal progressive disclosure — which is the correct rendering for the current schema. If the core ever adds one, at any letter and in any language, it is picked up without another change here.

The predicate lives in `report-sections.mjs` rather than in the component, for the reason that file already gives for splitting and heading cleanup: a rule duplicated in the viewer is what let `H) Draft Application Answers` drift in #2324.

## Verification

Red/green against the rule itself, not just a green run: reverting `isVerdictHeading` to the old `authorLetter(heading) === "F"` turns the three new tests red (13 pass / 3 fail); restoring it gives 16 pass / 0 fail.

- `node --test tests/lib/report-sections.test.mjs` — 16 passed
- `npm run typecheck` (web) — clean
- `node test-all.mjs` — **7289 passed, 0 failed**, 11 warnings (all pre-existing maintainer-name matches in `funding.json` / `HIRED.md` / `stats.go`, none from this diff)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (bug fix — exempt)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no user-layer files touched)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verdict callout detection using section headings rather than fixed section letters.
  * Recognizes verdict headings across localized content and supported marker formats.
  * Prevents interview plan and rationale sections from being incorrectly highlighted as verdicts.
  * Reports without a verdict now display all sections below the detected content.

* **Tests**
  * Added coverage for localized headings, marker-based verdict titles, plain verdict titles, and false-positive cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->