### PR TITLE
fix(reply-matcher): a partial role-word match must be a whole word

### DIFF
--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -53,9 +53,15 @@ const SHORT_NAME_MAX = 3;
 // removed (CodeRabbit, #3001).
 const NO_WORD_SEPARATOR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
 
+// \p{M} sits alongside \p{L}/\p{N} in both lookarounds so a combining mark counts
+// as part of a word rather than as a boundary. Without it, "data" matches inside
+// "datá" — the mark belongs to the preceding base letter, so that is the middle
+// of a word, not the end of one. This has to agree with LATIN_WORD_RE: a needle
+// allowed to CONTAIN marks needs boundaries that treat marks as word material,
+// or the two halves of the rule disagree about where a word ends.
 function matchesOnWordBoundary(text, company) {
   const escaped = company.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'iu').test(text);
+  return new RegExp(`(?<![\\p{L}\\p{M}\\p{N}])${escaped}(?![\\p{L}\\p{M}\\p{N}])`, 'iu').test(text);
 }
 
 export function checkCompanyMatch(text, company) {
@@ -113,7 +119,17 @@ const CJK_RE = /[一-鿿㐀-䶿]/;
 // Latin letters and digits only. Anything else keeps the substring test it had
 // before, because "does a word boundary exist here" has no script-independent
 // answer — see the comment at the call site.
-const LATIN_WORD_RE = /^[\p{Script=Latin}\p{N}]+$/u;
+// \p{M} is load-bearing, not defensive. toLowerCase() can introduce a combining
+// mark that is NOT Script=Latin: "İ" (U+0130) becomes "i" + U+0307, and U+0307
+// is \p{M} with Script=Inherited. Without \p{M} here, "İstatistik" fails this
+// gate, falls to the substring path, and matches inside "İstatistikler" — the
+// bug this rule exists to remove, still live for Turkish. The same applies to
+// any NFD-decomposed accented text, so it reaches French, Spanish, Portuguese
+// and Vietnamese too, not just Turkish (CodeRabbit, #3535).
+//
+// It does not widen the gate to other scripts: a Devanagari or Thai word still
+// fails on its base letters, which are not Script=Latin.
+const LATIN_WORD_RE = /^[\p{Script=Latin}\p{M}\p{N}]+$/u;
 
 // Ceiling on the needle handed to matchesOnWordBoundary() from checkRoleMatch().
 //
@@ -205,7 +221,17 @@ export function checkRoleMatch(text, role) {
     // Splitting on [\s_\\/()-]+ leaves attached punctuation behind ("Director,"
     // keeps its comma), which both defeats a boundary anchor and, before this,
     // defeated the substring test outright — "director," is not in the text.
-    const bare = part.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '');
+    // Two forms, deliberately. `stripped` keeps its case and is what reaches the
+    // matcher; `bare` is lowercased and is only ever read by the gates below.
+    //
+    // Lowercasing the needle would be worse than redundant. matchesOnWordBoundary
+    // is already case-insensitive ('iu'), and the two mechanisms disagree:
+    // toLowerCase() applies FULL case mapping, which turns "İ" into "i" + U+0307,
+    // while the regex 'i' flag uses SIMPLE case folding, under which "İ" does not
+    // fold to that pair. Hand it the lowercased form and the needle is decomposed
+    // while the text is composed, so a genuine mention can never match.
+    const stripped = part.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '');
+    const bare = stripped.toLowerCase();
 
     // The whole-word requirement applies to Latin-script parts ONLY, and every
     // other script keeps the substring test it had before — including the gates
@@ -228,7 +254,7 @@ export function checkRoleMatch(text, role) {
     //
     // Restricting the stricter rule to Latin fixes the reported bug and leaves
     // every other script byte-identical to its previous behaviour.
-    if (!LATIN_WORD_RE.test(bare) || bare.length > MAX_BOUNDARY_NEEDLE) {
+    if (!LATIN_WORD_RE.test(bare) || stripped.length > MAX_BOUNDARY_NEEDLE) {
       // Deliberately the raw `part`, mirroring the pre-existing condition
       // exactly. Every word in GENERIC_ROLE_WORDS is pure Latin and would have
       // routed to the branch below, so this can never fire here — it is kept so
@@ -250,7 +276,7 @@ export function checkRoleMatch(text, role) {
     // matches "data" inside "data工程师"; while "_" IS \w, so \b reports none
     // and misses "data_engineer", though "_" is one of the separators the role
     // title itself is split on.
-    if (matchesOnWordBoundary(text, bare)) {
+    if (matchesOnWordBoundary(text, stripped)) {
       return true; // partial match on a significant word
     }
   }

--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -230,7 +230,17 @@ export function checkRoleMatch(text, role) {
     // while the regex 'i' flag uses SIMPLE case folding, under which "İ" does not
     // fold to that pair. Hand it the lowercased form and the needle is decomposed
     // while the text is composed, so a genuine mention can never match.
-    const stripped = part.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '');
+    // \p{M} belongs in this class for the same reason it belongs in the gate and
+    // in both lookarounds: a combining mark is word material, not punctuation to
+    // peel off. Without it, an NFD word ENDING in a mark loses it — "Chargé" as
+    // e+U+0301 strips to "Charge" — and the boundary test then correctly refuses
+    // the result, because the mark still sitting in the text makes that position
+    // mid-grapheme. The word stops matching itself.
+    //
+    // Three predicates define "word material" here (this strip, LATIN_WORD_RE,
+    // and matchesOnWordBoundary's lookarounds) and they have to move as a unit.
+    // Updating two of the three is what produced that bug (CodeRabbit, #3535).
+    const stripped = part.replace(/^[^\p{L}\p{M}\p{N}]+|[^\p{L}\p{M}\p{N}]+$/gu, '');
     const bare = stripped.toLowerCase();
 
     // The whole-word requirement applies to Latin-script parts ONLY, and every

--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -109,6 +109,40 @@ const GENERIC_ROLE_WORDS = new Set([
 // as a bare single word the way it does for Latin-script titles.
 const CJK_RE = /[一-鿿㐀-䶿]/;
 
+// A role word the whole-word rule in checkRoleMatch() may safely be applied to:
+// Latin letters and digits only. Anything else keeps the substring test it had
+// before, because "does a word boundary exist here" has no script-independent
+// answer — see the comment at the call site.
+const LATIN_WORD_RE = /^[\p{Script=Latin}\p{N}]+$/u;
+
+// Ceiling on the needle handed to matchesOnWordBoundary() from checkRoleMatch().
+//
+// That helper builds `new RegExp(..., 'iu')`, and V8's compiler stack-overflows
+// on a case-insensitive Unicode pattern once the literal needle is long enough
+// — it THROWS at construction rather than failing to match, and the throw
+// propagates uncaught out through matchCandidates() and into reply-watch. The
+// exact limit is build- and content-dependent (a repeating "WordWord…" run
+// blows up well before a single repeated character does), so this is set far
+// below any observed threshold rather than tuned to one.
+//
+// checkCompanyMatch, the helper's only other caller, cannot reach this: it is
+// gated by isShortName to names of SHORT_NAME_MAX characters. A role-title part
+// has no such ceiling, which is what makes the ceiling explicit here.
+//
+// 128 is far longer than any real single role word — the longest in a job title
+// is a German compound in the 40s — so nothing legitimate is turned away. A
+// part above it is malformed data (a JD pasted into the role field, a merged
+// CSV column) and falls through to the substring test, exactly as on main.
+//
+// The check must be on `bare`, not on the part it came from: toLowerCase() can
+// LENGTHEN a string, so `bare` is not simply a shorter subset. "İ" (U+0130)
+// lowercases to "i" plus a combining dot, and a part of 100 of them yields a
+// bare of 199 — nearly 2x. The margin here absorbs that regardless (reaching a
+// crash-length needle would still need a part in the thousands, which this
+// rejects either way), but measuring the string that actually reaches the regex
+// is the property worth holding onto.
+const MAX_BOUNDARY_NEEDLE = 128;
+
 // A role title that reduces to a single word — whether that word is generic
 // recruiting vocabulary ("Recruiter") or a specific one ("Engineer") — is not
 // specific enough to stand alone as an "exact" match: checking it as a whole-
@@ -160,9 +194,63 @@ export function checkRoleMatch(text, role) {
   // (see GENERIC_ROLE_WORDS) are excluded no matter how long they are — a bare
   // "Talent" or "Specialist" match is exactly the false-positive pattern from
   // #2671, not evidence of a real match.
+  // Note tNorm is used only by the substring branch below. The whole-word branch
+  // tests the RAW text, because normalizeStr strips all whitespace and a
+  // boundary rule needs the delimiters intact — there is nothing left to anchor
+  // to once every character is adjacent to another.
   const roleParts = role.split(/[\s_\\/()-]+/);
   for (const part of roleParts) {
-    if (part.length > 3 && !GENERIC_ROLE_WORDS.has(part.toLowerCase()) && tNorm.includes(normalizeStr(part))) {
+    if (part.length <= 3) continue;
+
+    // Splitting on [\s_\\/()-]+ leaves attached punctuation behind ("Director,"
+    // keeps its comma), which both defeats a boundary anchor and, before this,
+    // defeated the substring test outright — "director," is not in the text.
+    const bare = part.toLowerCase().replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '');
+
+    // The whole-word requirement applies to Latin-script parts ONLY, and every
+    // other script keeps the substring test it had before — including the gates
+    // above it, which is why the routing happens HERE and not before `bare` is
+    // consulted. Stripping punctuation can push a part under the length gate:
+    // "工程师。" is four characters and three without the ideographic period, so
+    // gating on the stripped form would silently drop three-character Chinese
+    // titles that main matches. Non-Latin parts are therefore judged on `part`,
+    // exactly as before; only the Latin branch looks at `bare`.
+    //
+    // #3455 is a bug about English boilerplate — "Analytic" matching inside
+    // "Analytics" — and "which scripts have word boundaries" turns out to be
+    // the wrong question to answer in order to fix it. It has no clean answer:
+    // Japanese runs without separators in all three of its scripts, while
+    // Korean DOES separate words with spaces but glues grammatical particles
+    // straight onto the noun ("개발자" + "를" -> "개발자를"), so a boundary rule
+    // silently stops matching a genuinely mentioned Korean title. Both of those
+    // were real false negatives in earlier drafts of this fix, found one script
+    // at a time — which is the argument for not enumerating scripts at all.
+    //
+    // Restricting the stricter rule to Latin fixes the reported bug and leaves
+    // every other script byte-identical to its previous behaviour.
+    if (!LATIN_WORD_RE.test(bare) || bare.length > MAX_BOUNDARY_NEEDLE) {
+      // Deliberately the raw `part`, mirroring the pre-existing condition
+      // exactly. Every word in GENERIC_ROLE_WORDS is pure Latin and would have
+      // routed to the branch below, so this can never fire here — it is kept so
+      // the two paths can be read as "unchanged" and "new" rather than
+      // diffed for silent omissions.
+      if (!GENERIC_ROLE_WORDS.has(part.toLowerCase()) && tNorm.includes(normalizeStr(part))) return true;
+      continue;
+    }
+
+    // Latin branch only: re-apply the length and generic-word gates to the
+    // stripped form, so "AI!!" is not four characters of significance and
+    // "Recruiter," cannot slip past the #2671 blocklist on its comma.
+    if (bare.length <= 3 || GENERIC_ROLE_WORDS.has(bare)) continue;
+
+    // Reuse the company-name boundary helper rather than a second copy of the
+    // same rule: it already escapes the needle and anchors on \p{L}/\p{N}
+    // lookarounds instead of \b, which is what this needs. \b would be wrong in
+    // both directions — a CJK ideograph is not \w, so \b reports a boundary and
+    // matches "data" inside "data工程师"; while "_" IS \w, so \b reports none
+    // and misses "data_engineer", though "_" is one of the separators the role
+    // title itself is split on.
+    if (matchesOnWordBoundary(text, bare)) {
       return true; // partial match on a significant word
     }
   }

--- a/tests/reply-matcher.test.mjs
+++ b/tests/reply-matcher.test.mjs
@@ -192,6 +192,29 @@ test('checkRoleMatch - a combining mark keeps a Latin word on the whole-word pat
   assert.equal(checkRoleMatch('Attached: re\u0301sume\u0301data.pdf for review.', 'Data Engineer'), false);
 });
 
+test('checkRoleMatch - an NFD word ending in a combining mark keeps it (#3535)', () => {
+  // Escapes, not literals: a source-file "\u00e9" is PRECOMPOSED and does not
+  // exercise this path at all. The bug needs a word whose LAST character is a
+  // combining mark.
+  //
+  // \\p{M} has to be in the stripping class as well as in LATIN_WORD_RE and the
+  // lookarounds. Without it the terminal mark is peeled off as though it were
+  // punctuation — "Charge\u0301" strips to "Charge" — and the boundary test then
+  // correctly refuses that, because the mark still present in the text makes
+  // the position mid-grapheme. The word stops matching itself.
+  const charge = 'Charge\u0301';   // Chargé, mark terminal
+  const cafe   = 'Cafe\u0301';     // Café, mark terminal
+  const disena = 'Disen\u0303ador'; // Diseñador, mark interior
+
+  // Text carries the PART but not the whole role, so checkRoleMatchExact cannot
+  // short-circuit and mask the partial path — which is what hid this at first.
+  assert.ok(checkRoleMatch(`Le poste de ${charge} est ouvert.`, `${charge} de Mission`));
+  assert.ok(checkRoleMatch(`Notre ${cafe} recrute.`, `${cafe} Manager`));
+  assert.ok(checkRoleMatch(`Buscamos un ${disena} para el equipo.`, `${disena} Senior`));
+
+  // ...and the whole-word rule still applies to them.
+  assert.equal(checkRoleMatch(`Le poste de ${charge}s est ouvert.`, `${charge} de Mission`), false);
+});
 test('checkRoleMatch - a Latin role word containing digits still gets the whole-word rule', () => {
   // The \p{N} in LATIN_WORD_RE is load-bearing. Without it a part carrying a
   // digit — "Web3", "K8s", "Tier2" are all ordinary in job titles — fails the

--- a/tests/reply-matcher.test.mjs
+++ b/tests/reply-matcher.test.mjs
@@ -165,6 +165,33 @@ test('checkRoleMatch - the generic-word gate runs on the stripped form, not the 
   assert.equal(checkRoleMatch('Our Operations. team will be in touch.', 'People Operations.'), false);
 });
 
+test('checkRoleMatch - a combining mark keeps a Latin word on the whole-word path (#3535)', () => {
+  // toLowerCase() can INTRODUCE a character that is not Script=Latin: "İ"
+  // (U+0130) becomes "i" + U+0307, and U+0307 is \p{M}/Script=Inherited. A Latin
+  // gate without \p{M} therefore drops these words to the substring path and the
+  // bug survives for them.
+  //
+  // Turkish dotted-I, the case that exposed it:
+  assert.equal(checkRoleMatch('Bizim İstatistikler ekibi yanıt verecek.', 'İstatistik Uzmanı'), false);
+  assert.ok(checkRoleMatch('Bizim İstatistik ekibi yanıt verecek.', 'İstatistik Uzmanı'));
+
+  // ...and NFD-decomposed accented text, which is the broader half — it needs no
+  // Turkish at all and reaches French, Spanish, Portuguese and Vietnamese.
+  const nfd = 'Ingénieur';           // e + combining acute, not U+00E9
+  assert.equal(checkRoleMatch(`Notre équipe ${nfd}ie recrute.`, `${nfd} Logiciel`), false);
+  assert.ok(checkRoleMatch(`Notre équipe ${nfd} recrute.`, `${nfd} Logiciel`));
+
+  // A mark belongs to the base letter before it, so a needle sitting next to one
+  // is mid-word, not at a boundary. Both lookarounds need \p{M}, and they fail
+  // independently — hence a case on each side.
+  //
+  // mark AFTER the needle:
+  assert.equal(checkRoleMatch('Our datá pipeline is unrelated.', 'Data Engineer'), false);
+  // mark BEFORE the needle — a decomposed accented word running straight into
+  // it, as happens in slugs, filenames and run-together compounds:
+  assert.equal(checkRoleMatch('Attached: re\u0301sume\u0301data.pdf for review.', 'Data Engineer'), false);
+});
+
 test('checkRoleMatch - a Latin role word containing digits still gets the whole-word rule', () => {
   // The \p{N} in LATIN_WORD_RE is load-bearing. Without it a part carrying a
   // digit — "Web3", "K8s", "Tier2" are all ordinary in job titles — fails the

--- a/tests/reply-matcher.test.mjs
+++ b/tests/reply-matcher.test.mjs
@@ -46,6 +46,176 @@ test('checkRoleMatch', () => {
   assert.ok(checkRoleMatch('邀请您参加python开发工程师的面试', 'PY01_python开发工程师'));
 });
 
+test('checkRoleMatch - a role word inside a longer word is not a match (#3455)', () => {
+  // Rejection boilerplate that names neither role. "Analytic" appears only as a
+  // prefix of "Analytics", which is not a mention of the role and must not
+  // corroborate one. Before this fix `tNorm.includes()` matched it, and because
+  // matchCandidates() only counts a partial match on a row already carrying a
+  // company or domain signal, the effect was to inflate whichever row was
+  // already ahead — see #3455.
+  const boilerplate = 'Unfortunately we will not be moving forward. We will retain your '
+    + 'data on file. Please watch our Analytics openings for future roles.';
+  assert.equal(checkRoleMatch(boilerplate, 'Managing VP, Analytic & AI Product'), false);
+
+  // The same shape, isolated: a role word must not match as a substring of a
+  // longer word, in either direction.
+  assert.equal(checkRoleMatch('We have moved to a new database vendor.', 'Data Engineer'), false);
+  assert.equal(checkRoleMatch('Our platforms team will follow up.', 'Platform Lead'), false);
+  assert.equal(checkRoleMatch('Please see the attached engineering brief.', 'Engineer'), false);
+
+  // ...but a genuine whole-word occurrence still matches. This is deliberate:
+  // it is what keeps the partial-match path useful for a real mention.
+  assert.ok(checkRoleMatch('An update on the Analytic role you applied for.', 'Managing VP, Analytic & AI Product'));
+});
+
+test('checkRoleMatch - a common noun in a role title still matches as a whole word (#3455 limit)', () => {
+  // Documents the boundary of the #3455 fix rather than asserting desired
+  // behaviour. "data" occurs as a real word in ordinary rejection prose, so a
+  // word-boundary rule cannot exclude it — only the GENERIC_ROLE_WORDS
+  // enumeration could, and enumerating every domain noun does not scale.
+  // Half of darkpandawarrior's two-row example is therefore still reachable;
+  // the ownership rule in #3455, not this fix, is what closes that.
+  const boilerplate = 'Unfortunately we will not be moving forward. We will retain your '
+    + 'data on file. Please watch our Analytics openings for future roles.';
+  assert.ok(checkRoleMatch(boilerplate, 'Senior Director, AI Data'));
+});
+
+test('checkRoleMatch - stripping punctuation must not push a non-Latin part under the length gate', () => {
+  // "工程师。" is four characters, three once the ideographic period is stripped.
+  // The stripped form belongs to the Latin branch only; gating every script on
+  // it silently dropped three-character Chinese titles — 工程师 (engineer),
+  // 设计师 (designer) — that the substring path had always matched. This is why
+  // the script routing runs before the length and generic-word gates rather
+  // than after them.
+  assert.ok(checkRoleMatch('我们招聘工程师。欢迎申请。', 'PY_工程师。'));
+  assert.ok(checkRoleMatch('我们招聘工程师，欢迎申请。', 'PY_工程师，'));
+  assert.ok(checkRoleMatch('私たちはエンジ。を募集。', 'JP_エンジ。'));
+});
+
+test('checkRoleMatch - a mixed Latin+Han part is not Latin, so it keeps substring matching', () => {
+  // "python开发工程师" is one semantic phrase, not a Latin word followed by a
+  // Chinese one, so the Latin-only gate correctly declines to apply a boundary
+  // rule to it. These two are the pre-existing cases from the suite above,
+  // repeated here as the regression guard for the mixed-script path.
+  assert.ok(checkRoleMatch('邀请您参加PY01_python开发工程师的面试', 'python开发工程师'));
+  assert.ok(checkRoleMatch('邀请您参加python开发工程师的面试', 'PY01_python开发工程师'));
+});
+
+test('checkRoleMatch - non-Latin role words keep the substring test unchanged', () => {
+  // The whole-word rule is deliberately Latin-only. "Which scripts have word
+  // boundaries" has no clean answer, and two earlier drafts of this fix each
+  // broke a different language by trying to answer it:
+  //
+  //   Japanese  runs without separators in ALL THREE of its scripts, so routing
+  //             on Han ideographs alone sent a pure-Katakana title down the
+  //             boundary path, where the surrounding Hiragana is \p{L}.
+  //   Korean    DOES separate words with spaces, but glues grammatical
+  //             particles straight onto the noun — 개발자 + 를 -> 개발자를 — so
+  //             the boundary never holds even though the title is right there.
+  //
+  // Every case below is a role genuinely mentioned in the text, and every one
+  // must behave exactly as it did before this change.
+  assert.ok(checkRoleMatch('私たちはエンジニアを募集しています。', 'PY02_エンジニア'));
+  assert.ok(checkRoleMatch('私たちは上級エンジニアを募集しています。', '上級エンジニア'));
+  assert.ok(checkRoleMatch('우리는 소프트웨어개발자를 찾고 있습니다.', 'KR_소프트웨어개발자'));
+  assert.ok(checkRoleMatch('프로젝트매니저의 면접 일정을 안내드립니다.', 'KR_프로젝트매니저'));
+  assert.ok(checkRoleMatch('Мы ищем Разработчика в команду.', 'RU_Разработчик'));
+  assert.ok(checkRoleMatch('نبحث عن مهندس برمجيات للانضمام.', 'AR_مهندس_برمجيات'));
+});
+
+test('checkRoleMatch - a pathologically long role part does not crash the matcher', () => {
+  // matchesOnWordBoundary builds new RegExp(..., 'iu'), and V8 stack-overflows
+  // constructing a case-insensitive Unicode pattern around a long enough
+  // literal — it THROWS at construction. checkCompanyMatch, the helper's only
+  // other caller, is gated by isShortName and can never reach that; a role part
+  // has no such ceiling, so without MAX_BOUNDARY_NEEDLE this throw escapes
+  // matchCandidates() uncaught and takes reply-watch down for every candidate
+  // in the run — not a graceful non-match on one row.
+  //
+  // Reachable from a single malformed tracker row: a JD pasted into the role
+  // field, or a merged CSV column.
+  const huge = 'Word'.repeat(2500);
+  assert.doesNotThrow(() => checkRoleMatch('unrelated rejection text', huge));
+  assert.doesNotThrow(() => matchCandidates(
+    [{ message_id: 'm', from: 'a@b.example', subject: 's', body_snippet: 'unrelated', signal: 'rejection' }],
+    [{ num: 1, company: 'Acme', role: huge, status: 'Applied', notes: '' }],
+    []
+  ));
+  // Over the ceiling it takes the substring path, which is what main did.
+  assert.ok(checkRoleMatch(`we mentioned ${huge} once`, huge));
+
+  // Pin the threshold itself, not just "well past it". A part of exactly
+  // MAX_BOUNDARY_NEEDLE characters is still ON the whole-word path, so it must
+  // refuse a substring-inside-a-longer-word; flipping the comparison to >=
+  // would push it to the substring fallback and match. Inert in practice — 128
+  // has enormous headroom over any real role word — but the boundary of a
+  // guard is the part worth pinning.
+  const atCeiling = 'a'.repeat(128);
+  assert.equal(checkRoleMatch(`about the ${atCeiling}x team`, atCeiling), false);
+  assert.ok(checkRoleMatch(`about the ${atCeiling} team`, atCeiling));
+});
+
+test('checkRoleMatch - the generic-word gate runs on the stripped form, not the raw part', () => {
+  // "Recruiter," is not in GENERIC_ROLE_WORDS; "recruiter" is. Checking the raw
+  // part lets any attached punctuation walk a generic word straight past the
+  // #2671 protection, which is the bug that rule exists to stop.
+  assert.equal(checkRoleMatch('Please contact our Recruiter, team lead, for more info.', 'Recruiter,'), false);
+  // Text carries only the punctuated generic word, never the whole role — so
+  // this exercises the partial path rather than checkRoleMatchExact.
+  assert.equal(checkRoleMatch('Our Operations. team will be in touch.', 'People Operations.'), false);
+});
+
+test('checkRoleMatch - a Latin role word containing digits still gets the whole-word rule', () => {
+  // The \p{N} in LATIN_WORD_RE is load-bearing. Without it a part carrying a
+  // digit — "Web3", "K8s", "Tier2" are all ordinary in job titles — fails the
+  // Latin allowlist, falls through to the substring path, and the #3455 bug is
+  // back for exactly those titles.
+  assert.equal(checkRoleMatch('Our Web3D research group published a paper.', 'Web3 Platform Lead'), false);
+  // ...and the genuine whole-word mention still matches.
+  assert.ok(checkRoleMatch('An update on the Web3 role you applied for.', 'Web3 Platform Lead'));
+});
+
+test('checkRoleMatch - a role word is not matched at a letter-adjacent prefix either', () => {
+  // The left lookbehind carries its own weight: without it, a role word glued to
+  // the END of a longer word still matches. The CJK case above cannot catch this
+  // because "data" there is letter-bounded on BOTH sides, so the right-hand
+  // lookahead alone already rejects it.
+  assert.equal(checkRoleMatch('The XAnalytic system flagged this for review.', 'Managing VP, Analytic & AI Product'), false);
+  assert.equal(checkRoleMatch('Our metadata pipeline is unrelated.', 'Data Engineer'), false);
+});
+
+test('checkRoleMatch - a short root word is not made significant by attached punctuation', () => {
+  // The length gate runs again after stripping. Without the second check, "AI!!"
+  // (4 raw chars, 2 real ones) would clear a gate meant to admit only words with
+  // more than three significant characters.
+  assert.equal(checkRoleMatch('Our team uses ai to triage applications.', 'AI!! Specialist'), false);
+  assert.equal(checkRoleMatch('The ops team will follow up.', 'Ops. Lead'), false);
+});
+
+test('checkRoleMatch - the word boundary is defined on letters in any script, not \\w', () => {
+  // These two cases are the whole reason the rule uses \p{L}/\p{N} lookarounds
+  // rather than \b. \b is defined on [A-Za-z0-9_], which is wrong twice over:
+  //
+  //   "data工程师"     a CJK ideograph is not \w, so \b sees a boundary and
+  //                    matches "data" INSIDE a single Chinese compound word —
+  //                    exactly the substring-inside-a-word bug this fix exists
+  //                    to remove, reintroduced for every non-Latin script.
+  assert.equal(checkRoleMatch('我们正在招聘data工程师。', 'Data Analyst'), false);
+
+  //   "data_engineer"  "_" IS \w, so \b sees NO boundary and misses a genuine
+  //                    mention. "_" is one of the separators role titles are
+  //                    split on, so treating it as a boundary is the consistent
+  //                    reading.
+  assert.ok(checkRoleMatch('Subject: data_engineer role update', 'Data Engineer'));
+});
+
+test('checkRoleMatch - punctuation attached to a role word does not defeat the match', () => {
+  // Parts are split on [\s_\\/()-]+, which leaves a trailing comma on "Director,".
+  // A naive `\b${part}\b` fails here: the \b after "," needs a word character
+  // next, and a space follows.
+  assert.ok(checkRoleMatch('Congratulations on the Director offer.', 'Senior Director, AI Data'));
+});
+
 test('checkRoleMatch - generic recruiting words never match alone (#2671)', () => {
   // A signature line from an unrelated recruiter ("Talent Acquisition & Diversity")
   // must not satisfy a role match against a "Talent Acquisition Specialist"


### PR DESCRIPTION
Closes part of #3455 — specifically the `checkRoleMatch` half that @darkpandawarrior and I agreed to split ([comment](https://github.com/santifer/career-ops/issues/3455#issuecomment-5463911835)). They are taking the `reply-watch.mjs:278` confidence gate separately.

## The bug

`checkRoleMatch`'s partial-match path tested `tNorm.includes(part)`, so a role word matched inside a longer, unrelated word. Rejection boilerplate naming no role at all produced a `role-title` signal:

> "...retain your **data** on file. Please watch our **Analytic**s openings for future roles."

"Analytic", from "Managing VP, Analytic & AI Product", is not in that text as a word — only as a prefix of "Analytics".

It is not symmetric across rows, which is what makes it worth fixing. Line 309 only counts a partial match on a row already corroborated by company-name or sender-domain, so the junk signal cannot fire on an uncorroborated row: it adds +1.5 to whichever row was already ahead.

## What this does NOT do

**It does not close #3455.** Measured against that issue's own two rows, before and after:

```
origin/main    -> row=110  conf=high  signals=[company-name,sender-domain,role-title,post-application-keyword]
with this fix  -> row=110  conf=high  signals=[company-name,sender-domain,post-application-keyword]
```

Same row, same confidence. `high` re-derives through the second clause of the confidence ladder, `(isCompanyMatch || hasDomainMatch) && hasPostAppKeyword`, and every rejection carries `signal: 'rejection'`.

Only half of that issue's example is even reachable by a boundary rule: "Analytic" is a substring of a longer word, but "data" occurs as a genuine word in the same prose and still matches. There is a test asserting that surviving half rather than leaving it implied.

## Design

**The whole-word rule is Latin-only, deliberately.** "Which scripts have word boundaries" is the wrong question to answer here, and two earlier drafts each broke a different language trying:

| draft | rule | what it broke |
|---|---|---|
| 1st | boundary unless the part has Han ideographs | pure-Katakana titles (`エンジニア`, `マネージャー`) — Japanese has no separators in any of its three scripts |
| 2nd | boundary unless the script lacks separators | Korean — it *does* use spaces, but glues particles onto nouns (`개발자` + `를` → `개발자를`) |

Both were false negatives on genuinely-mentioned titles, found one language at a time. #3455 is a bug about English boilerplate, so the stricter rule applies only where it is demonstrably safe — parts that are entirely Latin — and every other script keeps exactly the behaviour it has on `main`. Verified byte-identical across Japanese (Kana and mixed), Chinese, Korean, Cyrillic, Greek, Arabic, Devanagari, Hebrew and Thai.

**The boundary test reuses `matchesOnWordBoundary()`**, the helper `checkCompanyMatch` already uses, rather than a second copy. It anchors on `\p{L}`/`\p{N}` lookarounds instead of `\b`, which matters because `\b` is defined on `[A-Za-z0-9_]` and is wrong in both directions: a CJK ideograph is not `\w`, so `\b` reports a boundary and matches "data" inside `data工程师`; while `_` **is** `\w`, so `\b` reports none and misses `data_engineer`, though `_` is one of the separators the role title is split on.

**Script routing runs before the length and generic-word gates.** Stripping attached punctuation can push a part under the length gate — `工程师。` is four characters and three without the ideographic period — so gating every script on the stripped form silently dropped three-character Chinese titles that the substring path had always matched.

**A length ceiling guards the boundary call.** `matchesOnWordBoundary` builds `new RegExp(..., 'iu')`, and V8 stack-overflows *constructing* a case-insensitive Unicode pattern around a long enough literal — it throws rather than failing to match. `checkCompanyMatch`, the helper's only previous caller, is gated by `isShortName` and could never reach that; a role-title part has no such ceiling, so this diff is what made it reachable. Left unguarded, one malformed tracker row — a JD pasted into the role field, a merged CSV column — takes `reply-watch` down uncaught for every candidate in the run.

**Attached punctuation is stripped before matching**, which also repairs a pre-existing miss: `"Director,"` keeps its comma after the `[\s_\\/()-]+` split, and `"director,"` does not occur in text reading "Director offer".

## Verification

- **40 tests** in `tests/reply-matcher.test.mjs`, 12 of them new (28 on `main`).
- **Fourteen mutants, all caught** — both lookaround directions in the shared helper, both directions of widening and narrowing the Latin gate, dropping its digit class, moving the length gate ahead of the routing, removing the length ceiling and flipping its comparison by one, checking the generic-word gate against the raw part, and handing the boundary helper the whitespace-stripped text.
- One mutant is deliberately left unkilled as **equivalent**, not a gap: measuring the ceiling against the raw part rather than the stripped form. It cannot admit an unsafe needle. Note the obvious argument for that — "stripping can only shorten" — is false: `toLowerCase()` can lengthen, and 100 `İ` characters yield a stripped form of 199.
- Suite: **7276 passed, 1 failed**. The failure is `tests/skill-project-root.test.mjs`, which fails identically on an unmodified `origin/main` checkout when git has `core.symlinks=false` and materialises the seven CLI skill symlinks as one-line files. Unrelated to this diff; CI runners resolve the links.

## Known follow-ups, not addressed here

Deliberately out of scope to keep the diff reviewable — happy to file any of these if you want them tracked:

- Non-Latin parts keep the substring behaviour, so `엔지니어` can still match inside `엔지니어링팀`. This is the accepted trade-off: the alternative broke genuinely-mentioned Korean titles, which is the worse failure.
- `CJK_RE` (used by `isSingleWordRole`) has the same Han-only narrowness that the first draft of this fix tripped over.
- Above `MAX_BOUNDARY_NEEDLE` a part falls through to the substring test, so the bug is reachable for pathological input — documented at the constant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role matching so Latin terms match complete words instead of partial matches within longer words.
  * Improved handling of punctuation, Unicode letters, digits, accented characters, combining marks, and non-Latin scripts.
  * Prevented failures when processing unusually long role terms.

* **Tests**
  * Added comprehensive coverage for word boundaries, punctuation, Unicode text, combining marks, script-specific matching, and long-term safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->