### PR TITLE
fix: point update checker and Hired Wall at career-ops-hq/career-ops

### DIFF
--- a/hired-share.mjs
+++ b/hired-share.mjs
@@ -34,7 +34,7 @@ import { isMainModule } from './lib/is-main-module.mjs';
 import { parseTrackerRow, resolveColumns, isSeparatorRow, isHeaderRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
 
-const REPO_URL = 'https://github.com/santifer/career-ops';
+const REPO_URL = 'https://github.com/career-ops-hq/career-ops';
 const TEMPLATE = 'i-got-hired.yml';
 const LEVELS = ['handle', 'role', 'count'];
 

--- a/scaffolder/bin/cli.mjs
+++ b/scaffolder/bin/cli.mjs
@@ -11,8 +11,8 @@ import { existsSync, readdirSync } from "node:fs";
 import { join, delimiter } from "node:path";
 import { ensureSkillEntrypoints } from "./skill-entrypoints.mjs";
 
-const REPO = "https://github.com/santifer/career-ops.git";
-const LATEST_RELEASE = "https://api.github.com/repos/santifer/career-ops/releases/latest";
+const REPO = "https://github.com/career-ops-hq/career-ops.git";
+const LATEST_RELEASE = "https://api.github.com/repos/career-ops-hq/career-ops/releases/latest";
 const NPM = process.platform === "win32" ? "npm.cmd" : "npm";
 
 // career-ops is AI-agnostic: every one of these CLIs reads AGENTS.md and works
@@ -35,7 +35,7 @@ Usage:
   npx career-ops init [folder]    Create a new workspace (default: ./career-ops)
 
 After setup, open your AI coding tool inside the folder and paste a job offer.
-Docs: https://github.com/santifer/career-ops`;
+Docs: https://github.com/career-ops-hq/career-ops`;
 
 function die(msg) {
   console.error(`\n✗ ${msg}\n`);

--- a/tests/hired-wall.test.mjs
+++ b/tests/hired-wall.test.mjs
@@ -123,7 +123,7 @@ const FIXTURE_AVATAR = join(ROOT, 'tests', 'fixtures', 'avatar-8x8.png');
   else fail(`weeks math wrong: ${weeks}`);
 
   const url = buildIssueUrl({ role: 'Data Engineer', story: 'a & b', feature: '', timeToHire: '7 weeks', anonymity: 'role' });
-  if (url.startsWith('https://github.com/santifer/career-ops/issues/new?') &&
+  if (url.startsWith('https://github.com/career-ops-hq/career-ops/issues/new?') &&
       url.includes('template=i-got-hired.yml') &&
       url.includes('anonymity=Role+and+location+only') &&
       url.includes('story=a+%26+b')) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -37,9 +37,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
 
-const CANONICAL_REPO = 'https://github.com/santifer/career-ops.git';
-const RAW_VERSION_URL = 'https://raw.githubusercontent.com/santifer/career-ops/main/VERSION';
-const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/latest';
+const CANONICAL_REPO = 'https://github.com/career-ops-hq/career-ops.git';
+const RAW_VERSION_URL = 'https://raw.githubusercontent.com/career-ops-hq/career-ops/main/VERSION';
+const RELEASES_API = 'https://api.github.com/repos/career-ops-hq/career-ops/releases/latest';
 
 // Matches a semver, with or without a leading `v` and an optional
 // Release Please component prefix (e.g. `career-ops-v1.9.0` → `1.9.0`).
@@ -1440,7 +1440,7 @@ async function check() {
   // deliberately conservative: version checks still work offline/behind a
   // restricted git transport.
   try { localCommit = gitQuiet('rev-parse', 'HEAD'); } catch { /* no git checkout */ }
-  const remoteRef = await curlGet('https://api.github.com/repos/santifer/career-ops/git/ref/heads/main', [
+  const remoteRef = await curlGet('https://api.github.com/repos/career-ops-hq/career-ops/git/ref/heads/main', [
     '--header', 'Accept: application/vnd.github+json',
     '--header', 'User-Agent: career-ops-update-checker',
   ]);

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -27,7 +27,7 @@ import { seedFixture, loadExpectations } from './seed-fixture.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
-const CANONICAL = 'https://github.com/santifer/career-ops.git';
+const CANONICAL = 'https://github.com/career-ops-hq/career-ops.git';
 const TAG_RE = /^career-ops-v(\d+)\.(\d+)\.(\d+)$/;
 
 function git(cwd, ...args) {


### PR DESCRIPTION
Fixes #3616.

The repo moved from `santifer/career-ops` to `career-ops-hq/career-ops`. `git clone`/`fetch` and `raw.githubusercontent.com` transparently redirect the old path, but `api.github.com` does not follow the rename for these endpoints — it returns HTTP 200 with a `{"message":"Moved Permanently", ...}` body instead of an error, which `update-system.mjs`'s `curl --fail` call treats as a successful (but empty) response.

This silently broke:
- `update-system.mjs`'s `RELEASES_API` version check
- `update-system.mjs`'s `git/ref/heads/main` drift-detection call (`remoteCommit` silently stayed empty)
- `scaffolder/bin/cli.mjs`'s post-install latest-tag check (uses `fetch()`, which follows redirects by default, so not broken today — but shouldn't rely on the old org staying reserved indefinitely)

Also repoints:
- `CANONICAL_REPO` (the git fetch target) in `update-system.mjs`, and the matching `CANONICAL` constant in its `upgrade-tests.mjs` fixture
- `hired-share.mjs`'s `REPO_URL`, which builds the prefilled Hired Wall "I got hired" issue link people open and submit from
- the one test (`tests/hired-wall.test.mjs`) asserting the old URL prefix

## Scope
Left the ~85 remaining `github.com/santifer/career-ops` references untouched (READMEs in a dozen languages, code comments citing issue numbers, `funding.json`, `CITATION.cff`, the Go dashboard, plugin registries) — those are cosmetic/doc-only and either resolve fine via GitHub's redirect or belong to a separate, larger sweep PR.

## Testing
`node tests/hired-wall.test.mjs` passes (16/16), including the updated URL-prefix assertion. Manually reproduced the broken `curl --fail` behavior against the old API path and confirmed the canonical path returns a real 200 with actual JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkxhZqZuNGzy8sWZLncnaD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated repository and release links to the current Career Ops GitHub location.
  - Hired Wall share links now direct users to the correct repository.
  - Scaffolding and update workflows reference the current repository for releases and version information.
  - Upgrade checks now validate against the current canonical repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->