### PR TITLE
docs(portals): clarify Welcome to the Jungle isn't Spain-only or tech-only

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -733,6 +733,12 @@ search_queries:
   #   query: 'site:jobfluent.com Madrid OR Barcelona "Engineer" OR "Manager" OR "Sales" OR "Marketing"'
   #   enabled: true
 
+  # NOTE: Welcome to the Jungle isn't a Spain-only or tech-only board — it
+  # also runs a large France listing and covers non-tech professions. The
+  # name/query below is scoped narrowly to Spain+AI/tech on purpose, to match
+  # this example profile's targeting; broaden the site: query (e.g. drop
+  # "Spain OR Madrid OR Barcelona" for France, or swap the title terms for
+  # your own profession) if you want its wider listings.
   - name: Welcome to the Jungle — Spain tech
     query: 'site:welcometothejungle.com Spain OR Madrid OR Barcelona "AI Engineer" OR "Solutions Architect" OR "DevRel" OR "Forward Deployed"'
     enabled: true


### PR DESCRIPTION
Fixes #3618.

The shipped example labels the WTTJ `site:` search '...Spain tech', which reads as if the board itself is Spain/tech-scoped. WTTJ also runs a large France listing and covers non-tech professions — the narrow query is just this example's own targeting, not a property of the board. Adds a comment so users adapting the example for another market or profession know to broaden it rather than assume WTTJ can't serve them.

Doc-only change, no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkxhZqZuNGzy8sWZLncnaD