### PR TITLE
docs(portals): add regional tech-ecosystem Getro board example (Invest Ottawa)

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -2542,6 +2542,22 @@ job_boards:
     enabled: false
     notes: "VC portfolio board (Getro), collection_id auto-resolved"
 
+  # ── Getro — regional / economic-development "tech ecosystem" boards ─
+  # Getro doesn't only power VC portfolio boards above -- city and regional
+  # economic-development orgs run their own Getro-backed "tech ecosystem" job
+  # board the same way, aggregating openings straight from each local
+  # employer's own ATS. Same provider, same config shape; just a different
+  # kind of network behind the collection. Worth adding one for any city/
+  # region you're targeting locally -- look for "[city] tech jobs" or
+  # "[region] talent network" run by a local innovation hub, chamber of
+  # commerce, or economic-development agency.
+  - name: Invest Ottawa — TechJobFinder  # Ottawa, Canada. Curated local tech-ecosystem board
+                                          # run by the region's economic-development agency.
+    careers_url: https://techjobfinder.investottawa.ca/jobs
+    provider: getro
+    enabled: false
+    notes: "Ottawa tech ecosystem board (Getro), collection_id auto-resolved from careers_url"
+
   # ── Consider (getconsider.com) — VC portfolio boards ───────────────
   # JS board backed by a same-origin JSON API. Set `consider_board` to the
   # board id — NOT the host (Founderful's board id is "wingman"). `careers_url`


### PR DESCRIPTION
Fixes #3620.

All existing Getro examples in `templates/portals.example.yml` are VC portfolio 'talent network' boards. Getro also powers a second, distinct category: city/regional economic-development orgs run their own Getro-backed 'tech ecosystem' board aggregating local employers' openings (discovered while building an Ottawa/NCR-targeted job search using Invest Ottawa's TechJobFinder). Same provider and config shape as the VC-portfolio boards, so no code changes — just documents the pattern so users targeting other cities/regions know to look for their own local economic-development agency's board.

Doc-only change (new `enabled: false` example entry + a comment), no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkxhZqZuNGzy8sWZLncnaD