### PR TITLE
docs(security): sync GitHub policy scope

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -19,6 +19,7 @@ Security issues in the following are in scope:
 
 - **Scripts** (`*.mjs`) — command injection, path traversal, SSRF
 - **Dashboard** (`dashboard/`) — any Go binary vulnerabilities
+- **Web dashboard** (`web/`) — anything reachable while it is running, including cross-origin requests from a page the user visits, requests from other hosts on the same network, and command injection through its API
 - **Templates** (`templates/`) — XSS in generated HTML/PDF
 - **Configuration** — secrets exposure, unsafe defaults
 
@@ -27,7 +28,9 @@ Security issues in the following are in scope:
 - Issues in third-party dependencies (report upstream)
 - Issues requiring physical access to the user's machine
 - Social engineering attacks
-- career-ops is a local tool — there is no hosted service to attack
+- Attacks on hosted infrastructure — career-ops runs locally, so there is no server of ours to attack
+
+**"Local" does not mean "unreachable".** The web dashboard is a local HTTP server, and a local server is still reachable by a cross-origin page the user happens to visit and by any device on the same network. If an issue needs nothing more than the user running career-ops and browsing normally, it is in scope — please report it rather than assuming the local-tool line excludes it.
 
 ## Disclosure Policy
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the security policy to cover the web dashboard.
  - Clarified that cross-origin requests, same-network hosts, and command injection through the API are in scope.
  - Updated out-of-scope guidance to explain that locally hosted features may still be reachable and reportable.
  - Confirmed that issues reproducible through normal browsing remain within the security policy’s scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->