### PR TITLE
test(updater): pin that a revert to an older upstream version is a local edit

### DIFF
--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -449,3 +449,55 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     fail(`#16 threw=${threw} atRisk=${JSON.stringify(atRisk)}`);
   }
 }
+
+// ── 17. A deliberate revert to an older upstream version is a local edit ──
+//    Case 14 filters out content a previous update installed. The bytes a user
+//    checks back out themselves are also bytes upstream published, so a filter
+//    that asks "did upstream ever ship this?" cannot tell the two apart and
+//    drops the revert from atRisk — overwriting it with no warning and no
+//    `.bak`, which is the protection #2337 exists for. Baselining on the last
+//    installed snapshot separates them by origin instead: a revert made after
+//    that snapshot sits between it and HEAD, so the diff still sees it (#3129).
+//
+//    Two updates are needed before the revert has anywhere to go: after a
+//    single update the install still holds v2, so checking v2 back out changes
+//    nothing and the case would pass without exercising anything.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  replayUpdate(repo, '2');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v3\n');
+  replayUpdate(repo, '3');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v4\n');
+  // The install is on v3 and prefers the v2 wording.
+  writeFileSync(join(repo.dir, 'modes', 'pdf.md'), 'shipped pdf v2\n');
+  repo.g('commit', '-qam', 'prefer the v2 wording of pdf.md');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 1 && atRisk[0] === 'modes/pdf.md') {
+    pass('a committed revert to an older upstream version is reported (#3129)');
+  } else {
+    fail(`#17 expected ['modes/pdf.md'], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 18. ...and uncommitted, which is the sharper edge ──
+//    The detector diffs the worktree, so an uncommitted revert should be caught
+//    the same way — and it matters more: there is no local commit to recover
+//    the content from once the checkout overwrites it.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  replayUpdate(repo, '2');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v3\n');
+  replayUpdate(repo, '3');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v4\n');
+  writeFileSync(join(repo.dir, 'modes', 'pdf.md'), 'shipped pdf v2\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 1 && atRisk[0] === 'modes/pdf.md') {
+    pass('an uncommitted revert to an older upstream version is reported too (#3129)');
+  } else {
+    fail(`#18 expected ['modes/pdf.md'], got ${JSON.stringify(atRisk)}`);
+  }
+}


### PR DESCRIPTION
## Description

Pins the case @Shaamak found in #3129: a deliberate revert to an older upstream version must be reported as a local edit, so it still gets its `.bak` instead of being silently overwritten.

The gap and both halves of its verification are @Shaamak's — he checked `main` before writing code, found `f93b6e9` had already replaced `contentPublishedUpstream()` with a baseline on the installed snapshot, and confirmed cases 14 and 16 stayed green. This PR only writes down what he established. The behaviour is correct today by construction; nothing stood where it used to.

Two cases, following the committed/uncommitted pair that cases 1 and 2 already use:

- **17** — a committed revert to the v2 wording is reported.
- **18** — the same uncommitted, which is the sharper edge: `git diff <baseline>` compares the worktree, and there is no local commit to recover the content from once the checkout lands.

## Linked Issue

Closes #3129

## One deviation from the shape in the issue, with the measurement behind it

The issue specifies `upstreamChange` to v2 → `replayUpdate` → `upstreamChange` to v3, then checking v2 back out. Written literally that is vacuous: after a single `replayUpdate` the install still holds v2, so writing v2 into the worktree changes nothing.

```
A) literal 3-step setup, then write v2 back:
   worktree pdf.md is already "shipped pdf v2\n"
   atRisk = []                      <- nothing exercised
B) two updates, install on v3, then revert to v2:
   atRisk = ["modes/pdf.md"]        <- the case actually fires
```

So both cases run a second `replayUpdate` first, putting the install on v3 before the user reverts to v2 — which is also the scenario the issue text describes ("say they are on v3, decide they preferred v2's `modes/pdf.md`"). Everything else is as specified, and I did not widen it beyond that.

## Testing

`node tests/updater-local-system-edits.test.mjs` — 18 passing, 0 failing. Cases 14, 15 and 16 are untouched and still green.

I checked the new cases aren't vacuous in two directions:

1. **Without the revert**, the same setup yields `atRisk = []` — so the assertion is driven by the revert and not by the two updates.
2. **Mutation.** These cases pin the absence of a content-origin filter, so a baseline change alone is the wrong thing to mutate — reverting to a `merge-base` baseline still catches the revert (it breaks case 14 instead). What case 17/18 actually guard against is re-introducing the "did upstream ever publish these bytes?" filter that #3129 describes. Adding one back temporarily:

```
✅ content installed by a previous update is not a local edit (#3094)   <- 14 still green
✅ a real local fix is still reported after a second update (#2337)     <- 15 still green
❌ #17 expected ['modes/pdf.md'], got []
❌ #18 expected ['modes/pdf.md'], got []
```

`got []` is the failure mode from the issue: dropped from `atRisk`, overwritten with no warning and no `.bak`. Cases 14 and 15 staying green is the part that matters — the mutation hits only what these cases exist to catch.

`update-system.mjs` is unchanged in this PR; the mutation above was reverted and the diff is the test file alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for detecting local edits when a system file is reverted to an older upstream version.
  * Verified detection for both committed and uncommitted reverts, ensuring the file is correctly flagged as at risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->