### PR TITLE
fix(tracker): resolve templates/states.yml from the module, not the cwd (#3508)

### DIFF
--- a/tests/tracker-cwd-independence.test.mjs
+++ b/tests/tracker-cwd-independence.test.mjs
@@ -1,0 +1,99 @@
+// tests/tracker-cwd-independence.test.mjs — tracker.mjs must work from any cwd
+// (#3508).
+//
+// templates/states.yml ships with the code, but tracker.mjs referenced it as the
+// bare relative string 'templates/states.yml', which resolves against
+// process.cwd(). Every command — sync, query, history, export, delete, all of
+// which reach loadStates() — therefore failed from anywhere but the repo root,
+// with an error that documented the constraint instead of fixing it:
+//
+//   Error: templates/states.yml not found — cannot validate statuses.
+//   Run from the career-ops root.
+//
+// That is the shape the data-root mechanism invites: cd to your data directory,
+// run the tool out of the checkout. It also breaks any cron entry, launchd job or
+// wrapper that does not cd into the repo first — the automation shapes
+// docs/AUTOMATION.md recommends.
+//
+// The suite could not see it because tests/helpers.mjs run() spawns every child
+// with `cwd: ROOT` — the one directory where the bug cannot appear. So this suite
+// sets cwd explicitly, and asserts on behavior (a real sync from a temp dir)
+// rather than on the shape of the source.
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\ntracker.mjs — runs from any working directory (#3508)');
+
+const work = mkdtempSync(join(tmpdir(), 'cops-cwd-'));
+const md = join(work, 'applications.md');
+
+writeFileSync(md, [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+  '| 1 | 2026-01-04 | Acme | Engineer | 4.2/5 | Evaluated | ❌ | [1](reports/001-acme-2026-01-04.md) | first |',
+  '',
+].join('\n'), 'utf-8');
+
+// Built once, deliberately, rather than spreading process.env and hoping. Suites
+// share one process and children inherit whatever it holds, so a path override
+// left set by an earlier suite would quietly redirect this one's index and turn a
+// pass into a confusing failure here. Only the tracker is pinned; everything else
+// this test reasons about must come from the module's own location.
+const childEnv = { ...process.env, CAREER_OPS_TRACKER: md };
+delete childEnv.CAREER_OPS_TRACKER_DB;
+delete childEnv.CAREER_OPS_ROOT;
+delete childEnv.CAREER_OPS_DATA_DIR;
+
+/** Run tracker.mjs from `work`, never from the repo root. Returns {ok, out}. */
+function trackerFromElsewhere(...args) {
+  try {
+    return {
+      ok: true,
+      out: execFileSync(NODE, [join(ROOT, 'tracker.mjs'), ...args], {
+        cwd: work,                       // the point of this suite
+        encoding: 'utf-8',
+        timeout: 30000,
+        env: childEnv,
+      }),
+    };
+  } catch (e) {
+    return { ok: false, out: `${e.stdout || ''}${e.stderr || ''}` };
+  }
+}
+
+try {
+  const sync = trackerFromElsewhere('sync');
+  sync.ok
+    ? pass('tracker.mjs sync succeeds from a cwd outside the repo root')
+    : fail(`tracker.mjs sync failed from another cwd: ${sync.out.trim().split('\n')[0]}`);
+
+  // The old failure was specifically a states.yml miss. Name it, so a future
+  // regression is recognizable rather than just "something broke".
+  /states\.yml not found/.test(sync.out)
+    ? fail('tracker.mjs still resolves templates/states.yml against the cwd (#3508)')
+    : pass('templates/states.yml resolves from the codebase, not the cwd');
+
+  existsSync(join(work, 'applications.db'))
+    ? pass('the derived index landed beside the tracker it was built from')
+    : fail('sync reported success but wrote no index beside the tracker');
+
+  // query exercises loadStates() down a different path (ensureFresh), and proves
+  // the row actually round-tripped rather than sync merely exiting 0.
+  const query = trackerFromElsewhere('query', '--json');
+  if (!query.ok) {
+    fail(`tracker.mjs query failed from another cwd: ${query.out.trim().split('\n')[0]}`);
+  } else {
+    let rows = null;
+    try { rows = JSON.parse(query.out); } catch { /* handled below */ }
+    Array.isArray(rows) && rows.length === 1 && rows[0].company === 'Acme' && rows[0].status === 'Evaluated'
+      ? pass('query returns the indexed row with its status validated against states.yml')
+      : fail(`query returned unexpected rows from another cwd: ${query.out.trim().slice(0, 200)}`);
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -37,7 +37,7 @@
 import { readFileSync, copyFileSync, existsSync, mkdirSync, statSync } from 'fs';
 import { createHash } from 'crypto';
 import { dirname, resolve, join, basename } from 'path';
-import { pathToFileURL } from 'url';
+import { pathToFileURL, fileURLToPath } from 'url';
 import { getCareerOpsRoot, resolveTrackerPath } from './path-resolver.mjs';
 import * as yaml from 'js-yaml';
 import { resolveColumns } from './tracker-parse.mjs';
@@ -92,7 +92,15 @@ function dbPath() {
   return path;
 }
 
-const STATES_PATH = 'templates/states.yml';
+// templates/states.yml ships with the code, so it is resolved from this module's
+// own directory. It used to be a bare relative path, i.e. resolved against
+// process.cwd(), which made every tracker.mjs command fail from anywhere but the
+// repo root — including the shape the data-root mechanism invites, where you cd
+// to your data directory and run the tool out of the checkout (#3508). Third
+// variant of #3500: that one looked for this file under the data root, this one
+// looked for it under whatever directory the shell happened to be in.
+const CODEBASE_ROOT = dirname(fileURLToPath(import.meta.url));
+const STATES_PATH = join(CODEBASE_ROOT, 'templates/states.yml');
 const HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |';
 const SEPARATOR = '|---|------|---------|------|-------|--------|-----|--------|-------|';
 
@@ -163,7 +171,9 @@ export function openDb(DatabaseSync) {
 
 function loadStates() {
   if (!existsSync(STATES_PATH)) {
-    console.error(`Error: ${STATES_PATH} not found — cannot validate statuses. Run from the career-ops root.`);
+    // No longer "run from the career-ops root" advice: the path is anchored to
+    // the module, so a miss here is a broken install, not a wrong cwd.
+    console.error(`Error: ${STATES_PATH} not found — cannot validate statuses (broken install: templates/states.yml ships with career-ops).`);
     process.exit(1);
   }
   const doc = yaml.load(readFileSync(STATES_PATH, 'utf-8'));


### PR DESCRIPTION
## What does this PR do?

`tracker.mjs` referenced `templates/states.yml` as a bare relative path, so it resolved against `process.cwd()` and every command failed from anywhere but the repo root. This anchors it to the module, the way every other consumer of that file already does, and adds a suite that runs the CLI from a temp directory.

## Related issue

Closes #3508

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

> **Stacked on #3507** (both touch `tracker.mjs`), which is itself independent of #3503. Review order #3507 → this; I'll rebase if #3507 lands with changes.

## Detail

**The bug.** `tracker.mjs:60` was `const STATES_PATH = 'templates/states.yml'`, and a bare relative path resolves against the working directory:

| cwd | `tracker.mjs sync` |
|---|---|
| the repo root | `Indexed 1 applications ...` |
| anywhere else | `Error: templates/states.yml not found — cannot validate statuses. Run from the career-ops root.`, exit 1 |

Same binary, same tracker, same env — only the shell's cwd differs. It hits `sync`, `query`, `history`, `export` and `delete` alike, since all five reach `loadStates()`.

Third variant of #3500: that one looked for this file under the *data* root, this one under whatever directory the shell happened to be in. Everything else in `tracker.mjs` is anchored properly — `MD_PATH` through `resolveTrackerPath(getCareerOpsRoot())`, the derived index beside it — so this constant was the outlier, and it was the last consumer of `states.yml` not bound to the codebase: `normalize-statuses.mjs` and `followup-cadence.mjs` (via #3503), `set-status.mjs:104`, `funnel-velocity.mjs:50` and `tracker-sync-check.mjs:105` all use `dirname(fileURLToPath(import.meta.url))`.

**Who it hits.** Mainly the `.career-ops-data` / `CAREER_OPS_ROOT` mechanism, where `cd`-ing to your data directory and running the tool from the checkout is the natural shape:

```bash
cd ~/job-search
node ~/src/career-ops/tracker.mjs query --json    # fails
```

Plus any cron entry, launchd job, npm script or editor task that does not `cd` into the repo first — the automation shapes `docs/AUTOMATION.md` recommends. Unlike #3500 nothing is silently corrupted: it exits non-zero and says so. The command simply cannot run.

**The error message** drops "Run from the career-ops root." along with the constraint. With the path anchored, a miss means a broken install, not a wrong cwd — advice that has become false is worse than none.

## Test

`tests/tracker-cwd-independence.test.mjs` runs `sync` and `query` with `cwd` set to a temp dir and asserts on behavior rather than on the shape of the source: sync succeeds, the failure is specifically *not* a `states.yml` miss, the index lands beside the tracker it was built from, and the row round-trips through `query --json` with its status validated against `states.yml`.

Mutation-checked: against the pre-fix `tracker.mjs` all four assertions fail with the original error.

The existing suite could not see this, because `tests/helpers.mjs:201` spawns every child with `cwd: ROOT` — the one directory where the bug cannot appear. Structurally the same blind spot as #3500, where the suite ran with the default data root and so could not see a data-root leak. Worth noting that default makes "runs outside the repo root" the untested case for *every* script, not just this one.

## Also in this PR (from the #3507 branch it is stacked on)

`tests/tracker-busy-timeout.test.mjs` set `CAREER_OPS_TRACKER_DB` at module scope and never restored it. Discovered suites share one process, so it outlived that file: every later suite, and every child they spawn, inherited a path pointing at a temp directory its own `finally` had already deleted. It surfaced here — the new suite's child inherited the dangling pin and wrote its index there instead of beside the tracker — which is exactly the expensive failure shape it invites: a later suite failing in a way that points at itself rather than at the leak. Now restored in `finally`, and the new suite builds its child env explicitly rather than trusting `process.env`.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (7297 passed, 0 failed, 12 pre-existing warnings)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files) — `templates/states.yml` is System Layer, and this restores it to being resolved from the codebase
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Not fixed here

The same grep turned up cwd-relative paths pointing at **User Layer** data, a different and possibly worse family — those resolve to a wrong-but-writable location instead of failing loudly. `scan.mjs:1988, 2037, 2110` (`BLACKLIST_PATH`, `SCAN_RUNS_PATH`, `PORTAL_HEALTH_PATH`) are bare `'data/...'` strings while the same file anchors `PORTALS_PATH`, `PIPELINE_PATH` and `APPLICATIONS_PATH` to `DATA_ROOT` at lines 77-92 — so `scan.mjs` writes `data/scan-runs.tsv` relative to cwd while `stats.mjs:36` reads `join(DATA_ROOT, 'data', 'scan-runs.tsv')`. Also `scan-ats-full.mjs:61, 62, 95` and `scan-interamt.mjs:207, 258`. Detailed in #3508; happy to open a separate issue if you want them tracked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The tracker now respects database-path configuration changes made after startup.
  - State templates resolve reliably regardless of the current working directory.
  - Improved messaging when required installation files are missing.

- **Tests**
  - Added coverage for working-directory independence and late database-path configuration.
  - Improved test cleanup to prevent environment settings from affecting later tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->