### PR TITLE
fix: ignore preserved excludes when staging updater paths

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2287,7 +2287,8 @@ async function apply() {
       // unstaged edit to a tracked file under a system directory, or an ignored
       // file that an earlier buggy run stranded in the index. Closing that is a
       // separate change to the commit call; this one only closes the add.
-      addPaths(expandToShippedFiles(pathsToStage));
+      const stageablePaths = pathsToStage.filter((spec) => !spec.startsWith(EXCLUDE_PATHSPEC_PREFIX));
+      addPaths(expandToShippedFiles(stageablePaths));
       // Scope the commit to only the staged update paths (#915 bug 2).
       // A bare `git commit` would sweep any unrelated pre-staged files into
       // the update commit. Passing the explicit pathspec list constrains the


### PR DESCRIPTION
## Summary
- Fixes the upgrade regression gate failure where preserved `:(exclude)...` pathspecs were passed into `git --literal-pathspecs add` and treated as literal filenames.
- Keeps preserved-file exclusions for checkout/commit scoping, but filters them out of the staging list.
- Unblocks PRs whose upgrade canary hits local preserved system-file paths (for example PR #3614/#3613 class failures).

## Test Plan
- `node --check update-system.mjs`
- `node --check upgrade-tests.mjs`
- `node tests/updater-add-paths.test.mjs`
- `node upgrade-tests.mjs --canary`
- `node upgrade-tests.mjs --pr-gate`
- `npm run lint`
- `npm install` to materialize Playwright dependency in isolated steward workspace
- `node test-all.mjs --quick` => 7570 passed / 0 failed / 13 warnings

Board context: github-steward autopilot tick 2026-09-01 15:42 CEST. Primary dirty career-ops worktree was not touched.