### PR TITLE
docs(i18n): hired wall section — zh-TW

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -16,6 +16,20 @@
   <em>現在，它開源了。</em>
 </p>
 
+<hr>
+
+<p align="center">
+  <a href="HIRED.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsantifer%2Fcareer-ops%2Fmain%2Fdocs%2Fhired-count.json&query=%24.count&label=%F0%9F%8E%89%20%E7%94%A8%20CAREER-OPS%20%E6%89%BE%E5%88%B0%E5%B7%A5%E4%BD%9C&suffix=%20%E4%BA%BA%E5%B7%B2%E9%A9%97%E8%AD%89&color=2ea44f&style=for-the-badge&labelColor=2b3137" alt="用 career-ops 找到工作：已驗證人數"></a>
+</p>
+
+<p align="center"><sub>你也上岸了嗎？<a href="https://github.com/santifer/career-ops/issues/new?template=i-got-hired.yml">分享你的故事 →</a> · 你的卡片會讓還在找的人看見：出路真的存在。</sub></p>
+
+<p align="center">
+  <a href="HIRED.md"><img src="docs/hired-wall.svg" alt="最近三則成功入職的故事" width="800"></a>
+</p>
+
+<p align="center"><sub>每一個數字都是一則公開的故事，你可以<a href="HIRED.md">親自查證 →</a> · 他們每一個人，都曾站在你現在的位置。</sub></p>
+
 <p align="center">
   <a href="https://trendshift.io/repositories/25195" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25195" alt="santifer%2Fcareer-ops | Trendshift" style="width: 245px; height: 54px; vertical-align: middle;" width="245" height="54"/></a>
   &nbsp;&nbsp;


### PR DESCRIPTION
## What does this PR do?

Brings the Hired Wall section to `README.zh-TW.md` — badge, share line, strip and audit line — taking the `zh-TW` row of the #3398 umbrella.

## Related issue

Refs #3398 (one language per PR; `zh-TW` was unclaimed)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## What was translated

The three pieces the umbrella asks for, plus both `alt` attributes:

| Piece | English | zh-TW |
|---|---|---|
| badge `label=` | `🎉 HIRED WITH CAREER-OPS` | `🎉 用 CAREER-OPS 找到工作` |
| badge `suffix=` | ` verified` | ` 人已驗證` |
| badge `alt` | Hired with career-ops: verified count | 用 career-ops 找到工作：已驗證人數 |
| share line | Landed yours? Share it → · your card shows someone mid-search that the way out exists. | 你也上岸了嗎？分享你的故事 → · 你的卡片會讓還在找的人看見：出路真的存在。 |
| strip `alt` | The three most recent hired stories | 最近三則成功入職的故事 |
| audit line | Every count is a public story you can audit → · every one of them started where you are now. | 每一個數字都是一則公開的故事，你可以親自查證 → · 他們每一個人，都曾站在你現在的位置。 |

A note on register, since the umbrella says the emotional tone matters more than literal fidelity: 「上岸」 is what people in Chinese-speaking job forums actually say for landing the job after a long search — it carries the relief the English "Landed yours?" carries, which a literal 「你找到工作了嗎？」 does not. The audit line's 「他們每一個人，都曾站在你現在的位置」 keeps the second person that makes the original land.

Everything else is byte-identical to `README.md`: same `HIRED.md` links, same `docs/hired-wall.svg`, same structure, same `<hr>` placement relative to the tagline.

## Verification

The badge is a live query, so I rendered the actual URL rather than trusting the encoding:

```
$ curl -s "https://img.shields.io/badge/dynamic/json?...label=%F0%9F%8E%89%20%E7%94%A8%20CAREER-OPS%20%E6%89%BE%E5%88%B0%E5%B7%A5%E4%BD%9C&suffix=%20%E4%BA%BA%E5%B7%B2%E9%A9%97%E8%AD%89..."
<title>🎉 用 CAREER-OPS 找到工作: 7 人已驗證</title>
```

The count comes through from the same `docs/hired-count.json`, so this stays live with no extra plumbing.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Translation — exempt from issue-first, and #3398 exists anyway
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs --quick` — 10497 passed, 1 failed. The failure is pre-existing: stashing this diff and re-running gives the identical 10497/1, and it is in the tracker-merge area, nowhere near a README.
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — System Layer only, one file
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a social-proof section to the Traditional Chinese README.
  * Displays the verified number of people who found jobs through career-ops.
  * Added a call-to-action for sharing success stories.
  * Included a wall image featuring recent hiring stories and public verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->