### PR TITLE
fix(templates): keep CJK fallback fonts active

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -517,9 +517,9 @@
      browser's per-glyph fallback picks the first installed CJK face for kana
      and kanji. Mirrors the lang="ar" precedent above. */
   html[lang="ja"] body {
-    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans',
+    font-family: var(--font-family), 'Hiragino Sans',
       'Hiragino Kaku Gothic ProN', 'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP',
-      'Noto Sans JP', Meiryo, 'MS PGothic', sans-serif);
+      'Noto Sans JP', Meiryo, 'MS PGothic', sans-serif;
   }
 
   html[lang="ja"] .header h1,
@@ -528,9 +528,9 @@
   html[lang="ja"] .project-title,
   html[lang="ja"] .competency-tag,
   html[lang="ja"] .skill-category {
-   font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+   font-family: var(--font-family), 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
       'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
-      Meiryo, 'MS PGothic', sans-serif);
+      Meiryo, 'MS PGothic', sans-serif;
   }
 
   /* === Simplified Chinese typography ===
@@ -540,9 +540,9 @@
      punctuation from producing clipped or awkward PDF lines. */
   html[lang="zh-CN"] body,
   html[lang="zh"] body {
-    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
+    font-family: var(--font-family), 'PingFang SC',
       'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
-      'Noto Sans SC', 'Source Han Sans SC', sans-serif);
+      'Noto Sans SC', 'Source Han Sans SC', sans-serif;
     line-break: strict;
     word-break: normal;
     overflow-wrap: break-word;
@@ -562,9 +562,9 @@
   html[lang="zh"] .contact-row,
   html[lang="zh"] .competency-tag,
   html[lang="zh"] .skill-category {
-    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
+    font-family: var(--font-family), 'PingFang SC',
       'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
-      'Noto Sans SC', 'Source Han Sans SC', sans-serif);
+      'Noto Sans SC', 'Source Han Sans SC', sans-serif;
   }
 
   /* === Korean typography ===
@@ -574,9 +574,9 @@
      zh blocks above: Latin-capable faces first for stable ATS extraction, then
      platform-native and open-source Korean faces for Hangul glyphs. */
   html[lang="ko"] body {
-    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'Apple SD Gothic Neo',
+    font-family: var(--font-family), 'Apple SD Gothic Neo',
       'Malgun Gothic', 'Noto Sans CJK KR',
-      'Noto Sans KR', 'Nanum Gothic', sans-serif);
+      'Noto Sans KR', 'Nanum Gothic', sans-serif;
     line-break: strict;
     word-break: normal;
     overflow-wrap: break-word;
@@ -590,9 +590,9 @@
   html[lang="ko"] .competency-tag,
   html[lang="ko"] .skill-category,
   html[lang="ko"] .skill-category {
-    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'Apple SD Gothic Neo',
+    font-family: var(--font-family), 'Apple SD Gothic Neo',
       'Malgun Gothic', 'Noto Sans CJK KR',
-      'Noto Sans KR', 'Nanum Gothic', sans-serif);
+      'Noto Sans KR', 'Nanum Gothic', sans-serif;
   }
 
   /* === Traditional Chinese typography ===

--- a/tests/theme-style.test.mjs
+++ b/tests/theme-style.test.mjs
@@ -86,22 +86,28 @@ try {
     if (hasRoot && usesVars && !circular) pass(`${tpl} declares :root theme defaults and reads them via var() (no circular refs)`);
     else fail(`${tpl}: hasRoot=${hasRoot} usesVars=${usesVars} circular=${circular}`);
   }
-  // Regression: localized CJK body font stacks must honor the profile
-  // --font-family override while keeping their curated fallback stacks.
+  // Regression: localized CJK font stacks must honor the profile
+  // --font-family override while keeping their curated fallbacks active after it.
   {
     const tplSrc = readFileSync(join(ROOT, 'templates/cv-template.html'), 'utf-8');
 
-    const jaBody = /html\[lang="ja"\]\s+body\s*\{[^}]*font-family:\s*var\(--font-family,\s*'Liberation Sans'/s.test(tplSrc);
-    const zhBody = /html\[lang="zh-CN"\]\s+body,\s*html\[lang="zh"\]\s+body\s*\{[^}]*font-family:\s*var\(--font-family,\s*'Liberation Sans'/s.test(tplSrc);
+    const jaBody = tplSrc.match(/html\[lang="ja"\]\s+body\s*\{[^}]*\}/s)?.[0] || '';
+    const jaHeadings = tplSrc.match(/html\[lang="ja"\]\s+\.header h1,[\s\S]*?\{[^}]*\}/)?.[0] || '';
+    const zhBody = tplSrc.match(/html\[lang="zh-CN"\]\s+body,[\s\S]*?\{[^}]*\}/)?.[0] || '';
+    const zhHeadings = tplSrc.match(/html\[lang="zh-CN"\]\s+\.header h1,[\s\S]*?\{[^}]*\}/)?.[0] || '';
+    const hasActiveFallback = (src, firstFace) => src.includes(`font-family: var(--font-family), '${firstFace}'`)
+      && /font-family:[^;]*sans-serif;/.test(src);
 
     const jaBodyCount = (tplSrc.match(/html\[lang="ja"\]\s+body\s*\{/g) || []).length;
     const zhCnBodyCount = (tplSrc.match(/html\[lang="zh-CN"\]\s+body/g) || []).length;
     const zhBodyCount = (tplSrc.match(/html\[lang="zh"\]\s+body/g) || []).length;
 
-    if (jaBody && zhBody && jaBodyCount === 1 && zhCnBodyCount === 1 && zhBodyCount === 1) {
-      pass('CJK body font stacks honor --font-family overrides without duplicate body selectors');
+    if (hasActiveFallback(jaBody, 'Hiragino Sans') && hasActiveFallback(jaHeadings, 'Hiragino Sans')
+        && hasActiveFallback(zhBody, 'PingFang SC') && hasActiveFallback(zhHeadings, 'PingFang SC')
+        && jaBodyCount === 1 && zhCnBodyCount === 1 && zhBodyCount === 1) {
+      pass('Japanese and Simplified Chinese font stacks keep CJK fallbacks after --font-family');
     } else {
-      fail(`CJK body font regression: ja=${jaBody} zh=${zhBody} jaCount=${jaBodyCount} zhCNCount=${zhCnBodyCount} zhCount=${zhBodyCount}`);
+      fail(`CJK font regression: jaBody=${hasActiveFallback(jaBody, 'Hiragino Sans')} jaHeadings=${hasActiveFallback(jaHeadings, 'Hiragino Sans')} zhBody=${hasActiveFallback(zhBody, 'PingFang SC')} zhHeadings=${hasActiveFallback(zhHeadings, 'PingFang SC')} jaCount=${jaBodyCount} zhCNCount=${zhCnBodyCount} zhCount=${zhBodyCount}`);
     }
   }
 
@@ -112,12 +118,13 @@ try {
     const koSrc = readFileSync(join(ROOT, 'templates/cv-template.html'), 'utf-8');
     const koBody = koSrc.match(/html\[lang="ko"\]\s+body\s*\{[^}]*\}/s)?.[0] || '';
     const koHeadings = koSrc.match(/html\[lang="ko"\]\s+\.header h1,[\s\S]*?\{[^}]*\}/)?.[0] || '';
-    const hasProfileFontFallback = (src) => /font-family:\s*var\(--font-family,/.test(src);
+    const hasActiveFallback = (src) => src.includes("font-family: var(--font-family), 'Apple SD Gothic Neo'")
+      && /font-family:[^;]*sans-serif;/.test(src);
     const hasDuplicateBodySelector = /html\[lang="ko"\]\s+body\s*,\s*html\[lang="ko"\]\s+body\s*\{/.test(koSrc);
-    if (hasProfileFontFallback(koBody) && hasProfileFontFallback(koHeadings) && !hasDuplicateBodySelector) {
-      pass('Korean body/headings honor --font-family theme override without duplicate selector');
+    if (hasActiveFallback(koBody) && hasActiveFallback(koHeadings) && !hasDuplicateBodySelector) {
+      pass('Korean font stacks keep CJK fallbacks after --font-family without duplicate selector');
     } else {
-      fail(`Korean theme contract: body=${hasProfileFontFallback(koBody)} headings=${hasProfileFontFallback(koHeadings)} duplicate=${hasDuplicateBodySelector}`);
+      fail(`Korean theme contract: body=${hasActiveFallback(koBody)} headings=${hasActiveFallback(koHeadings)} duplicate=${hasDuplicateBodySelector}`);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Moves the curated Japanese, Simplified Chinese, and Korean fallback faces outside the fallback argument of `var(--font-family)`, where they were unreachable because `--font-family` is always defined. The body and heading rules now match the ATS template’s font-stack shape: `var(--font-family)` first, followed by the relevant CJK faces and `sans-serif`.

The existing theme-style regression coverage now checks all six affected declarations and verifies that each font stack remains active and terminates with valid CSS.

## Related issue

Fixes #3527

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Verification

- `node test-all.mjs --only theme-style` — 26 passed, 0 failed
- `npm run test:cv-visual` — 4 passed, 0 failed; no snapshot changes required
- `node test-all.mjs` — 7,862 passed, 0 failed
- Confirmed that `templates/cv-template.html` contains no remaining `var(--font-family,` declarations
- Confirmed that the browser-computed stacks now include the curated CJK faces for `ja`, `zh-CN`, and `ko`

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Japanese, Simplified Chinese, and Korean font fallback behavior.
  * Ensured CJK text uses the configured font family with appropriate language-specific fallback fonts and `sans-serif`.

* **Tests**
  * Strengthened coverage for CJK font rendering in body content and headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->