### PR TITLE
docs: add Chinese interview skills README

### DIFF
--- a/modes/zh/interview/README.md
+++ b/modes/zh/interview/README.md
@@ -1,0 +1,33 @@
+# 面试技能
+
+一组可复用的端到端面试准备技能。
+
+## 技能
+
+| 技能 | 文件 | 使用时机 |
+|---|---|---|
+| 准备计划器 | `plan.md` | 给定职位描述和面试日期时，构建结构化、按时间分块的准备计划 |
+| 模拟面试官 | `practice.md` | 运行模拟面试，并提供结构化反馈 |
+| 面试后复盘 | `debrief.md` | 真实面试结束后，补齐短板并更新题库 |
+
+## 相关技能（位于父级 `modes/` 目录）
+
+| 技能 | 文件 | 使用时机 |
+|---|---|---|
+| 公司调研 | `../interview-prep.md` | 面试前研究具体的公司和岗位 |
+
+## 文件约定
+
+这些技能默认以下文件存在（career-ops 默认配置）：
+
+| 文件 | 用途 |
+|---|---|
+| `cv.md` | 候选人简历——经历和证明点的唯一事实来源 |
+| `article-digest.md` | 作品集中的精简证明点（可选） |
+| `config/profile.yml` | 候选人画像——目标岗位、薪酬和个人叙事 |
+| `modes/_profile.md` | 候选人原型、个人叙事和不可接受条件 |
+| `interview-prep/story-bank.md` | 累积的 STAR+R 故事 |
+| `interview-prep/question-bank.md` | 题库及短板跟踪（首次使用时创建） |
+| `interview-prep/interview-prep-guide.md` | 通用面试原则（可选） |
+| `interview-prep/{company}-{role}.md` | 特定岗位的准备文件 |
+| `interview-prep/retracted-claims.md` | 候选人认为站不住脚的主张——在模拟面试和复盘中的硬性门槛（格式：`**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`） |


### PR DESCRIPTION
## What does this PR do?

Adds the Chinese translation of `modes/interview/README.md` at `modes/zh/interview/README.md`, preserving the source structure, filenames, and links.

## Related issue

Related to #3564 (one language per PR)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Docs/translation change; issue-first requirement exempt
- [x] My PR does not include personal data
- [ ] I ran `node test-all.mjs` and all tests pass (the current checkout reports 7,248 passed, 12 failed, and 16 warnings; failures are in the existing test/fixture environment and this change only adds documentation)
- [x] My changes respect the Data Contract
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Chinese-language guide for reusable interview preparation skills.
  * Documented preparation planning, mock interviews, and post-interview debrief workflows.
  * Added references to company research and the files used to support interview preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->