### PR TITLE
test: tolerate a missing web/ subproject in the mjs-files syntax gate

### DIFF
--- a/tests/mjs-files.test.mjs
+++ b/tests/mjs-files.test.mjs
@@ -22,7 +22,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -82,8 +82,16 @@ test('the syntax gate reaches past the repository root', () => {
     `gate must cover far more than the root: ${files.length} total vs ${rootOnly.length} at root`);
   assert.ok(files.some((f) => f.startsWith('tests/')), 'tests/ must be inside the gate');
   assert.ok(files.some((f) => f.startsWith('providers/')), 'providers/ must be inside the gate');
-  assert.ok(files.some((f) => f.startsWith('web/')), 'web/ must be inside the gate');
   assert.ok(files.some((f) => f.startsWith('lib/')), 'lib/ must be inside the gate');
+
+  // web/ is the one opt-in subproject in this list (#2360): tests/, providers/
+  // and lib/ ship with every install, but a checkout that never took the web UI
+  // has no web/ on disk. Assert it's inside the gate when it exists; when it
+  // doesn't, the invariant is vacuously true — the same conditional the adjacent
+  // 'web/ test discovery contract' check already uses instead of hardcoding it.
+  if (existsSync(join(ROOT, 'web'))) {
+    assert.ok(files.some((f) => f.startsWith('web/')), 'web/ must be inside the gate when present');
+  }
 });
 
 test('both syntax checkers derive their file list from the shared collector', () => {


### PR DESCRIPTION
Fixes #3563.

## What

`tests/mjs-files.test.mjs`, in the `the syntax gate reaches past the repository root` test, asserts that `web/` is inside the gate with no guard:

```js
assert.ok(files.some((f) => f.startsWith('web/')), 'web/ must be inside the gate');
```

But `web/` is an opt-in subproject (#2360), not something every checkout has. The file right next to this one already knows that: `tests/web-test-layout.test.mjs` runs its whole discovery contract behind `existsSync(WEB_PKG)` and prints `web/ is not present in this checkout — discovery contract not applicable` when it's missing. So on any install that never took the web UI, `node test-all.mjs` goes red here for a directory that was never supposed to be mandatory.

## Fix

Guard the one `web/` assertion behind `existsSync(join(ROOT, 'web'))`, the same conditional the adjacent contract uses. `tests/`, `providers/` and `lib/` stay unconditional, since those ship with every install and are the real invariant. When `web/` exists the assertion runs exactly as before; when it doesn't, it's vacuously true instead of a false failure.

## Evidence

`web/` is present in a full clone, so I parked it (`mv web ../web-parked`) to reproduce a web-less checkout.

Before the fix, web-less checkout — reproduces the report:

```
✖ the syntax gate reaches past the repository root
  AssertionError [ERR_ASSERTION]: web/ must be inside the gate
      at tests/mjs-files.test.mjs:85:10
ℹ pass 4
ℹ fail 1
```

After the fix:

```
# web/ present (assertion still runs)
✔ the syntax gate reaches past the repository root
ℹ pass 5
ℹ fail 0

# web/ absent (parked)
✔ the syntax gate reaches past the repository root
ℹ pass 5
ℹ fail 0
```

The pre-fix failure is proof the guarded assertion still fires when `web/` is there, so nothing is weakened for the common case, it just stops treating an optional directory as required.

Tested on Node v26.4.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage checks to account for environments where the `web/` directory is not present.
  * Preserved validation for the `lib/` directory and existing web test discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->