### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Italian _shared.md (#2573)

### DIFF
--- a/modes/it/_shared.md
+++ b/modes/it/_shared.md
@@ -33,6 +33,8 @@
 
 **REGOLA: Non hardcodare MAI metriche provenienti dai proof point.** Leggerle da `cv.md` e `article-digest.md` al momento della valutazione.
 **REGOLA: Per metriche di articoli/progetti, `article-digest.md` ha priorità su `cv.md`** (`cv.md` può contenere dati meno recenti).
+**REGOLA: MAI affermare che il candidato è autore/creatore di un progetto, repository, libreria, strumento, framework o artefatto open-source, a meno che ciò non sia esplicitamente attribuito a lui in `cv.md` o `article-digest.md`.** Confondere "usare uno strumento" con "averlo creato" (usare X non significa aver creato X) è il pattern di invenzione più comune, ed è vietato.
+**REGOLA: Le parole chiave si riformulano, non si inventano mai.** Riordinare, riformulare, enfatizzare — ma mai inventare. Se un'affermazione non è supportata da un file nell'ambito consentito, chiedere al candidato; senza risposta, ometterla. Il silenzio su un argomento è meglio di un dettaglio inventato.
 
 ---
 


### PR DESCRIPTION
Part of #2573 (umbrella: restore the anti-fabrication RULES in the 16 localized `_shared.md` files).

`modes/it/_shared.md` carried two `REGOLA` blocks, both about metrics. The English source has the pair the umbrella targets — **authorship** and **reformulate-never-fabricate** — and they were missing here.

Added right after the existing metrics rules, before the North Star separator, matching the umbrella's placement instruction and the shipped `fr` / `es` / `pt` / `de` translations:

- **REGOLA (authorship):** never claim the candidate created a project/repo/library/tool/framework/OSS artefact unless `cv.md` or `article-digest.md` attributes it to them; tool-of-trade conflation is the common fabrication pattern and is forbidden.
- **REGOLA (reformulate):** keywords are reformulated, never invented; if a claim is not backed by an in-scope file, ask the candidate, and omit it absent an answer.

Meaning over literalness: "tool-of-trade conflation" is rendered as *confondere "usare uno strumento" con "averlo creato"*. `cv.md` and `article-digest.md` stay verbatim as filenames.

Italian only, per the one-language-per-PR convention.

### Test plan
- [x] `node tests/localized-guardrails.test.mjs` — 18/18 files still keep each guardrail marker followed by a RULE line
- [x] docs-only change; no code paths touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring authorship claims to be supported by approved source files.
  * Clarified that unsupported keywords or claims should be omitted or explicitly qualified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->