### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Danish _shared.md (#2573)

### DIFF
--- a/modes/da/_shared.md
+++ b/modes/da/_shared.md
@@ -33,6 +33,8 @@
 
 **REGEL: Aldrig hardcode metrics fra proof points.** Læs dem fra `cv.md` og `article-digest.md` på evalueringstidspunktet.
 **REGEL: For metrics om artikler/projekter har `article-digest.md` forrang frem for `cv.md`** (`cv.md` kan indeholde ældre tal).
+**REGEL: Påstå ALDRIG at kandidaten er forfatter/skaber af et projekt, repository, bibliotek, værktøj, framework eller open source-artefakt, medmindre det udtrykkeligt er tilskrevet vedkommende i `cv.md` eller `article-digest.md`.** At forveksle "at bruge et værktøj" med "at have skabt det" (at bruge X er ikke at have skabt X) er det mest almindelige opdigtningsmønster og er forbudt.
+**REGEL: Nøgleord omformuleres, aldrig opdigtes.** Omarranger, omformuler, fremhæv — men opfind aldrig. Hvis en påstand ikke er dækket af en fil inden for scope, så spørg kandidaten; uden svar udelades den. Tavshed om et emne er bedre end en opdigtet detalje.
 
 ---
 


### PR DESCRIPTION
Part of #2573 (umbrella: restore the anti-fabrication RULES in the 16 localized `_shared.md` files).

`modes/da/_shared.md` carried two `REGEL` blocks, both about metrics. The pair the umbrella targets — **authorship** and **reformulate-never-fabricate** — was missing.

Added right after the existing metrics rules, before the North Star separator, matching the umbrella's placement instruction and the shipped `fr` / `es` / `pt` / `de` translations:

- **REGEL (authorship):** never claim the candidate created a project/repo/library/tool/framework/OSS artefact unless `cv.md` or `article-digest.md` attributes it to them; tool-of-trade conflation is the common fabrication pattern and is forbidden.
- **REGEL (reformulate):** keywords are reformulated, never invented; if a claim is not backed by an in-scope file, ask the candidate, and omit it absent an answer.

Meaning over literalness: "tool-of-trade conflation" is rendered as *at forveksle "at bruge et værktøj" med "at have skabt det"*. `cv.md` and `article-digest.md` stay verbatim as filenames.

Danish only, per the one-language-per-PR convention.

### Test plan
- [x] `node tests/localized-guardrails.test.mjs` — 18/18 files still keep each guardrail marker followed by a RULE line
- [x] docs-only change; no code paths touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Guidelines**
  * Added Danish-language safeguards to prevent unsupported claims about project authorship or creation.
  * Added guidance to reformulate keywords accurately and omit or refer back unsupported claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->