### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the Indonesian _shared.md (#2573)

### DIFF
--- a/modes/id/_shared.md
+++ b/modes/id/_shared.md
@@ -33,6 +33,8 @@
 
 **ATURAN: JANGAN PERNAH menuliskan metrik dari proof point secara hardcode.** Baca metrik dari `cv.md` dan `article-digest.md` pada saat evaluasi.
 **ATURAN: Untuk metrik artikel/proyek, `article-digest.md` lebih diutamakan daripada `cv.md`** (`cv.md` bisa memuat angka yang lebih lama).
+**ATURAN: JANGAN PERNAH menyatakan bahwa kandidat adalah pembuat/pencipta suatu proyek, repositori, pustaka, alat, framework, atau artefak open-source, kecuali hal itu secara eksplisit dikaitkan dengannya di `cv.md` atau `article-digest.md`.** Menyamakan "memakai sebuah alat" dengan "menciptakannya" (memakai X bukan berarti menciptakan X) adalah pola fabrikasi yang paling umum, dan dilarang.
+**ATURAN: Kata kunci diformulasikan ulang, tidak pernah dikarang.** Susun ulang, bingkai ulang, tekankan — tetapi jangan pernah mengarang. Jika sebuah klaim tidak didukung oleh berkas dalam cakupan, tanyakan kepada kandidat; tanpa jawaban, hilangkan. Diam tentang suatu topik lebih baik daripada detail yang dikarang.
 
 ---
 


### PR DESCRIPTION
Part of #2573 (umbrella: restore the anti-fabrication RULES in the 16 localized `_shared.md` files).

`modes/id/_shared.md` carried two `ATURAN` blocks, both about metrics. The pair the umbrella targets — **authorship** and **reformulate-never-fabricate** — was missing.

Added right after the existing metrics rules, before the North Star separator, matching the umbrella's placement instruction and the shipped `fr` / `es` / `pt` / `de` translations:

- **ATURAN (authorship):** never claim the candidate created a project/repo/library/tool/framework/OSS artefact unless `cv.md` or `article-digest.md` attributes it to them; tool-of-trade conflation is the common fabrication pattern and is forbidden.
- **ATURAN (reformulate):** keywords are reformulated, never invented; if a claim is not backed by an in-scope file, ask the candidate, and omit it absent an answer.

Meaning over literalness: "tool-of-trade conflation" is rendered as *menyamakan "memakai sebuah alat" dengan "menciptakannya"*. `cv.md` and `article-digest.md` stay verbatim as filenames.

Indonesian only, per the one-language-per-PR convention.

### Test plan
- [x] `node tests/localized-guardrails.test.mjs` — 18/18 files still keep each guardrail marker followed by a RULE line
- [x] docs-only change; no code paths touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Career-related responses now distinguish between using a technology and creating it.
  * Project, repository, library, tool, framework, and open-source contributions are only attributed when supported by available candidate information.
  * Unsupported keywords and claims are omitted or flagged for clarification instead of being presented as facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->