### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Turkish _shared.md (#2573)

### DIFF
--- a/modes/tr/_shared.md
+++ b/modes/tr/_shared.md
@@ -31,6 +31,8 @@
 
 **KURAL: Kanıt noktalarındaki ölçüm değerlerini ASLA sabit kodlama.** Değerlendirme sırasında bunları cv.md + article-digest.md dosyalarından oku.
 **KURAL: Makale/proje metrikleri için `article-digest.md`, `cv.md`'ye göre önceliklidir.**
+**KURAL: `cv.md` veya `article-digest.md` içinde açıkça adaya atfedilmediği sürece, adayın bir projenin, deponun, kütüphanenin, aracın, framework'ün veya açık kaynak bir yapıtın yaratıcısı olduğunu ASLA iddia etme.** Bir aracı "kullanmak" ile onu "yaratmış olmak"ı karıştırmak (X'i kullanmak, X'i yaratmış olmak değildir) en yaygın uydurma kalıbıdır ve yasaktır.
+**KURAL: Anahtar kelimeler yeniden ifade edilir, asla uydurulmaz.** Yeniden sıralamak, yeniden çerçevelemek, öne çıkarmak — ama asla uydurmamak. Bir iddia kapsamdaki bir dosyayla desteklenmiyorsa adaya sor; yanıt yoksa çıkar. Bir konuda sessiz kalmak, uydurulmuş bir ayrıntıdan iyidir.
 **KURAL: `_profile.md`'yi bu dosyadan SONRA oku. Kullanıcının `_profile.md`'deki özelleştirmeleri buradaki varsayılanları geçersiz kılar.**
 
 ---


### PR DESCRIPTION
Part of #2573 (umbrella: restore the anti-fabrication RULES in the 16 localized `_shared.md` files).

`modes/tr/_shared.md` had `KURAL` blocks for metrics and file precedence, but not the pair the umbrella targets — **authorship** and **reformulate-never-fabricate**.

Added right after the metrics rules, matching the umbrella's placement instruction and the shipped `fr` / `es` / `pt` / `de` translations:

- **KURAL (authorship):** never claim the candidate created a project/repo/library/tool/framework/OSS artefact unless `cv.md` or `article-digest.md` attributes it to them; tool-of-trade conflation is the common fabrication pattern and is forbidden.
- **KURAL (reformulate):** keywords are reformulated, never invented; if a claim is not backed by an in-scope file, ask the candidate, and omit it absent an answer.

Meaning over literalness: "tool-of-trade conflation" is rendered as *bir aracı "kullanmak" ile onu "yaratmış olmak"ı karıştırmak*. `cv.md` and `article-digest.md` stay verbatim as filenames.

Turkish only, per the one-language-per-PR convention.

### Test plan
- [x] `node tests/localized-guardrails.test.mjs` — 18/18 files still keep each guardrail marker followed by a RULE line
- [x] docs-only change; no code paths touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that project, repository, library, tool, framework, and open-source creation claims must be explicitly supported by approved career materials.
  * Added guidance to reframe existing keywords without fabricating details; unsupported claims should be removed unless verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->