### PR TITLE
fix(workday): resolve a CXS-form URL as the endpoint, not a careers page (#3498)

### DIFF
--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -336,7 +336,7 @@ export function parseWorkdayHint(company) {
 
   // 2. URL form — check every field that might carry a Workday link. No
   // substring pre-filter here (CodeQL js/incomplete-url-substring-sanitization):
-  // the anchored regex below is the actual gate and already rejects anything
+  // the anchored regexes below are the actual gate and already reject anything
   // that isn't a well-formed *.myworkdayjobs.com URL.
   const urlCandidates = [company.workday, company.careers_url, company.website]
     .filter((v) => typeof v === 'string');
@@ -347,12 +347,17 @@ export function parseWorkdayHint(company) {
     // `careers_url: https://{tenant}.{instance}.myworkdayjobs.com/wday`, a
     // plausible-looking line for a board that doesn't exist (#3498). Checked
     // first, same as providers/workday.mjs resolveEndpoint().
-    const cxs = raw.match(/https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/wday\/cxs\/[\w-]+\/([^/?#]+)(?:\/jobs)?(?:[/?#]|$)/);
+    // Both patterns are anchored: unanchored, they match a Workday URL embedded
+    // anywhere in the candidate (e.g. `https://evil.example/r?next=https://acme
+    // .wd5.myworkdayjobs.com/Careers`), so a redirect wrapper silently yields
+    // coordinates for whatever tenant it carries. Anchoring is also what the
+    // comment above has always claimed this gate does.
+    const cxs = raw.match(/^https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/wday\/cxs\/[\w-]+\/([^/?#]+)(?:\/jobs)?(?:[/?#]|$)/);
     // The tenant comes from the host, not from the /wday/cxs/{tenant}/ segment:
     // these coordinates rebuild a careers URL host-first (buildWorkdayCandidates),
     // and the host is what has to stay reachable.
     const m = cxs
-      || raw.match(/https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
+      || raw.match(/^https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
     if (!m) continue;
     const [, tenant, instance, site] = m;
     if (clean(tenant) && clean(instance) && clean(site)) {

--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -311,8 +311,10 @@ const WORKDAY_SEGMENT_RE = /^[A-Za-z0-9_-]+$/;
 /**
  * Extract Workday coordinates {tenant, instance?, site} from a company's hints.
  * Accepts, in priority order:
- *   1. A full Workday URL in `workday`, `careers_url`, or `website`:
+ *   1. A full Workday URL in `workday`, `careers_url`, or `website`, either as a
+ *      careers page or as the CXS endpoint it resolves to:
  *      https://<tenant>.<instance>.myworkdayjobs.com[/<locale>]/<site>[/...]
+ *      https://<tenant>.<instance>.myworkdayjobs.com/wday/cxs/<tenant>/<site>[/jobs]
  *   2. An explicit object `workday: { tenant, site, instance? }`.
  * Returns null when no Workday coordinates are present. `instance` may be null
  * (caller then auto-probes WORKDAY_INSTANCES). Every returned segment is
@@ -339,8 +341,18 @@ export function parseWorkdayHint(company) {
   const urlCandidates = [company.workday, company.careers_url, company.website]
     .filter((v) => typeof v === 'string');
   for (const raw of urlCandidates) {
-    // Mirrors the tenant regex in providers/workday.mjs resolveEndpoint().
-    const m = raw.match(/https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
+    // A CXS endpoint carries the site one level deeper, behind /wday/cxs/{tenant}/.
+    // It also matches the careers-page pattern below, which captures the literal
+    // `wday` as the site — here that lands in a generated portals.yml entry as
+    // `careers_url: https://{tenant}.{instance}.myworkdayjobs.com/wday`, a
+    // plausible-looking line for a board that doesn't exist (#3498). Checked
+    // first, same as providers/workday.mjs resolveEndpoint().
+    const cxs = raw.match(/https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/wday\/cxs\/[\w-]+\/([^/?#]+)(?:\/jobs)?(?:[/?#]|$)/);
+    // The tenant comes from the host, not from the /wday/cxs/{tenant}/ segment:
+    // these coordinates rebuild a careers URL host-first (buildWorkdayCandidates),
+    // and the host is what has to stay reachable.
+    const m = cxs
+      || raw.match(/https?:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
     if (!m) continue;
     const [, tenant, instance, site] = m;
     if (clean(tenant) && clean(instance) && clean(site)) {

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -86,25 +86,48 @@ export function pageIsPastWindow(pageJobs, sinceMs) {
   return Math.min(...dated) < sinceMs - EARLY_STOP_MARGIN_MS;
 }
 
+// A careers page: `https://{tenant}.{instance}.myworkdayjobs.com[/{locale}]/{site}`.
+const CAREERS_RE = /^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/;
+// The CXS endpoint itself: `https://{host}.{instance}.myworkdayjobs.com/wday/cxs/{tenant}/{site}[/jobs|/job/...]`.
+// This is the *resolved* form, not a careers page — it already carries the
+// tenant and site in its path. It also passes CAREERS_RE (same host shape),
+// where `([^/?#]+)` captures the literal `wday` as the site and yields a
+// nonexistent `/wday/cxs/{tenant}/wday/jobs` endpoint: a live board silently
+// reports zero jobs and then reads as unreachable (#3498). Matched first so a
+// hand-verified CXS `api:` is honored as written instead of corrupting the entry.
+const CXS_RE = /^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/wday\/cxs\/([\w-]+)\/([^/?#]+)(?:\/jobs)?(?:[/?#]|$)/;
+
+function makeEndpoint(origin, tenant, site) {
+  return {
+    api: `${origin}/wday/cxs/${tenant}/${site}/jobs`,
+    // externalPath is relative to the site, not the host root — without the
+    // site segment the URL 404s.
+    jobBase: `${origin}/${site}`,
+    origin,
+  };
+}
+
 function resolveEndpoint(entry) {
   // Try api: first, then careers_url (mirrors greenhouse/ashby), returning the
   // first that matches the Workday tenant pattern. This lets a branded page
   // (e.g. https://www.ptc.com/en/careers) stay as careers_url while the Workday
   // tenant URL is pinned via api: — and, because we fall through on a non-match,
   // a non-Workday api: value doesn't shadow a valid careers_url.
+  //
+  // Either candidate may be given in either form; whichever matches resolves to
+  // the same endpoint, so adding a correct api: never changes what careers_url
+  // alone would have produced.
   for (const url of [entry.api, entry.careers_url]) {
     if (typeof url !== 'string' || !url) continue;
-    const m = url.match(/^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
+    const cxs = url.match(CXS_RE);
+    if (cxs) {
+      const [, host, instance, tenant, site] = cxs;
+      return makeEndpoint(`https://${host}.${instance}.myworkdayjobs.com`, tenant, site);
+    }
+    const m = url.match(CAREERS_RE);
     if (!m) continue;
     const [, tenant, instance, site] = m;
-    const origin = `https://${tenant}.${instance}.myworkdayjobs.com`;
-    return {
-      api: `${origin}/wday/cxs/${tenant}/${site}/jobs`,
-      // externalPath is relative to the site, not the host root — without the
-      // site segment the URL 404s.
-      jobBase: `${origin}/${site}`,
-      origin,
-    };
+    return makeEndpoint(`https://${tenant}.${instance}.myworkdayjobs.com`, tenant, site);
   }
   return null;
 }

--- a/tests/discover-ats.test.mjs
+++ b/tests/discover-ats.test.mjs
@@ -309,6 +309,20 @@ eq(
   'https://crowdstrike.wd5.myworkdayjobs.com/crowdstrikecareers',
 );
 
+// Both URL patterns are anchored, so a Workday URL embedded in a wrapper (a
+// redirect's next=, a tracking link) is not a hint. Unanchored, such a value
+// silently produces coordinates for whatever tenant it carries.
+eq(
+  'parseWorkdayHint ignores a careers URL embedded in a redirect wrapper',
+  parseWorkdayHint({ name: 'X', website: 'https://evil.example/r?next=https://acme.wd5.myworkdayjobs.com/Careers' }),
+  null,
+);
+eq(
+  'parseWorkdayHint ignores a CXS URL embedded in a redirect wrapper',
+  parseWorkdayHint({ name: 'X', website: 'https://evil.example/r?next=https://acme.wd5.myworkdayjobs.com/wday/cxs/acme/External/jobs' }),
+  null,
+);
+
 eq('parseWorkdayHint returns null without any hint', parseWorkdayHint({ name: 'Adyen', careers_url: 'https://adyen.com' }), null);
 eq('parseWorkdayHint rejects unsafe tenant', parseWorkdayHint({ name: 'X', workday: { tenant: 'a/b', site: 'S' } }), null);
 eq('parseWorkdayHint rejects object missing site', parseWorkdayHint({ name: 'X', workday: { tenant: 'a' } }), null);

--- a/tests/discover-ats.test.mjs
+++ b/tests/discover-ats.test.mjs
@@ -285,6 +285,30 @@ eq('parseWorkdayHint object form keeps underscores in site', wh3?.site, 'Externa
 const wh4 = parseWorkdayHint({ name: 'Nvidia', website: 'https://nvidia.wd5.myworkdayjobs.com/NVIDIAExternalCareerSite' });
 eq('parseWorkdayHint reads from website field', wh4?.tenant, 'nvidia');
 
+// A CXS endpoint pasted as the hint carries the site behind /wday/cxs/{tenant}/.
+// Parsed as a careers page it yields site `wday`, and the generated entry then
+// pins `careers_url: .../wday` — a plausible-looking line for a board that does
+// not exist (#3498). Coordinates must match what the careers-page form gives.
+const whCxs = parseWorkdayHint({ name: 'CrowdStrike', workday: 'https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/crowdstrikecareers/jobs' });
+const whPlain = parseWorkdayHint({ name: 'CrowdStrike', workday: 'https://crowdstrike.wd5.myworkdayjobs.com/crowdstrikecareers' });
+eq('parseWorkdayHint CXS URL site', whCxs?.site, 'crowdstrikecareers');
+eq('parseWorkdayHint CXS URL tenant', whCxs?.tenant, 'crowdstrike');
+eq('parseWorkdayHint CXS URL instance', whCxs?.instance, 'wd5');
+eq('parseWorkdayHint CXS URL === careers-page URL', JSON.stringify(whCxs), JSON.stringify(whPlain));
+
+const whCxsBare = parseWorkdayHint({ name: 'CrowdStrike', careers_url: 'https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/crowdstrikecareers' });
+eq('parseWorkdayHint CXS URL without trailing /jobs', whCxsBare?.site, 'crowdstrikecareers');
+
+const whCxsJob = parseWorkdayHint({ name: 'Acme', website: 'https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/job/Toronto-ON/Eng_R1' });
+eq('parseWorkdayHint per-job CXS URL keeps the site', whCxsJob?.site, 'External');
+
+// The whole point of the coordinates: they rebuild a careers_url that resolves.
+eq(
+  'buildWorkdayCandidates from a CXS hint yields the real board URL',
+  buildWorkdayCandidates(whCxs)[0].careers_url,
+  'https://crowdstrike.wd5.myworkdayjobs.com/crowdstrikecareers',
+);
+
 eq('parseWorkdayHint returns null without any hint', parseWorkdayHint({ name: 'Adyen', careers_url: 'https://adyen.com' }), null);
 eq('parseWorkdayHint rejects unsafe tenant', parseWorkdayHint({ name: 'X', workday: { tenant: 'a/b', site: 'S' } }), null);
 eq('parseWorkdayHint rejects object missing site', parseWorkdayHint({ name: 'X', workday: { tenant: 'a' } }), null);

--- a/tests/providers/workday.test.mjs
+++ b/tests/providers/workday.test.mjs
@@ -72,6 +72,50 @@ try {
     fail(`workday.detect(fallthrough) returned ${JSON.stringify(hitFallthrough)}`);
   }
 
+  // A CXS-form api: is the *resolved* endpoint, not a careers page. It matches
+  // the careers-page host shape too, so parsing it as one captured the literal
+  // `wday` as the site and produced a nonexistent endpoint — a live board
+  // reporting zero jobs and then reading as unreachable (#3498). The invariant:
+  // a correct api: resolves to exactly what careers_url alone resolves to.
+  const cxsCareers = 'https://crowdstrike.wd5.myworkdayjobs.com/crowdstrikecareers';
+  const cxsApi = 'https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/crowdstrikecareers/jobs';
+  const withoutApi = workday.detect({ name: 'CrowdStrike', careers_url: cxsCareers });
+  const withApi = workday.detect({ name: 'CrowdStrike', careers_url: cxsCareers, api: cxsApi });
+  if (withApi && withoutApi && withApi.url === withoutApi.url && withApi.url === cxsApi) {
+    pass('workday.detect() resolves a CXS-form api: to the same endpoint as careers_url alone');
+  } else {
+    fail(`workday.detect(cxs api) returned ${JSON.stringify(withApi)}, careers_url alone ${JSON.stringify(withoutApi)}`);
+  }
+
+  // Same shape given as careers_url (no api: at all) — the misparse was in the
+  // shared pattern, not in the api: slot.
+  const cxsAsCareers = workday.detect({ name: 'CrowdStrike', careers_url: cxsApi });
+  if (cxsAsCareers && cxsAsCareers.url === cxsApi) {
+    pass('workday.detect() accepts a CXS-form careers_url');
+  } else {
+    fail(`workday.detect(cxs careers_url) returned ${JSON.stringify(cxsAsCareers)}`);
+  }
+
+  // The trailing /jobs is optional — a CXS base URL names the same board.
+  const cxsNoJobs = workday.detect({ name: 'CrowdStrike', api: 'https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/crowdstrikecareers' });
+  if (cxsNoJobs && cxsNoJobs.url === cxsApi) {
+    pass('workday.detect() accepts a CXS api: without the trailing /jobs');
+  } else {
+    fail(`workday.detect(cxs no-/jobs) returned ${JSON.stringify(cxsNoJobs)}`);
+  }
+
+  // jobBase is derived from the CXS site too, so posting URLs stay on the
+  // site path (an externalPath hung off the host root 404s).
+  const cxsJobs = parseWorkdayResponse(
+    { jobPostings: [{ title: 'SRE', externalPath: '/job/Austin/SRE_R1', locationsText: 'Austin, TX' }] },
+    { name: 'CrowdStrike', careers_url: cxsCareers, api: cxsApi },
+  );
+  if (cxsJobs.length === 1 && cxsJobs[0].url === 'https://crowdstrike.wd5.myworkdayjobs.com/crowdstrikecareers/job/Austin/SRE_R1') {
+    pass('parseWorkdayResponse builds site-relative posting URLs from a CXS-form api:');
+  } else {
+    fail(`parseWorkdayResponse(cxs api) row 0 = ${JSON.stringify(cxsJobs[0])}`);
+  }
+
   // Path-spoofed URL: myworkdayjobs.com in path, not hostname
   if (workday.detect({ name: 'Spoof', careers_url: 'https://evil.example/test.wd5.myworkdayjobs.com/en-US/board' }) === null) {
     pass('workday.detect() rejects path-spoofed URL');


### PR DESCRIPTION
Fixes #3498.

## The bug

`providers/workday.mjs`'s `resolveEndpoint()` prefers `entry.api` over `entry.careers_url` but parses it with the *careers-page* pattern. A CXS endpoint passes that pattern — it is a `{tenant}.{instance}.myworkdayjobs.com` URL — and `([^/?#]+)` greedily captures the literal `wday` as the site:

```
careers_url only     → https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/crowdstrikecareers/jobs  ✅
+ correct CXS api:   → https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/wday/jobs                ❌
```

Adding the *correct* API URL replaces the site with `wday`. The board returns zero jobs while being fully live, and the entry reads as unreachable run after run — with `verify-portals.mjs` reporting HTTP 404 on the tenant, since it calls the same `detect()`.

The existing fall-through guard was written for a foreign `api:` host: that fails the regex and falls through to `careers_url`. It cannot cover the right-host-wrong-shape case, which neither falls through nor resolves.

## The fix

Recognize the CXS form first and build the endpoint from its own tenant/site rather than re-deriving it.

I honored the CXS URL rather than rejecting it (falling through to `careers_url` would also fix the breakage) — silently ignoring a value someone deliberately set seemed worse than using it. Trailing `/jobs` is optional, and a per-job CXS URL resolves to its board endpoint. The branded-`careers_url` + pinned-tenant-`api:` case and the non-Workday-`api:` fall-through are untouched.

## Also: `discover-ats.mjs` (found while fixing the above)

`parseWorkdayHint()` carried the same pattern, one line of which says it mirrors `providers/workday.mjs`. It has a worse failure mode, because the misparse gets *written down*:

```
workday: https://crowdstrike.wd5.myworkdayjobs.com/wday/cxs/crowdstrike/crowdstrikecareers/jobs
  → {tenant: "crowdstrike", instance: "wd5", site: "wday"}
  → careers_url: https://crowdstrike.wd5.myworkdayjobs.com/wday
```

That lands in a generated `portals.yml` entry as a plausible-looking line for a board that does not exist — the same corruption as the provider bug, except now it is committed config that reads as hand-verified.

Fixed the same way, with one deliberate difference: the tenant comes from the **host subdomain**, not the `/wday/cxs/{tenant}/` path segment. These coordinates get rebuilt host-first by `buildWorkdayCandidates()`, so the host is the part that has to stay reachable; only the site is taken from the CXS path. Noted inline. The `WORKDAY_SEGMENT_RE` guard still applies to every returned segment, so the unsafe-token rejections are unchanged.

## Tests

Both suites pin the equivalence that was violated — it holds for every Workday tenant:

- `detect()` returns the same endpoint with and without a correct CXS `api:`
- `parseWorkdayHint()` returns the same coordinates for the CXS and careers-page forms of the same board
- plus: CXS given as `careers_url`, the `/jobs`-less base, a per-job CXS URL, site-relative posting URLs from `parseWorkdayResponse()`, and `buildWorkdayCandidates()` emitting the real board URL from CXS-derived coordinates

```
node test-all.mjs --only providers/workday   → 65 passed, 0 failed  (was 61)
node test-all.mjs --only discover-ats        → 138 passed, 0 failed  (was 131)
node discover-ats.mjs --self-test            → 50 passed, 0 failed
```

Full suite: 7272 passed, 5 failed — the 5 are `js-yaml`-missing crashes from an absent `node_modules` in my worktree, identical before and after this change and unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Workday job board detection for CXS API URLs, including URLs with or without the `/jobs` suffix.
  * Prevented incorrect career page URLs from being generated when processing Workday endpoints.
  * Preserved tenant and site information when resolving Workday job listings.
  * Improved construction of job posting links from Workday endpoint URLs.
  * Ignored embedded Workday URLs that are not standalone hints.

* **Tests**
  * Added regression coverage for CXS URLs, equivalent career pages, endpoint resolution, and job link generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->