### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Polish _shared.md (#2573)

### DIFF
--- a/modes/pl/_shared.md
+++ b/modes/pl/_shared.md
@@ -33,6 +33,8 @@
 
 **REGUŁA: NIGDY nie zakodowuj na sztywno metryk pochodzących z proof points.** Czytaj je z `cv.md` i `article-digest.md` w momencie oceny.
 **REGUŁA: Dla metryk z artykułów/projektów `article-digest.md` ma priorytet nad `cv.md`** (`cv.md` może zawierać starsze liczby).
+**REGUŁA: NIGDY nie twierdź, że kandydat jest autorem/twórcą projektu, repozytorium, biblioteki, narzędzia, frameworka ani artefaktu open-source, chyba że jest to wprost przypisane jemu w `cv.md` lub `article-digest.md`.** Mylenie "używania narzędzia" z "jego stworzeniem" (używanie X to nie jest stworzenie X) to najczęstszy wzorzec zmyślania i jest zabronione.
+**REGUŁA: Słowa kluczowe się przeformułowuje, nigdy nie zmyśla.** Zmieniać kolejność, ujęcie, akcent — ale nigdy nie wymyślać. Jeśli twierdzenie nie jest poparte plikiem w zakresie, zapytać kandydata; bez odpowiedzi — pominąć je. Milczenie na dany temat jest lepsze niż zmyślony szczegół.
 
 ---
 


### PR DESCRIPTION
Part of #2573 (umbrella: restore the anti-fabrication RULES in the 16 localized `_shared.md` files).

`modes/pl/_shared.md` carried two `REGUŁA` blocks, both about metrics. The pair the umbrella targets — **authorship** and **reformulate-never-fabricate** — was missing.

Added right after the existing metrics rules, before the North Star separator, matching the umbrella's placement instruction and the shipped `fr` / `es` / `pt` / `de` translations:

- **REGUŁA (authorship):** never claim the candidate created a project/repo/library/tool/framework/OSS artefact unless `cv.md` or `article-digest.md` attributes it to them; tool-of-trade conflation is the common fabrication pattern and is forbidden.
- **REGUŁA (reformulate):** keywords are reformulated, never invented; if a claim is not backed by an in-scope file, ask the candidate, and omit it absent an answer.

Meaning over literalness: "tool-of-trade conflation" is rendered as *mylenie "używania narzędzia" z "jego stworzeniem"*. `cv.md` and `article-digest.md` stay verbatim as filenames.

Polish only, per the one-language-per-PR convention.

### Test plan
- [x] `node tests/localized-guardrails.test.mjs` — 18/18 files still keep each guardrail marker followed by a RULE line
- [x] docs-only change; no code paths touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Polish-language guidance requiring explicit source attribution before crediting candidates with creating projects, repositories, libraries, tools, frameworks, or open-source work.
  * Clarified that keywords may be reformulated but unsupported claims must be omitted or verified rather than invented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->