### PR TITLE
test(win): skip the write-failure assertions where a write-deny cannot bind

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -31,6 +31,9 @@ import { acquireTrackerLock } from './tracker-utils.mjs';
 // and fail for the hours of the day where they differ — a test that passes
 // only in part of the UTC day.
 import { localToday } from './lib/local-today.mjs';
+// Shared with tests/mark-pdf-ready.test.mjs so the two write-failure setups
+// cannot drift apart again (#3423).
+import { directoryDenyBinds } from './tests/helpers.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const NODE = process.execPath;
@@ -769,6 +772,11 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
 {
   if (process.platform !== 'win32' && process.getuid?.() === 0) {
     pass('write-failure: skipped (running as root — directory permissions are not enforced)');
+  } else if (process.platform === 'win32' && !directoryDenyBinds()) {
+    // Same escape hatch as root above, for the platform whose privilege model
+    // most often bypasses a permission bit. Loud on purpose: it names what was
+    // measured, so nobody reads it as the write-failure path being exercised.
+    pass('write-failure: skipped (an icacls write-deny does not bind this token - elevated shell)');
   } else {
     const dir = mkdtempSync(join(tmpdir(), 'co-setstatus-wf-'));
     const roDir = join(dir, 'ro');

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -633,3 +633,55 @@ export function hermeticGitEnv(gitConfigPath, base = process.env) {
   delete env.GIT_CONFIG;
   return env;
 }
+
+/**
+ * Can a directory write-deny actually stop THIS process from creating a file?
+ *
+ * Two suites arrange a write failure by making the tracker's directory
+ * unwritable and asserting the structured error that follows. An elevated
+ * Windows shell is not bound by that ACE: the temp-file write lands, the CLI
+ * exits 0, and the assertion reports `code=0 json=undefined`, which reads like
+ * the CLI is broken rather than like a setup step that could not be arranged
+ * (#3423). That is the same "permissions do not apply to me" case those suites
+ * already skip for root on POSIX, so it takes the same loud skip.
+ *
+ * Measured, never inferred: this performs the very operation those tests depend
+ * on - apply the deny, then create a file with the same fs API - instead of
+ * asking a proxy whether the shell is elevated. A proxy is the wrong tool here.
+ * A restricted token still lists the Administrators SID in `whoami /groups`
+ * (present for deny only), and inside one elevated token PowerShell's
+ * Set-Content is refused while Node's writeFileSync succeeds, so "is elevated"
+ * and "can still write" are genuinely different questions.
+ *
+ * Fails toward RUNNING the assertion: if the probe cannot be arranged at all
+ * (no icacls, a non-zero exit, anything thrown) it answers true so the caller
+ * still executes its check. A skip on an inconclusive probe would quietly turn
+ * "the failure could not be arranged" into "the failure handling is fine",
+ * which is the blind spot those assertions exist to catch.
+ *
+ * Lives here rather than in each suite because the two copies of this setup
+ * have already drifted once: `tests/mark-pdf-ready.test.mjs` says it mirrors
+ * `set-status-tests.mjs`, and it mirrored this bug along with the arrangement.
+ *
+ * @returns {boolean} true when the deny binds, or when it could not be evaluated.
+ */
+export function directoryDenyBinds() {
+  let probeDir = null;
+  try {
+    probeDir = mkdtempSync(join(tmpdir(), 'co-denyprobe-'));
+    execFileSync('icacls', [probeDir, '/deny', '*S-1-1-0:(WD,AD)'], { stdio: 'ignore' });
+    try {
+      writeFileSync(join(probeDir, 'canary.tmp'), 'x');
+      return false;
+    } catch {
+      return true;
+    }
+  } catch {
+    return true;
+  } finally {
+    if (probeDir) {
+      try { execFileSync('icacls', [probeDir, '/remove:d', '*S-1-1-0'], { stdio: 'ignore' }); } catch {}
+      rmSync(probeDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -680,8 +680,16 @@ export function directoryDenyBinds() {
     return true;
   } finally {
     if (probeDir) {
+      // Cleanup must not escape this function. A throw from `finally` replaces
+      // the value the try block already computed, so a failed rmSync would turn
+      // a decided probe into an exception and take both callers down with it -
+      // the opposite of the fail-toward-running-the-assertion contract above.
+      // Windows makes that reachable: rmSync can answer EPERM for a while after
+      // a child exits (the reason the wrapper retries at all), and this
+      // directory carries a deny ACE. A leaked temp directory is the cheaper
+      // failure.
       try { execFileSync('icacls', [probeDir, '/remove:d', '*S-1-1-0'], { stdio: 'ignore' }); } catch {}
-      rmSync(probeDir, { recursive: true, force: true });
+      try { rmSync(probeDir, { recursive: true, force: true }); } catch {}
     }
   }
 }

--- a/tests/mark-pdf-ready.test.mjs
+++ b/tests/mark-pdf-ready.test.mjs
@@ -9,7 +9,7 @@
 // Auto-discovered by test-all.mjs (tests/**/*.test.mjs, #1440) — imported
 // in-process alongside every other discovered suite, so this file must NEVER
 // exit the process itself; only pass()/fail() from ./helpers.mjs.
-import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { pass, fail, NODE, ROOT, directoryDenyBinds } from './helpers.mjs';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync } from 'fs';
@@ -405,6 +405,10 @@ const TRACKER_DUP_REPORT = `# Applications Tracker
 {
   if (process.platform !== 'win32' && process.getuid?.() === 0) {
     pass('write-failure: skipped (running as root — directory permissions are not enforced)');
+  } else if (process.platform === 'win32' && !directoryDenyBinds()) {
+    // Same escape hatch as root above. This suite mirrors set-status-tests.mjs's
+    // write-failure test, and mirrored its Windows blind spot with it (#3423).
+    pass('write-failure: skipped (an icacls write-deny does not bind this token - elevated shell)');
   } else {
     // Given the tracker's directory is readable but not writable
     const dir = mkdtempSync(join(tmpdir(), 'co-markpdf-wf-'));


### PR DESCRIPTION
Closes #3423.

`set-status-tests.mjs` section 16 and `tests/mark-pdf-ready.test.mjs` section 14 both arrange a write failure by denying write-data/append-data on the tracker's directory. An elevated Windows shell is not bound by that ACE, so the temp-file write lands, the CLI exits 0, and both report `code=0 json=undefined` - which reads like the CLI is broken rather than like a setup step that could not be arranged.

Both files already skip the same "permissions do not apply to me" case for root on POSIX. `process.platform !== 'win32'` excluded Windows from it, so the one platform whose privilege model most often bypasses a permission bit was the one platform with no escape hatch.

## Why a probe and not an elevation check

Measured on the box, not inferred. In a **single elevated token**, same directory, same deny:

| operation | result |
|---|---|
| Node `writeFileSync` | create SUCCEEDS - the deny does not bind |
| PowerShell `Set-Content` | create BLOCKED (`UnauthorizedAccessException`) |

Dropping to a restricted token (`runas /trustlevel:0x20000`), same directory, same Node call: `EPERM`. So a normal token *is* bound; the elevated one walks through, and only for some APIs.

That rules out the proxy detectors. A restricted token still lists the Administrators SID in `whoami /groups` (present for deny only), so a group check reports "elevated" for a token the deny actually binds. The probe instead performs the very operation the tests depend on - apply the deny, create a file with the same fs API - and answers the question that actually matters: can this environment arrange the failure at all.

Two properties worth keeping:

1. **The skip is loud** and names what was measured rather than guessing a cause.
2. **The probe fails toward running the assertion.** If it cannot be arranged (no `icacls`, non-zero exit, anything thrown) it reports that the deny binds, so the assertion still executes. Skipping on an inconclusive probe is what would turn "the failure could not be arranged" into "the failure handling is fine".

## Per-site verification, including the mutation

|  | set-status-tests | mark-pdf-ready |
|---|---|---|
| elevated, unpatched | 95 pass / 1 fail | FAIL write-failure |
| elevated, patched | 96 pass / 0 fail | PASS (loud skip) |
| restricted token | 96 pass / 0 fail | PASS (assertion runs) |
| macOS non-root | 96 pass / 0 fail | PASS (assertion runs) |
| probe forced inconclusive | 95 pass / 1 fail | FAIL (assertion runs) |

The last row is the mutation: forcing the probe's `icacls` call to exit non-zero puts **both** sites back to red rather than to a green skip, so the skip has to be earned.

Full suite, Windows 11 elevated, Node v24.19.0: **7284 passed / 2 failed before, 7286 passed / 0 failed after.** macOS: 7289 passed / 0 failed. Patching `set-status-tests.mjs` alone leaves 7285 / 1, which is why both sites are in one change.

## The shape question from the issue

I asked whether you wanted the probe duplicated per suite or defined once, and went with once in `tests/helpers.mjs` - `mark-pdf-ready`'s own comment says it mirrors `set-status-tests.mjs`, and it mirrored this blind spot along with the setup, which is the drift the `tracker-utils.mjs` / `pipeline-lock.mjs` header warns about. The cost is one new edge: `set-status-tests.mjs` now imports from `tests/` for the first time. `helpers.mjs` has no import-time side effects, and its counters are untouched by importing a single function, but if you would rather not add that edge I will duplicate the probe in both files instead - say the word and I will push that shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Windows compatibility for write-failure validation.
  * Tests now skip scenarios when system permissions prevent the write-denial check from being applied, avoiding false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->