### PR TITLE
fix(tracker): sort the applications table by # ascending on write (#3515)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,6 +463,8 @@ One TSV file per evaluation at `batch/tracker-additions/{num}-{company-slug}.tsv
 
 **Report link normalization:** the TSV always carries a root-relative `[num](reports/...)` link; `merge-tracker.mjs` rewrites it relative to the tracker's own directory (`../reports/...` at `data/applications.md`, `reports/...` at root) so links stay clickable. Idempotent; fix an existing tracker with `node merge-tracker.mjs --migrate` (#760).
 
+**Row order (#3515):** `merge-tracker.mjs` writes the table sorted by `#` **ascending** — matching how rows are referred to ("row 42") and how `reports/` is numbered on disk. The sort runs over the whole table on every write, so a tracker left in merge-batch order by an older version is repaired in place on the next merge; no migration flag is needed. Rows whose `#` is a backfill sentinel (`N/A` / `—` / `-`) sort to the end of the table in their existing relative order.
+
 **Req/posting ID in notes disambiguates same-title postings (#1524, #2009):** when a company posts two genuinely different requisitions whose titles fuzzy-match (e.g. a leveled variant and its bare title, or two sibling team roles), put the req/job/posting ID in the **notes** column on both rows. `merge-tracker.mjs` reads it (`REQ_NUMBER_RE`) and treats rows carrying *different* recognizable IDs as distinct openings, overriding fuzzy title matching. Recognized forms are a `job id` / `posting id` / `requisition` / `req` / `jr` / `job` / `posting` / `ref` / `r_` label followed by an alphanumeric ID containing at least one digit — e.g. `req JR-10423`, `job id 88214`, `ref R_2291`. Prefer this whenever the JD exposes an ID; it is the only signal that survives near-identical titles.
 
 ### Pipeline Integrity

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -800,6 +800,59 @@ if (MIGRATE_VIA) {
   process.exit(0);
 }
 
+// #3515: keep the tracker table ordered by `#` ascending on every write.
+//
+// Rows used to be spliced in immediately after the separator row and never
+// reordered, so the table ended up ordered by *when a batch was merged*: each
+// merge froze its own internal order in place and landed on top of the previous
+// one. Finding row #42 meant reading the whole table — the one thing an ordered
+// `#` column should make unnecessary.
+//
+// Sorting happens at write time over the whole data block, so an existing
+// tracker is repaired in place on the next merge with no separate migration.
+// Ascending matches how rows are referred to ("row 42") and how reports/ is
+// numbered on disk.
+//
+// Rows whose `#` cell is non-numeric — the backfilled `N/A` / `—` / `-`
+// sentinels described in AGENTS.md, or a row too malformed to parse — keep a
+// defined position at the END of the table, in their existing relative order.
+// They are never dropped and never throw the comparator.
+//
+// Only the contiguous run of table rows directly after the separator is
+// touched; any prose or second table further down the file is left alone.
+// Returns the number of rows whose position changed.
+function sortTrackerRowsInPlace(lines) {
+  let sepIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (SEPARATOR_ROW_RE.test(lines[i])) { sepIdx = i; break; }
+  }
+  if (sepIdx < 0) return 0;
+  let end = sepIdx + 1;
+  while (end < lines.length && lines[end].startsWith('|')) end++;
+  const block = lines.slice(sepIdx + 1, end);
+  if (block.length < 2) return 0;
+  const numOf = (line) => {
+    const parts = line.split('|').map(s => s.trim());
+    const n = parseInt(parts[COLMAP.num], 10);
+    return Number.isNaN(n) ? null : n;
+  };
+  const decorated = block.map((line, i) => ({ line, i, num: numOf(line) }));
+  decorated.sort((a, b) => {
+    // Sentinel-numbered rows sink to the bottom; ties (and sentinel-vs-sentinel)
+    // fall back to the original index so the sort is fully deterministic.
+    if (a.num === null || b.num === null) {
+      if (a.num === b.num) return a.i - b.i;
+      return a.num === null ? 1 : -1;
+    }
+    return a.num === b.num ? a.i - b.i : a.num - b.num;
+  });
+  const sorted = decorated.map(d => d.line);
+  let moved = 0;
+  for (let i = 0; i < sorted.length; i++) if (sorted[i] !== block[i]) moved++;
+  lines.splice(sepIdx + 1, block.length, ...sorted);
+  return moved;
+}
+
 const appLines = appContent.split('\n');
 // Detect the tracker's column layout via header names so parsing and writing
 // both work whether the table uses the original 9-column layout or a customized
@@ -936,7 +989,12 @@ updated += pdfSynced;
 // Read tracker additions
 if (!existsSync(ADDITIONS_DIR)) {
   console.log('No tracker-additions directory found.');
-  if (pdfSynced > 0 && !DRY_RUN) writeFileAtomic(APPS_FILE, appLines.join('\n'));
+  // Nothing to merge, but an existing tracker left unsorted by earlier versions
+  // is still repaired here (#3515) — that is the whole point of sorting at write
+  // time rather than at insert time.
+  const moved = DRY_RUN ? 0 : sortTrackerRowsInPlace(appLines);
+  if (moved > 0) console.log(`🔢 Sorted tracker by # ascending (${moved} row(s) repositioned).`);
+  if ((pdfSynced > 0 || moved > 0) && !DRY_RUN) writeFileAtomic(APPS_FILE, appLines.join('\n'));
   if (DRY_RUN) console.log('(dry-run — no changes written)');
   trackerLock.release();
   process.exit(0);
@@ -945,7 +1003,12 @@ if (!existsSync(ADDITIONS_DIR)) {
 const tsvFiles = readdirSync(ADDITIONS_DIR).filter(f => f.endsWith('.tsv'));
 if (tsvFiles.length === 0) {
   console.log('✅ No pending additions to merge.');
-  if (pdfSynced > 0 && !DRY_RUN) writeFileAtomic(APPS_FILE, appLines.join('\n'));
+  // Nothing to merge, but an existing tracker left unsorted by earlier versions
+  // is still repaired here (#3515) — that is the whole point of sorting at write
+  // time rather than at insert time.
+  const moved = DRY_RUN ? 0 : sortTrackerRowsInPlace(appLines);
+  if (moved > 0) console.log(`🔢 Sorted tracker by # ascending (${moved} row(s) repositioned).`);
+  if ((pdfSynced > 0 || moved > 0) && !DRY_RUN) writeFileAtomic(APPS_FILE, appLines.join('\n'));
   if (DRY_RUN) console.log('(dry-run — no changes written)');
   trackerLock.release();
   process.exit(0);
@@ -1367,6 +1430,8 @@ if (newLines.length > 0) {
 
 // Write back
 if (!DRY_RUN) {
+  const moved = sortTrackerRowsInPlace(appLines);
+  if (moved > 0) console.log(`\n🔢 Sorted tracker by # ascending (${moved} row(s) repositioned).`);
   writeFileAtomic(APPS_FILE, appLines.join('\n'));
 
   // Move processed files to merged/ — but only the ones actually applied.

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -831,6 +831,15 @@ function sortTrackerRowsInPlace(lines) {
   while (end < lines.length && lines[end].startsWith('|')) end++;
   const block = lines.slice(sepIdx + 1, end);
   if (block.length < 2) return 0;
+  // Bare parseInt, deliberately — the same reading of the `#` cell that
+  // parseAppLine and the usedNumbers pass use. It accepts a numeric prefix, so
+  // a malformed `12draft` cell reads as 12 here exactly as it does there: that
+  // row is #12 to dedup, to number allocation and to maxNum, so sorting it into
+  // position 12 is what keeps the table consistent with the rest of the script.
+  // A stricter full-cell test would park a row at the bottom that every other
+  // code path still calls #12 — a row you cannot find by its number, which is
+  // the problem this sort exists to solve. The sentinels that matter (`N/A`,
+  // `—`, `-`) are NaN under both readings and land at the end either way.
   const numOf = (line) => {
     const parts = line.split('|').map(s => s.trim());
     const n = parseInt(parts[COLMAP.num], 10);

--- a/tests/merge-tracker-sort.test.mjs
+++ b/tests/merge-tracker-sort.test.mjs
@@ -135,6 +135,30 @@ try {
     fail(`merge-tracker lost rows while sorting: ${sentinelNums.length} of 5 remain`);
   }
 
+  // A `#` cell with a numeric prefix (`12draft`) sorts as 12, NOT with the
+  // sentinels. This is deliberate and is asserted so it cannot be "tightened"
+  // by accident: parseAppLine and the usedNumbers pass both read that cell with
+  // a bare parseInt, so such a row is #12 to dedup, to number allocation and to
+  // maxNum. Parking it at the bottom would leave a row every other code path
+  // calls #12 sitting where nobody can find it by number — the exact failure
+  // this sort exists to fix. Raised in review on #3529.
+  const prefixed = runMerge({
+    rows: [
+      row(20, 'Zulu'),
+      '| 12draft | 2026-01-07 | Whiskey | Eng | 4.0/5 | Applied | ❌ | — | malformed # cell |',
+      '| N/A | 2026-01-05 | Sierra | Eng | N/A | Applied | ❌ | — | backfilled, no evaluation |',
+    ],
+    additions: {
+      '5-acme.tsv': '5\t2026-02-01\tAcme\tML Eng\tEvaluated\t4.5/5\t❌\t[5](reports/5-acme-2026-02-01.md)\tnew\n',
+    },
+  });
+  const prefixedNums = numColumn(prefixed.tracker);
+  if (prefixedNums.join(' ') === '5 12draft 20 N/A') {
+    pass('merge-tracker sorts a numeric-prefix # cell as its number, matching parseAppLine');
+  } else {
+    fail(`merge-tracker mishandled a numeric-prefix # cell: got [${prefixedNums.join(' ')}], want [5 12draft 20 N/A]`);
+  }
+
   // --dry-run writes nothing, sort included.
   const scrambled = [row(4, 'Delta'), row(1, 'Alfa')];
   const dry = runMerge({

--- a/tests/merge-tracker-sort.test.mjs
+++ b/tests/merge-tracker-sort.test.mjs
@@ -1,0 +1,163 @@
+// tests/merge-tracker-sort.test.mjs — #3515: the tracker table is written in
+// ascending `#` order.
+//
+// Rows used to be spliced in directly after the separator row and never
+// reordered, so the table was ordered by *when a batch merged* rather than by
+// `#`: ascending runs, descending runs and stragglers, all frozen in place.
+// Sorting happens at write time, which also repairs an already-scrambled
+// tracker on the next merge with no separate migration step.
+//
+// CLI integration, like tests/merge-tracker.test.mjs: importing
+// merge-tracker.mjs would run the merge at import time, so these drive the real
+// script through the CAREER_OPS_TRACKER / CAREER_OPS_ADDITIONS overrides.
+import { pass, fail, NODE, ROOT, rmSync } from './helpers.mjs';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nmerge-tracker.mjs — table sorted by # ascending (#3515)');
+
+const TRACKER_HEADER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+  '',
+].join('\n');
+
+const row = (num, company) =>
+  `| ${num} | 2026-01-01 | ${company} | Eng | 4.0/5 | Evaluated | ❌ | `
+  + `[${num}](../reports/${num}-${String(company).toLowerCase()}-2026-01-01.md) | seeded |`;
+
+/**
+ * One merge run in an isolated workspace.
+ * @param {{rows?: string[], additions?: Record<string,string>, args?: string[]}} opts
+ * @returns {{tracker: string, output: string}}
+ */
+function runMerge(opts = {}) {
+  const work = mkdtempSync(join(tmpdir(), 'cops-merge-sort-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const addsDir = join(work, 'adds');
+    mkdirSync(addsDir, { recursive: true });
+    writeFileSync(tracker, TRACKER_HEADER + (opts.rows ?? []).join('\n') + '\n');
+    for (const [name, line] of Object.entries(opts.additions ?? {})) {
+      writeFileSync(join(addsDir, name), line);
+    }
+    let output = '';
+    try {
+      output = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs'), ...(opts.args ?? [])], {
+        encoding: 'utf-8',
+        timeout: 30000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: addsDir },
+      });
+    } catch (e) {
+      output = String(e.stdout ?? '') + String(e.stderr ?? '');
+    }
+    return { tracker: readFileSync(tracker, 'utf-8'), output };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+/** The `#` cell of every table row, in file order (non-numeric cells kept raw). */
+function numColumn(trackerText) {
+  return trackerText.split('\n')
+    .filter(l => l.startsWith('|') && !/^\|\s*#\s*\|/.test(l) && !/^\|(?:\s*:?-+:?\s*\|)+\s*$/.test(l))
+    .map(l => l.split('|')[1].trim());
+}
+
+try {
+  // A newly merged batch lands in numeric order, not at the top of the table.
+  const merged = runMerge({
+    rows: [row(3, 'Cyberdyne'), row(9, 'Initech')],
+    additions: {
+      '5-acme.tsv': '5\t2026-02-01\tAcme\tML Eng\tEvaluated\t4.5/5\t❌\t[5](reports/5-acme-2026-02-01.md)\tnew\n',
+      '7-globex.tsv': '7\t2026-02-02\tGlobex\tData Eng\tEvaluated\t4.1/5\t❌\t[7](reports/7-globex-2026-02-02.md)\tnew\n',
+    },
+  });
+  const mergedNums = numColumn(merged.tracker);
+  if (mergedNums.join(' ') === '3 5 7 9') {
+    pass('merge-tracker interleaves a new batch in ascending # order');
+  } else {
+    fail(`merge-tracker did not sort a merged batch ascending: got [${mergedNums.join(' ')}], want [3 5 7 9]`);
+  }
+
+  // An existing scrambled tracker is repaired in place by the same write.
+  const repaired = runMerge({
+    rows: [row(4, 'Delta'), row(12, 'Lima'), row(2, 'Bravo'), row(11, 'Kilo'), row(1, 'Alfa')],
+    additions: {
+      '6-echo.tsv': '6\t2026-02-03\tEcho\tPM\tEvaluated\t4.0/5\t❌\t[6](reports/6-echo-2026-02-03.md)\tnew\n',
+    },
+  });
+  const repairedNums = numColumn(repaired.tracker);
+  if (repairedNums.join(' ') === '1 2 4 6 11 12') {
+    pass('merge-tracker repairs a pre-existing out-of-order tracker on write');
+  } else {
+    fail(`merge-tracker left the tracker unsorted: got [${repairedNums.join(' ')}], want [1 2 4 6 11 12]`);
+  }
+
+  // 11 must sort after 2 — numeric compare, not lexicographic. Covered by the
+  // assertion above; asserted separately so a string-sort regression names
+  // itself instead of hiding inside the ordering diff.
+  if (repairedNums.indexOf('11') > repairedNums.indexOf('2')) {
+    pass('merge-tracker sorts # numerically (11 after 2, not lexicographically)');
+  } else {
+    fail(`merge-tracker sorted # lexicographically: [${repairedNums.join(' ')}]`);
+  }
+
+  // Sentinel-numbered rows (AGENTS.md #1799: backfilled rows carry N/A, — or -)
+  // get a defined position at the end, in their existing relative order. They
+  // are never dropped and never throw the comparator.
+  const sentinelRows = [
+    row(8, 'Hotel'),
+    '| N/A | 2026-01-05 | Sierra | Eng | N/A | Applied | ❌ | — | backfilled, no evaluation |',
+    row(3, 'Cyberdyne'),
+    '| — | 2026-01-06 | Tango | Eng | — | Applied | ❌ | — | backfilled, no evaluation |',
+  ];
+  const sentinel = runMerge({
+    rows: sentinelRows,
+    additions: {
+      '5-acme.tsv': '5\t2026-02-01\tAcme\tML Eng\tEvaluated\t4.5/5\t❌\t[5](reports/5-acme-2026-02-01.md)\tnew\n',
+    },
+  });
+  const sentinelNums = numColumn(sentinel.tracker);
+  if (sentinelNums.join(' ') === '3 5 8 N/A —') {
+    pass('merge-tracker parks sentinel-# rows at the end, in their original relative order');
+  } else {
+    fail(`merge-tracker mishandled sentinel # rows: got [${sentinelNums.join(' ')}], want [3 5 8 N/A —]`);
+  }
+  if (sentinelNums.length === 5) {
+    pass('merge-tracker drops no rows while sorting');
+  } else {
+    fail(`merge-tracker lost rows while sorting: ${sentinelNums.length} of 5 remain`);
+  }
+
+  // --dry-run writes nothing, sort included.
+  const scrambled = [row(4, 'Delta'), row(1, 'Alfa')];
+  const dry = runMerge({
+    rows: scrambled,
+    additions: {
+      '6-echo.tsv': '6\t2026-02-03\tEcho\tPM\tEvaluated\t4.0/5\t❌\t[6](reports/6-echo-2026-02-03.md)\tnew\n',
+    },
+    args: ['--dry-run'],
+  });
+  if (numColumn(dry.tracker).join(' ') === '4 1') {
+    pass('merge-tracker --dry-run leaves the table order untouched');
+  } else {
+    fail(`merge-tracker --dry-run rewrote the table: [${numColumn(dry.tracker).join(' ')}]`);
+  }
+
+  // With nothing pending, the merge still repairs an unsorted table — that is
+  // the point of sorting at write time rather than at insert time.
+  const noAdditions = runMerge({ rows: [row(4, 'Delta'), row(1, 'Alfa')] });
+  if (numColumn(noAdditions.tracker).join(' ') === '1 4') {
+    pass('merge-tracker sorts an existing tracker even with no pending additions');
+  } else {
+    fail(`merge-tracker skipped the sort with no additions: [${numColumn(noAdditions.tracker).join(' ')}]`);
+  }
+} catch (e) {
+  fail(`merge-tracker sort tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
## What does this PR do?

`merge-tracker.mjs` spliced every new batch in directly after the table separator and never reordered anything, so `data/applications.md` ended up ordered by *when a batch merged* rather than by `#` — ascending runs, descending runs and stragglers, each merge freezing its own internal order permanently. This sorts the table's data rows by `#` **ascending** at write time.

Sorting on write rather than at insert means an already-scrambled tracker is repaired in place on the next merge, with no separate migration step or flag.

Details:

- New `sortTrackerRowsInPlace()` sorts the contiguous run of table rows after the separator, numerically (11 sorts after 2, not lexicographically). Anything past that block — prose, a second table — is untouched.
- Called at all three tracker write points, including the two no-additions early exits, which now write when (and only when) the sort actually moved a row. A bare `node merge-tracker.mjs` therefore fixes an existing tracker's order.
- Rows whose `#` is a backfill sentinel (`N/A` / `—` / `-` per AGENTS.md #1799), or that are otherwise too malformed to parse a number from, keep a defined position at the **end** of the table in their existing relative order — never dropped, never throwing the comparator. Ties fall back to the original index, so the result is deterministic.
- `--dry-run` writes nothing, sort included.

Direction is the product call the issue flagged; ascending matches how rows are referred to out loud ("row 42") and how `reports/` is numbered on disk. Documented in AGENTS.md beside the other tracker write-path rules.

New suite `tests/merge-tracker-sort.test.mjs` (auto-discovered, 7 assertions) covers batch interleaving, in-place repair of a pre-existing scrambled table, numeric-vs-lexicographic ordering, sentinel-row placement, no row loss, `--dry-run`, and the no-additions repair path. Verified as a real regression test: 4 of the 7 fail against the pre-fix script.

#3516 (URL column formatting) is untouched — the issue notes the two are independent.

## Related issue

Fixes #3515

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (7296 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracker tables are now automatically sorted by numeric `#` value whenever changes are written.
  * Backfill rows marked `N/A`, `—`, or `-` remain at the end in their existing order.
  * Existing unsorted tracker tables are repaired automatically without migration steps.

* **Bug Fixes**
  * Sorting now also occurs when there are no pending additions, ensuring consistent tracker order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->