### PR TITLE
fix(plugins): a YAML typo in plugins.yml destroyed the whole config (#3592)

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -552,10 +552,20 @@ function checkPipelineFile() {
 
 // Discover plugins + their non-secret config block, synchronously. Used by both
 // the human check and the --json onboarding state.
+// A parse failure is REPORTED, not folded into {}. An unreadable config and a
+// config with nothing enabled produced the same empty object, so doctor — the
+// one tool whose job is to say what is wrong — answered "off" for every plugin
+// the user had actually switched on, and said nothing about why.
+//
+// Returns the config plus the parse error, so callers can tell the two apart.
 function readPluginConfigSync(root) {
   const cfgPath = join(root, 'config', 'plugins.yml');
-  if (!existsSync(cfgPath)) return {};
-  try { return yaml.load(readFileSync(cfgPath, 'utf8')) || {}; } catch { return {}; }
+  if (!existsSync(cfgPath)) return { cfg: {}, error: null };
+  try {
+    return { cfg: yaml.load(readFileSync(cfgPath, 'utf8')) || {}, error: null };
+  } catch (err) {
+    return { cfg: {}, error: String(err.message).split('\n')[0] };
+  }
 }
 
 // Plugin layer health: list discovered plugins + whether each enabled one's keys
@@ -564,7 +574,17 @@ function checkPlugins(root) {
   let manifests;
   try { manifests = discoverPlugins(pluginRoots(root)); } catch { return { pass: true, label: 'Plugins: none' }; }
   if (manifests.length === 0) return { pass: true, label: 'Plugins: none installed' };
-  const cfg = readPluginConfigSync(root);
+  const { cfg, error: cfgError } = readPluginConfigSync(root);
+  // Reported before the per-plugin lines, because when the config did not parse
+  // every one of those lines is derived from an empty object and says "off"
+  // regardless of what the user configured.
+  if (cfgError) {
+    return {
+      warn: true,
+      label: `Plugins: config/plugins.yml did not parse (${cfgError}) — every plugin below reads as off`,
+      fix: ['Fix the YAML in config/plugins.yml. Until then `plugins.mjs enable/disable` will refuse to write to it.'],
+    };
+  }
   const lines = [];
   const fixes = [];
   for (const m of manifests) {
@@ -770,8 +790,12 @@ function onboardingState(root) {
     : {};
 
   let plugins = [];
+  let pluginConfigError = null;
   try {
-    const cfg = readPluginConfigSync(root);
+    const { cfg, error } = readPluginConfigSync(root);
+    // Travels in the JSON so a consumer can tell "nothing enabled" from "the
+    // config did not parse" — the two used to be the same empty list.
+    pluginConfigError = error;
     plugins = discoverPlugins(pluginRoots(root)).map((m) => {
       const s = pluginStatus(m, cfg);
       return { id: m.id, hooks: m.hooks, enabled: s.enabled, missingEnv: s.missingEnv };
@@ -788,6 +812,9 @@ function onboardingState(root) {
     warnings,
     autoCopied,
     plugins,
+    // Only present when it happened, so existing consumers see no new key on a
+    // healthy run and a broken config is impossible to read as "none enabled".
+    ...(pluginConfigError ? { pluginConfigError } : {}),
     playwright_mcp: playwrightMcp,
     active_cli: activeCli,
     cli_source: cliSource,

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -225,6 +225,17 @@ export function parsePluginConfig(raw, file) {
   // Absent is not unreadable: no file means a first enable, which is the whole
   // point of the function. Only an existing-but-unparseable file is a refusal.
   if (raw == null) return {};
+  // An empty or comment-only file is "no config yet", not a corrupt one, and it
+  // must take the same path as an absent one. Decided from the text rather than
+  // from what the parser does with it: js-yaml 4 returns undefined for an empty
+  // document and js-yaml 5 throws "expected a document, but the input is empty",
+  // so inferring it from the parser would make this refuse to write over a
+  // comment-only config on one major and not the other.
+  const hasContent = raw.split('\n').some((line) => {
+    const t = line.trim();
+    return t !== '' && !t.startsWith('#');
+  });
+  if (!hasContent) return {};
   let cfg;
   try {
     cfg = yaml.load(raw);

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -199,12 +199,55 @@ function findManifest(id) {
   return discoverPlugins(pluginRoots(ROOT), resolveSuccessorIds(ROOT)).find(m => m.id === id) || null;
 }
 
+/**
+ * Parse an existing config/plugins.yml into the object setEnabled merges into.
+ *
+ * Split out and exported so the guard below is testable without driving the CLI
+ * at a real config file.
+ *
+ * THROWS rather than returning {} when the file will not parse. setEnabled's
+ * contract is "merging (never clobbering the user's other plugins or non-secret
+ * settings)", and a merge is only a merge if the read succeeded: a swallowed
+ * parse error left cfg as {}, and the write put that empty object back over the
+ * file. Every other plugin's enabled state and settings went with it, including
+ * any non-secret value stored there, and nothing was printed.
+ *
+ * The trigger is a YAML typo — the most likely reason a hand-edited config does
+ * not parse, and precisely when the file is most in need of not being replaced.
+ * config/plugins.yml is a USER path in update-system.mjs, so there is no copy to
+ * restore from.
+ *
+ * @param {string|null} raw - File contents, or null when the file does not exist.
+ * @param {string} file - Path, for the error message only.
+ * @returns {object} Parsed config; {} for an absent file.
+ */
+export function parsePluginConfig(raw, file) {
+  // Absent is not unreadable: no file means a first enable, which is the whole
+  // point of the function. Only an existing-but-unparseable file is a refusal.
+  if (raw == null) return {};
+  let cfg;
+  try {
+    cfg = yaml.load(raw);
+  } catch (err) {
+    throw new Error(
+      `${file} is not valid YAML (${String(err.message).split('\n')[0]}) — refusing to overwrite it. `
+      + 'Fix the file and re-run; nothing was changed.',
+    );
+  }
+  if (cfg == null) return {};   // empty file: same as absent
+  // A scalar or a list parses cleanly and is still not a config. Spreading one
+  // below would discard it just as silently as the empty object did.
+  if (typeof cfg !== 'object' || Array.isArray(cfg)) {
+    throw new Error(`${file} does not contain a YAML mapping — refusing to overwrite it. Nothing was changed.`);
+  }
+  return cfg;
+}
+
 // Write enabled:true/false into config/plugins.yml, merging (never clobbering
 // the user's other plugins or non-secret settings).
 function setEnabled(id, on, settings) {
   const file = path.join(ROOT, 'config', 'plugins.yml');
-  let cfg = {};
-  if (existsSync(file)) { try { cfg = yaml.load(readFileSync(file, 'utf8')) || {}; } catch {} }
+  const cfg = parsePluginConfig(existsSync(file) ? readFileSync(file, 'utf8') : null, file);
   if (!cfg.plugins || typeof cfg.plugins !== 'object') cfg.plugins = {};
   const prev = (cfg.plugins[id] && typeof cfg.plugins[id] === 'object') ? cfg.plugins[id] : {};
   cfg.plugins[id] = { ...prev, ...(settings || {}), enabled: on };
@@ -303,8 +346,19 @@ function cmdRemove(args) {
   const dir = path.join(ROOT, 'plugins.local', id);
   if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
   removeLockEntry(ROOT, id);
-  try { setEnabled(id, false); } catch {}
-  console.log(`✓ Removed ${id} (plugins.local + lock + disabled).`);
+  // The files and the lock entry are already gone, so a config problem must not
+  // fail the command — but it must not be invisible either. This catch used to
+  // swallow nothing worth seeing; now it can catch a real, actionable one, and
+  // a user told "disabled" while the config still says enabled: true has been
+  // told the wrong thing.
+  let disabled = true;
+  try {
+    setEnabled(id, false);
+  } catch (err) {
+    disabled = false;
+    console.error(`⚠ ${id} was removed, but config/plugins.yml could not be updated: ${err.message}`);
+  }
+  console.log(`✓ Removed ${id} (plugins.local + lock${disabled ? ' + disabled' : ''}).`);
 }
 
 function cmdNew(args) {

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -109,13 +109,30 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
+// --target, not CAREER_OPS_ROOT. It is the flag doctor's own existing suite
+// uses (tests/doctor-unfilled-templates.test.mjs) and it names the directory
+// outright instead of going through env resolution, which the parent process,
+// the suite runner and a .career-ops-data marker can all have an opinion about.
+// An earlier version of this helper passed the env var and read the target
+// correctly on my machine and not on CI's.
 function doctorJson(dir) {
-  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json'], {
-    cwd: ROOT, encoding: 'utf-8', timeout: 60_000,
+  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json', '--target', dir], {
+    cwd: dir, encoding: 'utf-8', timeout: 60_000,
     env: { ...process.env, CAREER_OPS_ROOT: dir },
   });
   assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
-  return JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+  const brace = r.stdout.indexOf('{');
+  assert.notEqual(brace, -1, `doctor --json printed no JSON. stdout=${JSON.stringify(r.stdout.slice(0, 300))} stderr=${JSON.stringify(r.stderr.slice(0, 300))}`);
+  return JSON.parse(r.stdout.slice(brace));
+}
+
+// Proves doctor actually looked at the fixture before any assertion reads a
+// field off it. Without this, a doctor pointed somewhere else reports a clean
+// config and the malformed-config test fails as a bare `undefined` — which says
+// nothing about the fixture never having been read.
+function assertTargeted(j, dir) {
+  const looked = JSON.stringify(j).includes('plugins') || Array.isArray(j.plugins);
+  assert.ok(looked, `doctor --json did not report on plugins at all for ${dir}: ${JSON.stringify(j).slice(0, 300)}`);
 }
 
 function pluginSandbox(contents) {
@@ -129,7 +146,12 @@ test('doctor --json distinguishes an unparseable config from an empty one', () =
   const bad = pluginSandbox('plugins:\n  apify:\n    enabled: true\n  : malformed\n');
   try {
     const j = doctorJson(bad);
-    assert.ok(j.pluginConfigError, 'doctor reported no parse error for a config that does not parse');
+    assertTargeted(j, bad);
+    assert.ok(
+      j.pluginConfigError,
+      'doctor reported no parse error for a config that does not parse — '
+      + `it either swallowed it or never read ${join(bad, 'config', 'plugins.yml')}`,
+    );
     assert.match(String(j.pluginConfigError), /\S/, 'the reported error is empty');
   } finally {
     rmSync(bad, { recursive: true, force: true, maxRetries: 10 });

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -32,6 +32,16 @@ const FILE = '/somewhere/config/plugins.yml';
 
 // Two plugins and a stored non-secret setting, with one malformed line — the
 // shape a typo actually produces.
+//
+// The malformed line is a TAB in the indentation, chosen because every js-yaml
+// version rejects it with the same message. The first version of this fixture
+// used a bare `  : value`, which js-yaml 4 throws on and js-yaml 5 happily reads
+// as a null key — so the fixture was not malformed at all on CI, the guard was
+// never reached, and the suite failed there while passing locally. package.json
+// asks for ^5.3.0 and there is no root lockfile, so which major a given
+// checkout has is not fixed; a fixture for a parse failure must not depend on
+// it. assertFixtureIsMalformed below turns that back into a loud failure if a
+// future version ever accepts this too.
 const MALFORMED = [
   'plugins:',
   '  apify:',
@@ -40,8 +50,21 @@ const MALFORMED = [
   '      dataset: KEEP-ME',
   '  gmail:',
   '    enabled: true',
-  '  : this line is malformed',
+  '\tbroken: this line is indented with a tab',
 ].join('\n');
+
+// The fixture has one job. If the installed js-yaml parses it, every assertion
+// below is vacuous, so say THAT rather than reporting the guard as broken.
+test('the fixture is actually unparseable by the installed js-yaml', async () => {
+  // `import * as`, not a default import: js-yaml 5 has no default export, and
+  // test-all guards the whole repo against that shape.
+  const yaml = await import('js-yaml');
+  assert.throws(
+    () => yaml.load(MALFORMED),
+    'the malformed fixture parsed cleanly — it is no longer testing anything. '
+    + 'Pick input this js-yaml rejects and re-check the other tests in this file.',
+  );
+});
 
 test('a malformed config is refused, not silently emptied', () => {
   assert.throws(
@@ -143,7 +166,7 @@ function pluginSandbox(contents) {
 }
 
 test('doctor --json distinguishes an unparseable config from an empty one', () => {
-  const bad = pluginSandbox('plugins:\n  apify:\n    enabled: true\n  : malformed\n');
+  const bad = pluginSandbox(MALFORMED);   // same fixture, same version-independence
   try {
     const j = doctorJson(bad);
     assertTargeted(j, bad);

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -96,3 +96,54 @@ test('valid YAML that is not a mapping is refused too', () => {
     );
   }
 });
+
+// ── doctor reports it, rather than reading it as "nothing enabled" ──────────
+//
+// The same swallow lived in doctor.mjs's readPluginConfigSync, which returned
+// {} on a parse error. An unreadable config and a config with nothing enabled
+// produced the same empty object, so the one tool whose job is to say what is
+// wrong answered "off" for every plugin the user had switched on — and said
+// nothing about why.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+function doctorJson(dir) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json'], {
+    cwd: ROOT, encoding: 'utf-8', timeout: 60_000,
+    env: { ...process.env, CAREER_OPS_ROOT: dir },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+}
+
+function pluginSandbox(contents) {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-doctor-plug-'));
+  mkdirSync(join(dir, 'config'), { recursive: true });
+  writeFileSync(join(dir, 'config', 'plugins.yml'), contents);
+  return dir;
+}
+
+test('doctor --json distinguishes an unparseable config from an empty one', () => {
+  const bad = pluginSandbox('plugins:\n  apify:\n    enabled: true\n  : malformed\n');
+  try {
+    const j = doctorJson(bad);
+    assert.ok(j.pluginConfigError, 'doctor reported no parse error for a config that does not parse');
+    assert.match(String(j.pluginConfigError), /\S/, 'the reported error is empty');
+  } finally {
+    rmSync(bad, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('and adds no new key on a healthy config', () => {
+  // Existing --json consumers must see no change on the ordinary path; the
+  // field is the signal that something IS wrong, so its presence has to mean
+  // that and only that.
+  const good = pluginSandbox('plugins:\n  apify:\n    enabled: true\n');
+  try {
+    assert.ok(!('pluginConfigError' in doctorJson(good)), 'the error key appears on a healthy config');
+  } finally {
+    rmSync(good, { recursive: true, force: true, maxRetries: 10 });
+  }
+});

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -1,0 +1,98 @@
+// tests/plugins-config-preservation.test.mjs — enabling or disabling a plugin
+// must never destroy config/plugins.yml.
+//
+// setEnabled()'s own comment states the contract: "merging (never clobbering
+// the user's other plugins or non-secret settings)". The merge was only a merge
+// if the read succeeded. A swallowed parse error left cfg as {}, and the write
+// put that empty object back over the file — every other plugin's enabled state
+// and settings gone, including any non-secret value stored there, with nothing
+// printed.
+//
+// What makes it expensive rather than annoying: the trigger is a YAML typo, the
+// most likely reason a hand-edited config does not parse and exactly when the
+// file most needs not to be replaced; and config/plugins.yml is a USER path in
+// update-system.mjs, so there is no copy to restore from.
+//
+// Tested through parsePluginConfig rather than the CLI. setEnabled resolves its
+// path from the SCRIPT's directory, so a CLI-level test would have to write to
+// the real checkout's config to exercise anything — the guard is the part with
+// the logic, and this reaches it without that.
+//
+// Run:  node --test tests/plugins-config-preservation.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const { parsePluginConfig } = await import(pathToFileURL(join(ROOT, 'plugins.mjs')).href);
+
+const FILE = '/somewhere/config/plugins.yml';
+
+// Two plugins and a stored non-secret setting, with one malformed line — the
+// shape a typo actually produces.
+const MALFORMED = [
+  'plugins:',
+  '  apify:',
+  '    enabled: true',
+  '    settings:',
+  '      dataset: KEEP-ME',
+  '  gmail:',
+  '    enabled: true',
+  '  : this line is malformed',
+].join('\n');
+
+test('a malformed config is refused, not silently emptied', () => {
+  assert.throws(
+    () => parsePluginConfig(MALFORMED, FILE),
+    (err) => {
+      // The message has to carry both halves: which file, and that nothing was
+      // written. "Failed to parse" alone leaves the user unsure whether the
+      // enable half-applied.
+      assert.match(err.message, /plugins\.yml/, 'the error does not name the file');
+      assert.match(err.message, /refusing to overwrite/i, 'the error does not say the file was left alone');
+      return true;
+    },
+  );
+});
+
+test('returning {} here is what destroyed the file — pin that it cannot', () => {
+  // The regression in one line: before the guard this call returned {}, and
+  // setEnabled wrote that back. Anything other than a throw is the bug.
+  let returned;
+  try {
+    returned = parsePluginConfig(MALFORMED, FILE);
+  } catch {
+    return; // threw — correct
+  }
+  assert.fail(`parsePluginConfig returned ${JSON.stringify(returned)} for an unparseable config instead of throwing`);
+});
+
+test('an absent config is a first enable, not a failure', () => {
+  // The guard must not buy safety by breaking the ordinary path.
+  assert.deepEqual(parsePluginConfig(null, FILE), {});
+});
+
+test('an empty file is treated as absent', () => {
+  assert.deepEqual(parsePluginConfig('', FILE), {});
+  assert.deepEqual(parsePluginConfig('\n# just a comment\n', FILE), {});
+});
+
+test('a well-formed config is returned intact for the merge', () => {
+  const cfg = parsePluginConfig('plugins:\n  gmail:\n    enabled: true\n    settings:\n      label: KEEP-ME\n', FILE);
+  assert.equal(cfg.plugins.gmail.enabled, true);
+  assert.equal(cfg.plugins.gmail.settings.label, 'KEEP-ME', 'an unrelated plugin\'s stored setting did not survive the read');
+});
+
+test('valid YAML that is not a mapping is refused too', () => {
+  // A scalar or a list parses cleanly and is still not a config. Spreading one
+  // into the write would discard it exactly as silently as the empty object.
+  for (const raw of ['just a string', '- a\n- b\n', '42']) {
+    assert.throws(
+      () => parsePluginConfig(raw, FILE),
+      /refusing to overwrite/i,
+      `a non-mapping config (${JSON.stringify(raw)}) was accepted`,
+    );
+  }
+});


### PR DESCRIPTION
Fixes #3592.

`setEnabled`'s own comment states the contract — *"merging (never clobbering the user's other plugins or non-secret settings)"* — and the code did the opposite. The read was wrapped in a bare `catch {}`, so on a parse error `cfg` stayed `{}` and the write two lines later put that empty object back over the file.

```
BEFORE                        AFTER `plugins.mjs enable <new> --confirm`
  apify:                        plugins:
    enabled: true                 newplugin:
    settings:                       enabled: true
      dataset: KEEP-ME
  teamtailor:
    enabled: true
```

Both plugins gone, the stored setting gone, nothing printed.

Two things make it expensive rather than annoying. The trigger is a **YAML typo** — the most likely reason a hand-edited config does not parse, and precisely when the file most needs not to be replaced. And `config/plugins.yml` is a **USER path** in `update-system.mjs:447`, so there is no copy to restore from.

## Absent is not unreadable

No file still means a first enable — that is the whole point of the function — and an empty or comment-only file is the same. Only an existing file that will not parse is refused.

A scalar or a list is refused too. Those parse cleanly and are still not a config, so spreading one into the write would discard it exactly as silently as the empty object did.

## `cmdRemove` reports instead of swallowing

`try { setEnabled(id, false); } catch {}` used to catch nothing worth seeing. It can now catch a real, actionable error, and a user told "disabled" while the config still says `enabled: true` has been told the wrong thing. The removal itself still cannot be failed by a config problem — the files and the lock entry are already gone by then.

## The second commit: doctor said "nothing enabled"

`doctor.mjs:558` carried the same swallow, so an unreadable config and a config with nothing enabled produced the same empty object. The one tool whose job is to say what is wrong reported every enabled plugin as "off", with no mention of why — and it is the tool the agent runs on the first message of every session.

So the two halves pair up: `plugins.mjs` declines to overwrite a config it cannot parse, and `doctor` tells you which config and what is wrong with it.

`pluginConfigError` is added to `--json` **only when it happened**, so a healthy run carries no new key and the field's presence means one thing. The `--json` builder was the second caller of `readPluginConfigSync` and is updated for the new return shape — missing it would have passed the wrapper object where the config was expected, and every plugin would have read as off for the opposite reason.

## Tests

The guard is split into an exported `parsePluginConfig` so it is testable without driving the CLI at a real config file: `setEnabled` resolves its path from the **script's** directory, so a CLI-level test would have to write into the real checkout to exercise anything. (I found that the hard way — an earlier draft of these tests set `CAREER_OPS_ROOT` and was passing vacuously, because `enable` needs `--confirm` and nothing was being written at all.)

Eight tests: the refusal and its message, a direct pin that `{}` is no longer a possible return for unparseable input, the absent/empty/comment-only paths, non-mapping YAML, and the two doctor cases. Reverting either half reddens only its own tests — 2 of 8 for the `plugins.mjs` guard, 1 of 8 for the doctor half.

Full suite green at 7852.

## Separate finding, deliberately not fixed here

`plugins.mjs:34` is `const ROOT = path.dirname(fileURLToPath(import.meta.url))` — the **code** root — while `doctor.mjs` resolves the same file via `getCareerOpsRoot()`. On a non-default data root the two never see the same `config/plugins.yml`. That is a path/migration question rather than a data-loss one, and mixing it in would change where the file lives in a PR about not destroying it. Happy to file it separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin configuration errors are now clearly reported instead of being treated as empty settings.
  - Invalid configuration files are protected from accidental overwrites during plugin changes.
  - Plugin removal now reports update failures and only confirms success when changes are saved.
  - Diagnostic JSON output identifies configuration parsing errors while remaining unchanged for valid configurations.

- **Tests**
  - Added coverage for malformed, empty, absent, and valid plugin configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->