### PR TITLE
fix(skill-extract): recognize marketing/GTM skills, and stop reporting tracked employers as gaps

### DIFF
--- a/skill-extract.mjs
+++ b/skill-extract.mjs
@@ -91,6 +91,75 @@ export const SKILL_TOKENS = [
   //
   // 'SAFe' is NOT here either — it is handled case-sensitively below, for the
   // same reason 'Go' is: 'safe' is an everyday English word.
+
+  // ── Marketing / GTM / revenue operations (added 2026-08-30) ──────────────
+  // The certification block above records that the vocabulary, not the scoring,
+  // was the constraint for delivery and program managers. The same hole ran one
+  // discipline further over: every token above this line is an engineering tool
+  // or a delivery credential, so a marketing-operations candidate was
+  // structurally invisible to the gap map.
+  //
+  // Measured on a real marketing-operations corpus: "ABM" was logged as an
+  // explicit soft_gap in several linked reports — twice flagged in the report
+  // text itself as a recurring gap — and never once reached the output. The
+  // map's top-ranked entry was instead an observability vendor's name, matched
+  // out of the provenance asides inside those very ABM sentences (a report
+  // logging a recurring gap tends to cite the sibling companies where it was
+  // logged before). The same blindness ran on the known-skills side: a
+  // marketing cv.md yielded a known-skills set of FIVE, so almost nothing could
+  // be excluded as already-held.
+  //
+  // Longest-first within each family, matching the 'React Native'-before-'React'
+  // and 'Lean Six Sigma'-before-'Six Sigma' convention above.
+  'Account-Based Marketing', 'Account Based Marketing', 'ABM',
+  'Demand-Side Platform', 'Demand Side Platform', 'DSPs', 'DSP',
+  // Only the MEDIA senses of "programmatic" — see the omission note below.
+  'Programmatic Advertising', 'Programmatic Display', 'Programmatic Media',
+  'Programmatic Buying',
+  'Media Agency Management', 'Media Agencies', 'Media Agency',
+  'Demand Generation', 'Demand Gen',
+  'Marketing Automation', 'Marketing Operations',
+  'Revenue Operations', 'RevOps',
+  'Lifecycle Marketing', 'Growth Marketing', 'Product Marketing',
+  'Partner Marketing', 'Performance Marketing', 'Field Marketing',
+  'Content Marketing', 'Email Marketing',
+  'Paid Media', 'Paid Social', 'Paid Search',
+  'Conversion Rate Optimization',
+  'Marketing Mix Modeling', 'Media Mix Modeling', 'Incrementality',
+  'Lead Scoring', 'Marketing Attribution',
+  // 'SEMrush' precedes 'SEM' by convention; the (?!\w) boundary already stops
+  // 'SEM' from firing inside it, and the ordering keeps that independent of the
+  // boundary rule.
+  'SEMrush', 'SEO', 'SEM', 'PPC',
+  // Platforms a marketing CV actually lists. These earn their place mostly on
+  // the KNOWN side of the comparison: without them the known-skills set built
+  // from a marketing cv.md cannot suppress anything the candidate already has.
+  'HubSpot', 'Marketo', 'Pardot', 'Braze', 'Klaviyo', 'OneSignal', 'Intercom',
+  'Ahrefs', 'Demandbase', '6sense', 'Google Tag Manager', 'Google Analytics',
+  'Google Ads', 'GA4', 'Amplitude', 'Mixpanel', 'n8n', 'Zapier',
+  //
+  // DELIBERATELY OMITTED from this block, on the same asymmetry the 'CSM' note
+  // above sets out — a missing token costs a real skill once, visibly, while a
+  // colliding one mints a phantom gap out of ordinary prose on every posting:
+  //
+  //   'CRO'          — Conversion Rate Optimization in marketing copy, Chief
+  //                    Revenue Officer in the org chart, and GTM postings are
+  //                    full of the second ("reports to the CRO"). The spelled-out
+  //                    'Conversion Rate Optimization' is listed instead.
+  //   'GEO'          — Generative Engine Optimization in AI-search work, and
+  //                    "geography" everywhere else, including the location prose
+  //                    in most postings ("the EMEA geo").
+  //   'Programmatic' — bare, it is an everyday engineering adjective
+  //                    ("programmatic access to the API"). Only the media senses
+  //                    are listed above; each canonicalizes to 'Programmatic',
+  //                    so the display name survives without the collision.
+  //   'Segment'      — the CDP, but "segment" is an everyday noun in exactly the
+  //                    prose this block was added to read.
+  //   'Iterable'     — the ESP, but this module is shared with jd-skill-gap,
+  //                    which runs over full engineering JDs where "iterable" is
+  //                    a language term.
+  //   'MOps'/'MMM'   — abbreviations whose expansions are already listed and
+  //                    whose bare forms read as noise ("mops", "mmm").
 ];
 
 // 'SAFe' cannot join the case-insensitive list — "a safe environment", "safe to
@@ -176,6 +245,42 @@ export const CANONICAL = {
   'prince 2': 'PRINCE2',
   'lean six-sigma': 'Lean Six Sigma',
   'six-sigma': 'Six Sigma',
+  // Marketing / GTM (2026-08-30). Only ALTERNATE spellings need an entry —
+  // DISPLAY already resolves a token to its own casing ('abm' -> 'ABM'), so a
+  // single-spelling token like 'HubSpot' needs nothing here. What must be
+  // aliased is every way the same skill gets written, because the known-skills
+  // set is built from the CV's spelling and the gap map from the report's, and
+  // the two only cancel if both collapse to one display form.
+  'account-based marketing': 'ABM', 'account based marketing': 'ABM',
+  'demand-side platform': 'DSP', 'demand side platform': 'DSP', 'dsps': 'DSP',
+  // Every media sense of "programmatic" lands on one display name, so the gap
+  // map does not split one competency across four rows.
+  'programmatic advertising': 'Programmatic',
+  'programmatic display': 'Programmatic',
+  'programmatic media': 'Programmatic',
+  'programmatic buying': 'Programmatic',
+  // "Lead relationships with media agencies" and "media agency management" are
+  // the same competency in gap prose; splitting them would halve the count of a
+  // gap that is already only named a handful of times.
+  'media agency management': 'Media Agency Management',
+  'media agencies': 'Media Agency Management',
+  'media agency': 'Media Agency Management',
+  'demand gen': 'Demand Generation',
+  'revenue operations': 'RevOps',
+  'marketing mix modeling': 'Media Mix Modeling',
+  //
+  // NOT aliased, deliberately, and the most consequential line in this block:
+  // 'demandbase' does NOT map to 'ABM'. Demandbase is an ABM PLATFORM, and
+  // holding a seat in it is not owning an ABM program — the corpus this block
+  // was built from makes that distinction explicitly, in report after report,
+  // because it is the difference between a defensible CV claim and an
+  // indefensible one.
+  // Aliasing the tool to the discipline would put ABM into the known-skills set
+  // of anyone whose CV lists the tool, suppressing the exact gap this
+  // vocabulary exists to surface — and it would read as "no gap found", which
+  // is strictly worse than the silence being fixed. Same rule as the
+  // no-umbrella-aliases policy above: "cloud" must never count as knowing AWS.
+  //
   // NOTE: no 'safe' entry here, deliberately. canonicalize() lowercases its
   // input before reading this map, so a 'safe' key would make
   // canonicalize('safe') return 'SAFe' — re-opening through the exported

--- a/tests/skill-extract.test.mjs
+++ b/tests/skill-extract.test.mjs
@@ -174,6 +174,187 @@ try {
     fail(`extractSkills standalone CSM => ${[...csmAlone].join(',')}`);
   }
 
+  // ── Marketing / GTM vocabulary ────────────────────────────────────────────
+  // Same structural blindness the certification block was added for, one
+  // discipline over. Every token above the marketing block is an engineering
+  // tool or a delivery credential, so a marketing-operations candidate's gap
+  // map could only ever report the handful of engineering words that happened
+  // to appear in their reports. Measured on a real marketing-operations
+  // corpus: "ABM" was named as an explicit gap in several linked reports and
+  // was invisible throughout, while the top-ranked gap the tool could see was
+  // a COMPANY NAME quoted inside those same ABM sentences.
+  //
+  // Table-driven, both halves, exactly like the certification table: the token
+  // is recognized from lowercase prose AND canonicalizes to its display form.
+  // A token added to SKILL_TOKENS without a matching CANONICAL entry falls
+  // through to DISPLAY, which title-cases it ("abm" -> "Abm") and misses the
+  // known-skills set — silent drift, the class this module exists to prevent.
+  const marketingCases = [
+    ['ABM', 'ABM'],
+    ['account-based marketing', 'ABM'],
+    ['account based marketing', 'ABM'],
+    ['DSP', 'DSP'],
+    ['demand-side platform', 'DSP'],
+    ['demand side platform', 'DSP'],
+    ['programmatic display', 'Programmatic'],
+    ['programmatic advertising', 'Programmatic'],
+    ['programmatic media', 'Programmatic'],
+    ['media agency management', 'Media Agency Management'],
+    ['media agency', 'Media Agency Management'],
+    ['demand generation', 'Demand Generation'],
+    ['demand gen', 'Demand Generation'],
+    ['marketing automation', 'Marketing Automation'],
+    ['marketing operations', 'Marketing Operations'],
+    ['revenue operations', 'RevOps'],
+    ['revops', 'RevOps'],
+    ['lifecycle marketing', 'Lifecycle Marketing'],
+    ['product marketing', 'Product Marketing'],
+    ['partner marketing', 'Partner Marketing'],
+    ['performance marketing', 'Performance Marketing'],
+    ['growth marketing', 'Growth Marketing'],
+    ['field marketing', 'Field Marketing'],
+    ['content marketing', 'Content Marketing'],
+    ['email marketing', 'Email Marketing'],
+    ['paid media', 'Paid Media'],
+    ['paid social', 'Paid Social'],
+    ['paid search', 'Paid Search'],
+    ['conversion rate optimization', 'Conversion Rate Optimization'],
+    ['marketing mix modeling', 'Media Mix Modeling'],
+    ['media mix modeling', 'Media Mix Modeling'],
+    ['seo', 'SEO'],
+    ['sem', 'SEM'],
+    ['ppc', 'PPC'],
+    // Platforms a marketing CV actually lists. These matter most on the KNOWN
+    // side: without them the known-skills set built from a marketing cv.md came
+    // back with 5 entries, so almost nothing could be excluded as already-held.
+    ['hubspot', 'HubSpot'],
+    ['marketo', 'Marketo'],
+    ['pardot', 'Pardot'],
+    ['braze', 'Braze'],
+    ['klaviyo', 'Klaviyo'],
+    ['onesignal', 'OneSignal'],
+    ['intercom', 'Intercom'],
+    ['semrush', 'SEMrush'],
+    ['ahrefs', 'Ahrefs'],
+    ['demandbase', 'Demandbase'],
+    ['6sense', '6sense'],
+    ['google ads', 'Google Ads'],
+    ['google analytics', 'Google Analytics'],
+    ['ga4', 'GA4'],
+    ['google tag manager', 'Google Tag Manager'],
+    ['amplitude', 'Amplitude'],
+    ['mixpanel', 'Mixpanel'],
+    ['n8n', 'n8n'],
+    ['zapier', 'Zapier'],
+  ];
+  const marketingFailures = [];
+  for (const [raw, display] of marketingCases) {
+    const found = extractSkills(`Experience with ${raw} required.`);
+    if (!found.has(display)) marketingFailures.push(`extract "${raw}" => ${[...found].join(',') || '(none)'}`);
+    if (canonicalize(raw) !== display) marketingFailures.push(`canonicalize("${raw}") => ${canonicalize(raw)}`);
+  }
+  if (marketingFailures.length === 0) {
+    pass(`extractSkills + canonicalize cover all ${marketingCases.length} marketing/GTM tokens`);
+  } else {
+    fail(`marketing vocabulary coverage => ${marketingFailures.join(' | ')}`);
+  }
+
+  // Longest-first alternation within the marketing families, same convention as
+  // 'React Native' before 'React' and 'Lean Six Sigma' before 'Six Sigma'.
+  const mktPrecedence = extractSkills('Own media agency management and account-based marketing.');
+  if (mktPrecedence.has('Media Agency Management') && mktPrecedence.has('ABM')) {
+    pass('extractSkills prefers the longest marketing form ("Media Agency Management", "Account-Based Marketing")');
+  } else {
+    fail(`marketing precedence => ${[...mktPrecedence].join(',')}`);
+  }
+
+  // A soft_gap sentence in the shape reports actually write them: the skill
+  // named inside quoted JD language and prose, not as a bare list item. This is
+  // the string shape the tool was silently dropping.
+  const realGap = extractSkills(
+    "ABM: 'Building a world-class Account-Based Marketing capability' is a CORE REMIT, " +
+    "and 'deep expertise across… ABM' sits in the basic quals"
+  );
+  if (realGap.has('ABM')) pass('extractSkills finds ABM in a report-shaped soft_gap sentence');
+  else fail(`soft_gap sentence => ${[...realGap].join(',') || '(none)'}`);
+
+  // ── Deliberate omissions (the CSM precedent) ──────────────────────────────
+  // Each of these is a legitimate marketing abbreviation whose everyday or
+  // adjacent meaning collides hard enough that admitting it would mint phantom
+  // gaps out of ordinary prose. Same asymmetry argument as 'CSM': a missing
+  // alias costs a real skill once, visibly; a false one costs "go learn X" on
+  // every posting that happens to use the word.
+
+  // 'CRO' is Conversion Rate Optimization in marketing prose and Chief Revenue
+  // Officer in the org chart, and GTM postings are full of the second one.
+  const cro = extractSkills('This role reports to the CRO and partners with Sales.');
+  if (!cro.has('CRO') && !cro.has('Conversion Rate Optimization')) {
+    pass('extractSkills does not treat "CRO" as a skill (Chief Revenue Officer collision)');
+  } else {
+    fail(`CRO collision => ${[...cro].join(',')}`);
+  }
+
+  // 'GEO' is Generative Engine Optimization in AI-search work and "geography"
+  // everywhere else, including the location prose in most postings.
+  const geo = extractSkills('Supports customers across the EMEA geo and the APAC geo.');
+  if (!geo.has('GEO')) pass('extractSkills does not read a geography "geo" as Generative Engine Optimization');
+  else fail(`GEO collision => ${[...geo].join(',')}`);
+
+  // Bare 'programmatic' is an everyday engineering adjective. Only the media
+  // senses ('programmatic display/advertising/media/buying') count.
+  const progAccess = extractSkills('Provides programmatic access to the billing API.');
+  if (!progAccess.has('Programmatic')) {
+    pass('extractSkills does not read "programmatic access" as programmatic media buying');
+  } else {
+    fail(`programmatic-access collision => ${[...progAccess].join(',')}`);
+  }
+
+  // 'Segment' (the CDP) is the worst offender in this family: "segment" is an
+  // everyday noun in exactly the prose this vocabulary was added to read, and
+  // marketing JDs are built out of it.
+  const segmentProse = extractSkills('Define the enterprise segment and re-route each segment through the journey.');
+  if (!segmentProse.has('Segment')) pass('extractSkills does not read an audience "segment" as the Segment CDP');
+  else fail(`Segment collision => ${[...segmentProse].join(',')}`);
+
+  // 'Iterable' (the ESP) collides with the programming term, and this module is
+  // shared with jd-skill-gap, which runs over full engineering JDs.
+  const iterableProse = extractSkills('The function accepts any iterable and returns a generator.');
+  if (!iterableProse.has('Iterable')) pass('extractSkills does not read a programming "iterable" as the Iterable ESP');
+  else fail(`Iterable collision => ${[...iterableProse].join(',')}`);
+
+  // ── ABM is NOT Demandbase ─────────────────────────────────────────────────
+  // The single most consequential boundary in this block, and the one an
+  // "obvious" alias would get wrong. Demandbase is an ABM PLATFORM; owning a
+  // seat in it is not owning an ABM program, and a careful evaluation says so
+  // explicitly — platform familiarity is the honest adjacent claim, program
+  // ownership is not.
+  //
+  // Aliasing Demandbase -> ABM would put ABM in the known-skills set built from
+  // a CV that lists the tool, suppressing the exact gap this vocabulary was
+  // added to surface — re-burying the bug one layer deeper, where it reads as
+  // "no gap found" instead of "vocabulary missing". Same rule as the module's
+  // no-umbrella-aliases policy: "cloud" must never count as knowing AWS.
+  if (canonicalize('demandbase') === 'Demandbase' && canonicalize('abm') === 'ABM') {
+    pass('canonicalize keeps Demandbase and ABM distinct (platform familiarity is not program ownership)');
+  } else {
+    fail(`Demandbase/ABM conflation => demandbase=${canonicalize('demandbase')} abm=${canonicalize('abm')}`);
+  }
+
+  const dbOnly = extractSkills('**Paid:** Google Ads, Demandbase');
+  if (dbOnly.has('Demandbase') && !dbOnly.has('ABM')) {
+    pass('a CV line listing Demandbase does not put ABM in the known-skills set');
+  } else {
+    fail(`Demandbase line leaked ABM => ${[...dbOnly].join(',')}`);
+  }
+
+  // 'SEM' must not fire inside 'SEMrush', and 'SEO' must survive next to it.
+  const semBoundary = extractSkills('Search: SEMrush, Google Ads/AdWords');
+  if (semBoundary.has('SEMrush') && !semBoundary.has('SEM')) {
+    pass('extractSkills matches SEMrush without also firing the shorter SEM token');
+  } else {
+    fail(`SEM/SEMrush boundary => ${[...semBoundary].join(',')}`);
+  }
+
   // empty / falsy input
   if (extractSkills('').size === 0 && extractSkills(null).size === 0) pass('extractSkills returns an empty set for empty/null input');
   else fail('extractSkills should return {} for empty/null');

--- a/tests/upskill-company-names.test.mjs
+++ b/tests/upskill-company-names.test.mjs
@@ -1,0 +1,147 @@
+// tests/upskill-company-names.test.mjs — a company the user has evaluated must
+// never be reported as a skill they are missing.
+//
+// The bug, observed on a real marketing-operations corpus: the gap map's
+// top-ranked entry was a data-platform vendor's name, and every occurrence came
+// from PROVENANCE prose inside other reports' gap notes. Reports log a recurring
+// gap by naming the sibling companies where it was logged before, in asides
+// shaped like:
+//
+//   "RECURRING GAP, third+ occurrence (<company> logged it; <company> earlier)"
+//   "a recurring gap (4th log: <company>, <company>, now here)"
+//
+// Those vendors are legitimate tokens in SKILL_TOKENS, so the extractor matched
+// them correctly; what it could not know is that in that corpus the words named
+// companies in the user's OWN pipeline, quoted while logging a different gap
+// entirely. The tool then ranked "learn <vendor>" above every real gap —
+// including the one those very sentences were recording.
+//
+// The exclusion is deliberately narrow: a token only drops out if it matches a
+// company in the user's own tracker. And it is REPORTED, never silent. The
+// module's own hard-won lesson (see upskill.mjs's known-skills header) is that
+// "suppressed because known" being indistinguishable from "never appeared" is
+// what made the original suppression bug expensive. An engineer who genuinely
+// needs Snowflake-the-tool and once applied to Snowflake-the-company sees it
+// listed under excludedAsCompanyName rather than losing it without a trace.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nupskill.mjs company-name exclusion (a tracked employer is not a skill gap)');
+
+try {
+  const { aggregateGaps, extractSkills, knownSkillsText } =
+    await import(pathToFileURL(join(ROOT, 'upskill.mjs')).href);
+
+  // ── the reported bug, reproduced in the shape reports actually write ──────
+  {
+    const reports = [
+      {
+        num: 34,
+        score: 4.5,
+        gapText: "ABM program ownership named ('martech ecosystem to support ABM') — "
+          + 'RECURRING GAP, third+ occurrence (Acme logged it; Snowflake earlier). '
+          + 'Demandbase in cv.md skills is the honest adjacent',
+      },
+      {
+        num: 35,
+        score: 4.1,
+        gapText: "ABM: 'Building a world-class Account-Based Marketing capability' is a "
+          + 'CORE REMIT — a recurring gap (4th log: Snowflake, Acme, Globex, now here)',
+      },
+    ];
+    const companyNames = new Set(['snowflake', 'acme', 'globex', 'initech']);
+    const { gaps, excludedAsCompanyName } = aggregateGaps(reports, new Set(), companyNames);
+    const names = gaps.map(g => g.skill);
+
+    if (!names.includes('Snowflake')) {
+      pass('a company from the user\'s own tracker is not reported as a skill gap');
+    } else {
+      fail(`Snowflake still reported as a skill gap => ${names.join(',')}`);
+    }
+
+    if (excludedAsCompanyName?.some(e => e.skill === 'Snowflake' && e.reports === 2)) {
+      pass('the excluded company name is REPORTED (2 reports), not silently dropped');
+    } else {
+      fail(`excludedAsCompanyName => ${JSON.stringify(excludedAsCompanyName)}`);
+    }
+
+    // The gap those sentences were actually recording must now be the one that
+    // surfaces — this is the whole point of the fix.
+    const abm = gaps.find(g => g.skill === 'ABM');
+    if (abm && abm.reports === 2) {
+      pass('ABM surfaces from the same two sentences that used to yield only the vendor name');
+    } else {
+      fail(`ABM not aggregated => ${JSON.stringify(gaps.map(g => [g.skill, g.reports]))}`);
+    }
+  }
+
+  // ── matching is case- and whitespace-insensitive ──────────────────────────
+  {
+    const { gaps } = aggregateGaps(
+      [{ num: 1, score: 3.0, gapText: 'No exposure to Snowflake or Kubernetes' }],
+      new Set(),
+      new Set(['  SNOWFLAKE  ']),
+    );
+    const names = gaps.map(g => g.skill);
+    if (!names.includes('Snowflake') && names.includes('Kubernetes')) {
+      pass('company matching is case/whitespace-insensitive and excludes only the company');
+    } else {
+      fail(`case-insensitive company match => ${names.join(',')}`);
+    }
+  }
+
+  // ── known-skill exclusion still wins, and stays in its own bucket ─────────
+  // A company that is ALSO a genuine known skill must be reported as known, not
+  // as a company — the two buckets answer different questions ("you have this"
+  // vs "this is an employer you looked at") and collapsing them loses the first.
+  {
+    const { excludedAsKnown, excludedAsCompanyName } = aggregateGaps(
+      [{ num: 1, score: 3.0, gapText: 'Needs Salesforce administration' }],
+      new Set(['Salesforce']),
+      new Set(['salesforce']),
+    );
+    if (excludedAsKnown.some(e => e.skill === 'Salesforce')
+        && !excludedAsCompanyName.some(e => e.skill === 'Salesforce')) {
+      pass('known-skill exclusion takes precedence over company-name exclusion');
+    } else {
+      fail(`bucket precedence => known=${JSON.stringify(excludedAsKnown)} company=${JSON.stringify(excludedAsCompanyName)}`);
+    }
+  }
+
+  // ── an empty/absent company set changes nothing ──────────────────────────
+  // Callers that pass two arguments must behave exactly as before.
+  {
+    const reports = [{ num: 1, score: 3.0, gapText: 'Needs Snowflake and Kubernetes' }];
+    const legacy = aggregateGaps(reports, new Set());
+    const explicit = aggregateGaps(reports, new Set(), new Set());
+    if (legacy.gaps.map(g => g.skill).includes('Snowflake')
+        && JSON.stringify(legacy.gaps) === JSON.stringify(explicit.gaps)) {
+      pass('aggregateGaps stays backward-compatible when no company set is supplied');
+    } else {
+      fail(`backward compatibility => legacy=${JSON.stringify(legacy.gaps.map(g => g.skill))}`);
+    }
+  }
+
+  // ── the Demandbase trap, end to end ──────────────────────────────────────
+  // Demandbase is an ABM PLATFORM. If the vocabulary ever aliases the tool to
+  // the discipline, the CV line below puts ABM into the known-skills set and the
+  // gap disappears again — this time reading as "no gap found", which is
+  // strictly worse than the silence being fixed here.
+  {
+    const knownText = knownSkillsText('## Marketing platforms\n**Paid:** Google Ads, Demandbase\n', '');
+    const known = extractSkills(knownText);
+    const { gaps, excludedAsKnown } = aggregateGaps(
+      [{ num: 1, score: 4.1, gapText: 'ABM program ownership not claimed (Demandbase tooling listed)' }],
+      known,
+    );
+    const names = gaps.map(g => g.skill);
+    if (names.includes('ABM') && excludedAsKnown.some(e => e.skill === 'Demandbase')) {
+      pass('Demandbase on the CV is excluded as known WITHOUT suppressing the ABM gap');
+    } else {
+      fail(`Demandbase/ABM end to end => gaps=${names.join(',')} known=${excludedAsKnown.map(e => e.skill).join(',')}`);
+    }
+  }
+} catch (e) {
+  fail(`upskill company-name tests crashed: ${e.stack || e.message}`);
+}

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -86,7 +86,12 @@ function readTextIfExists(path) {
 // older runs non-comparable. The upskill mode's diff-vs-previous section only
 // compares reports with the same schema_version, so a regex change can't
 // masquerade as "gap closed".
-export const SCHEMA_VERSION = 1;
+// v2 (2026-08-30): the marketing/GTM vocabulary block in skill-extract.mjs and
+// the company-name exclusion below both change WHICH skills a report yields, so
+// a v1 gap list and a v2 one are not comparable — a gap "appearing" in v2 may
+// simply be a word the v1 vocabulary could not see, and a gap "closing" may be
+// an employer name that v1 mistook for a skill.
+export const SCHEMA_VERSION = 2;
 
 // Reports below this global score count as "low fit" — the population whose
 // gaps matter most. Matches the apply threshold in Ethical Use (CLAUDE.md).
@@ -306,24 +311,59 @@ export function parseReportGaps(content) {
 }
 
 /**
+ * Normalized lookup key for a company name. Lowercased and whitespace-collapsed
+ * so a tracker cell (`  Snowflake `) matches an extracted skill token
+ * (`Snowflake`).
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function companyKey(name) {
+  return String(name ?? '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
  * Pure aggregation over parsed reports. Exported for self-testing.
  *
  * @param {Array<{num:number|string, score:number|null, gapText:string}>} reports
  * @param {Set<string>} knownSkills — canonical names already in cv/profile
+ * @param {Set<string>} [companyNames] — normalized names of companies the user
+ *   has evaluated (see companyKey). A skill token that IS one of them is an
+ *   employer being cited, not a skill being demanded.
  */
-export function aggregateGaps(reports, knownSkills) {
+export function aggregateGaps(reports, knownSkills, companyNames = new Set()) {
   const scored = reports.filter(r => Number.isFinite(r.score));
   const lowFit = scored.filter(r => r.score < LOW_FIT_SCORE);
   const totalLowFit = lowFit.length;
 
+  // Accept either an already-normalized set or raw tracker cells.
+  const companyLookup = new Set([...companyNames].map(companyKey).filter(Boolean));
+
   const bySkill = new Map();
   const excludedCounts = new Map();
+  const companyCounts = new Map();
 
   for (const report of reports) {
     const skills = extractSkills(report.gapText);
     for (const skill of skills) {
       if (knownSkills.has(skill)) {
         excludedCounts.set(skill, (excludedCounts.get(skill) || 0) + 1);
+        continue;
+      }
+      // A company from the user's OWN pipeline appearing in gap prose is
+      // almost always provenance, not demand — a report logging a recurring
+      // gap names the sibling companies where it was logged before ("4th
+      // occurrence: <company>, <company>, now here"), and the extractor cannot
+      // tell that from a JD asking for the tool of the same name.
+      //
+      // Checked AFTER known-skills so a company that is also a genuine known
+      // skill stays in the bucket that says "you already have this". Counted
+      // and reported rather than dropped: this module's own history (see the
+      // known-skills header above) is that a silent suppression is
+      // indistinguishable from "never appeared", which is what made the
+      // original bug expensive.
+      if (companyLookup.has(companyKey(skill))) {
+        companyCounts.set(skill, (companyCounts.get(skill) || 0) + 1);
         continue;
       }
       if (!bySkill.has(skill)) {
@@ -358,7 +398,11 @@ export function aggregateGaps(reports, knownSkills) {
     .map(([skill, reports]) => ({ skill, reports }))
     .sort((a, b) => b.reports - a.reports);
 
-  return { gaps, excludedAsKnown, totalLowFit };
+  const excludedAsCompanyName = [...companyCounts.entries()]
+    .map(([skill, reports]) => ({ skill, reports }))
+    .sort((a, b) => b.reports - a.reports);
+
+  return { gaps, excludedAsKnown, excludedAsCompanyName, totalLowFit };
 }
 
 /**
@@ -401,6 +445,13 @@ function analyze(minReports) {
   let reportsRead = 0;
   let reportsWithMachineSummary = 0;
   const parsedReports = [];
+  // Every company the user has evaluated, linked report or not — a row with no
+  // report still names an employer that can turn up in someone else's gap prose.
+  // '?' is the tracker's locale-invariant marker for an unknown end employer
+  // (see AGENTS.md) and names nothing, so it is skipped.
+  const companyNames = new Set(
+    rows.map(r => companyKey(r.company)).filter(name => name && name !== '?')
+  );
 
   for (const row of rows) {
     const linkMatch = (row.report || '').match(/\]\(([^)]+)\)/);
@@ -445,7 +496,8 @@ function analyze(minReports) {
   );
   const knownSkills = extractSkills(knownText);
 
-  const { gaps, excludedAsKnown, totalLowFit } = aggregateGaps(parsedReports, knownSkills);
+  const { gaps, excludedAsKnown, excludedAsCompanyName, totalLowFit } =
+    aggregateGaps(parsedReports, knownSkills, companyNames);
 
   return {
     schema_version: SCHEMA_VERSION,
@@ -457,9 +509,11 @@ function analyze(minReports) {
       lowFitReports: totalLowFit,
       lowFitScoreThreshold: LOW_FIT_SCORE,
       knownSkillCount: knownSkills.size,
+      trackedCompanyCount: companyNames.size,
     },
     gaps,
     excludedAsKnown,
+    excludedAsCompanyName,
     knownSkills: [...knownSkills].sort(),
   };
 }
@@ -485,6 +539,12 @@ function printSummary(result) {
   if (result.excludedAsKnown.length > 0) {
     console.log('');
     console.log(`Excluded (already in cv.md/profile): ${result.excludedAsKnown.map(e => e.skill).join(', ')}`);
+  }
+  // Printed, never silent: if one of these is genuinely a tool the user needs
+  // rather than an employer they cited, this line is how they find out.
+  if (result.excludedAsCompanyName?.length > 0) {
+    console.log('');
+    console.log(`Excluded (company in your tracker, not a skill): ${result.excludedAsCompanyName.map(e => e.skill).join(', ')}`);
   }
 }
 


### PR DESCRIPTION
## The bug

`extractSkills` is a closed allowlist, and every token in it is an engineering tool or a delivery credential. A marketing-operations user is therefore structurally invisible to `upskill`: their gap map can only ever report the handful of engineering words that happen to appear in their reports.

This is the same hole the certification block (#2603) was added to close, one discipline further over, and it fails the same way — silently, producing a plausible-looking gap map that simply omits the recurring gap.

Measured on a real marketing-operations corpus:

- **"ABM" was an explicit `soft_gap` in several linked reports** — twice flagged *in the report text itself* as a recurring gap — and never once reached the output.
- The **top-ranked entry was a data-platform vendor's NAME**, matched out of the provenance asides inside those very ABM sentences. A report logging a recurring gap names the sibling companies where it was logged before (`"4th log: <company>, <company>, now here"`), and the extractor cannot tell that from a JD asking for the tool of the same name.
- So the tool ranked *"learn `<vendor>`"* above the gap those sentences were recording.
- On the known-skills side the same blindness left a marketing `cv.md` yielding a known-skills set of **five**, so almost nothing could be excluded as already-held.

Worth stressing that this is **not** a multi-word or casing problem — multi-word tokens like `React Native` and `Lean Six Sigma` already work. The vocabulary, not the scoring, was the constraint, exactly as the #2603 comment records.

## The fix

**`skill-extract.mjs`** gains a marketing/GTM vocabulary block: ABM, programmatic/DSP, media agency management, the demand/lifecycle/paid disciplines, and the platforms a marketing CV lists. Longest-first within each family, matching the existing `React Native`-before-`React` convention.

Two deliberate boundaries, both tested:

- **ABM is NOT aliased to Demandbase.** The platform is not the program. Aliasing them would put ABM into the known-skills set of anyone whose CV lists the tool and re-bury the gap as *"no gap found"* — worse than the silence being fixed, because it reads as a verified absence. Same rule as the existing no-umbrella-aliases policy (`"cloud"` must never count as knowing AWS).
- **`CRO`, `GEO`, bare `Programmatic`, `Segment` and `Iterable` are omitted**, on the asymmetry the `CSM` note already sets out. Each collides with everyday or adjacent prose — *"reports to the CRO"*, *"the EMEA geo"*, *"programmatic access to the API"*, *"each segment"*, *"any iterable"* — and a false token mints a phantom gap on every posting that uses the word. `Iterable` matters especially because this module is shared with `jd-skill-gap`, which runs over full engineering JDs. Guard tests pin all five.

**`upskill.mjs`** excludes skill tokens that name a company in the user's own tracker, checked *after* known-skills so a genuine known skill keeps its bucket. Reported as `excludedAsCompanyName` rather than dropped — this module's own history (see the known-skills header) is that a silent suppression is indistinguishable from *"never appeared"*, which is what made the original suppression bug expensive. Someone who genuinely needs the tool and once applied to the company of the same name sees it listed rather than losing it without a trace.

`SCHEMA_VERSION` 1 → 2, since a v1 and a v2 gap list are not comparable: a gap "appearing" in v2 may be a word v1 could not see, and one "closing" may be an employer name v1 mistook for a skill.

## Result

On the corpus above, same data, before and after:

| | before | after |
|---|---|---|
| top gap | `<vendor>` (a company name) | **ABM** — Critical, 6 reports |
| marketing gaps found | none | ABM, DSP, Programmatic, Media Agency Management, Demand Generation, Paid Media, … |
| `knownSkillCount` | 5 | 24 |
| company names as gaps | 2 | 0 (reported under `excludedAsCompanyName`) |

## Tests

- `tests/skill-extract.test.mjs` — 27 assertions: table-driven over the whole new vocabulary asserting **both** halves (extraction from lowercase prose *and* canonicalization to the display form, the drift class this module exists to prevent), the five omission guards, longest-first precedence, the `SEM`/`SEMrush` boundary, and the Demandbase/ABM boundary.
- `tests/upskill-company-names.test.mjs` (new) — the exclusion, that it is reported and not silent, bucket precedence vs known-skills, case/whitespace-insensitivity, and backward compatibility when no company set is passed (`aggregateGaps` keeps its 2-arg behaviour exactly).

All green, plus `upskill.mjs --self-test`. Full suite shows no new failures against a clean `main` tree.

Fixtures are synthetic throughout — the corpus that surfaced this is a real job search, so no company names, report contents or CV lines from it appear here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded skill recognition and normalization for marketing, GTM, revenue operations, analytics, and marketing platforms.
  - Reports now distinguish tracked company names from genuine skill gaps.
  - Added company-excluded skill counts and tracked-company totals to report summaries.

- **Bug Fixes**
  - Improved handling of aliases, spelling variations, case, and whitespace.
  - Preserved valid ABM gaps when related companies such as Demandbase are tracked.
  - Updated report schema to reflect non-comparable results after these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->