### PR TITLE
fix(tests): stop the photo suite writing cv-preview.html into the user's data root

### DIFF
--- a/tests/profile-photo.test.mjs
+++ b/tests/profile-photo.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -29,8 +29,26 @@ function render(inputPayload, { preview = false } = {}) {
   const args = preview
     ? ['build-cv-html.mjs', '--preview', input, TEMPLATE]
     : ['build-cv-html.mjs', input, output, TEMPLATE];
-  const stdout = execFileSync(process.execPath, args, { cwd: ROOT, encoding: 'utf8' });
-  return { html: readFileSync(preview ? join(ROOT, 'output', 'cv-preview.html') : output, 'utf8'), stdout, output };
+
+  // --preview ignores the output argument and resolves its destination from the
+  // DATA ROOT (build-cv-html.mjs's only use of it), which is the candidate's own
+  // output/ -- not the checkout. Unqualified, this test drops a "Test Candidate"
+  // fixture into a real user's CV output directory on every run, from any
+  // checkout, and then reads it back from the CHECKOUT's output/. Those two
+  // paths are the same file only on a layout where the data root is the repo,
+  // so the assertion passes by luck and the write escapes the sandbox.
+  // Point the data root at this render's own temp dir: the preview lands there,
+  // is read back from there, and nothing outside the sandbox is touched.
+  const env = { ...process.env };
+  let previewRoot;
+  if (preview) {
+    previewRoot = join(dir, 'data-root');
+    mkdirSync(join(previewRoot, 'output'), { recursive: true });
+    env.CAREER_OPS_ROOT = previewRoot;
+  }
+
+  const stdout = execFileSync(process.execPath, args, { cwd: ROOT, encoding: 'utf8', env });
+  return { html: readFileSync(preview ? join(previewRoot, 'output', 'cv-preview.html') : output, 'utf8'), stdout, output };
 }
 
 test('no photo emits no img and reserves no photo markup', () => {


### PR DESCRIPTION
## What

`build-cv-html.mjs --preview` ignores its output argument and resolves the destination from the **data root**:

https://github.com/santifer/career-ops/blob/main/build-cv-html.mjs#L740

That line is the file's only use of `DATA_ROOT`. On the default layout the data root is the checkout, so this is invisible. On the external-data-root layout (#524, and the symlink workaround people use for it) it is the candidate's own `output/` directory, somewhere else on the machine entirely.

`tests/profile-photo.test.mjs` calls `--preview` directly, so **running the test suite writes a "Test Candidate" fixture into a real user's CV output directory** — from any checkout, on every run.

I hit this from a throwaway worktree under `/tmp`, which had no business touching the user's data at all: a `cv-preview.html` appeared in their `output/` alongside 64 real tailored CVs, timestamped to that suite run.

## The assertion passes by luck

The test writes via `DATA_ROOT` and reads back via `ROOT`:

```js
readFileSync(preview ? join(ROOT, 'output', 'cv-preview.html') : output, 'utf8')
```

Those are the same file only when the data root *is* the repo. On any other layout the write escapes the sandbox and the read still succeeds against whatever happens to be sitting there — so the test stays green while doing the wrong thing in both directions.

## Change

Point `CAREER_OPS_ROOT` at the render's own `mkdtemp` dir for the preview spawn. The artifact lands there, is read back from there, and the two paths are equal by construction rather than by coincidence.

Scoped to the `preview` branch so the non-preview renders are untouched. Photo resolution uses `__dirname` (line 146) and is unaffected regardless.

Test-only — no change to `--preview`'s real behaviour, which is arguably correct as-is: `output/*` is user layer per the Data Contract, so writing there is the point. The bug is that the *test* uses the real path.

## Verification

With `CAREER_OPS_ROOT` pointed at a stand-in data root:

| | leaked into data root | suite |
|---|---|---|
| `origin/main` | `cv-preview.html` | 8/8 pass |
| this branch | *(empty)* | 8/8 pass |

Full `node test-all.mjs`: **7570 passed, 0 failed** (unchanged).

Related: #524.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved profile photo preview test isolation by using a temporary data directory.
  * Prevented test-generated preview files from being written to the project’s output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->