### PR TITLE
fix(reserve-report-num): handle --help/-h explicitly

### DIFF
--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -301,6 +301,19 @@ async function runCli() {
   const [,, cmd, arg] = process.argv;
   const options = {};
 
+  if (cmd === '--help' || cmd === '-h') {
+    process.stdout.write([
+      'Usage: node reserve-report-num.mjs [--count <1-N>] [--release <NNN>[-<MMM>]] [--gc]',
+      '',
+      '  (no flags)                Reserve 1 report number (default)',
+      `  --count <1-${MAX_COUNT}>            Reserve N report numbers, printed as a range`,
+      '  --release <NNN>[-<MMM>]  Release a previously reserved number or range',
+      '  --gc                      Garbage-collect stale reservation sentinels',
+      '',
+    ].join('\n'));
+    return 0;
+  }
+
   if (cmd === '--release') {
     const match = (arg || '').match(/^(\d+)(?:-(\d+))?$/);
     if (!match) {

--- a/tests/reserve-report-num.test.mjs
+++ b/tests/reserve-report-num.test.mjs
@@ -5,11 +5,12 @@
 // #2026 and the next reservation jumped to 2027 — silently, and permanently.
 
 import { strict as assert } from 'assert';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { spawnSync } from 'child_process';
 import { reserveReportNumbers, releaseReportNumbers } from '../reserve-report-num.mjs';
-import { pass, fail } from './helpers.mjs';
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
 
 // Reserve one slot in a scratch root and report which number it got. Released
 // afterwards so the assertion reflects the occupancy scan, not leftover state.
@@ -69,5 +70,30 @@ for (const c of cases) {
     pass(`${c.name} → ${got}`);
   } catch {
     fail(`${c.name}: expected ${c.expect}, got ${got}`);
+  }
+}
+
+// Regression: `--help`/`-h` used to fall through the CLI's cmd dispatch into
+// the default reserve-1 path — silently burning a real report-number slot
+// instead of printing usage. It must now short-circuit before touching any
+// reports/tracker path at all.
+for (const flag of ['--help', '-h']) {
+  const dir = mkdtempSync(join(tmpdir(), 'rrn-help-'));
+  try {
+    const result = spawnSync(NODE, [join(ROOT, 'reserve-report-num.mjs'), flag], {
+      cwd: dir,
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+    const sentinels = existsSync(join(dir, 'reports'))
+      ? readdirSync(join(dir, 'reports')).filter((f) => /-RESERVED\.md$/.test(f))
+      : [];
+    if (result.status === 0 && /Usage: node reserve-report-num\.mjs/.test(result.stdout) && sentinels.length === 0) {
+      pass(`${flag} prints usage and reserves nothing`);
+    } else {
+      fail(`${flag}: exit=${result.status}, sentinels=${sentinels.length}, stdout=${JSON.stringify(result.stdout.slice(0, 120))}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary
- `reserve-report-num.mjs`'s CLI dispatch only special-cases `--release`, `--gc`, and `--count`; any other argument (including `--help`/`-h`) falls through to the default reserve-1-slot path.
- Found this the hard way: a parallel-fanout worker ran `node reserve-report-num.mjs --help` expecting usage text, and instead it silently claimed a real report-number reservation.
- Adds an explicit `--help`/`-h` branch that prints usage and returns `0` before touching any reports/tracker path.

## Test plan
- [x] `node reserve-report-num.mjs --help` / `-h` print usage, exit 0, create no `*-RESERVED.md` sentinel (manually verified)
- [x] New regression test in `tests/reserve-report-num.test.mjs` spawns the CLI with both flags and asserts on stdout + no sentinel
- [x] `node tests/reserve-report-num.test.mjs` — all cases pass
- [x] `node --check` on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--help` and `-h` options to display CLI usage information.
  * Help requests now complete successfully without performing other actions.

* **Bug Fixes**
  * Prevented help commands from creating reservation marker files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->