### PR TITLE
fix(data-root): resolve templates/states.yml from the codebase, not the data root (#3500)

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -22,6 +22,9 @@ import { localToday } from './lib/local-today.mjs';
 import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
+// templates/states.yml is System Layer — resolved from the codebase, not from
+// the user's data root (#3500).
+const CODEBASE_ROOT = dirname(fileURLToPath(import.meta.url));
 const CAREER_OPS = getCareerOpsRoot();
 const APPS_FILE = resolveTrackerPath(CAREER_OPS);
 
@@ -120,16 +123,19 @@ function statusAliasMap() {
   if (aliasMapCache) return aliasMapCache;
   const map = new Map();
   try {
-    for (const st of loadCanonicalStates(join(CAREER_OPS, 'templates', 'states.yml'))) {
+    for (const st of loadCanonicalStates(join(CODEBASE_ROOT, 'templates', 'states.yml'))) {
       const id = st.id.toLowerCase();
       map.set(foldStatusInput(id), id);
       if (st.label) map.set(foldStatusInput(st.label), id);
       for (const a of st.aliases) map.set(foldStatusInput(a), id);
     }
-  } catch {
+  } catch (err) {
     // A missing/malformed states.yml is a broken install. Degrade to
     // identity-normalization rather than resurrecting a hardcoded table: a
     // fallback copy is the same copy in disguise and drifts the same way.
+    // Report it, though — degrading silently is what hid #3500, and here it
+    // costs every localized status its place in the funnel.
+    console.error(`[followup-cadence] cannot read canonical states from templates/states.yml: ${err.message}`);
     return (aliasMapCache = new Map());
   }
   return (aliasMapCache = map);

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -22,6 +22,12 @@ import {
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
+// System Layer files (templates/, modes/, scripts) live in the codebase and are
+// resolved from this module's own directory; only User Layer data follows the
+// configurable data root. Binding both to getCareerOpsRoot() made states.yml
+// unreadable under CAREER_OPS_ROOT / .career-ops-data, and the catch below
+// turned that into a silent "everything is unknown" (#3500).
+const CODEBASE_ROOT = dirname(fileURLToPath(import.meta.url));
 const CAREER_OPS = getCareerOpsRoot();
 const APPS_FILE = resolveTrackerPath(CAREER_OPS);
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -34,10 +40,17 @@ let statesCache = null;
 /** Canonical states from templates/states.yml, read once per CLI run. */
 function canonicalStates() {
   if (statesCache) return statesCache;
+  const statesFile = join(CODEBASE_ROOT, 'templates', 'states.yml');
   try {
-    statesCache = loadCanonicalStates(join(CAREER_OPS, 'templates', 'states.yml'));
-  } catch {
-    statesCache = []; // broken install: fall through to "unknown", never a stale copy
+    statesCache = loadCanonicalStates(statesFile);
+  } catch (err) {
+    // Broken install: fall through to "unknown", never a stale copy — but say
+    // so. The silent [] is what made #3500 invisible: a states.yml looked up in
+    // the wrong tree is indistinguishable from one that is genuinely missing,
+    // and the whole tracker normalized to unknown without a word.
+    console.error(`[normalize-statuses] cannot read canonical states from ${statesFile}: ${err.message}`);
+    console.error('[normalize-statuses] every status will be reported as unknown until this is fixed.');
+    statesCache = [];
   }
   return statesCache;
 }

--- a/tests/system-layer-under-data-root.test.mjs
+++ b/tests/system-layer-under-data-root.test.mjs
@@ -1,0 +1,99 @@
+// tests/system-layer-under-data-root.test.mjs — System Layer files must resolve
+// from the codebase, never from the configurable data root (#3500).
+//
+// DATA_CONTRACT.md: "System Layer files continue to be resolved relative to the
+// codebase/repository root, keeping code and personal data completely separate."
+//
+// normalize-statuses.mjs broke that for templates/states.yml: one variable served
+// both roles, so `join(getCareerOpsRoot(), 'templates', 'states.yml')` looked for a
+// System Layer file inside the user's data directory. A data root that legitimately
+// has no templates/ is indistinguishable from the broken checkout the surrounding
+// `catch` was written for, so every status silently normalized to unknown — the
+// documented tracker repair path rewriting 156 localized spellings to nothing.
+// followup-cadence.mjs carried the identical join.
+//
+// The suite never caught it because it runs with the default root, where data root
+// and codebase root are the same directory. These checks therefore run the modules
+// with a data root configured, and additionally scan for the pattern itself so a
+// new consumer of states.yml cannot reintroduce the leak.
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nSystem Layer resolution under a configured data root (#3500)');
+
+const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-dataroot-'));
+mkdirSync(join(dataRoot, 'data'), { recursive: true });
+
+/** Run a snippet in the repo with a data root configured; return trimmed stdout. */
+function runWithDataRoot(snippet, envVar = 'CAREER_OPS_ROOT') {
+  return execFileSync(NODE, ['-e', snippet], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: { ...process.env, CAREER_OPS_ROOT: '', CAREER_OPS_DATA_DIR: '', [envVar]: dataRoot },
+  }).trim();
+}
+
+try {
+  // 1. normalize-statuses still canonicalizes with a data root set — English,
+  //    Spanish, and a localized alias, i.e. exactly the table in the bug report.
+  for (const envVar of ['CAREER_OPS_ROOT', 'CAREER_OPS_DATA_DIR']) {
+    const out = runWithDataRoot(
+      `import('./normalize-statuses.mjs').then(m => console.log(` +
+      `['Accepted','Contratado','Evaluada','Rechazado'].map(v => v + '=' + (m.normalizeStatus(v).status ?? 'unknown')).join(' ')))`,
+      envVar,
+    );
+    const expected = 'Accepted=Hired Contratado=Hired Evaluada=Evaluated Rechazado=Rejected';
+    out === expected
+      ? pass(`normalize-statuses canonicalizes under ${envVar} (${expected})`)
+      : fail(`normalize-statuses under ${envVar} produced "${out}", expected "${expected}"`);
+  }
+
+  // 2. followup-cadence reads the same System Layer file for its alias map; a
+  //    localized status resolving to '' there drops the row out of the funnel.
+  const cadence = runWithDataRoot(
+    `import('./followup-cadence.mjs').then(m => console.log(` +
+    `['Contratado','Aplicado','Entrevista'].map(v => v + '=' + (m.normalizeStatus(v) || 'unknown')).join(' ')))`,
+  );
+  const cadenceExpected = 'Contratado=hired Aplicado=applied Entrevista=interview';
+  cadence === cadenceExpected
+    ? pass(`followup-cadence resolves states.yml aliases under a data root (${cadenceExpected})`)
+    : fail(`followup-cadence under a data root produced "${cadence}", expected "${cadenceExpected}"`);
+
+  // 3. Source-level guard against the class: a variable bound to getCareerOpsRoot()
+  //    must not be joined onto a System Layer directory. modes/_profile.md,
+  //    _custom.md and _brief.md are the documented exceptions — those specific
+  //    files ARE user data that happens to live under modes/.
+  const USER_FILES_IN_MODES = /^_(profile|custom|brief)\.md$/;
+  const offenders = [];
+  for (const file of readdirSync(ROOT).filter(f => f.endsWith('.mjs'))) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    const dataVars = [...src.matchAll(/const\s+(\w+)\s*=\s*getCareerOpsRoot\(\)/g)].map(m => m[1]);
+    if (!dataVars.length) continue;
+    for (const v of dataVars) {
+      const re = new RegExp(`join\\(\\s*${v}\\s*,\\s*['"\`](templates|modes)\\b([^)]*)\\)`, 'g');
+      for (const m of src.matchAll(re)) {
+        // Everything after the dir name, whether written as one 'modes/_profile.md'
+        // argument or as separate 'modes', '_profile.md' arguments.
+        const rest = m[2].replace(/['"\`,\s]+/g, '').replace(/^\/+/, '');
+        if (m[1] === 'modes' && USER_FILES_IN_MODES.test(rest)) continue;
+        offenders.push(`${file}: join(${v}, '${m[1]}${m[2]})`);
+      }
+    }
+  }
+  offenders.length === 0
+    ? pass('no root-level script joins a System Layer dir onto the data root')
+    : fail(`System Layer path(s) resolved through the data root (#3500): ${offenders.join('; ')}`);
+
+  // 4. A genuinely unreadable states.yml must be loud, not a silent empty list —
+  //    the property that made the original path bug invisible.
+  const src = readFileSync(join(ROOT, 'normalize-statuses.mjs'), 'utf-8');
+  /console\.error\(/.test(src.slice(src.indexOf('function canonicalStates'), src.indexOf('function normalizeStatus')))
+    ? pass('normalize-statuses reports an unreadable states.yml on stderr instead of degrading silently')
+    : fail('normalize-statuses swallows a states.yml load failure with no diagnostic (#3500)');
+} finally {
+  rmSync(dataRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}


### PR DESCRIPTION
## What does this PR do?

`normalize-statuses.mjs` resolved `templates/states.yml` — a System Layer file — through the *data* root, so any install using `CAREER_OPS_ROOT` / `CAREER_OPS_DATA_DIR` / `.career-ops-data` silently normalized every status to unknown. This resolves it from the codebase instead, fixes the same defect in `followup-cadence.mjs`, makes both fallbacks report themselves on stderr, and adds a suite that pins the layer boundary.

## Related issue

Closes #3500

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Detail

**The bug.** One variable served both roles. `resolveTrackerPath(CAREER_OPS)` is right — the tracker *is* user data — but the next lines joined `templates/states.yml` onto the same root, where it does not exist. The surrounding `catch` then turned a path bug into a silent one: its reasoning is sound in isolation (prefer `unknown` over a stale hardcoded copy), but it was written for a missing file in a broken checkout, and a data root that legitimately has no `templates/` is indistinguishable from that.

| | `normalizeStatus('Accepted')` | `('Contratado')` | `('Evaluada')` |
|---|---|---|---|
| no marker | `{status: "Hired"}` | `{status: "Hired"}` | `{status: "Evaluated"}` |
| marker set (before) | `{status: null, unknown: true}` | `{status: null, unknown: true}` | `{status: null, unknown: true}` |
| marker set (after) | `{status: "Hired"}` | `{status: "Hired"}` | `{status: "Evaluated"}` |

This is not cosmetic: `normalize-statuses.mjs` is the documented tracker repair path, so under a data root it rewrote recognized statuses to unknown rather than canonicalizing them. Localized trackers lost the most — all 156 non-English spellings stopped resolving.

**A second site.** `followup-cadence.mjs` carried the identical join, inline in `statusAliasMap()`, where an empty alias map drops every localized row out of the `ACTIONABLE`/`ADVANCED` sets. It escaped the audit in #3500 because it has no hoisted `STATES_FILE` constant to grep for.

`set-status.mjs`, `funnel-velocity.mjs`, `tracker-sync-check.mjs` and `check-table-freshness.mjs` were already correct — they bind their root to `dirname(fileURLToPath(import.meta.url))`.

**Both catches now report to stderr** before degrading. Fallback behavior is unchanged (still an empty list, never a resurrected hardcoded table); what changed is that it says so. Degrading silently is what made this invisible.

## Test

`tests/system-layer-under-data-root.test.mjs` (auto-discovered), five assertions:

1. `normalize-statuses` canonicalizes `Accepted` / `Contratado` / `Evaluada` / `Rechazado` under `CAREER_OPS_ROOT` **and** `CAREER_OPS_DATA_DIR` — the table above, run with a data root configured.
2. `followup-cadence` resolves Spanish aliases to `hired` / `applied` / `interview` under a data root.
3. A source-level guard against the whole class: no root-level `.mjs` may join a `getCareerOpsRoot()`-bound variable onto `templates/` or `modes/`. `modes/_profile.md`, `_custom.md` and `_brief.md` are whitelisted — those specific files *are* user data that happens to live under `modes/`, which is why `gemini-eval.mjs` and `ollama-eval.mjs` legitimately resolve them through the data root.
4. The `catch` in `normalize-statuses` emits a diagnostic rather than a bare `[]`.

Mutation-checked: reverting either join fails both the behavioral assertion and the source guard.

The existing suite could not see any of this, because it runs with the default root — where the data root and the codebase root are the same directory.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (7294 passed, 0 failed, 12 pre-existing warnings)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files) — restoring its System/User Layer split is the point of the change
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Noticed while verifying, not fixed here

Running the full suite creates a stray `applications.db` in the repo root. `tests/tracker-busy-timeout.test.mjs` sets `CAREER_OPS_TRACKER_DB` before importing `tracker.mjs`, but by then an inline section of `test-all.mjs` (`removeRowByNum`, ~line 5035) has already imported that module into the same process, so `DB_PATH` was resolved at first import and the pin is a no-op. `openDb()` then creates the schema at the unpinned path. It passes either way, so nothing flags it. Happy to send that separately if you'd like it filed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected status and follow-up processing to consistently use the application’s built-in configuration.
  * Improved error reporting when status definitions cannot be loaded, making fallback behavior clear.

* **Tests**
  * Added coverage to verify configuration resolution, localized status handling, and diagnostics for unreadable status definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->