### PR TITLE
fix(scan): align modes/scan.md scan-history columns with the writer (#3458)

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -260,7 +260,11 @@ Levels are additive — they are executed in order, and results are merged and d
 
 8. **For each new verified offer that passes filters**:
    a. Add to the `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
-   b. Record in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+   b. Record a row in `scan-history.tsv` with status `added`, in the full
+      12-column format documented under [Scan History](#scan-history) below —
+      the same shape `formatScanHistoryRow` / `appendToScanHistory` in `scan.mjs`
+      emit. Leave a trailing column empty when you have no value for it; never
+      write a short row.
 
 9. **Offers filtered by title**: record in `scan-history.tsv` with status `skipped_title`.
 10. **Duplicate offers**: record with status `skipped_dup`.
@@ -286,7 +290,10 @@ If a non-publicly accessible URL is found:
 
 ## Scan History
 
-`data/scan-history.tsv` tracks ALL seen URLs. Each row has nine tab-separated columns:
+`data/scan-history.tsv` tracks ALL seen URLs. Each row has twelve tab-separated
+columns, in writer order (`formatScanHistoryRow` in `scan.mjs`). Columns 8-12 are
+append-only additions; older rows may carry fewer columns and every reader indexes
+by position and tolerates their absence.
 
 | # | Column | Example | Notes |
 |---|--------|---------|-------|
@@ -294,21 +301,24 @@ If a non-publicly accessible URL is found:
 | 2 | `first_seen` | `2026-02-10` | ISO date the URL was first encountered |
 | 3 | `portal` | `Ashby — AI PM` | Query name from `portals.yml` |
 | 4 | `title` | `PM AI` | Job title as returned by the ATS |
-| 5 | `company` | `Acme` | Company name |
-| 6 | `status` | `added` | `added`, `skipped_dup`, `skipped_title`, `skipped_expired` |
+| 5 | `company` | `Acme` | Company name as returned by the ATS |
+| 6 | `status` | `added` | `added`, `skipped_dup`, `skipped_title`, `skipped_expired`, `skipped_error` |
 | 7 | `location` | `Remote — Europe` | Location string (may be empty); persisted for later auditing |
-| 8 | `jd_fingerprint` | `a3f1c8d2e4b70592` | 64-bit SimHash of the JD text (16 hex chars); empty when no usable body was available |
-| 9 | `postedAt` | `2026-02-08` | ISO date the role was originally posted (as reported by the ATS); empty when not available |
+| 8 | `fingerprint` | `a3f1c8d2e4b70592` | 64-bit SimHash of the JD text (16 hex chars); empty when no usable body was available |
+| 9 | `posted_at` | `2026-02-08` | ISO date the role was originally posted (as reported by the ATS); empty when not available |
+| 10 | `trust_score` | `72` | Posting-legitimacy score (#1743); empty unless the scanner flagged the posting (score < 100) |
+| 11 | `trust_flags` | `no_company_site,reposted` | Comma-joined legitimacy flags; empty when `trust_score` is empty |
+| 12 | `normalized_company` | `acme` | Canonical company key (#2093) — lowercased, punctuation/whitespace folded, legal-entity suffixes stripped — so repost/name matching never has to re-derive it |
 
 ```tsv
-url	first_seen	portal	title	company	status	location	jd_fingerprint	postedAt
-https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added	Remote	a3f1c8d2e4b70592	2026-02-08
+url	first_seen	portal	title	company	status	location	fingerprint	posted_at	trust_score	trust_flags	normalized_company
+https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added	Remote	a3f1c8d2e4b70592	2026-02-08			acme
 ```
 
 ### Filtering by posted date
 
 `first_seen` (column 2) is when **our scanner** spotted the URL — not when the
-employer actually posted it. That real posting date is column 9 (`postedAt`).
+employer actually posted it. That real posting date is column 9 (`posted_at`).
 To scope a scan to an absolute posting-date window (e.g. "only postings from
 the 17th to the 20th"), pass `--posted-after`/`--posted-before` on the CLI —
 both optional, both `YYYY-MM-DD`, both inclusive:
@@ -385,7 +395,7 @@ weekly, `--since 10` keeps a margin for a skipped run.
 
 ### Cross-listing detection
 
-The `jd_fingerprint` column exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.
+The `fingerprint` column (column 8) exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.
 
 How it works:
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4658,35 +4658,41 @@ if (scanMode.includes('secondaryLocations') && scanMode.includes('descriptionPla
 // modes/scan.md documents the scan-history.tsv column layout an agent-driven
 // scan has to reproduce by hand. It drifted once already: the doc said "nine
 // columns" and step 8b spelled out a six-column row while formatScanHistoryRow
-// emits twelve (#3458). Nothing tied the doc to the writer. This asserts the
-// header the doc shows in its ```tsv block is byte-identical to the one
+// emits twelve (#3458). Nothing tied the doc to the writer. This asserts both
+// surfaces under "## Scan History" — the fenced ```tsv header and the ordered
+// "| N | `name` |" column table — match, position for position, the header
 // appendToScanHistory writes on fresh-file creation, and that step 8b no longer
 // carries the short literal that can drift again.
 {
   const writerMatch = scanScript.match(/writeFileSync\(SCAN_HISTORY_PATH,\s*'([^']+)'/);
-  const docMatch = scanMode.match(/##\s*Scan History[\s\S]*?```tsv\r?\n([^\r\n]+)\r?\n/);
+  // Scope to the "## Scan History" section only (up to the next `##`/`###`
+  // heading) so the table parse can't pick up a numbered list elsewhere.
+  const sectionMatch = scanMode.match(/##\s*Scan History\b([\s\S]*?)(?:\r?\n#{2,3}\s|$)/);
+  const section = sectionMatch ? sectionMatch[1] : '';
+  const docMatch = section.match(/```tsv\r?\n([^\r\n]+)\r?\n/);
+  // Ordered column names from the "| N | `name` | ... |" table rows.
+  const tableCols = [...section.matchAll(/^\|\s*\d+\s*\|\s*`([^`]+)`\s*\|/gm)].map((m) => m[1]);
   if (!writerMatch) {
     fail('scan-history header parity: could not find the writeFileSync(SCAN_HISTORY_PATH, ...) header literal in scan.mjs');
   } else if (!docMatch) {
     fail('scan-history header parity: could not find the fenced tsv header block under "## Scan History" in modes/scan.md');
+  } else if (tableCols.length === 0) {
+    fail('scan-history header parity: could not parse the "| N | `name` |" column table under "## Scan History" in modes/scan.md');
   } else {
     const writerHeader = writerMatch[1].replace(/\\n$/, '');
     const writerCols = writerHeader.split('\\t');
     const docCols = docMatch[1].split('\t');
     const shortLiteral = scanMode.includes('{company}\\tadded');
-    const missingFromTable = writerCols.filter((c) => !scanMode.includes(`\`${c}\``));
-    if (
-      writerHeader === docCols.join('\\t') &&
-      !shortLiteral &&
-      missingFromTable.length === 0
-    ) {
+    const tsvMatchesWriter = writerHeader === docCols.join('\\t');
+    const tableMatchesWriter = tableCols.join('\\t') === writerCols.join('\\t');
+    if (tsvMatchesWriter && tableMatchesWriter && !shortLiteral) {
       pass(`scan.md documents the scan-history.tsv layout matching formatScanHistoryRow (${writerCols.length} columns, in writer order)`);
     } else if (shortLiteral) {
       fail('scan.md step 8b still spells out the pre-#3458 six-column scan-history row (`{company}\\tadded`) — defer to the 12-column format instead');
-    } else if (writerHeader !== docCols.join('\\t')) {
-      fail(`scan.md scan-history tsv header drifted from scan.mjs: doc has [${docCols.join(', ')}], writer emits [${writerCols.join(', ')}]`);
+    } else if (!tsvMatchesWriter) {
+      fail(`scan.md scan-history tsv example header drifted from scan.mjs: doc has [${docCols.join(', ')}], writer emits [${writerCols.join(', ')}]`);
     } else {
-      fail(`scan.md scan-history column table is missing entries the writer emits: ${missingFromTable.join(', ')}`);
+      fail(`scan.md scan-history column table drifted from scan.mjs (missing/extra/reordered): table has [${tableCols.join(', ')}], writer emits [${writerCols.join(', ')}]`);
     }
   }
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4655,6 +4655,42 @@ if (scanMode.includes('secondaryLocations') && scanMode.includes('descriptionPla
   fail('scan.md parse conventions drifted from providers/*.mjs — missing secondaryLocations (ashby) or descriptionPlain (lever) that scan.mjs filters consume');
 }
 
+// modes/scan.md documents the scan-history.tsv column layout an agent-driven
+// scan has to reproduce by hand. It drifted once already: the doc said "nine
+// columns" and step 8b spelled out a six-column row while formatScanHistoryRow
+// emits twelve (#3458). Nothing tied the doc to the writer. This asserts the
+// header the doc shows in its ```tsv block is byte-identical to the one
+// appendToScanHistory writes on fresh-file creation, and that step 8b no longer
+// carries the short literal that can drift again.
+{
+  const writerMatch = scanScript.match(/writeFileSync\(SCAN_HISTORY_PATH,\s*'([^']+)'/);
+  const docMatch = scanMode.match(/##\s*Scan History[\s\S]*?```tsv\r?\n([^\r\n]+)\r?\n/);
+  if (!writerMatch) {
+    fail('scan-history header parity: could not find the writeFileSync(SCAN_HISTORY_PATH, ...) header literal in scan.mjs');
+  } else if (!docMatch) {
+    fail('scan-history header parity: could not find the fenced tsv header block under "## Scan History" in modes/scan.md');
+  } else {
+    const writerHeader = writerMatch[1].replace(/\\n$/, '');
+    const writerCols = writerHeader.split('\\t');
+    const docCols = docMatch[1].split('\t');
+    const shortLiteral = scanMode.includes('{company}\\tadded');
+    const missingFromTable = writerCols.filter((c) => !scanMode.includes(`\`${c}\``));
+    if (
+      writerHeader === docCols.join('\\t') &&
+      !shortLiteral &&
+      missingFromTable.length === 0
+    ) {
+      pass(`scan.md documents the scan-history.tsv layout matching formatScanHistoryRow (${writerCols.length} columns, in writer order)`);
+    } else if (shortLiteral) {
+      fail('scan.md step 8b still spells out the pre-#3458 six-column scan-history row (`{company}\\tadded`) — defer to the 12-column format instead');
+    } else if (writerHeader !== docCols.join('\\t')) {
+      fail(`scan.md scan-history tsv header drifted from scan.mjs: doc has [${docCols.join(', ')}], writer emits [${writerCols.join(', ')}]`);
+    } else {
+      fail(`scan.md scan-history column table is missing entries the writer emits: ${missingFromTable.join(', ')}`);
+    }
+  }
+}
+
 if (!fileExists('scripts/parsers/cohere_jobs.py')) {
   pass('Cohere parser example is not bundled as a runtime script');
 } else {


### PR DESCRIPTION
## What does this PR do?

`modes/scan.md` documented `scan-history.tsv` as **nine** columns and its step 8b told the agent to record a **six**-column row (`{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`), while `formatScanHistoryRow` in `scan.mjs` has emitted **twelve** since the fingerprint / `posted_at` / trust / `normalized_company` columns landed. Because `modes/*.md` are agent instructions, an agent following step 8b literally writes malformed rows into real data. This aligns the doc with the writer and adds a parity guard so the two can't drift apart again.

## Related issue

Fixes #3458

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Details

**`modes/scan.md`**
- "Scan History" section: `nine` → `twelve` columns, table extended to all 12 in writer order (adds `fingerprint`, `posted_at`, `trust_score`, `trust_flags`, `normalized_company`), fenced `tsv` example updated.
- Step 8b now defers to the documented 12-column format / `formatScanHistoryRow` instead of spelling out a literal that can drift.
- Renamed `jd_fingerprint` → `fingerprint` and `postedAt` → `posted_at` in the surrounding prose so the doc matches its own table and the header literal.

**`test-all.mjs`** (section 9, beside the existing `scan.md` convention guards)
- New parity check: the `tsv` header shown in `scan.md` must be byte-identical to the header `appendToScanHistory` writes on fresh-file creation; step 8b must no longer carry the short literal; every emitted column must appear in the doc's table.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix / docs — exempt from issue-first (issue exists anyway: #3458)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` — 7286 passed. The single failure (`tests/skill-project-root.test.mjs`) is a pre-existing Windows-only symlink issue (#3364), unrelated to this change and reproduces with these changes stashed.
- [x] My changes respect the Data Contract (system-layer files only: `modes/scan.md`, `test-all.mjs`)
- [x] Aligns with the roadmap (doc/writer consistency, guard-the-guard testing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated scan history documentation to reflect the current 12-column format.
  * Clarified renamed fields and added trust and normalized company information.
  * Updated cross-listing detection and row-recording instructions.

* **Tests**
  * Added validation to ensure the documented scan history format matches the format produced by the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->