### PR TITLE
fix(tests): answer gitignore probes that cross a user-layer symlink

### DIFF
--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -55,6 +55,50 @@ function isSymlink(rel) {
   }
 }
 
+/**
+ * The outermost symlink on the way down to `rel`, if any.
+ *
+ * git stops at the FIRST symlink it meets walking a pathspec, so that entry --
+ * not the leaf -- is the one it can still answer for. Returns the repo-relative
+ * path of that ancestor (or `rel` itself when the leaf is the symlink), else null.
+ *
+ * @param {string} rel - Repo-relative path.
+ * @returns {string|null}
+ */
+function symlinkedAncestor(rel) {
+  const parts = rel.split('/').filter(Boolean);
+  for (let i = 1; i <= parts.length; i += 1) {
+    const prefix = parts.slice(0, i).join('/');
+    if (isSymlink(prefix)) return prefix;
+  }
+  return null;
+}
+
+/**
+ * checkIgnore, but able to answer for probes that cross a user-layer symlink.
+ *
+ * The loop over the AGENTS.md paths below has resolved this since #3165: when
+ * git refuses a pathspec, ask about the symlinked entry instead, because that
+ * entry is what actually governs whether `git add .` can stage anything through
+ * it -- the contents live outside the repository. That fallback was written
+ * inline, so the derived-index probe list added later did not inherit it and
+ * went permanently red on the symlinked layout. Keeping it in one helper is
+ * what lets the next probe list opt in with one call instead of rediscovering
+ * exit 128 the hard way.
+ *
+ * @param {string} probe - Repo-relative path to test.
+ * @returns {{verdict: 'ignored'|'not-ignored'|'unanswerable', stderr: string, via: string|null}}
+ */
+function checkIgnoreThroughSymlinks(probe) {
+  const direct = checkIgnore(probe);
+  if (direct.verdict !== 'unanswerable') return { ...direct, via: null };
+
+  const ancestor = symlinkedAncestor(probe);
+  if (!ancestor) return { ...direct, via: null };
+
+  return { ...checkIgnore(ancestor), via: ancestor };
+}
+
 console.log('\n🔒 user-layer files are git-ignored');
 
 // Pull the declared user-layer paths straight out of AGENTS.md so the test tracks
@@ -168,10 +212,19 @@ const derivedIndexProbes = derivedIndexLocations.flatMap(
 );
 
 for (const path of derivedIndexProbes) {
-  const { verdict, stderr } = checkIgnore(path);
-  if (verdict === 'ignored') pass(`${path} is git-ignored`);
-  else if (verdict === 'not-ignored') fail(`${path} is NOT git-ignored — the derived index holds the same PII as the tracker`);
-  else fail(`${path}: git check-ignore could not answer — ${stderr}`);
+  const { verdict, stderr, via } = checkIgnoreThroughSymlinks(path);
+  if (verdict === 'ignored') {
+    pass(via ? `${path} is git-ignored (reached through the ${via} symlink; checked that entry)` : `${path} is git-ignored`);
+  } else if (verdict === 'not-ignored' && via) {
+    // Same call as the user-layer loop above: the index lives outside the repo,
+    // so staging the link commits its target path, not the tracker's contents.
+    warn(`${path} sits behind the ${via} symlink and that entry is NOT ignored — `
+      + `\`git add .\` would commit the link, not the index. Add a rule matching the entry itself, e.g. \`/${via}\`.`);
+  } else if (verdict === 'not-ignored') {
+    fail(`${path} is NOT git-ignored — the derived index holds the same PII as the tracker`);
+  } else {
+    fail(`${path}: git check-ignore could not answer — ${stderr}`);
+  }
 }
 
 // Not user-layer data, but the same mechanism: this one is about what a


### PR DESCRIPTION
## What

`tests/user-layer-gitignored.test.mjs` has three probe lists. The AGENTS.md user-layer loop handles `git check-ignore`'s exit 128 (`fatal: pathspec '...' is beyond a symbolic link`); the `derivedIndexProbes` list added alongside the new `*.db` / `*.db-wal` / `*.db-shm` rules does not, and fails hard on it.

That exit-128 case is the one #3165 was about, fixed in #3172. The fallback was written inline in the first loop, so the probe list added afterwards didn't inherit it.

## Impact

On the symlinked-user-layer layout (the manual workaround for #524, where `data/` points outside the repo), this puts three assertions permanently red on a checkout where the rules are present and correct:

```
❌ data/applications.db: git check-ignore could not answer — fatal: pathspec 'data/applications.db' is beyond a symbolic link
❌ data/applications.db-wal: ...
❌ data/applications.db-shm: ...
```

Test-only. The `.gitignore` rules work; the index lives outside the repository where git can't reach it either way. But it's the same false negative #3165 called out: noise in the one suite whose whole job is to be trustworthy about PII.

## Change

Lifts the fallback into `checkIgnoreThroughSymlinks()`. When git refuses a pathspec, it asks about the outermost symlink on the way down instead, since that entry is what actually governs whether `git add .` can stage anything through it.

It mirrors the existing loop's policy rather than inventing one: `warn` (not `fail`) when only the link entry is unignored, because staging a link commits its target path, not the user's data. `data/*` doesn't match `data`, so stock rules land there.

The helper is deliberately shared so the next probe list can opt in with one call rather than rediscovering exit 128.

## Verification

Reproduced the layout by pointing `data/` at a directory outside the repo:

| | failures |
|---|---|
| `origin/main` | 3 |
| this branch | 0 |

Full `node test-all.mjs` on the standard layout: **7570 passed, 0 failed** (unchanged).

Related: #3165, #3172, #524.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of ignore rules for files accessed through symbolic links.
  * Added clearer checks and diagnostics for cases where ignore status cannot be determined.
  * Distinguishes successful, warning, and failure outcomes when validating derived indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->