### PR TITLE
fix(scan): resolve scanner user data against the data root, not the cwd (#3510)

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -48,18 +48,24 @@ import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
 import icims from './providers/icims.mjs';
-import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays } from './scan.mjs';
+import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays, PORTALS_PATH, PIPELINE_PATH } from './scan.mjs';
 import { localToday } from './lib/local-today.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
-const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
-const PIPELINE_PATH = 'data/pipeline.md';
-const CACHE_DIR = 'data/cache/ats-companies';
+// PORTALS_PATH and PIPELINE_PATH are imported from scan.mjs rather than
+// re-derived here (#3510). This file appends results through scan.mjs's
+// appendToPipeline, so its own bare-relative copy meant it could create an empty
+// data/pipeline.md in the cwd and then write the actual matches somewhere else.
+// Its portals fallback had the same split: it honored CAREER_OPS_PORTALS but
+// otherwise looked in the cwd instead of the data root.
+const DATA_ROOT = getCareerOpsRoot();
+const CACHE_DIR = path.join(DATA_ROOT, 'data/cache/ats-companies');
 const CACHE_TTL_HOURS = 24;
 // Tracks `main` deliberately: the dataset's value is freshness (new boards
 // appear weekly), so pinning a commit would defeat the purpose. Integrity rests
@@ -92,7 +98,10 @@ const RESOLVER_FAILURE_LIMIT = 50;
 // Crash insurance for multi-hour directory sweeps: progress + matches are
 // checkpointed every CHECKPOINT_EVERY companies so --resume can continue a
 // dead run (with its ORIGINAL date window) instead of restarting from zero.
-const CHECKPOINT_PATH = 'data/cache/ats-full-checkpoint.json';
+// Anchored too (#3510): a sweep resumed from a different directory found no
+// checkpoint and silently restarted a multi-hour run from zero — the one failure
+// mode --resume exists to prevent.
+const CHECKPOINT_PATH = path.join(DATA_ROOT, 'data/cache/ats-full-checkpoint.json');
 const CHECKPOINT_EVERY = 500;
 
 export function loadCheckpoint(file = CHECKPOINT_PATH) {

--- a/scan-hn.mjs
+++ b/scan-hn.mjs
@@ -16,7 +16,7 @@ try {
 import { readFileSync, existsSync } from 'fs';
 import * as yaml from 'js-yaml';
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { appendToPipeline, appendToScanHistory, loadSeenUrls } from './scan.mjs';
+import { appendToPipeline, appendToScanHistory, loadSeenUrls, PORTALS_PATH } from './scan.mjs';
 import { localToday } from './lib/local-today.mjs';
 
 // Import the deterministic provider
@@ -24,7 +24,7 @@ import hnProvider from './providers/hackernews.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 // ── Configuration ────────────────────────────────────────────────────
-const PORTALS_PATH = 'portals.yml';
+// Imported from scan.mjs so it honors CAREER_OPS_PORTALS and the data root (#3510).
 
 function loadKeywords() {
   const defaultKeywords = ["Software Engineer"];

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -19,14 +19,23 @@
 
 import { chromium } from 'playwright';
 import { readFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
 import * as yaml from 'js-yaml';
-import { appendToPipeline, appendToScanHistory, loadSeenUrls } from './scan.mjs';
+import { appendToPipeline, appendToScanHistory, loadSeenUrls, PORTALS_PATH, SCAN_HISTORY_PATH } from './scan.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 // ── Config ───────────────────────────────────────────────────────────
 
-const PORTALS_PATH    = 'portals.yml';
-const SCAN_HISTORY    = 'data/scan-history.tsv';
+// Both imported from scan.mjs (#3510). This scanner appends through
+// scan.mjs's appendToScanHistory — anchored to the data root — while reading its
+// own bare-relative copy to work out the last scan date, so within a single run
+// it could write one history file and read another. Its portals copy also
+// ignored CAREER_OPS_PORTALS, which #2271 added so a second search lane does not
+// poison the first one's dedup history.
+const SCAN_HISTORY    = SCAN_HISTORY_PATH;
+const DATA_ROOT       = getCareerOpsRoot();
 const INTERAMT_HOME   = 'https://interamt.de/koop/app/';
 // Direct offer URL — constructed from StellenangebotId.
 // Wicket adds a session version number (?28&id=...) during live navigation,
@@ -204,12 +213,17 @@ async function searchInteramt(page, keyword, isFirst) {
   ]).catch(() => null);
 
   if (DEBUG) {
-    mkdirSync('output', { recursive: true });
-    await page.screenshot({ path: 'output/debug-interamt.png', fullPage: true });
+    // output/ is User Layer, so the debug dump follows the data root rather than
+    // appearing in whatever directory the scan was launched from (#3510).
+    const debugDir = join(DATA_ROOT, 'output');
+    const debugPng = join(debugDir, 'debug-interamt.png');
+    const debugHtml = join(debugDir, 'debug-interamt.html');
+    mkdirSync(debugDir, { recursive: true });
+    await page.screenshot({ path: debugPng, fullPage: true });
     const { writeFileSync: wf } = await import('fs');
-    wf('output/debug-interamt.html', await page.content());
-    console.log('  [debug] screenshot → output/debug-interamt.png');
-    console.log('  [debug] html       → output/debug-interamt.html');
+    wf(debugHtml, await page.content());
+    console.log(`  [debug] screenshot → ${debugPng}`);
+    console.log(`  [debug] html       → ${debugHtml}`);
     console.log('  [debug] url:', page.url());
     const rowCount = await page.$$eval('tr', rows => rows.length);
     console.log(`  [debug] total <tr> on page: ${rowCount}`);
@@ -255,7 +269,7 @@ async function searchInteramt(page, keyword, isFirst) {
 // ── Main ─────────────────────────────────────────────────────────────
 
 async function main() {
-  mkdirSync('data', { recursive: true });
+  mkdirSync(join(DATA_ROOT, 'data'), { recursive: true });
 
   const { seen } = loadSeenUrls();
   const date = localToday();
@@ -361,7 +375,15 @@ async function main() {
   console.log('\n→ Run /career-ops pipeline to evaluate new offers.');
 }
 
-main().catch(err => {
-  console.error('Fatal:', err.message);
-  process.exit(1);
-});
+// Guarded like every sibling scanner (scan-hn.mjs:122, scan-ats-full.mjs:1115).
+// Unguarded, merely IMPORTING this module drove a live browser scan of
+// interamt.de and appended its results to the user's pipeline and scan history —
+// so the file could not be imported by a test, or by anything else, without
+// doing that. A module should not scan the internet as a side effect of being
+// loaded (#3510).
+if (isMainModule(import.meta.url)) {
+  main().catch(err => {
+    console.error('Fatal:', err.message);
+    process.exit(1);
+  });
+}

--- a/scan.mjs
+++ b/scan.mjs
@@ -74,7 +74,7 @@ import { getCareerOpsRoot } from './path-resolver.mjs';
 const CODE_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
 
-const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || path.join(DATA_ROOT, 'portals.yml');
+export const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || path.join(DATA_ROOT, 'portals.yml');
 const PROFILE_PATH = process.env.CAREER_OPS_PROFILE || path.join(DATA_ROOT, 'config/profile.yml');
 // Overridable for the same reason the two inputs above are (#2271). A second
 // search lane - a bridge/income track, a career-change track, a partner sharing
@@ -82,8 +82,13 @@ const PROFILE_PATH = process.env.CAREER_OPS_PROFILE || path.join(DATA_ROOT, 'con
 // two it still writes into the one inbox and the one dedup history. That is not
 // just untidy: scan-history.tsv IS the dedup source, so a posting surfaced in
 // lane A is silently counted as a duplicate in lane B and never shown at all.
-const SCAN_HISTORY_PATH = process.env.CAREER_OPS_SCAN_HISTORY || path.join(DATA_ROOT, 'data/scan-history.tsv');
-const PIPELINE_PATH = process.env.CAREER_OPS_PIPELINE || path.join(DATA_ROOT, 'data/pipeline.md');
+// Exported because scan-ats-full.mjs, scan-interamt.mjs and scan-hn.mjs write to
+// these same files through appendToPipeline/appendToScanHistory. They each used
+// to carry their own bare-relative copy, so a sibling could check existence and
+// create data/pipeline.md in the cwd, then append the actual results to the
+// anchored one (#3510). One resolution, imported, cannot drift.
+export const SCAN_HISTORY_PATH = process.env.CAREER_OPS_SCAN_HISTORY || path.join(DATA_ROOT, 'data/scan-history.tsv');
+export const PIPELINE_PATH = process.env.CAREER_OPS_PIPELINE || path.join(DATA_ROOT, 'data/pipeline.md');
 const APPLICATIONS_PATH = path.join(DATA_ROOT, 'data/applications.md');
 const PROVIDERS_DIR = path.resolve(CODE_ROOT, 'providers');
 
@@ -1985,7 +1990,12 @@ export async function appendToScanHistory(offers, date, status = 'added') {
 
 // ── Company blacklist (#1742) ───────────────────────────────────────
 
-const BLACKLIST_PATH = 'data/blacklist.md';
+// User Layer, so it follows the data root like every other input this file reads
+// (#3510). It was a bare relative string, i.e. resolved against process.cwd(),
+// which meant a user with a data root configured got whatever blacklist happened
+// to sit in the directory they ran from — usually none, so their do-not-apply
+// list was silently empty while the run reported no filtering at all.
+const BLACKLIST_PATH = path.join(DATA_ROOT, 'data/blacklist.md');
 
 /**
  * Parse the user's do-not-apply list (data/blacklist.md, user layer, opt-in).
@@ -2034,7 +2044,11 @@ export function loadBlacklist(filePath = BLACKLIST_PATH) {
 
 // ── Scan-run persistence (#1604) ────────────────────────────────────
 
-const SCAN_RUNS_PATH = 'data/scan-runs.tsv';
+// Anchored for the same reason (#3510), and with a reader to agree with:
+// stats.mjs:36 reads join(DATA_ROOT, 'data', 'scan-runs.tsv'). While this was
+// cwd-relative the writer and the reader could name different files, and the
+// trend stats simply under-reported whatever landed elsewhere.
+const SCAN_RUNS_PATH = path.join(DATA_ROOT, 'data/scan-runs.tsv');
 
 // One row of run counters per non-dry scan — today these numbers are printed
 // once in the summary and lost when the terminal scrolls. Full ISO timestamp
@@ -2107,7 +2121,18 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
 
 // ── Portal health persistence (#1744) ───────────────────────────────
 
-const PORTAL_HEALTH_PATH = 'data/portal-health.tsv';
+// Anchored to the data root (#3510), read by stats.mjs:39 at the same anchor.
+//
+// This path has moved twice. It was dirname(fileURLToPath(import.meta.url)) —
+// the script's own directory — until 96c578b made it cwd-relative, because a
+// sandboxed run was writing fixture rows into the live data/portal-health.tsv of
+// whatever checkout owned scan.mjs. That problem was real; the mechanism traded
+// one unanchored path for another, and left this file with two different rules
+// for where user data lives. Isolation now comes from CAREER_OPS_ROOT, which is
+// how the rest of the suite already sandboxes writes — see
+// tests/portal-health-path.test.mjs, which still asserts the checkout's own data
+// directory is never touched.
+const PORTAL_HEALTH_PATH = path.join(DATA_ROOT, 'data/portal-health.tsv');
 export const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
 
 // Locked (portal-health-lock.mjs) so a concurrent read-modify-write of this

--- a/tests/portal-health-path.test.mjs
+++ b/tests/portal-health-path.test.mjs
@@ -1,21 +1,29 @@
-// tests/portal-health-path.test.mjs — appendPortalHealth()/loadPortalHealth()
-// must resolve their default path against process.cwd(), not the directory
-// scan.mjs lives in.
+// tests/portal-health-path.test.mjs — appendPortalHealth() must resolve its
+// default path against the CONFIGURED DATA ROOT, and must never write into the
+// checkout that owns scan.mjs.
 //
-// Every sibling data path in scan.mjs (SCAN_HISTORY_PATH, PIPELINE_PATH,
-// APPLICATIONS_PATH, BLACKLIST_PATH, SCAN_RUNS_PATH) is a bare cwd-relative
-// string. PORTAL_HEALTH_PATH used to be the one exception, resolved via
-// path.dirname(fileURLToPath(import.meta.url)) -- the script's own directory.
-// Any invocation with a sandboxed cwd (a test run, a temp dir, a CI checkout)
-// still wrote fixture rows straight into the real data/portal-health.tsv of
-// whatever checkout happens to own scan.mjs, polluting real pipeline data with
-// test fixtures.
+// The second half is what this test has always been for. It was written when
+// PORTAL_HEALTH_PATH resolved via path.dirname(fileURLToPath(import.meta.url)) --
+// the script's own directory -- so any invocation with a sandboxed cwd (a test
+// run, a temp dir, a CI checkout) wrote fixture rows straight into the real
+// data/portal-health.tsv of whatever checkout happened to own scan.mjs. That
+// guarantee is unchanged and still asserted below.
 //
-// This spawns a real child process with cwd pinned to a temp dir that is NOT
-// the directory scan.mjs lives in, then calls appendPortalHealth() with no
-// filePath argument -- the exact call scan.mjs's own production code path
-// makes. The row must land under the given cwd, and the script's own
-// directory must be provably untouched.
+// What changed is the mechanism (#3510). Resolving from the cwd fixed the
+// pollution but left scan.mjs with two rules for where user data lives: this
+// path followed the shell, while SCAN_HISTORY_PATH, PIPELINE_PATH and
+// APPLICATIONS_PATH had already followed DATA_ROOT since the data-root feature
+// landed in 02daaf1 -- and stats.mjs:39, the only reader of this file, reads it
+// at join(DATA_ROOT, 'data', 'portal-health.tsv'). A user with a data root
+// configured got rows written somewhere their own reader never looked.
+//
+// So isolation now comes from CAREER_OPS_ROOT, the mechanism the rest of the
+// suite already uses, rather than from the cwd. This spawns a real child with a
+// data root pinned to a temp dir AND a cwd pinned to a second temp dir, so the
+// two are provably distinguishable, then calls appendPortalHealth() with no
+// filePath argument -- the exact call scan.mjs's own production path makes. The
+// row must land under the data root, not the cwd, and the script's own directory
+// must be provably untouched.
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
 import { spawnSync } from 'child_process';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
@@ -25,10 +33,11 @@ import { pathToFileURL } from 'url';
 import { randomUUID } from 'crypto';
 import { applyScriptDirGuard } from './portal-health-guard.mjs';
 
-console.log('\nscan.mjs — portal-health.tsv resolves against cwd, not script dir');
+console.log('\nscan.mjs — portal-health.tsv resolves against the data root, never the checkout');
 
 const scanUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan.mjs')).href);
-const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-'));
+const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-cwd-'));
+const sandboxRoot = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-root-'));
 
 // The script's own directory is ROOT in this checkout -- the same directory
 // the pre-fix bug always resolved to regardless of the cwd it was given.
@@ -51,9 +60,13 @@ try {
   `;
 
   const res = spawnSync(NODE, ['--input-type=module', '-e', script], {
+    // cwd and data root deliberately differ: if the two were the same directory
+    // this test could not tell an anchored path from a cwd-relative one, which
+    // is exactly how the resolution drifted in the first place.
     cwd: sandboxCwd,
     encoding: 'utf-8',
     timeout: 30000,
+    env: { ...process.env, CAREER_OPS_ROOT: sandboxRoot, CAREER_OPS_DATA_DIR: '' },
   });
 
   if (res.error || res.status !== 0) {
@@ -62,12 +75,22 @@ try {
     pass('appendPortalHealth() runs cleanly with a sandbox cwd');
   }
 
-  // 1. The row lands under the cwd the process was given, not the script dir.
-  const sandboxHealthPath = join(sandboxCwd, 'data', 'portal-health.tsv');
-  if (existsSync(sandboxHealthPath) && readFileSync(sandboxHealthPath, 'utf-8').includes(marker)) {
-    pass('the fixture row is written under the sandbox cwd');
+  // 1. The row lands under the configured data root, not the script dir.
+  const rootHealthPath = join(sandboxRoot, 'data', 'portal-health.tsv');
+  if (existsSync(rootHealthPath) && readFileSync(rootHealthPath, 'utf-8').includes(marker)) {
+    pass('the fixture row is written under the configured data root');
   } else {
-    fail(`expected ${sandboxHealthPath} to contain the fixture row, it does not`);
+    fail(`expected ${rootHealthPath} to contain the fixture row, it does not`);
+  }
+
+  // 1b. And NOT under the cwd, which is a different directory here. stats.mjs
+  //     reads this file at the data root; a row under the cwd is a row its only
+  //     reader will never see.
+  const cwdHealthPath = join(sandboxCwd, 'data', 'portal-health.tsv');
+  if (!existsSync(cwdHealthPath)) {
+    pass('nothing was written under the cwd, which no reader looks at');
+  } else {
+    fail(`appendPortalHealth() wrote to the cwd at ${cwdHealthPath} instead of the data root (#3510)`);
   }
 
   // 2. The script's own directory -- the real user-layer data dir in a normal
@@ -84,6 +107,7 @@ try {
   }
 } finally {
   rmSync(sandboxCwd, { recursive: true, force: true });
+  rmSync(sandboxRoot, { recursive: true, force: true });
   // Defensive cleanup, matching the pattern in tests/scan-no-targets.test.mjs
   // and tests/intake-mutex.test.mjs -- never observed to trigger once the path
   // is fixed, but leaves the tree exactly as found if it somehow still does.

--- a/tests/scan-ats-full-outage-checkpoint.test.mjs
+++ b/tests/scan-ats-full-outage-checkpoint.test.mjs
@@ -10,9 +10,10 @@
 // Driven end-to-end in a child process rather than against an exported helper:
 // the bug is not in any single function but in the interaction between the
 // breaker, the checkpoint writer, and the exit path, and only a whole run
-// exercises all three. The child runs in a sandbox cwd (every path
-// scan-ats-full.mjs touches is relative) with a stubbed `dns.lookup`, so no
-// network is involved and the resolver's behaviour is exact:
+// exercises all three. The child runs against a sandbox data root — pointed at
+// by CAREER_OPS_ROOT, since scan-ats-full.mjs's paths follow the data root
+// rather than the cwd (#3510) — with a stubbed `dns.lookup`, so no network is
+// involved and the resolver's behaviour is exact:
 //
 //   EAI_AGAIN  — a resolver-level failure; trips the breaker  → checkpoint kept
 //   ENOTFOUND  — NXDOMAIN, an ordinary dead board; no outage  → checkpoint deleted
@@ -42,6 +43,8 @@ const CHECKPOINT_REL = join('data', 'cache', 'ats-full-checkpoint.json');
  * @returns {string} Sandbox directory.
  */
 function makeSandbox() {
+  // Laid out exactly like a real data root — portals.yml at the top,
+  // data/cache/ beneath it — because that is what it is handed to the child as.
   const dir = mkdtempSync(join(tmpdir(), 'career-ops-outage-'));
   // Minimal portals.yml: main() exits early without one. The filters never
   // matter here — no board is reachable, so no posting reaches them.
@@ -92,7 +95,17 @@ function sweep(dir, dnsCode, extraArgs = []) {
   return run(NODE, [join(dir, 'launch.mjs'), '--ats', 'greenhouse', '--json', ...extraArgs], {
     cwd: dir,
     // Pacing would only add wall-clock time to a run whose every lookup fails.
-    env: { ...process.env, STUB_DNS_CODE: dnsCode, CAREER_OPS_DNS_LOOKUPS_PER_MIN: '0' },
+    // CAREER_OPS_ROOT is what actually isolates this sweep: cwd stays pinned too,
+    // so a path that quietly went back to following the shell would still be
+    // caught by tests/scan-data-paths-under-data-root.test.mjs rather than
+    // silently reading this fixture through the other route.
+    env: {
+      ...process.env,
+      CAREER_OPS_ROOT: dir,
+      CAREER_OPS_DATA_DIR: '',
+      STUB_DNS_CODE: dnsCode,
+      CAREER_OPS_DNS_LOOKUPS_PER_MIN: '0',
+    },
     timeout: 120_000,
   });
 }

--- a/tests/scan-data-paths-under-data-root.test.mjs
+++ b/tests/scan-data-paths-under-data-root.test.mjs
@@ -1,0 +1,132 @@
+// tests/scan-data-paths-under-data-root.test.mjs — the scanners' User Layer data
+// follows the configured data root, not the shell's working directory (#3510).
+//
+// scan.mjs anchored some of its data paths to DATA_ROOT (SCAN_HISTORY_PATH,
+// PIPELINE_PATH, PORTALS_PATH, APPLICATIONS_PATH) and left others as bare
+// relative strings resolved against process.cwd() (blacklist, scan-runs,
+// portal-health), with the sibling scanners carrying their own cwd-relative
+// copies of paths they then WROTE to through scan.mjs's anchored ones. One
+// command, one dataset, two destinations.
+//
+// Nothing failed loudly, which is what made it worth a test: a wrong-but-writable
+// path is silently accepted. The sharpest case is the blacklist — AGENTS.md
+// documents data/blacklist.md as respected by scan.mjs, and a user with a data
+// root got an empty list with no indication their do-not-apply companies had
+// been let through.
+//
+// Every check below runs the real module in a child process with the data root
+// and the cwd pointed at DIFFERENT directories, each holding a decoy copy of the
+// file under test. A path that follows the cwd picks the decoy; one that follows
+// the data root picks the real file. If the two directories were the same, this
+// suite could not tell them apart — which is precisely how the drift survived.
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+
+console.log('\nscanners — user data follows the data root, not the cwd (#3510)');
+
+const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-scanroot-'));
+const decoyCwd = mkdtempSync(join(tmpdir(), 'career-ops-scandecoy-'));
+mkdirSync(join(dataRoot, 'data', 'cache'), { recursive: true });
+mkdirSync(join(decoyCwd, 'data', 'cache'), { recursive: true });
+
+/** Run one ESM snippet with the data root and the cwd deliberately separated. */
+function inChild(snippet) {
+  return execFileSync(NODE, ['--input-type=module', '-e', snippet], {
+    cwd: decoyCwd,
+    encoding: 'utf-8',
+    timeout: 60000,
+    env: { ...process.env, CAREER_OPS_ROOT: dataRoot, CAREER_OPS_DATA_DIR: '' },
+  }).trim();
+}
+
+const scanUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+const atsUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
+
+const blacklistRow = (company) =>
+  `| Company | Since | Scope | Reason |\n|---|---|---|---|\n| ${company} | 2026-01-01 | company | fixture |\n`;
+
+try {
+  // 1. The blacklist the user actually owns is the one that gets read.
+  writeFileSync(join(dataRoot, 'data', 'blacklist.md'), blacklistRow('RealCo'), 'utf-8');
+  writeFileSync(join(decoyCwd, 'data', 'blacklist.md'), blacklistRow('DecoyCo'), 'utf-8');
+  const seen = inChild(`
+    const m = await import(${scanUrl});
+    console.log([...m.loadBlacklist().keys()].join(','));
+  `);
+  seen === 'realco'
+    ? pass('loadBlacklist() reads the data root’s blacklist, not the cwd’s')
+    : fail(`loadBlacklist() read the wrong file — saw [${seen}], expected [realco] (#3510)`);
+
+  // 2. scan-runs.tsv is written where stats.mjs:36 reads it. A writer and a
+  //    reader naming different files is not a lost row, it is a wrong number.
+  inChild(`
+    const m = await import(${scanUrl});
+    m.appendScanRunSummary({ companies: 1, boards: 1, found: 0 });
+  `);
+  const runsAtRoot = join(dataRoot, 'data', 'scan-runs.tsv');
+  const runsAtCwd = join(decoyCwd, 'data', 'scan-runs.tsv');
+  existsSync(runsAtRoot) && !existsSync(runsAtCwd)
+    ? pass('appendScanRunSummary() writes under the data root, where stats.mjs reads')
+    : fail(`scan-runs.tsv landed wrong — root:${existsSync(runsAtRoot)} cwd:${existsSync(runsAtCwd)} (#3510)`);
+
+  // 3. The ATS sweep's resume checkpoint. Reading the cwd's copy means a
+  //    multi-hour sweep resumed from another directory restarts from zero — the
+  //    one failure --resume exists to prevent.
+  const checkpoint = (tag) => JSON.stringify({ version: 1, current: null, tag });
+  writeFileSync(join(dataRoot, 'data', 'cache', 'ats-full-checkpoint.json'), checkpoint('data-root'), 'utf-8');
+  writeFileSync(join(decoyCwd, 'data', 'cache', 'ats-full-checkpoint.json'), checkpoint('cwd'), 'utf-8');
+  const tag = inChild(`
+    const m = await import(${atsUrl});
+    console.log(m.loadCheckpoint()?.tag ?? 'none');
+  `);
+  tag === 'data-root'
+    ? pass('loadCheckpoint() resumes from the data root’s checkpoint')
+    : fail(`loadCheckpoint() read the ${tag} checkpoint — a resume would restart or resume the wrong sweep (#3510)`);
+
+  // 4. The sibling scanners must not re-derive paths they write to through
+  //    scan.mjs. Importing one and comparing the resolved constants is the only
+  //    check that stays true as the files move around.
+  const shared = inChild(`
+    const scan = await import(${scanUrl});
+    const ats = await import(${atsUrl});
+    console.log(JSON.stringify({ pipeline: scan.PIPELINE_PATH, portals: scan.PORTALS_PATH }));
+  `);
+  const paths = JSON.parse(shared);
+  // Undefined means the export is missing entirely — a sibling re-deriving its
+  // own copy. Checked rather than dereferenced, so a regression here reports
+  // itself instead of aborting the checks below.
+  typeof paths.pipeline === 'string' && typeof paths.portals === 'string'
+    && paths.pipeline.startsWith(dataRoot) && paths.portals.startsWith(dataRoot)
+    ? pass('scan.mjs exports pipeline/portals paths anchored to the data root')
+    : fail(`scan.mjs does not export pipeline/portals paths under the data root: ${shared}`);
+
+  // 5. scan-interamt.mjs must not scan the internet just because it was
+  //    imported. It called main() unguarded, so importing it drove a live
+  //    browser scan and appended the results to the user's pipeline.
+  const interamtSrc = readFileSync(join(ROOT, 'scan-interamt.mjs'), 'utf-8');
+  /isMainModule\(import\.meta\.url\)/.test(interamtSrc)
+    ? pass('scan-interamt.mjs runs its scan behind a main guard, like its siblings')
+    : fail('scan-interamt.mjs calls main() at module scope — importing it starts a live scan (#3510)');
+
+  // 6. No scanner may reintroduce a bare-relative user-data path. The behavioral
+  //    checks above cover today's constants; this covers the next one added.
+  const offenders = [];
+  for (const file of ['scan.mjs', 'scan-ats-full.mjs', 'scan-interamt.mjs', 'scan-hn.mjs']) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    for (const m of src.matchAll(/^(?:export )?const\s+(\w+)\s*=\s*'((?:data|output)\/[^']*|portals\.yml)'/gm)) {
+      offenders.push(`${file}: ${m[1]} = '${m[2]}'`);
+    }
+  }
+  offenders.length === 0
+    ? pass('no scanner declares a bare cwd-relative user-data path')
+    : fail(`cwd-relative user-data path(s) reintroduced (#3510): ${offenders.join('; ')}`);
+} catch (e) {
+  fail(`scan data-path suite crashed: ${e.message}`);
+} finally {
+  rmSync(dataRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  rmSync(decoyCwd, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}


### PR DESCRIPTION
## What does this PR do?

The scanners resolved part of their User Layer data against `process.cwd()` and the rest against `DATA_ROOT`, so one command wrote one dataset to two places. This anchors all of it to the data root, gives the sibling scanners one shared resolution to import instead of their own copies, and adds a suite that separates the data root from the cwd so the difference is actually observable.

## Related issue

Closes #3510 — which has the full analysis, including the one decision I'd like a second opinion on (below).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Detail

**What broke.** Nothing failed loudly — a wrong-but-writable path is silently accepted, which is why this outlived #3500 and #3508.

| call | read/wrote | should have |
|---|---|---|
| `loadBlacklist()` | the cwd's `data/blacklist.md` | the data root's |
| `appendScanRunSummary()` | the cwd's `data/scan-runs.tsv` | the data root's, where `stats.mjs:36` reads |
| `appendPortalHealth()` | the cwd's `data/portal-health.tsv` | the data root's, where `stats.mjs:39` reads |
| `loadCheckpoint()` (scan-ats-full) | the cwd's checkpoint | the data root's |

The blacklist is the one that matters: `AGENTS.md` documents `data/blacklist.md` as respected by `scan.mjs`, so a user with a data root got an empty list and their do-not-apply companies came back in the results, with nothing to indicate anything had been let through.

**The siblings were worse than inconsistent.** They import `appendToPipeline` / `appendToScanHistory` from `scan.mjs`, so they *appended* through anchored paths while checking existence, creating and reading through their own cwd-relative copies. `scan-ats-full.mjs:1017` could create an empty `data/pipeline.md` in the cwd and then write the actual matches somewhere else; `scan-interamt.mjs` read one scan-history to compute its last-scan date and appended to another. Both silently ignored `CAREER_OPS_PORTALS` / `CAREER_OPS_SCAN_HISTORY`, which #2271 added precisely so a second search lane cannot poison the first one's dedup history. `scan.mjs` now exports `PORTALS_PATH`, `PIPELINE_PATH` and `SCAN_HISTORY_PATH`; the siblings import them.

## The part worth a second opinion

`PORTAL_HEALTH_PATH` was cwd-relative **deliberately**. `96c578b` changed it from `dirname(fileURLToPath(import.meta.url))` because sandboxed runs were writing fixture rows into the live `data/portal-health.tsv` of whatever checkout owned `scan.mjs`, and `tests/portal-health-path.test.mjs` locked that in.

That problem was real. But the fix swapped one unanchored path for another and left the file with two rules for where user data lives — and `getCareerOpsRoot()` falls back to the codebase root, so "anchor to DATA_ROOT" and "anchor to the script dir" are the same directory on a default install, which is why making it consistent trips that test as written.

I kept the guarantee and changed the mechanism: the test still asserts the checkout's own data directory is never touched, but isolates with `CAREER_OPS_ROOT` — what the rest of the suite already uses — instead of relying on cwd. It now pins the data root and the cwd to **different** temp dirs and asserts the row lands under the root and *not* under the cwd, which the original could not distinguish.

Worth noting that test's premise had gone stale: it says "every sibling data path in scan.mjs (SCAN_HISTORY_PATH, PIPELINE_PATH, APPLICATIONS_PATH, BLACKLIST_PATH, SCAN_RUNS_PATH) is a bare cwd-relative string", but `02daaf1` had already anchored the first three.

#3510 lays out the alternative (use `DATA_ROOT` only when a root is *explicitly* configured, else stay cwd-relative). It preserves today's behavior exactly for unconfigured installs at the cost of a third resolution mode. I went with consistency; say the word if you prefer the other and I'll rework it.

## One extra change, deliberately included

`scan-interamt.mjs` calls `main()` at module scope — no `isMainModule` guard, unlike `scan-hn.mjs:122` and `scan-ats-full.mjs:1115`. Importing the module therefore drove a **live browser scan of interamt.de** and appended 118 offers to the pipeline. I found this the hard way, by importing it to check my own change; the artifacts were cleaned up.

It is in scope because the file could not otherwise be imported by a test at all, and because it is the same family of accident: a script doing real work somewhere nobody asked it to. Happy to split it out if you'd rather.

## Test

`tests/scan-data-paths-under-data-root.test.mjs` runs each module in a child process with the data root and the cwd pointed at **different** directories, each holding a decoy copy of the file under test — so a path that follows the shell picks the decoy and is caught. Six assertions: blacklist, scan-runs, ATS checkpoint, the exported shared paths, the interamt main guard, and a source guard against a new bare-relative user-data constant.

All six fail against the pre-fix code:

```
❌ loadBlacklist() read the wrong file — saw [decoyco], expected [realco]
❌ scan-runs.tsv landed wrong — root:false cwd:true
❌ loadCheckpoint() read the cwd checkpoint — a resume would restart or resume the wrong sweep
❌ scan.mjs does not export pipeline/portals paths under the data root: {}
❌ scan-interamt.mjs calls main() at module scope — importing it starts a live scan
❌ cwd-relative user-data path(s) reintroduced: ...9 constants...
```

`tests/scan-ats-full-outage-checkpoint.test.mjs` also needed updating: it built a sandbox **cwd** holding `portals.yml` and the dataset cache. That layout is already exactly a data root, so it now hands the directory to the child as `CAREER_OPS_ROOT` and keeps the cwd pinned there too.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (7296 passed, 0 failed, 12 pre-existing warnings)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files) — restoring the User Layer to the configured data root is the point of the change
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

Independent of #3503, #3507 and #3509 — different files, branched from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scanner configuration, history, pipeline results, health reports, and checkpoints now consistently use the configured data location.
  * Resuming a paused ATS scan from another directory now correctly finds its checkpoint instead of restarting from the beginning.
  * Prevented scan results and related files from being accidentally created in the current working directory.
  * Improved consistency across supported portal scanners and safer module imports.

* **Tests**
  * Added regression coverage for data-path handling, checkpoint recovery, and scanner isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->