### PR TITLE
fix: harden plugin config parsing

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -552,10 +552,20 @@ function checkPipelineFile() {
 
 // Discover plugins + their non-secret config block, synchronously. Used by both
 // the human check and the --json onboarding state.
+// A parse failure is REPORTED, not folded into {}. An unreadable config and a
+// config with nothing enabled produced the same empty object, so doctor — the
+// one tool whose job is to say what is wrong — answered "off" for every plugin
+// the user had actually switched on, and said nothing about why.
+//
+// Returns the config plus the parse error, so callers can tell the two apart.
 function readPluginConfigSync(root) {
   const cfgPath = join(root, 'config', 'plugins.yml');
-  if (!existsSync(cfgPath)) return {};
-  try { return yaml.load(readFileSync(cfgPath, 'utf8')) || {}; } catch { return {}; }
+  if (!existsSync(cfgPath)) return { cfg: {}, error: null };
+  try {
+    return { cfg: yaml.load(readFileSync(cfgPath, 'utf8')) || {}, error: null };
+  } catch (err) {
+    return { cfg: {}, error: String(err.message).split('\n')[0] };
+  }
 }
 
 // Plugin layer health: list discovered plugins + whether each enabled one's keys
@@ -564,7 +574,17 @@ function checkPlugins(root) {
   let manifests;
   try { manifests = discoverPlugins(pluginRoots(root)); } catch { return { pass: true, label: 'Plugins: none' }; }
   if (manifests.length === 0) return { pass: true, label: 'Plugins: none installed' };
-  const cfg = readPluginConfigSync(root);
+  const { cfg, error: cfgError } = readPluginConfigSync(root);
+  // Reported before the per-plugin lines, because when the config did not parse
+  // every one of those lines is derived from an empty object and says "off"
+  // regardless of what the user configured.
+  if (cfgError) {
+    return {
+      warn: true,
+      label: `Plugins: config/plugins.yml did not parse (${cfgError}) — every plugin below reads as off`,
+      fix: ['Fix the YAML in config/plugins.yml. Until then `plugins.mjs enable/disable` will refuse to write to it.'],
+    };
+  }
   const lines = [];
   const fixes = [];
   for (const m of manifests) {
@@ -770,8 +790,12 @@ function onboardingState(root) {
     : {};
 
   let plugins = [];
+  let pluginConfigError = null;
   try {
-    const cfg = readPluginConfigSync(root);
+    const { cfg, error } = readPluginConfigSync(root);
+    // Travels in the JSON so a consumer can tell "nothing enabled" from "the
+    // config did not parse" — the two used to be the same empty list.
+    pluginConfigError = error;
     plugins = discoverPlugins(pluginRoots(root)).map((m) => {
       const s = pluginStatus(m, cfg);
       return { id: m.id, hooks: m.hooks, enabled: s.enabled, missingEnv: s.missingEnv };
@@ -788,6 +812,9 @@ function onboardingState(root) {
     warnings,
     autoCopied,
     plugins,
+    // Only present when it happened, so existing consumers see no new key on a
+    // healthy run and a broken config is impossible to read as "none enabled".
+    ...(pluginConfigError ? { pluginConfigError } : {}),
     playwright_mcp: playwrightMcp,
     active_cli: activeCli,
     cli_source: cliSource,

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -558,11 +558,26 @@ function checkPipelineFile() {
 // the user had actually switched on, and said nothing about why.
 //
 // Returns the config plus the parse error, so callers can tell the two apart.
+function hasNullYamlKey(value) {
+  if (!value || typeof value !== 'object') return false;
+  if (Object.prototype.hasOwnProperty.call(value, 'null')) return true;
+  return Object.values(value).some(hasNullYamlKey);
+}
+
 function readPluginConfigSync(root) {
   const cfgPath = join(root, 'config', 'plugins.yml');
   if (!existsSync(cfgPath)) return { cfg: {}, error: null };
   try {
-    return { cfg: yaml.load(readFileSync(cfgPath, 'utf8')) || {}, error: null };
+    const raw = readFileSync(cfgPath, 'utf8');
+    if (raw.split('\n').every((line) => line.trim() === '' || line.trim().startsWith('#'))) {
+      return { cfg: {}, error: null };
+    }
+    const cfg = yaml.load(raw);
+    if (cfg == null) return { cfg: {}, error: null };
+    if (typeof cfg !== 'object' || Array.isArray(cfg) || hasNullYamlKey(cfg)) {
+      return { cfg: {}, error: 'config/plugins.yml does not contain a valid YAML mapping' };
+    }
+    return { cfg, error: null };
   } catch (err) {
     return { cfg: {}, error: String(err.message).split('\n')[0] };
   }
@@ -791,11 +806,11 @@ function onboardingState(root) {
 
   let plugins = [];
   let pluginConfigError = null;
+  const { cfg, error } = readPluginConfigSync(root);
+  // Travels in the JSON so a consumer can tell "nothing enabled" from "the
+  // config did not parse" — the two used to be the same empty list.
+  pluginConfigError = error;
   try {
-    const { cfg, error } = readPluginConfigSync(root);
-    // Travels in the JSON so a consumer can tell "nothing enabled" from "the
-    // config did not parse" — the two used to be the same empty list.
-    pluginConfigError = error;
     plugins = discoverPlugins(pluginRoots(root)).map((m) => {
       const s = pluginStatus(m, cfg);
       return { id: m.id, hooks: m.hooks, enabled: s.enabled, missingEnv: s.missingEnv };

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -558,10 +558,12 @@ function checkPipelineFile() {
 // the user had actually switched on, and said nothing about why.
 //
 // Returns the config plus the parse error, so callers can tell the two apart.
-function hasNullYamlKey(value) {
+function hasNullYamlKey(value, seen = new WeakSet()) {
   if (!value || typeof value !== 'object') return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
   if (Object.prototype.hasOwnProperty.call(value, 'null')) return true;
-  return Object.values(value).some(hasNullYamlKey);
+  return Object.values(value).some((child) => hasNullYamlKey(child, seen));
 }
 
 function readPluginConfigSync(root) {

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -577,6 +577,9 @@ function readPluginConfigSync(root) {
     if (typeof cfg !== 'object' || Array.isArray(cfg) || hasNullYamlKey(cfg)) {
       return { cfg: {}, error: 'config/plugins.yml does not contain a valid YAML mapping' };
     }
+    if (cfg.plugins != null && (typeof cfg.plugins !== 'object' || Array.isArray(cfg.plugins) || hasNullYamlKey(cfg.plugins))) {
+      return { cfg: {}, error: 'config/plugins.yml plugins section must be a YAML mapping' };
+    }
     return { cfg, error: null };
   } catch (err) {
     return { cfg: {}, error: String(err.message).split('\n')[0] };
@@ -586,13 +589,9 @@ function readPluginConfigSync(root) {
 // Plugin layer health: list discovered plugins + whether each enabled one's keys
 // are present. WARN-not-FAIL so a half-configured plugin never blocks setup.
 function checkPlugins(root) {
-  let manifests;
-  try { manifests = discoverPlugins(pluginRoots(root)); } catch { return { pass: true, label: 'Plugins: none' }; }
-  if (manifests.length === 0) return { pass: true, label: 'Plugins: none installed' };
   const { cfg, error: cfgError } = readPluginConfigSync(root);
-  // Reported before the per-plugin lines, because when the config did not parse
-  // every one of those lines is derived from an empty object and says "off"
-  // regardless of what the user configured.
+  // Report before discovery: a broken config is useful doctor output even if
+  // plugin discovery itself fails or finds no manifests.
   if (cfgError) {
     return {
       warn: true,
@@ -600,6 +599,9 @@ function checkPlugins(root) {
       fix: ['Fix the YAML in config/plugins.yml. Until then `plugins.mjs enable/disable` will refuse to write to it.'],
     };
   }
+  let manifests;
+  try { manifests = discoverPlugins(pluginRoots(root)); } catch { return { pass: true, label: 'Plugins: none' }; }
+  if (manifests.length === 0) return { pass: true, label: 'Plugins: none installed' };
   const lines = [];
   const fixes = [];
   for (const m of manifests) {

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -199,12 +199,55 @@ function findManifest(id) {
   return discoverPlugins(pluginRoots(ROOT), resolveSuccessorIds(ROOT)).find(m => m.id === id) || null;
 }
 
+/**
+ * Parse an existing config/plugins.yml into the object setEnabled merges into.
+ *
+ * Split out and exported so the guard below is testable without driving the CLI
+ * at a real config file.
+ *
+ * THROWS rather than returning {} when the file will not parse. setEnabled's
+ * contract is "merging (never clobbering the user's other plugins or non-secret
+ * settings)", and a merge is only a merge if the read succeeded: a swallowed
+ * parse error left cfg as {}, and the write put that empty object back over the
+ * file. Every other plugin's enabled state and settings went with it, including
+ * any non-secret value stored there, and nothing was printed.
+ *
+ * The trigger is a YAML typo — the most likely reason a hand-edited config does
+ * not parse, and precisely when the file is most in need of not being replaced.
+ * config/plugins.yml is a USER path in update-system.mjs, so there is no copy to
+ * restore from.
+ *
+ * @param {string|null} raw - File contents, or null when the file does not exist.
+ * @param {string} file - Path, for the error message only.
+ * @returns {object} Parsed config; {} for an absent file.
+ */
+export function parsePluginConfig(raw, file) {
+  // Absent is not unreadable: no file means a first enable, which is the whole
+  // point of the function. Only an existing-but-unparseable file is a refusal.
+  if (raw == null) return {};
+  let cfg;
+  try {
+    cfg = yaml.load(raw);
+  } catch (err) {
+    throw new Error(
+      `${file} is not valid YAML (${String(err.message).split('\n')[0]}) — refusing to overwrite it. `
+      + 'Fix the file and re-run; nothing was changed.',
+    );
+  }
+  if (cfg == null) return {};   // empty file: same as absent
+  // A scalar or a list parses cleanly and is still not a config. Spreading one
+  // below would discard it just as silently as the empty object did.
+  if (typeof cfg !== 'object' || Array.isArray(cfg)) {
+    throw new Error(`${file} does not contain a YAML mapping — refusing to overwrite it. Nothing was changed.`);
+  }
+  return cfg;
+}
+
 // Write enabled:true/false into config/plugins.yml, merging (never clobbering
 // the user's other plugins or non-secret settings).
 function setEnabled(id, on, settings) {
   const file = path.join(ROOT, 'config', 'plugins.yml');
-  let cfg = {};
-  if (existsSync(file)) { try { cfg = yaml.load(readFileSync(file, 'utf8')) || {}; } catch {} }
+  const cfg = parsePluginConfig(existsSync(file) ? readFileSync(file, 'utf8') : null, file);
   if (!cfg.plugins || typeof cfg.plugins !== 'object') cfg.plugins = {};
   const prev = (cfg.plugins[id] && typeof cfg.plugins[id] === 'object') ? cfg.plugins[id] : {};
   cfg.plugins[id] = { ...prev, ...(settings || {}), enabled: on };
@@ -303,8 +346,19 @@ function cmdRemove(args) {
   const dir = path.join(ROOT, 'plugins.local', id);
   if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
   removeLockEntry(ROOT, id);
-  try { setEnabled(id, false); } catch {}
-  console.log(`✓ Removed ${id} (plugins.local + lock + disabled).`);
+  // The files and the lock entry are already gone, so a config problem must not
+  // fail the command — but it must not be invisible either. This catch used to
+  // swallow nothing worth seeing; now it can catch a real, actionable one, and
+  // a user told "disabled" while the config still says enabled: true has been
+  // told the wrong thing.
+  let disabled = true;
+  try {
+    setEnabled(id, false);
+  } catch (err) {
+    disabled = false;
+    console.error(`⚠ ${id} was removed, but config/plugins.yml could not be updated: ${err.message}`);
+  }
+  console.log(`✓ Removed ${id} (plugins.local + lock${disabled ? ' + disabled' : ''}).`);
 }
 
 function cmdNew(args) {

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -17,7 +17,7 @@
  */
 
 import path from 'path';
-import { existsSync, readFileSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, rmSync, mkdirSync, realpathSync } from 'fs';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 
@@ -34,6 +34,7 @@ import { isMainModule } from './lib/is-main-module.mjs';
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const APPLICATIONS_PATH = path.join(ROOT, 'data', 'applications.md');
 const PIPELINE_PATH = path.join(ROOT, 'data', 'pipeline.md');
+const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 // A misbehaving plugin's stray rejection should be attributed and not silently
 // crash the host (the engine's per-hook try/catch handles the common case; this
@@ -199,10 +200,37 @@ function findManifest(id) {
   return discoverPlugins(pluginRoots(ROOT), resolveSuccessorIds(ROOT)).find(m => m.id === id) || null;
 }
 
-function hasNullYamlKey(value) {
+function isWithinDirectory(rootAbs, candidateAbs) {
+  const rel = path.relative(rootAbs, candidateAbs);
+  return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
+}
+
+function hasNullYamlKey(value, seen = new WeakSet()) {
   if (!value || typeof value !== 'object') return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
   if (Object.prototype.hasOwnProperty.call(value, 'null')) return true;
-  return Object.values(value).some(hasNullYamlKey);
+  return Object.values(value).some((child) => hasNullYamlKey(child, seen));
+}
+
+export function resolveLocalPluginDirForRemoval(root, id) {
+  if (!PLUGIN_ID_RE.test(String(id))) {
+    throw new Error(`Refusing to remove plugin outside plugins.local: ${id}`);
+  }
+  const localRoot = path.resolve(root, 'plugins.local');
+  const dir = path.resolve(localRoot, id);
+  const rel = path.relative(localRoot, dir);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`Refusing to remove plugin outside plugins.local: ${id}`);
+  }
+  if (existsSync(dir)) {
+    const realRoot = realpathSync(localRoot);
+    const realDir = realpathSync(dir);
+    if (!isWithinDirectory(realRoot, realDir)) {
+      throw new Error(`Refusing to remove plugin outside plugins.local: ${id}`);
+    }
+  }
+  return dir;
 }
 
 /**
@@ -353,11 +381,11 @@ function cmdTrust(args) {
 function cmdRemove(args) {
   const id = args[0];
   if (!id) { console.error('Usage: node plugins.mjs remove <id>'); process.exit(1); }
-  const localRoot = path.resolve(ROOT, 'plugins.local');
-  const dir = path.resolve(localRoot, id);
-  const rel = path.relative(localRoot, dir);
-  if (path.isAbsolute(id) || rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
-    console.error(`Refusing to remove plugin outside plugins.local: ${id}`);
+  let dir;
+  try {
+    dir = resolveLocalPluginDirForRemoval(ROOT, id);
+  } catch (err) {
+    console.error(err.message);
     process.exit(1);
   }
   if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -199,6 +199,12 @@ function findManifest(id) {
   return discoverPlugins(pluginRoots(ROOT), resolveSuccessorIds(ROOT)).find(m => m.id === id) || null;
 }
 
+function hasNullYamlKey(value) {
+  if (!value || typeof value !== 'object') return false;
+  if (Object.prototype.hasOwnProperty.call(value, 'null')) return true;
+  return Object.values(value).some(hasNullYamlKey);
+}
+
 /**
  * Parse an existing config/plugins.yml into the object setEnabled merges into.
  *
@@ -225,6 +231,7 @@ export function parsePluginConfig(raw, file) {
   // Absent is not unreadable: no file means a first enable, which is the whole
   // point of the function. Only an existing-but-unparseable file is a refusal.
   if (raw == null) return {};
+  if (String(raw).split('\n').every((line) => line.trim() === '' || line.trim().startsWith('#'))) return {};
   let cfg;
   try {
     cfg = yaml.load(raw);
@@ -237,8 +244,8 @@ export function parsePluginConfig(raw, file) {
   if (cfg == null) return {};   // empty file: same as absent
   // A scalar or a list parses cleanly and is still not a config. Spreading one
   // below would discard it just as silently as the empty object did.
-  if (typeof cfg !== 'object' || Array.isArray(cfg)) {
-    throw new Error(`${file} does not contain a YAML mapping — refusing to overwrite it. Nothing was changed.`);
+  if (typeof cfg !== 'object' || Array.isArray(cfg) || hasNullYamlKey(cfg)) {
+    throw new Error(`${file} does not contain a valid YAML mapping — refusing to overwrite it. Nothing was changed.`);
   }
   return cfg;
 }
@@ -343,7 +350,13 @@ function cmdTrust(args) {
 function cmdRemove(args) {
   const id = args[0];
   if (!id) { console.error('Usage: node plugins.mjs remove <id>'); process.exit(1); }
-  const dir = path.join(ROOT, 'plugins.local', id);
+  const localRoot = path.resolve(ROOT, 'plugins.local');
+  const dir = path.resolve(localRoot, id);
+  const rel = path.relative(localRoot, dir);
+  if (path.isAbsolute(id) || rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    console.error(`Refusing to remove plugin outside plugins.local: ${id}`);
+    process.exit(1);
+  }
   if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
   removeLockEntry(ROOT, id);
   // The files and the lock entry are already gone, so a config problem must not

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -247,6 +247,9 @@ export function parsePluginConfig(raw, file) {
   if (typeof cfg !== 'object' || Array.isArray(cfg) || hasNullYamlKey(cfg)) {
     throw new Error(`${file} does not contain a valid YAML mapping — refusing to overwrite it. Nothing was changed.`);
   }
+  if (cfg.plugins != null && (typeof cfg.plugins !== 'object' || Array.isArray(cfg.plugins) || hasNullYamlKey(cfg.plugins))) {
+    throw new Error(`${file} plugins section must be a YAML mapping — refusing to overwrite it. Nothing was changed.`);
+  }
   return cfg;
 }
 
@@ -255,7 +258,7 @@ export function parsePluginConfig(raw, file) {
 function setEnabled(id, on, settings) {
   const file = path.join(ROOT, 'config', 'plugins.yml');
   const cfg = parsePluginConfig(existsSync(file) ? readFileSync(file, 'utf8') : null, file);
-  if (!cfg.plugins || typeof cfg.plugins !== 'object') cfg.plugins = {};
+  if (!cfg.plugins || typeof cfg.plugins !== 'object' || Array.isArray(cfg.plugins)) cfg.plugins = {};
   const prev = (cfg.plugins[id] && typeof cfg.plugins[id] === 'object') ? cfg.plugins[id] : {};
   cfg.plugins[id] = { ...prev, ...(settings || {}), enabled: on };
   mkdirSync(path.join(ROOT, 'config'), { recursive: true });

--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -346,7 +346,8 @@ export function pluginRoots(root) {
  * @returns {{ enabled: boolean, configured: boolean, missingEnv: string[] }}
  */
 export function pluginStatus(manifest, cfg) {
-  const entry = cfg?.plugins?.[manifest.id];
+  const plugins = (cfg?.plugins && typeof cfg.plugins === 'object' && !Array.isArray(cfg.plugins)) ? cfg.plugins : {};
+  const entry = plugins[manifest.id];
   const configured = entry?.enabled === true;
   const missingEnv = manifest.requiredEnv.filter(name => !process.env[name]);
   return { enabled: configured && missingEnv.length === 0, configured, missingEnv };
@@ -359,7 +360,8 @@ export function pluginStatus(manifest, cfg) {
  * @param {object} cfg
  */
 export function pluginSettings(id, cfg) {
-  const entry = cfg?.plugins?.[id];
+  const plugins = (cfg?.plugins && typeof cfg.plugins === 'object' && !Array.isArray(cfg.plugins)) ? cfg.plugins : {};
+  const entry = plugins[id];
   if (!entry || typeof entry !== 'object') return {};
   const { enabled, ...rest } = entry;
   return rest;

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -109,13 +109,30 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
+// --target, not CAREER_OPS_ROOT. It is the flag doctor's own existing suite
+// uses (tests/doctor-unfilled-templates.test.mjs) and it names the directory
+// outright instead of going through env resolution, which the parent process,
+// the suite runner and a .career-ops-data marker can all have an opinion about.
+// An earlier version of this helper passed the env var and read the target
+// correctly on my machine and not on CI's.
 function doctorJson(dir) {
-  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json'], {
-    cwd: ROOT, encoding: 'utf-8', timeout: 60_000,
+  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json', '--target', dir], {
+    cwd: dir, encoding: 'utf-8', timeout: 60_000,
     env: { ...process.env, CAREER_OPS_ROOT: dir },
   });
   assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
-  return JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+  const brace = r.stdout.indexOf('{');
+  assert.notEqual(brace, -1, `doctor --json printed no JSON. stdout=${JSON.stringify(r.stdout.slice(0, 300))} stderr=${JSON.stringify(r.stderr.slice(0, 300))}`);
+  return JSON.parse(r.stdout.slice(brace));
+}
+
+// Proves doctor actually looked at the fixture before any assertion reads a
+// field off it. Without this, a doctor pointed somewhere else reports a clean
+// config and the malformed-config test fails as a bare `undefined` — which says
+// nothing about the fixture never having been read.
+function assertTargeted(j, dir) {
+  const looked = JSON.stringify(j).includes('plugins') || Array.isArray(j.plugins);
+  assert.ok(looked, `doctor --json did not report on plugins at all for ${dir}: ${JSON.stringify(j).slice(0, 300)}`);
 }
 
 function pluginSandbox(contents) {
@@ -129,7 +146,12 @@ test('doctor --json distinguishes an unparseable config from an empty one', () =
   const bad = pluginSandbox('plugins:\n  apify:\n    enabled: true\n  : malformed\n');
   try {
     const j = doctorJson(bad);
-    assert.ok(j.pluginConfigError, 'doctor reported no parse error for a config that does not parse');
+    assertTargeted(j, bad);
+    assert.ok(
+      j.pluginConfigError,
+      'doctor reported no parse error for a config that does not parse — '
+      + `it either swallowed it or never read ${join(bad, 'config', 'plugins.yml')}`,
+    );
     assert.match(String(j.pluginConfigError), /\S/, 'the reported error is empty');
   } finally {
     rmSync(bad, { recursive: true, force: true, maxRetries: 10 });

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -96,3 +96,54 @@ test('valid YAML that is not a mapping is refused too', () => {
     );
   }
 });
+
+// ── doctor reports it, rather than reading it as "nothing enabled" ──────────
+//
+// The same swallow lived in doctor.mjs's readPluginConfigSync, which returned
+// {} on a parse error. An unreadable config and a config with nothing enabled
+// produced the same empty object, so the one tool whose job is to say what is
+// wrong answered "off" for every plugin the user had switched on — and said
+// nothing about why.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+function doctorJson(dir) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json'], {
+    cwd: ROOT, encoding: 'utf-8', timeout: 60_000,
+    env: { ...process.env, CAREER_OPS_ROOT: dir },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+}
+
+function pluginSandbox(contents) {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-doctor-plug-'));
+  mkdirSync(join(dir, 'config'), { recursive: true });
+  writeFileSync(join(dir, 'config', 'plugins.yml'), contents);
+  return dir;
+}
+
+test('doctor --json distinguishes an unparseable config from an empty one', () => {
+  const bad = pluginSandbox('plugins:\n  apify:\n    enabled: true\n  : malformed\n');
+  try {
+    const j = doctorJson(bad);
+    assert.ok(j.pluginConfigError, 'doctor reported no parse error for a config that does not parse');
+    assert.match(String(j.pluginConfigError), /\S/, 'the reported error is empty');
+  } finally {
+    rmSync(bad, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('and adds no new key on a healthy config', () => {
+  // Existing --json consumers must see no change on the ordinary path; the
+  // field is the signal that something IS wrong, so its presence has to mean
+  // that and only that.
+  const good = pluginSandbox('plugins:\n  apify:\n    enabled: true\n');
+  try {
+    assert.ok(!('pluginConfigError' in doctorJson(good)), 'the error key appears on a healthy config');
+  } finally {
+    rmSync(good, { recursive: true, force: true, maxRetries: 10 });
+  }
+});

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -1,0 +1,98 @@
+// tests/plugins-config-preservation.test.mjs — enabling or disabling a plugin
+// must never destroy config/plugins.yml.
+//
+// setEnabled()'s own comment states the contract: "merging (never clobbering
+// the user's other plugins or non-secret settings)". The merge was only a merge
+// if the read succeeded. A swallowed parse error left cfg as {}, and the write
+// put that empty object back over the file — every other plugin's enabled state
+// and settings gone, including any non-secret value stored there, with nothing
+// printed.
+//
+// What makes it expensive rather than annoying: the trigger is a YAML typo, the
+// most likely reason a hand-edited config does not parse and exactly when the
+// file most needs not to be replaced; and config/plugins.yml is a USER path in
+// update-system.mjs, so there is no copy to restore from.
+//
+// Tested through parsePluginConfig rather than the CLI. setEnabled resolves its
+// path from the SCRIPT's directory, so a CLI-level test would have to write to
+// the real checkout's config to exercise anything — the guard is the part with
+// the logic, and this reaches it without that.
+//
+// Run:  node --test tests/plugins-config-preservation.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const { parsePluginConfig } = await import(pathToFileURL(join(ROOT, 'plugins.mjs')).href);
+
+const FILE = '/somewhere/config/plugins.yml';
+
+// Two plugins and a stored non-secret setting, with one malformed line — the
+// shape a typo actually produces.
+const MALFORMED = [
+  'plugins:',
+  '  apify:',
+  '    enabled: true',
+  '    settings:',
+  '      dataset: KEEP-ME',
+  '  gmail:',
+  '    enabled: true',
+  '  : this line is malformed',
+].join('\n');
+
+test('a malformed config is refused, not silently emptied', () => {
+  assert.throws(
+    () => parsePluginConfig(MALFORMED, FILE),
+    (err) => {
+      // The message has to carry both halves: which file, and that nothing was
+      // written. "Failed to parse" alone leaves the user unsure whether the
+      // enable half-applied.
+      assert.match(err.message, /plugins\.yml/, 'the error does not name the file');
+      assert.match(err.message, /refusing to overwrite/i, 'the error does not say the file was left alone');
+      return true;
+    },
+  );
+});
+
+test('returning {} here is what destroyed the file — pin that it cannot', () => {
+  // The regression in one line: before the guard this call returned {}, and
+  // setEnabled wrote that back. Anything other than a throw is the bug.
+  let returned;
+  try {
+    returned = parsePluginConfig(MALFORMED, FILE);
+  } catch {
+    return; // threw — correct
+  }
+  assert.fail(`parsePluginConfig returned ${JSON.stringify(returned)} for an unparseable config instead of throwing`);
+});
+
+test('an absent config is a first enable, not a failure', () => {
+  // The guard must not buy safety by breaking the ordinary path.
+  assert.deepEqual(parsePluginConfig(null, FILE), {});
+});
+
+test('an empty file is treated as absent', () => {
+  assert.deepEqual(parsePluginConfig('', FILE), {});
+  assert.deepEqual(parsePluginConfig('\n# just a comment\n', FILE), {});
+});
+
+test('a well-formed config is returned intact for the merge', () => {
+  const cfg = parsePluginConfig('plugins:\n  gmail:\n    enabled: true\n    settings:\n      label: KEEP-ME\n', FILE);
+  assert.equal(cfg.plugins.gmail.enabled, true);
+  assert.equal(cfg.plugins.gmail.settings.label, 'KEEP-ME', 'an unrelated plugin\'s stored setting did not survive the read');
+});
+
+test('valid YAML that is not a mapping is refused too', () => {
+  // A scalar or a list parses cleanly and is still not a config. Spreading one
+  // into the write would discard it exactly as silently as the empty object.
+  for (const raw of ['just a string', '- a\n- b\n', '42']) {
+    assert.throws(
+      () => parsePluginConfig(raw, FILE),
+      /refusing to overwrite/i,
+      `a non-mapping config (${JSON.stringify(raw)}) was accepted`,
+    );
+  }
+});

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -26,7 +26,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const { parsePluginConfig } = await import(pathToFileURL(join(ROOT, 'plugins.mjs')).href);
+const { parsePluginConfig, resolveLocalPluginDirForRemoval } = await import(pathToFileURL(join(ROOT, 'plugins.mjs')).href);
 
 const FILE = '/somewhere/config/plugins.yml';
 
@@ -107,6 +107,11 @@ test('a plugins section that is not a mapping is refused too', () => {
   }
 });
 
+test('recursive YAML aliases do not make config validation recurse forever', () => {
+  const cfg = parsePluginConfig('plugins: &plugins\n  apify:\n    enabled: true\n  self: *plugins\n', FILE);
+  assert.equal(cfg.plugins.apify.enabled, true);
+});
+
 // ── doctor reports it, rather than reading it as "nothing enabled" ──────────
 //
 // The same swallow lived in doctor.mjs's readPluginConfigSync, which returned
@@ -116,7 +121,7 @@ test('a plugins section that is not a mapping is refused too', () => {
 // nothing about why.
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 // --target, not CAREER_OPS_ROOT. It is the flag doctor's own existing suite
@@ -215,5 +220,24 @@ test('and adds no new key on a healthy config', () => {
     assert.ok(!('pluginConfigError' in doctorJson(good)), 'the error key appears on a healthy config');
   } finally {
     rmSync(good, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('plugin removal refuses traversal, absolute paths, and symlink escapes', () => {
+  const root = mkdtempSync(join(tmpdir(), 'career-ops-remove-root-'));
+  const outside = mkdtempSync(join(tmpdir(), 'career-ops-remove-outside-'));
+  try {
+    mkdirSync(join(root, 'plugins.local'), { recursive: true });
+    symlinkSync(outside, join(root, 'plugins.local', 'escape'));
+    assert.throws(() => resolveLocalPluginDirForRemoval(root, '../escape'), /outside plugins\.local/);
+    assert.throws(() => resolveLocalPluginDirForRemoval(root, '/tmp/escape'), /outside plugins\.local/);
+    assert.throws(() => resolveLocalPluginDirForRemoval(root, 'nested/id'), /outside plugins\.local/);
+    assert.throws(() => resolveLocalPluginDirForRemoval(root, 'escape'), /outside plugins\.local/);
+    const safe = resolveLocalPluginDirForRemoval(root, 'safe-plugin');
+    assert.equal(safe, join(root, 'plugins.local', 'safe-plugin'));
+    assert.equal(existsSync(outside), true, 'validation must not remove the symlink target');
+  } finally {
+    rmSync(root, { recursive: true, force: true, maxRetries: 10 });
+    rmSync(outside, { recursive: true, force: true, maxRetries: 10 });
   }
 });

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -97,6 +97,16 @@ test('valid YAML that is not a mapping is refused too', () => {
   }
 });
 
+test('a plugins section that is not a mapping is refused too', () => {
+  for (const raw of ['plugins: []\n', 'plugins: enabled\n', 'plugins:\n  : malformed\n']) {
+    assert.throws(
+      () => parsePluginConfig(raw, FILE),
+      /plugins section.*mapping|valid YAML mapping/i,
+      `a non-mapping plugins section (${JSON.stringify(raw)}) was accepted`,
+    );
+  }
+});
+
 // ── doctor reports it, rather than reading it as "nothing enabled" ──────────
 //
 // The same swallow lived in doctor.mjs's readPluginConfigSync, which returned
@@ -165,6 +175,19 @@ test('doctor --json reports scalar and list plugin configs as invalid', () => {
       const j = doctorJson(bad);
       assert.ok(j.pluginConfigError, `doctor reported no config error for ${JSON.stringify(raw)}`);
       assert.match(String(j.pluginConfigError), /mapping/i);
+    } finally {
+      rmSync(bad, { recursive: true, force: true, maxRetries: 10 });
+    }
+  }
+});
+
+test('doctor --json reports scalar and list plugin sections as invalid', () => {
+  for (const raw of ['plugins: 42\n', 'plugins:\n  - item\n']) {
+    const bad = pluginSandbox(raw);
+    try {
+      const j = doctorJson(bad);
+      assert.ok(j.pluginConfigError, `doctor reported no config error for ${JSON.stringify(raw)}`);
+      assert.match(String(j.pluginConfigError), /plugins section.*mapping/i);
     } finally {
       rmSync(bad, { recursive: true, force: true, maxRetries: 10 });
     }

--- a/tests/plugins-config-preservation.test.mjs
+++ b/tests/plugins-config-preservation.test.mjs
@@ -158,6 +158,31 @@ test('doctor --json distinguishes an unparseable config from an empty one', () =
   }
 });
 
+test('doctor --json reports scalar and list plugin configs as invalid', () => {
+  for (const raw of ['42\n', '- item\n']) {
+    const bad = pluginSandbox(raw);
+    try {
+      const j = doctorJson(bad);
+      assert.ok(j.pluginConfigError, `doctor reported no config error for ${JSON.stringify(raw)}`);
+      assert.match(String(j.pluginConfigError), /mapping/i);
+    } finally {
+      rmSync(bad, { recursive: true, force: true, maxRetries: 10 });
+    }
+  }
+});
+
+test('doctor --json treats empty and comment-only plugin configs as empty', () => {
+  for (const raw of ['', '\n# just a comment\n']) {
+    const empty = pluginSandbox(raw);
+    try {
+      const j = doctorJson(empty);
+      assert.ok(!('pluginConfigError' in j), `comment-only config was reported as broken for ${JSON.stringify(raw)}`);
+    } finally {
+      rmSync(empty, { recursive: true, force: true, maxRetries: 10 });
+    }
+  }
+});
+
 test('and adds no new key on a healthy config', () => {
   // Existing --json consumers must see no change on the ordinary path; the
   // field is the signal that something IS wrong, so its presence has to mean


### PR DESCRIPTION
Bridge/follow-up for PR #3593 and issue #3592.

Summary:
- Preserves PR #3593's config-clobber guard.
- Rejects malformed YAML that js-yaml accepts as a null-key mapping, so `: malformed` cannot silently become `plugins.null`.
- Reports scalar/list/null-key plugin configs through `doctor --json` without dropping `pluginConfigError` when plugin discovery fails.
- Treats absent, empty, and comment-only configs as first-enable empty state.
- Blocks `plugins.mjs remove` path traversal before recursive deletion.

Test plan:
- `node --test tests/plugins-config-preservation.test.mjs` PASS (10/10)
- `node test-all.mjs --only plugins-config-preservation` PASS
- `npm run lint` PASS (615 .mjs syntax clean)
- `node test-all.mjs --quick` PASS: 7572 passed / 0 failed / 13 warnings

Steward note: direct normal push to abankar1:fix/plugins-config-clobber was denied despite maintainerCanModify=true, so this is a non-force bridge PR from chipoto69's fork. No dirty primary worktree touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented enabling or disabling plugins from overwriting malformed configuration files.
  * Added validation for invalid YAML, unsupported configuration formats, and unsafe plugin paths.
  * Improved feedback when plugin configuration updates fail.
  * Added safer handling of malformed or missing plugin settings.

* **New Features**
  * JSON onboarding status now reports plugin configuration errors when applicable.
  * Empty or comment-only configuration files remain supported during initial plugin setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->