### PR TITLE
fix(web): order the Today action queue before truncating it

### DIFF
--- a/web/src/components/home/today-dashboard.tsx
+++ b/web/src/components/home/today-dashboard.tsx
@@ -12,6 +12,8 @@ import { DiscoveryCard } from "@/components/explore/discovery-card";
 import { FollowUpCard, type FollowUp } from "@/components/home/follow-up-card";
 import { DecisionCard } from "@/components/home/decision-card";
 import { QuickEvaluate } from "@/components/quick-evaluate";
+import { scoreNum } from "@/lib/format";
+import { pickAwaitingDecision } from "@/lib/home/awaiting.mjs";
 
 // The retention "Today": a dual-loop action queue (the maintainer's
 // "N new matches this week · M follow-ups due"). SUPPLY loop = fresh free-scan
@@ -72,11 +74,10 @@ export function TodayDashboard({
     return () => window.removeEventListener("co-job-done", onDone);
   }, [refetch, router]);
 
-  // Awaiting decision: scored (Evaluated) but no terminal status yet.
-  const awaiting = useMemo(
-    () => applications.filter((a) => /^evaluat/i.test(a.status)).slice(0, 6),
-    [applications],
-  );
+  // Awaiting decision: scored (Evaluated) but no terminal status yet. The
+  // ordering lives in lib/home/awaiting.mjs so it can be tested — see the file
+  // for why "first six in the array" was a bug waiting for #3529.
+  const awaiting = useMemo(() => pickAwaitingDecision(applications, scoreNum), [applications]);
 
   const newThisWeek = freshCount;
   const allClear = newThisWeek === 0 && overdue === 0 && awaiting.length === 0;

--- a/web/src/lib/home/awaiting.mjs
+++ b/web/src/lib/home/awaiting.mjs
@@ -1,0 +1,53 @@
+/**
+ * Which scored-but-undecided applications the Today page shows, and in what
+ * order.
+ *
+ * WHY THIS IS NOT INLINE IN today-dashboard.tsx: the card list used to be
+ * `applications.filter(isEvaluated).slice(0, 6)` with no sort at all, so which
+ * six you saw was a property of the ORDER OF ROWS IN data/applications.md
+ * rather than of the queue. That was always fragile and #3529 made it live:
+ * merge-tracker now re-sorts the tracker by # on every write, which would have
+ * quietly changed the card set with no code change anywhere near this file.
+ *
+ * Newest first is what a "Today" queue means. The score breaks ties so that on
+ * a day with several evaluations the better opportunity leads.
+ *
+ * Plain .mjs (same pattern as tracker-table.mjs and cv-selection.mjs) so the
+ * test suite imports it with no build step and no `@/` alias loader — the whole
+ * reason to extract it is that the ordering is testable and a TSX component is
+ * not.
+ *
+ * `scoreOf` is injected rather than imported: the one parser for a score cell
+ * lives in lib/format.ts (`scoreNum`) and this module must not grow a second
+ * definition of what "4.1/5" means.
+ *
+ * Generic in the row type so the caller keeps its own (`Application`) rather
+ * than being narrowed to the three fields this function reads.
+ *
+ * @template {{date?: string, score?: string, status?: string}} T
+ * @param {T[]} applications
+ * @param {(score: string) => number} scoreOf  parser returning NaN when absent
+ * @param {number} [limit]  how many cards the caller renders
+ * @returns {T[]}
+ */
+export function pickAwaitingDecision(applications, scoreOf, limit = 6) {
+  // -1, not -Infinity: two unscored rows would subtract to NaN, and a NaN
+  // comparator leaves the sort order undefined rather than merely arbitrary.
+  const rank = (s) => {
+    const n = scoreOf(s ?? "");
+    return Number.isNaN(n) ? -1 : n;
+  };
+  return applications
+    .filter((a) => /^evaluat/i.test(a.status ?? ""))
+    // A row with no date sorts LAST rather than jumping the queue. "" compares
+    // LESS than any real date, and the comparison is descending (b before a),
+    // so "least" lands at the end — which is where an undated row belongs in a
+    // recency queue. Covered by a test, because that is two negations deep and
+    // the wrong one is silent.
+    .sort((a, b) => {
+      const byDate = (b.date || "").localeCompare(a.date || "");
+      if (byDate !== 0) return byDate;
+      return rank(b.score) - rank(a.score);
+    })
+    .slice(0, limit);
+}

--- a/web/tests/lib/awaiting-order.test.mjs
+++ b/web/tests/lib/awaiting-order.test.mjs
@@ -1,0 +1,93 @@
+// Tests for the Today page's "Awaiting your decision" card list.
+//
+// The behaviour under test is the one that used not to exist: before this,
+// the page took `applications.filter(isEvaluated).slice(0, 6)` with no sort,
+// so the six cards were whichever six sat first in data/applications.md.
+// #3529 made merge-tracker re-sort that file by # on every write, which would
+// have changed the card set with no change to this component.
+//
+// Run:  node --test tests/lib/awaiting-order.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickAwaitingDecision } from "../../src/lib/home/awaiting.mjs";
+
+// The real parser is lib/format.ts's scoreNum, which a .mjs test cannot import.
+// This stub must stay behaviourally identical for the cases below: a leading
+// number wins, anything unparseable is NaN.
+const scoreOf = (s) => {
+  const m = String(s).match(/(\d+(?:\.\d+)?)/);
+  return m ? parseFloat(m[1]) : NaN;
+};
+
+const row = (date, score, status = "Evaluated") => ({ date, score, status, company: `${date}|${score}` });
+
+test("only scored-but-undecided rows are offered", () => {
+  const rows = [row("2026-08-20", "4.0/5"), row("2026-08-21", "4.0/5", "Applied"), row("2026-08-22", "4.0/5", "Rejected")];
+  assert.deepEqual(
+    pickAwaitingDecision(rows, scoreOf).map((r) => r.date),
+    ["2026-08-20"],
+  );
+});
+
+test("the status match is a case-insensitive prefix, so a dated or lowercase Evaluated still counts", () => {
+  // The tracker carries dated and localized-cased statuses; the page's own
+  // regex has always been /^evaluat/i and the extraction must not narrow it.
+  const rows = [row("2026-08-20", "4.0/5", "evaluated"), row("2026-08-21", "4.0/5", "Evaluated 2026-08-21")];
+  assert.equal(pickAwaitingDecision(rows, scoreOf).length, 2);
+});
+
+test("newest first, whatever order the tracker file happens to be in", () => {
+  // Deliberately supplied oldest-first: this is the case #3529 can reshuffle.
+  const rows = [row("2026-08-01", "3.0/5"), row("2026-08-30", "3.0/5"), row("2026-08-15", "3.0/5")];
+  assert.deepEqual(
+    pickAwaitingDecision(rows, scoreOf).map((r) => r.date),
+    ["2026-08-30", "2026-08-15", "2026-08-01"],
+  );
+});
+
+test("the score breaks a same-day tie so the better offer leads", () => {
+  const rows = [row("2026-08-20", "3.0/5"), row("2026-08-20", "4.7/5"), row("2026-08-20", "4.1/5")];
+  assert.deepEqual(
+    pickAwaitingDecision(rows, scoreOf).map((r) => r.score),
+    ["4.7/5", "4.1/5", "3.0/5"],
+  );
+});
+
+test("an undated row sorts last even with the highest score", () => {
+  // Two negations deep: "" compares LESS than any date, and the comparison is
+  // descending, so least lands at the end. Getting this backwards would put
+  // every malformed row at the top of the user's action queue, silently.
+  const rows = [row("2026-08-01", "1.0/5"), row("", "5.0/5")];
+  assert.deepEqual(
+    pickAwaitingDecision(rows, scoreOf).map((r) => r.score),
+    ["1.0/5", "5.0/5"],
+  );
+});
+
+test("two unscored rows do not produce a NaN comparator", () => {
+  // rank() returns -1 rather than -Infinity precisely so this subtraction stays
+  // finite; -Infinity - -Infinity is NaN and leaves the sort order undefined.
+  const rows = [row("2026-08-20", ""), row("2026-08-20", "n/a")];
+  const out = pickAwaitingDecision(rows, scoreOf);
+  assert.equal(out.length, 2);
+  assert.equal(out.every((r) => r && typeof r.date === "string"), true);
+});
+
+test("the limit truncates AFTER sorting, never before", () => {
+  // The whole point: slicing an unsorted list is what made the card set a
+  // property of the file rather than of the queue.
+  const rows = Array.from({ length: 10 }, (_, i) => row(`2026-08-${String(i + 1).padStart(2, "0")}`, "3.0/5"));
+  assert.deepEqual(
+    pickAwaitingDecision(rows, scoreOf, 3).map((r) => r.date),
+    ["2026-08-10", "2026-08-09", "2026-08-08"],
+  );
+});
+
+test("the caller's array is not reordered underneath it", () => {
+  // `applications` is shared with the pipeline table and the analytics tiles;
+  // sorting it in place would reorder those too, from a memo in the Today page.
+  const rows = [row("2026-08-01", "3.0/5"), row("2026-08-30", "3.0/5")];
+  pickAwaitingDecision(rows, scoreOf);
+  assert.deepEqual(rows.map((r) => r.date), ["2026-08-01", "2026-08-30"]);
+});


### PR DESCRIPTION
## What

"Awaiting your decision" on the Today page rendered `applications.filter(isEvaluated).slice(0, 6)` with no sort. Which six cards you saw was therefore a property of the **row order in `data/applications.md`**, not of the queue.

## Why now

That has always been fragile, but #3529 made it live: `merge-tracker.mjs` now re-sorts the tracker by `#` on every write, so the card set could change with no edit anywhere near this component and no test to notice.

Found while answering the contract question for #3529 — I checked every reader of `applications.md` on the web side for a dependency on physical row order, and this was the only one. `pipeline-view.tsx:108` re-sorts, `analytics/page.tsx` aggregates, `actions/registry.ts` looks up by `a.n`, `/api/status` matches on the `#` column, and `tracker-table.mjs:147` validates a row by `/^\d+$/.test(cells[0])`. So this was the last implicit order in the web, and it was mine.

## The ordering

Newest first, because that is what a "Today" queue means. The score breaks a same-day tie so the better opportunity leads when several land together. A row with no date sorts **last** rather than first.

That last one is two negations deep — `""` compares *less* than any real date, and the comparison is descending, so "least" lands at the end — which is exactly the kind of thing that is silently backwards, so it has its own test.

## Why a new module

The ordering moves to `web/src/lib/home/awaiting.mjs` because a TSX component is not testable here and the behaviour is worth eight assertions. Same pattern as `tracker-table.mjs` and `cv-selection.mjs`: plain `.mjs`, no build step, no `@/` alias loader.

The score parser is **injected** rather than imported: `scoreNum` lives in `lib/format.ts` and a `.mjs` cannot import it, and adding a second definition of what `"4.1/5"` means is the drift this codebase keeps paying for (#2156, #2324). The call site passes the real one; the test passes a stub whose behaviour is documented as having to match.

## Verification

- `node --test web/tests/lib/*.test.mjs` → **440/440**, 8 of them new.
- `tsc --noEmit` → clean. The module is generic in the row type (`@template`), so the caller keeps `Application` instead of being narrowed to the three fields the function reads.
- The caller's array is not sorted in place — `applications` is shared with the pipeline table and the analytics tiles, and a memo in the Today page must not reorder those. That has a test too.

---

Opened by the web agent (`career-ops-ui`). Both the author and the reviewer here are `@santifer`, so this cannot receive an independent approval and will be merged with `--admin` — saying so out loud rather than letting the branch protection look satisfied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Awaiting your decision” list to show only scored, evaluated applications.
  * Sorted items by newest date, with scores used to break ties.
  * Ensured undated applications appear later and results remain limited to six items.
  * Added consistent handling for status capitalization and preserved the original application order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->