### PR TITLE
fix(tracker): resolve the index path at call time, not at import (#3506)

### DIFF
--- a/tests/tracker-busy-timeout.test.mjs
+++ b/tests/tracker-busy-timeout.test.mjs
@@ -14,9 +14,18 @@ import { tmpdir } from 'os';
 
 console.log('\ntracker.mjs — SQLite busy_timeout (#1957)');
 
-// openDb reads DB_PATH once at import time, so point it at a throwaway file
-// before importing tracker.mjs — the test never touches a real applications.db.
+// Point the index at a throwaway file so the test never touches a real
+// applications.db. openDb() resolves the path per call (#3506), so this holds
+// even though test-all.mjs has already imported tracker.mjs earlier in the same
+// process — which is precisely what it did NOT do while the path was a
+// module-scope const.
+//
+// Restored in the finally below. Suites share one process, so an env var left
+// set here outlives this file: every later suite, and every child process they
+// spawn, would inherit a CAREER_OPS_TRACKER_DB pointing at a directory this
+// test has already deleted.
 const work = mkdtempSync(join(tmpdir(), 'cops-busy-'));
+const priorDbEnv = process.env.CAREER_OPS_TRACKER_DB;
 process.env.CAREER_OPS_TRACKER_DB = join(work, 'applications.db');
 
 try {
@@ -35,5 +44,7 @@ try {
 } catch (e) {
   fail(`tracker busy_timeout test crashed: ${e.message}`);
 } finally {
+  if (priorDbEnv === undefined) delete process.env.CAREER_OPS_TRACKER_DB;
+  else process.env.CAREER_OPS_TRACKER_DB = priorDbEnv;
   rmSync(work, { recursive: true, force: true });
 }

--- a/tests/tracker-db-path-late-env.test.mjs
+++ b/tests/tracker-db-path-late-env.test.mjs
@@ -28,6 +28,18 @@ console.log('\ntracker.mjs — CAREER_OPS_TRACKER_DB honored after import (#3506
 const work = mkdtempSync(join(tmpdir(), 'cops-db-late-'));
 const before = process.env.CAREER_OPS_TRACKER_DB;
 
+// The path a frozen DB_PATH would have used — computed the way tracker.mjs
+// computes it, from the ambient env, before this suite changes anything. That is
+// where the pre-fix build writes, and it is outside the fixture by definition, so
+// the suite has to name it: assert nothing appeared there, and clean up if
+// something did. Otherwise a FAILING run of this test leaves behind exactly the
+// stray database the change is meant to prevent — and only ever removes what it
+// created itself, never a real index that was already on disk.
+const { getCareerOpsRoot, resolveTrackerPath } = await import('../path-resolver.mjs');
+const mdPath = resolveTrackerPath(getCareerOpsRoot());
+const fallbackDb = mdPath.endsWith('.md') ? mdPath.slice(0, -3) + '.db' : mdPath + '.db';
+const fallbackExisted = existsSync(fallbackDb);
+
 try {
   const { DatabaseSync } = await import('node:sqlite');
 
@@ -53,11 +65,18 @@ try {
       ? pass('the pinned database carries the index schema (applications, status_events)')
       : fail(`pinned database is missing index tables, got: ${tables.join(', ') || 'none'}`);
 
-    // And that the fixture is self-contained — one db, nothing else alongside it.
+    // The fixture is self-contained — one db, nothing else alongside it.
     const stray = readdirSync(work).filter(f => !f.startsWith('applications.db'));
     stray.length === 0
-      ? pass('no files written outside the pinned database')
+      ? pass('no files written beside the pinned database')
       : fail(`openDb() wrote unexpected files into the fixture: ${stray.join(', ')}`);
+
+    // And nothing was written at the unpinned fallback, which is the whole point:
+    // #3506 was not "the pin is ignored" in the abstract, it was a database
+    // appearing somewhere nobody asked for one.
+    fallbackExisted || !existsSync(fallbackDb)
+      ? pass('no database created at the unpinned fallback path')
+      : fail(`openDb() wrote a database outside the fixture at ${fallbackDb} (#3506)`);
   } finally {
     db.close();
   }
@@ -66,5 +85,10 @@ try {
 } finally {
   if (before === undefined) delete process.env.CAREER_OPS_TRACKER_DB;
   else process.env.CAREER_OPS_TRACKER_DB = before;
+  // Only when this run created it. A pre-existing index belongs to whoever owns
+  // the workspace — a test that tidies away real data is worse than the leak.
+  if (!fallbackExisted && existsSync(fallbackDb)) {
+    rmSync(fallbackDb, { force: true, maxRetries: 10, retryDelay: 100 });
+  }
   rmSync(work, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 }

--- a/tests/tracker-db-path-late-env.test.mjs
+++ b/tests/tracker-db-path-late-env.test.mjs
@@ -1,0 +1,70 @@
+// tests/tracker-db-path-late-env.test.mjs — openDb() must honor
+// CAREER_OPS_TRACKER_DB set AFTER tracker.mjs is already in the module cache
+// (#3506).
+//
+// tracker.mjs resolved DB_PATH at module scope. That is correct for a CLI — one
+// process, one invocation, env fixed before node starts — and wrong the moment
+// the module is imported rather than executed: the first importer froze the path
+// for the whole process, and a later assignment to the documented override was
+// silently ignored.
+//
+// tests/tracker-busy-timeout.test.mjs is exactly that shape. It pins the variable
+// before importing tracker.mjs, but test-all.mjs imports tracker.mjs earlier in
+// the same process (removeRowByNum), so under a full-suite run the pin did
+// nothing and openDb() created its schema at the unpinned path — a stray
+// applications.db in the repo root, or in a user's data/ if they ran the suite
+// inside a live workspace. It passed either way: PRAGMA busy_timeout reads back
+// 5000 no matter which file was opened, so the assertion could not tell.
+//
+// This suite reproduces that ordering deliberately: import FIRST, set the env
+// var SECOND, then assert on the file that actually appeared on disk.
+import { pass, fail } from './helpers.mjs';
+import { join } from 'path';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\ntracker.mjs — CAREER_OPS_TRACKER_DB honored after import (#3506)');
+
+const work = mkdtempSync(join(tmpdir(), 'cops-db-late-'));
+const before = process.env.CAREER_OPS_TRACKER_DB;
+
+try {
+  const { DatabaseSync } = await import('node:sqlite');
+
+  // 1. Import with the override ABSENT, the way an unrelated consumer would.
+  //    Any module-scope resolution happens here, at the wrong path.
+  delete process.env.CAREER_OPS_TRACKER_DB;
+  const { openDb } = await import(new URL('../tracker.mjs', import.meta.url).href);
+
+  // 2. Only now pin it. A module-scope const cannot see this.
+  const pinned = join(work, 'applications.db');
+  process.env.CAREER_OPS_TRACKER_DB = pinned;
+
+  const db = openDb(DatabaseSync);
+  try {
+    existsSync(pinned)
+      ? pass('openDb() opened the pinned path set after import')
+      : fail(`openDb() ignored a CAREER_OPS_TRACKER_DB set after import — nothing at ${pinned} (#3506)`);
+
+    // The index is only useful if it is a real one: prove the schema landed in
+    // the pinned file rather than the file merely being touched.
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map(r => r.name);
+    tables.includes('applications') && tables.includes('status_events')
+      ? pass('the pinned database carries the index schema (applications, status_events)')
+      : fail(`pinned database is missing index tables, got: ${tables.join(', ') || 'none'}`);
+
+    // And that the fixture is self-contained — one db, nothing else alongside it.
+    const stray = readdirSync(work).filter(f => !f.startsWith('applications.db'));
+    stray.length === 0
+      ? pass('no files written outside the pinned database')
+      : fail(`openDb() wrote unexpected files into the fixture: ${stray.join(', ')}`);
+  } finally {
+    db.close();
+  }
+} catch (e) {
+  fail(`tracker db-path late-env test crashed: ${e.message}`);
+} finally {
+  if (before === undefined) delete process.env.CAREER_OPS_TRACKER_DB;
+  else process.env.CAREER_OPS_TRACKER_DB = before;
+  rmSync(work, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}

--- a/tests/tracker-db-path-late-env.test.mjs
+++ b/tests/tracker-db-path-late-env.test.mjs
@@ -20,7 +20,8 @@
 // var SECOND, then assert on the file that actually appeared on disk.
 import { pass, fail } from './helpers.mjs';
 import { join } from 'path';
-import { mkdtempSync, rmSync, existsSync, readdirSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'fs';
+import { createHash } from 'crypto';
 import { tmpdir } from 'os';
 
 console.log('\ntracker.mjs — CAREER_OPS_TRACKER_DB honored after import (#3506)');
@@ -39,6 +40,13 @@ const { getCareerOpsRoot, resolveTrackerPath } = await import('../path-resolver.
 const mdPath = resolveTrackerPath(getCareerOpsRoot());
 const fallbackDb = mdPath.endsWith('.md') ? mdPath.slice(0, -3) + '.db' : mdPath + '.db';
 const fallbackExisted = existsSync(fallbackDb);
+// Content, not just existence. On a machine where a real index already sits at
+// the fallback path — a live workspace, exactly where this matters — "did a file
+// appear?" can never fail, so it would prove nothing there. openDb() runs its
+// CREATE TABLE statements against whatever it opens, so compare the bytes.
+const fallbackDigest = () =>
+  existsSync(fallbackDb) ? createHash('sha256').update(readFileSync(fallbackDb)).digest('hex') : null;
+const fallbackBefore = fallbackDigest();
 
 try {
   const { DatabaseSync } = await import('node:sqlite');
@@ -65,18 +73,34 @@ try {
       ? pass('the pinned database carries the index schema (applications, status_events)')
       : fail(`pinned database is missing index tables, got: ${tables.join(', ') || 'none'}`);
 
-    // The fixture is self-contained — one db, nothing else alongside it.
-    const stray = readdirSync(work).filter(f => !f.startsWith('applications.db'));
+    // The fixture is self-contained — the database and the sidecars SQLite may
+    // create beside it, nothing else. Named exactly rather than by prefix: a
+    // prefix match also accepts applications.db.bak and friends, so an
+    // unexpected file could be written and still pass.
+    const ALLOWED = new Set([
+      'applications.db',
+      'applications.db-wal',      // write-ahead log
+      'applications.db-shm',      // shared-memory index for the WAL
+      'applications.db-journal',  // rollback journal, in the non-WAL modes
+    ]);
+    const stray = readdirSync(work).filter(f => !ALLOWED.has(f));
     stray.length === 0
       ? pass('no files written beside the pinned database')
       : fail(`openDb() wrote unexpected files into the fixture: ${stray.join(', ')}`);
 
-    // And nothing was written at the unpinned fallback, which is the whole point:
-    // #3506 was not "the pin is ignored" in the abstract, it was a database
-    // appearing somewhere nobody asked for one.
-    fallbackExisted || !existsSync(fallbackDb)
-      ? pass('no database created at the unpinned fallback path')
-      : fail(`openDb() wrote a database outside the fixture at ${fallbackDb} (#3506)`);
+    // And the unpinned fallback is untouched, which is the whole point: #3506 was
+    // not "the pin is ignored" in the abstract, it was a database appearing —
+    // or being written to — somewhere nobody asked for one.
+    const fallbackAfter = fallbackDigest();
+    if (fallbackAfter === fallbackBefore) {
+      pass(fallbackExisted
+        ? 'the pre-existing database at the unpinned fallback path is byte-identical'
+        : 'no database created at the unpinned fallback path');
+    } else if (!fallbackExisted) {
+      fail(`openDb() wrote a database outside the fixture at ${fallbackDb} (#3506)`);
+    } else {
+      fail(`openDb() modified the pre-existing database at ${fallbackDb} — a real workspace index (#3506)`);
+    }
   } finally {
     db.close();
   }

--- a/tests/tracker-db-path-late-env.test.mjs
+++ b/tests/tracker-db-path-late-env.test.mjs
@@ -44,9 +44,19 @@ const fallbackExisted = existsSync(fallbackDb);
 // the fallback path — a live workspace, exactly where this matters — "did a file
 // appear?" can never fail, so it would prove nothing there. openDb() runs its
 // CREATE TABLE statements against whatever it opens, so compare the bytes.
-const fallbackDigest = () =>
-  existsSync(fallbackDb) ? createHash('sha256').update(readFileSync(fallbackDb)).digest('hex') : null;
-const fallbackBefore = fallbackDigest();
+//
+// Sidecars included, because in WAL mode they ARE where the write lands: a
+// CREATE TABLE goes to fallbackDb-wal and the main file stays byte-identical
+// until a checkpoint. Hashing only the main file would report "unchanged" on a
+// database that had just been written to.
+const FALLBACK_FILES = ['', '-wal', '-shm', '-journal'];
+const fallbackSnapshot = () => FALLBACK_FILES.map((suffix) => {
+  const file = fallbackDb + suffix;
+  return `${suffix || '(db)'}=${existsSync(file)
+    ? createHash('sha256').update(readFileSync(file)).digest('hex')
+    : 'absent'}`;
+}).join(' ');
+const fallbackBefore = fallbackSnapshot();
 
 try {
   const { DatabaseSync } = await import('node:sqlite');
@@ -88,21 +98,26 @@ try {
       ? pass('no files written beside the pinned database')
       : fail(`openDb() wrote unexpected files into the fixture: ${stray.join(', ')}`);
 
-    // And the unpinned fallback is untouched, which is the whole point: #3506 was
-    // not "the pin is ignored" in the abstract, it was a database appearing —
-    // or being written to — somewhere nobody asked for one.
-    const fallbackAfter = fallbackDigest();
-    if (fallbackAfter === fallbackBefore) {
-      pass(fallbackExisted
-        ? 'the pre-existing database at the unpinned fallback path is byte-identical'
-        : 'no database created at the unpinned fallback path');
-    } else if (!fallbackExisted) {
-      fail(`openDb() wrote a database outside the fixture at ${fallbackDb} (#3506)`);
-    } else {
-      fail(`openDb() modified the pre-existing database at ${fallbackDb} — a real workspace index (#3506)`);
-    }
   } finally {
     db.close();
+  }
+
+  // The unpinned fallback is untouched, which is the whole point: #3506 was not
+  // "the pin is ignored" in the abstract, it was a database appearing — or being
+  // written to — somewhere nobody asked for one.
+  //
+  // Checked AFTER the handle is closed. A WAL database can hold the write in its
+  // sidecar and only fold it into the main file on close, so a snapshot taken
+  // while the connection is still open reads an in-between state.
+  const fallbackAfter = fallbackSnapshot();
+  if (fallbackAfter === fallbackBefore) {
+    pass(fallbackExisted
+      ? 'the pre-existing database at the unpinned fallback path is byte-identical'
+      : 'no database created at the unpinned fallback path');
+  } else if (!fallbackExisted) {
+    fail(`openDb() wrote a database outside the fixture at ${fallbackDb} (#3506)`);
+  } else {
+    fail(`openDb() modified the pre-existing database at ${fallbackDb} — a real workspace index (#3506)\n     before: ${fallbackBefore}\n     after:  ${fallbackAfter}`);
   }
 } catch (e) {
   fail(`tracker db-path late-env test crashed: ${e.message}`);

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -48,15 +48,50 @@ import { isMainModule } from './lib/is-main-module.mjs';
 
 const CAREER_OPS = getCareerOpsRoot();
 const MD_PATH = resolveTrackerPath(CAREER_OPS);
-const DB_PATH = process.env.CAREER_OPS_TRACKER_DB
-  || (MD_PATH.endsWith('.md') ? MD_PATH.slice(0, -3) + '.db' : MD_PATH + '.db');
 
-// SQLite must never open the source of truth itself (an explicit
-// CAREER_OPS_TRACKER_DB could point both names at the same file).
-if (resolve(MD_PATH) === resolve(DB_PATH)) {
-  console.error(`Error: DB path must differ from the markdown path (${MD_PATH}).`);
-  process.exit(1);
+/**
+ * Where the derived SQLite index lives, resolved at call time.
+ *
+ * This used to be a module-scope `const`, which is the right shape for a CLI —
+ * one process, one invocation, env fixed before node starts — and the wrong one
+ * the moment the module is IMPORTED rather than executed. The first importer in
+ * a process froze the path for every later one, so a subsequent
+ * `process.env.CAREER_OPS_TRACKER_DB = ...` was silently ignored: no error, no
+ * warning, and an assignment that reads as though it took effect.
+ *
+ * That is how the test suite came to create an applications.db outside its own
+ * fixtures (#3506). tests/tracker-busy-timeout.test.mjs pins the variable before
+ * importing this module, but test-all.mjs imports tracker.mjs earlier in the same
+ * process for removeRowByNum, so module scope had already run and openDb() built
+ * its schema at the unpinned path. The test passed either way — busy_timeout
+ * reads back 5000 whichever file was opened — so nothing flagged it.
+ *
+ * Resolving per call costs nothing here (openDb is called once per command) and
+ * makes the documented override mean the same thing to an importer as it does on
+ * the command line.
+ *
+ * MD_PATH stays import-time on purpose: it is the source of truth, every writer
+ * reaches it through openTrackerTransaction(MD_PATH), and a tracker path that
+ * could change underneath an open transaction is a different and worse problem
+ * than the one this solves.
+ *
+ * @returns {string} Absolute or relative path to the derived index.
+ */
+function dbPath() {
+  const path = process.env.CAREER_OPS_TRACKER_DB
+    || (MD_PATH.endsWith('.md') ? MD_PATH.slice(0, -3) + '.db' : MD_PATH + '.db');
+  // SQLite must never open the source of truth itself (an explicit
+  // CAREER_OPS_TRACKER_DB could point both names at the same file). Checked here
+  // rather than at import: a module that exits the process as a side effect of
+  // being imported takes its importer down with it, and the check is only
+  // meaningful at the moment the path is actually used.
+  if (resolve(MD_PATH) === resolve(path)) {
+    console.error(`Error: DB path must differ from the markdown path (${MD_PATH}).`);
+    process.exit(1);
+  }
+  return path;
 }
+
 const STATES_PATH = 'templates/states.yml';
 const HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |';
 const SEPARATOR = '|---|------|---------|------|-------|--------|-----|--------|-------|';
@@ -85,8 +120,9 @@ async function loadSqlite() {
 }
 
 export function openDb(DatabaseSync) {
-  mkdirSync(dirname(DB_PATH) || '.', { recursive: true });
-  const db = new DatabaseSync(DB_PATH);
+  const path = dbPath();
+  mkdirSync(dirname(path) || '.', { recursive: true });
+  const db = new DatabaseSync(path);
   // Wait up to 5s for a lock instead of throwing SQLITE_BUSY on the first
   // contention. The index is read by concurrent callers — a CLI query, a
   // `set-status` write and the Go TUI dashboard can all hit the same db at
@@ -354,7 +390,7 @@ async function sync(args) {
   const DatabaseSync = await loadSqlite();
   const db = openDb(DatabaseSync);
   const { apps, diag } = syncIndex(db, states);
-  console.error(`Indexed ${apps.length} applications from ${MD_PATH} into ${DB_PATH}`);
+  console.error(`Indexed ${apps.length} applications from ${MD_PATH} into ${dbPath()}`);
   reportDiagnostics(diag);
 }
 


### PR DESCRIPTION
## What does this PR do?

`tracker.mjs` resolved the derived-index path at module scope, so the documented `CAREER_OPS_TRACKER_DB` override was silently ignored by anything that set it *after* the module was already imported. This resolves it at call time and adds a regression suite that reproduces the ordering.

## Related issue

Closes #3506

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Detail

**The symptom.** Every full `node test-all.mjs` run left a stray `applications.db` in the repo root — untracked and not gitignored, so it shows up as a dirty working tree.

**The cause.** `tests/tracker-busy-timeout.test.mjs` pins `CAREER_OPS_TRACKER_DB` before importing `tracker.mjs`, and its comment explains exactly why:

```js
// openDb reads DB_PATH once at import time, so point it at a throwaway file
// before importing tracker.mjs — the test never touches a real applications.db.
```

The reasoning is right and the conclusion does not hold under a full-suite run. Discovered suites are imported into `test-all.mjs`'s own process, and `test-all.mjs:5035` has already imported `tracker.mjs` for `removeRowByNum`. By the time the suite sets the variable the module is cached, module scope has run, and `openDb()` builds its schema at the unpinned path.

Nothing flagged it because the test's assertion cannot see it: `PRAGMA busy_timeout` reads back 5000 whichever file was opened.

Module-scope resolution is the right shape for a CLI — one process, one invocation, env fixed before `node` starts — and the wrong one as soon as the module is *imported* rather than executed. The first importer freezes the path for the whole process, and a later assignment to the override does nothing while reading as though it did.

**Impact.** Mild but not nil. In this repo it is clutter. In a live workspace the write lands on `data/applications.db`; `CREATE TABLE IF NOT EXISTS` will not wipe a populated index, so the realistic worst case is a workspace that never ran `tracker.mjs sync` acquiring an empty-but-present index for the Go dashboard to read. `test-all.mjs:322-326` already documents that running the suite inside an active workspace must not mutate user data — that reasoning was applied to the `--dry-run` smoke scripts and never reached this path.

**The change.** `dbPath()` resolves per call. It costs nothing (`openDb` runs once per command) and makes the override mean the same thing to an importer as it does on the command line. This fixes the class rather than the instance: any future in-process consumer that sets the variable after an unrelated import now gets what it asked for.

The must-differ guard moves into `dbPath()` with it, and is better placed there — a module that calls `process.exit()` as a side effect of being *imported* takes its importer down with it, and the check is only meaningful at the moment the path is actually used. Verified still firing: pointing both env vars at one file exits 1 with the same message.

`MD_PATH` deliberately stays import-time. It is the source of truth, every writer reaches it through `openTrackerTransaction(MD_PATH)`, and a tracker path that can change underneath an open transaction is a different and worse problem than the one this solves.

## Test

`tests/tracker-db-path-late-env.test.mjs` (auto-discovered) reproduces the ordering rather than describing it: import `tracker.mjs` with the override **absent**, set `CAREER_OPS_TRACKER_DB` **afterwards**, then assert on what actually appeared on disk — the pinned file exists, it carries the real index schema (`applications`, `status_events`) rather than just being touched, and nothing else was written beside it.

Mutation-checked: against the pre-fix `tracker.mjs` it fails, and the stray root `applications.db` reappears.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (7292 passed, 0 failed, 12 pre-existing warnings) — and the run no longer leaves an `applications.db` behind
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Note

Branched from `main` and independent of #3503 (#3500), which touches different files — either can merge first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The tracker now recognizes changes to `CAREER_OPS_TRACKER_DB` made after startup.
  * Database operations and progress messages consistently use the currently configured location.
  * Added protection against accidentally using the Markdown file as the database.

* **Tests**
  * Added coverage for late database configuration, schema creation, cleanup, and temporary database handling.
  * Improved validation for database path changes and busy-database scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->