### PR TITLE
feat(cv-facts): flag AI-resume-sameness patterns as advisory warnings

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -324,7 +324,7 @@ Usage:
     // Cover letters are candidate-facing documents too. Reuse the CV fact
     // validator before importing Playwright or writing a PDF so a failed gate
     // cannot leave behind a misleading artifact.
-    const factCheck = assertFacts(html, { label: "cover letter" });
+    const factCheck = assertFacts(html, { label: "cover letter", checkGenericity: true });
     // Ahead of the verdict, because it qualifies it: with no config the phrase
     // lists are empty, so a silent gate here covers metrics and facts only.
     if (factCheck.configMissing) {

--- a/lib/context-budget.mjs
+++ b/lib/context-budget.mjs
@@ -70,6 +70,7 @@ export const SECTION_PRIORITY = {
   'writing style calibration': 2,
   'writing style': 2,
   'professional writing & ats compatibility': 2,
+  'genericity check': 2,
 };
 
 /**

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -232,3 +232,40 @@ A mode may tell you to run work in a background subagent (e.g. `scan`, or parall
 - Working demo + metrics > perfection
 - Apply sooner > learn more
 - 80/20 approach, timebox everything
+
+## Genericity Check (AI-Resume-Sameness)
+
+`verify-cv-facts.mjs` answers "is this true?" — it never answers "does this
+bullet tell a recruiter anything, or would it fit almost any candidate in this
+role?" A first AI draft can pass every fact check and still read as
+interchangeable filler: a stock phrase that makes no checkable claim at all
+("results-driven professional with a proven track record"), or a bullet that
+only lists a responsibility with no stated outcome ("Responsible for
+stakeholder communication and project coordination."). `genericityFindings()`
+(exported from `verify-cv-facts.mjs`) flags both, and is wired in as an
+advisory, non-blocking `warn` — never a `block` — on the two candidate-facing
+paths where it matters: the `pdf` mode's fact-gate step (Step 19,
+`node verify-cv-facts.mjs {html-path}`, on by default) and every cover letter
+PDF (`generate-cover-letter.mjs`).
+
+**When a run surfaces a genericity warning** (`generic phrase: "..."` or
+`task-only bullet, no outcome/scope shown: "..."` in the fact-gate output),
+do not silently rewrite the bullet and do not silently leave it — walk the
+user through it the same way an unconfirmed `story-bank.md` figure gets
+confirmed (see the Confirmation UX invariant in `AGENTS.md`): present the
+flagged bullet plainly and offer four distinct outcomes, never just
+confirm/cut:
+
+- **(a) It's accurate and specific enough as written** — keep it.
+- **(b) Make it concrete** — ask what changed, who was affected, or what the
+  scope was (the article's own prompts apply: where did this happen, what did
+  you personally own, what changed because you were involved, is there a
+  number that helps), and rewrite using only what the user confirms — never
+  invent the missing detail yourself.
+- **(c) It's narrative/context, not a claim that needs specificity** — leave
+  it as-is, deliberately.
+- **(d) Cut it** — a generic bullet that cannot be made specific is weaker
+  than no bullet at all.
+
+Never treat a genericity warning as a reason to block or delay handing over
+the PDF; it is a prompt for a two-minute conversation, not a gate.

--- a/modes/cover.md
+++ b/modes/cover.md
@@ -294,6 +294,12 @@ or `block` verdict. Advisory `warn_phrases` do not stop PDF generation; a
 `block` verdict does, so add the missing evidence or obtain a verified
 allowlist exception first.
 
+The same call also checks for AI-resume-sameness — stock filler phrasing in
+the opening/closing and task-only sentences with no outcome shown — and
+surfaces it as an advisory `warn`, never a `block`. See **Genericity Check**
+in `modes/_shared.md` for how to walk the user through a flagged sentence
+before finalizing.
+
 Assemble the JSON payload:
 
 ```json

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -45,6 +45,7 @@ Run `npm run jd:similarity -- {bundle-root}/jd/current.md {bundle-root}/jd/previ
 19. Run the fact gate against the generated HTML: `node verify-cv-facts.mjs {html-path}`
     - This is a hard gate before PDF rendering.
     - If it fails, stop and fix the generated HTML by removing invented metrics or adding verified evidence to `cv.md`, `article-digest.md`, or `config/cv-facts.json`.
+    - A `warn` verdict does not fail the gate, but check `result.generic` (or the `advisory phrase:` lines in CLI output) for AI-resume-sameness findings — stock filler phrases and task-only bullets with no outcome shown. See **Genericity Check** in `modes/_shared.md` for how to walk the user through a flagged bullet before finalizing.
 20. **Hiring-manager audit — off by default, opt-in only.** Run `modes/pdf/hm-audit.md` if and only if one of these is true; otherwise skip straight to Step 21 without prompting.
     - The invocation carried `--hm-audit` (`/career-ops pdf --hm-audit`, or the same flag on a natural-language request).
     - `modes/_custom.md` turns it on as a house rule.

--- a/tests/cv-genericity-check.test.mjs
+++ b/tests/cv-genericity-check.test.mjs
@@ -1,0 +1,110 @@
+// tests/cv-genericity-check.test.mjs — AI-resume-sameness signals.
+//
+// verify-cv-facts.mjs answers "is this true?"; genericityFindings() answers
+// "does this bullet tell a recruiter anything?" — stock filler phrases and
+// task-only bullets with no outcome/scope shown, the failure mode a first AI
+// draft produces even when every claim in it is perfectly truthful. Neither
+// signal is a fabrication, so neither may ever turn a verdict into 'block' —
+// that boundary gets its own assertions below, alongside the opt-in wiring
+// (existing callers that don't ask for this must see byte-identical output).
+import { pass, fail } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { genericityFindings, verifyFacts, assertFacts } from '../verify-cv-facts.mjs';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+console.log('\nCV/cover-letter genericity check');
+
+// ── genericityFindings(): buzzword phrases ──────────────────────────────────
+{
+  const { buzzwords } = genericityFindings('<p>Results-driven professional with a proven track record.</p>');
+  if (buzzwords.includes('results-driven professional') && buzzwords.includes('proven track record')) {
+    pass('flags stock filler phrases regardless of casing');
+  } else fail(`missed a filler phrase: ${JSON.stringify(buzzwords)}`);
+
+  const clean = genericityFindings('<p>Cut infrastructure spend 30% by consolidating three redundant vendors.</p>');
+  if (clean.buzzwords.length === 0) pass('a specific, evidenced sentence has no buzzword findings');
+  else fail(`false positive on specific prose: ${JSON.stringify(clean.buzzwords)}`);
+}
+
+// ── genericityFindings(): task-only bullets, across formats ────────────────
+{
+  const html = genericityFindings('<ul><li>Responsible for stakeholder communication and project coordination.</li></ul>');
+  if (html.taskOnlyBullets.length === 1 && !/\.\.\s*\.$/.test(html.taskOnlyBullets[0])) {
+    pass('an HTML task-only bullet with no number is flagged, with clean trailing punctuation');
+  } else fail(`HTML task-only bullet not flagged cleanly: ${JSON.stringify(html.taskOnlyBullets)}`);
+
+  const md = genericityFindings('- Managed the onboarding process for new employees.\n- Cut onboarding time 40% by digitizing paperwork.');
+  if (md.taskOnlyBullets.length === 1 && md.taskOnlyBullets[0].startsWith('Managed the onboarding')) {
+    pass('a markdown task-only bullet is flagged while its evidenced sibling is not');
+  } else fail(`markdown bullets misclassified: ${JSON.stringify(md.taskOnlyBullets)}`);
+
+  const tex = genericityFindings('\\item Oversaw vendor relationships and contract renewals.');
+  if (tex.taskOnlyBullets.length === 1) pass('a LaTeX \\item task-only bullet is flagged');
+  else fail(`LaTeX bullet not flagged: ${JSON.stringify(tex.taskOnlyBullets)}`);
+}
+
+// ── no false positives ───────────────────────────────────────────────────────
+{
+  const numbered = genericityFindings('<li>Managed a $550K budget across 3 teams.</li>');
+  if (numbered.taskOnlyBullets.length === 0) pass('the same opener with a number attached is not flagged');
+  else fail(`false positive on a bullet carrying real scope: ${JSON.stringify(numbered.taskOnlyBullets)}`);
+
+  const specific = genericityFindings('<li>Migrated the legacy monolith to Kubernetes using a strangler-fig pattern.</li>');
+  if (specific.taskOnlyBullets.length === 0) pass('a specific bullet with no generic opener is not flagged even without a number');
+  else fail(`false positive on specific bullet: ${JSON.stringify(specific.taskOnlyBullets)}`);
+
+  const prose = genericityFindings('I improved reliability for 25 users.');
+  if (prose.taskOnlyBullets.length === 0) pass('cover-letter prose with no bullet markers yields no task-only findings');
+  else fail(`false positive on non-bulleted prose: ${JSON.stringify(prose.taskOnlyBullets)}`);
+}
+
+// ── verifyFacts(): opt-in, warn-only, never a block ─────────────────────────
+{
+  const bulletHtml = '<li>Responsible for onboarding.</li>';
+
+  const byDefault = verifyFacts(bulletHtml, { sourcePaths: [] });
+  if (byDefault.verdict === 'pass' && byDefault.warnings.length === 0 && byDefault.generic.taskOnlyBullets.length === 0) {
+    pass('checkGenericity defaults to off — existing callers see unchanged behavior');
+  } else fail(`genericity fired without opting in: ${JSON.stringify(byDefault)}`);
+
+  const optedIn = verifyFacts(bulletHtml, { sourcePaths: [], checkGenericity: true });
+  if (optedIn.verdict === 'warn' && optedIn.forbidden.length === 0 && optedIn.generic.taskOnlyBullets.length === 1) {
+    pass('opting in surfaces a genericity finding as a warning, never a block');
+  } else fail(`unexpected verdict when opted in: ${JSON.stringify(optedIn)}`);
+
+  try {
+    assertFacts(bulletHtml, { sourcePaths: [], checkGenericity: true });
+    pass('assertFacts does not throw on a genericity-only warning');
+  } catch (error) {
+    fail(`assertFacts threw on an advisory-only finding: ${error.message}`);
+  }
+}
+
+// ── end-to-end: generate-cover-letter.mjs's own fact-gate call opts in ──────
+{
+  const tmp = mkdtempSync(join(tmpdir(), 'career-ops-cover-genericity-'));
+  try {
+    const source = join(tmp, 'cv.md');
+    writeFileSync(source, 'Cut onboarding time 40% by digitizing paperwork.');
+    const html = buildHtml({
+      candidate: { name: 'Jane Doe' },
+      letter: {
+        role_title: 'Engineer',
+        opening: 'Results-driven professional with a proven track record.',
+        profile_intro: 'Profile.',
+      },
+    });
+    // Mirrors the exact call generate-cover-letter.mjs makes before rendering
+    // a PDF: checkGenericity: true. A regression here (someone dropping the
+    // flag) would go back to a stable 'pass' the way this test's opening line
+    // would if genericity were never checked.
+    const result = verifyFacts(html, { sourcePaths: [source], checkGenericity: true });
+    if (result.verdict === 'warn' && result.generic.buzzwords.length > 0) {
+      pass('a cover letter opening built from stock filler phrases warns under the wiring generate-cover-letter.mjs uses');
+    } else fail(`cover letter genericity wiring did not fire: ${JSON.stringify(result)}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -770,16 +770,117 @@ function sourceContainsFact(sourceText, value) {
   return new RegExp(`(?:^|[^\\p{L}\\p{N}+#/-])${escaped}(?=$|[^\\p{L}\\p{N}+#/-])`, 'iu').test(sourceText);
 }
 
+// ── Genericity: catch AI-resume-sameness patterns, not fabrication ─────────
+//
+// The fact gate above answers "is this true?"; this answers a different
+// question: "does this bullet tell a recruiter anything, or would it fit
+// almost any candidate in this role?" Both are documented failure modes of
+// leaning on a first AI draft — filler phrasing that survives every fact
+// check because it makes no checkable claim at all, and a task-listing
+// bullet ("Responsible for X") that never states what changed because of the
+// work. Neither is a lie, so neither ever blocks — both only ever add to
+// `warnings`, the same non-blocking channel `warn_phrases` already uses.
+//
+// Kept to a short, defensible list of full PHRASES rather than individual
+// words ("motivated", "leadership") — those are ordinary vocabulary a
+// specific bullet still needs; it is the interchangeable stock phrase, not
+// the word, that reads as AI sameness.
+const GENERIC_RESUME_PHRASES = [
+  'results-driven professional',
+  'results-oriented professional',
+  'proven track record',
+  'strong team player',
+  'excellent communicator',
+  'excellent communication skills',
+  'proven leader',
+  'hard-working professional',
+  'detail-oriented team player',
+  'highly motivated individual',
+  'dynamic professional',
+  'self-starter with a proven track record',
+  'strong work ethic',
+  'extensive experience in',
+  'proven ability to',
+  'think outside the box',
+  'hit the ground running',
+  'wear many hats',
+  'passionate about delivering',
+];
+
+// Openers that list a responsibility without saying what happened as a
+// result. Narrow on purpose: a bullet starting with one of these AND
+// carrying no digit anywhere (count, %, currency — any of the scope signals
+// the metric/fact checks above already parse) is exactly the shape the
+// article's "too broad" examples share ("Responsible for stakeholder
+// communication and project coordination."). A specific bullet with no
+// opener in this list (e.g. "Migrated the legacy monolith to Kubernetes
+// using a strangler-fig pattern") is never flagged, even with no number in
+// it — this only catches the passive/task-only framing, not the absence of
+// a metric on its own.
+const TASK_ONLY_OPENERS = [
+  'responsible for', 'managed', 'helped with', 'assisted with', 'worked on',
+  'involved in', 'participated in', 'supported', 'handled', 'oversaw',
+  'coordinated', 'contributed to', 'in charge of',
+];
+
+// Bullet/list-item boundaries across the three formats this gate reads
+// (rendered HTML <li>, Markdown -/*/•, LaTeX \item). Matched against the RAW
+// text before stripMarkup, since stripMarkup collapses <li> boundaries into a
+// '. ' sentence break and would erase markdown bullet markers the same way.
+const BULLET_BOUNDARY_RE = /<li\b[^>]*>|^[ \t]*[-*•][ \t]+|\\item\b/gim;
+
+/** Split raw candidate-facing text into individual bullet/list-item strings. */
+function splitBullets(rawText) {
+  const text = String(rawText);
+  const marks = [...text.matchAll(BULLET_BOUNDARY_RE)];
+  const bullets = [];
+  for (let i = 0; i < marks.length; i++) {
+    const start = marks[i].index + marks[i][0].length;
+    const end = i + 1 < marks.length ? marks[i + 1].index : text.length;
+    // Trailing close tags after the bullet's real content (</li>, then
+    // </ul>/</ol> closing the whole list) each become their own '. '
+    // sentence break in stripMarkup, stacking into "content.. ." — collapse
+    // that run back to the single period the source text actually ended with.
+    const bullet = stripMarkup(text.slice(start, end)).replace(/(?:\s*\.){2,}\s*$/, '.').trim();
+    if (bullet) bullets.push(bullet);
+  }
+  return bullets;
+}
+
+/**
+ * Scan candidate-facing text for AI-resume-sameness patterns: stock filler
+ * phrases and task-only bullets with no outcome or scope shown. Read-only —
+ * this never rewrites or drops anything, only reports.
+ *
+ * @param {string} rawText generated candidate-facing HTML/Markdown/LaTeX
+ * @returns {{ buzzwords: string[], taskOnlyBullets: string[] }}
+ */
+export function genericityFindings(rawText) {
+  const plain = stripMarkup(rawText).toLowerCase();
+  const buzzwords = GENERIC_RESUME_PHRASES.filter((phrase) => plain.includes(phrase));
+  const taskOnlyBullets = splitBullets(rawText).filter((bullet) => {
+    const lower = bullet.toLowerCase();
+    return TASK_ONLY_OPENERS.some((opener) => lower.startsWith(opener)) && !/\d/.test(bullet);
+  });
+  return { buzzwords, taskOnlyBullets };
+}
+
 /**
  * @param {string} targetText generated candidate-facing HTML/Markdown/text
- * @param {{ sourcePaths?: string[], configPath?: string, cwd?: string }} options
- * @returns {{ verdict: 'pass'|'warn'|'block', invented: string[], unsupportedFacts: object[], forbidden: string[], warnings: string[] }}
+ * @param {{ sourcePaths?: string[], configPath?: string, cwd?: string, checkGenericity?: boolean }} options
+ * @returns {{ verdict: 'pass'|'warn'|'block', invented: string[], unsupportedFacts: object[], forbidden: string[], warnings: string[], generic: { buzzwords: string[], taskOnlyBullets: string[] } }}
  * @throws when the config is invalid
  */
 export function verifyFacts(targetText, {
   sourcePaths = DEFAULT_SOURCES,
   configPath = DEFAULT_CONFIG,
   cwd = process.cwd(),
+  // Opt-in: existing callers that don't ask for this keep byte-identical
+  // behavior. generate-cover-letter.mjs and the verify-cv-facts.mjs CLI both
+  // turn it on explicitly, since those are the two candidate-facing paths the
+  // AI-resume-sameness pattern actually targets (résumé bullets and cover
+  // letter prose).
+  checkGenericity = false,
 } = {}) {
   const sourceText = sourcePaths.map(path => readIfExists(resolveInputPath(path, cwd))).join('\n');
   const { missing: configMissing, config } = loadFactConfig(resolveInputPath(configPath, cwd));
@@ -794,12 +895,19 @@ export function verifyFacts(targetText, {
   const forbidden = config.forbidden_phrases
       .filter(Boolean)
       .filter(phrase => stripMarkup(targetText).toLowerCase().includes(String(phrase).toLowerCase()));
-  const warnings = config.warn_phrases
+  const generic = checkGenericity ? genericityFindings(targetText) : { buzzwords: [], taskOnlyBullets: [] };
+  const warnings = [
+    ...config.warn_phrases
       .filter(Boolean)
-      .filter(phrase => stripMarkup(targetText).toLowerCase().includes(String(phrase).toLowerCase()));
+      .filter(phrase => stripMarkup(targetText).toLowerCase().includes(String(phrase).toLowerCase())),
+    ...generic.buzzwords.map((phrase) => `generic phrase: "${phrase}"`),
+    ...generic.taskOnlyBullets.map((bullet) =>
+      `task-only bullet, no outcome/scope shown: "${bullet.length > 100 ? bullet.slice(0, 100) + '…' : bullet}"`),
+  ];
   // Never downgrades a block and never creates one: a document that fails on
-  // real evidence still fails on that, and a coverage gap only turns a would-be
-  // 'pass' into 'warn' so the caller is told the gate could not read it.
+  // real evidence still fails on that, and a coverage gap or a genericity
+  // finding only ever turns a would-be 'pass' into 'warn' — both are advisory,
+  // never proof of fabrication.
   const coverage = diagnoseCoverage(targetText);
   const blocked = invented.length || unsupportedFacts.length || forbidden.length;
   return {
@@ -813,6 +921,7 @@ export function verifyFacts(targetText, {
     // finding. It rides along so a caller can say the phrase lists were never
     // loaded instead of printing a clean result the reader takes for "checked".
     configMissing,
+    generic,
   };
 }
 
@@ -835,6 +944,10 @@ function parseCliArgs(args) {
   let targetArg = '';
   let configPath = DEFAULT_CONFIG;
   let json = false;
+  // On by default for the CLI path: a human or agent running this file
+  // directly is deliberately gating candidate-facing content, so it should
+  // see the full advisory signal unless it opts out.
+  let checkGenericity = true;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '--source' || arg === '--config') {
@@ -845,6 +958,8 @@ function parseCliArgs(args) {
       return { help: true };
     } else if (arg === '--json') {
       json = true;
+    } else if (arg === '--no-genericity') {
+      checkGenericity = false;
     } else if (arg.startsWith('--')) {
       throw new Error(`unknown option: ${arg}`);
     } else if (!targetArg) {
@@ -853,17 +968,19 @@ function parseCliArgs(args) {
       throw new Error(`unexpected extra positional argument: ${arg}`);
     }
   }
-  return { targetArg, sourcePaths, configPath, json, help: false };
+  return { targetArg, sourcePaths, configPath, json, checkGenericity, help: false };
 }
 
 /** Return the command-line usage text. */
 function usage() {
-  return `Usage: node verify-cv-facts.mjs <generated-document> [--source path] [--config path] [--json]
+  return `Usage: node verify-cv-facts.mjs <generated-document> [--source path] [--config path] [--json] [--no-genericity]
        node verify-cv-facts.mjs --self-test
 
 Checks generated candidate-facing text for unsupported metrics and explicitly asserted
 non-metric facts (employers, titles, tools, and delegated-work authorship) absent
-from source files.
+from source files, plus (unless --no-genericity) advisory AI-resume-sameness signals:
+stock filler phrases and task-only bullets with no outcome or scope shown. The
+sameness signals never block — only invented/unsupported facts and forbidden phrases do.
 Default sources: cv.md, article-digest.md
 Default config:  config/cv-facts.json (optional)`;
 }
@@ -1192,6 +1309,54 @@ function runSelfTest() {
     ['50 servers']
   );
 
+  // ── genericity: AI-resume-sameness signals ──────────────────────────
+  equal(
+    'a stock filler phrase is flagged',
+    genericityFindings('<p>Results-driven professional with a proven track record.</p>').buzzwords,
+    ['results-driven professional', 'proven track record']
+  );
+  equal(
+    'an HTML task-only bullet with no number is flagged',
+    genericityFindings('<ul><li>Responsible for stakeholder communication and project coordination.</li></ul>').taskOnlyBullets,
+    ['Responsible for stakeholder communication and project coordination.']
+  );
+  equal(
+    'a markdown task-only bullet with no number is flagged',
+    genericityFindings('- Managed the onboarding process for new employees.').taskOnlyBullets,
+    ['Managed the onboarding process for new employees.']
+  );
+  equal(
+    'the same opener with a number attached is not flagged',
+    genericityFindings('<li>Managed a $550K budget across 3 teams.</li>').taskOnlyBullets,
+    []
+  );
+  equal(
+    'a specific bullet with no generic opener is not flagged even without a number',
+    genericityFindings('<li>Migrated the legacy monolith to Kubernetes using a strangler-fig pattern.</li>').taskOnlyBullets,
+    []
+  );
+  equal(
+    'prose with no bullet markers yields no task-only findings',
+    genericityFindings('I improved reliability for 25 users.').taskOnlyBullets,
+    []
+  );
+  equal(
+    'genericity is opt-in: verifyFacts default leaves warnings/verdict unchanged',
+    (() => {
+      const r = verifyFacts('<li>Responsible for onboarding.</li>', { sourcePaths: [] });
+      return { verdict: r.verdict, warnings: r.warnings, generic: r.generic };
+    })(),
+    { verdict: 'pass', warnings: [], generic: { buzzwords: [], taskOnlyBullets: [] } }
+  );
+  equal(
+    'genericity findings surface as warnings, never as a block',
+    (() => {
+      const r = verifyFacts('<li>Responsible for onboarding.</li>', { sourcePaths: [], checkGenericity: true });
+      return { verdict: r.verdict, forbidden: r.forbidden };
+    })(),
+    { verdict: 'warn', forbidden: [] }
+  );
+
   console.log(`verify-cv-facts self-test: ${passed} passed, ${failed} failed`);
   return failed ? 1 : 0;
 }
@@ -1219,6 +1384,7 @@ export function runCli(args = process.argv.slice(2)) {
     const result = verifyFacts(readFileSync(targetPath, 'utf-8'), {
       sourcePaths: parsed.sourcePaths.length ? parsed.sourcePaths : DEFAULT_SOURCES,
       configPath: parsed.configPath,
+      checkGenericity: parsed.checkGenericity,
     });
     // On stderr, before any verdict line and regardless of it: with no config
     // the phrase lists are empty, so "passed" below means the phrase check never


### PR DESCRIPTION
Fixes #3623

## What

`verify-cv-facts.mjs` already gates whether generated CV/cover-letter content is *true* (metric/fact fabrication). It had no signal for content that is true but generic enough to fit almost any candidate — the "applicant sameness" pattern of leaning too heavily on a first AI draft ([source](https://www.altis.com/learn/how-to-use-ai-to-write-a-resume-without-sounding-ai-generated)).

Adds `genericityFindings()`:
- A short, curated list of full stock phrases ("results-driven professional", "proven track record", ...) — not single common words, which are just ordinary vocabulary.
- A narrow task-only-bullet heuristic: a bullet starting with a generic responsibility opener ("Responsible for", "Managed", "Assisted with", ...) **and** containing no digit anywhere. A specific bullet with no such opener is never flagged, even without a number — this only catches the passive/task-listing framing, not the mere absence of a metric.
- Splits bullets across the three formats this gate already reads: HTML `<li>`, Markdown `-`/`*`/`•`, LaTeX `\item`.

## How it's wired

`checkGenericity` is an **opt-in** parameter on `verifyFacts()`/`assertFacts()`, default `false` — every existing caller (including the CLI's own self-test and every current test file) sees byte-identical behavior. It's turned on explicitly in the two places this actually matters:
- The `pdf` mode's fact-gate step (`node verify-cv-facts.mjs {html-path}`) — on by default for the CLI, with a `--no-genericity` opt-out.
- `generate-cover-letter.mjs`'s existing `assertFacts()` call.

Findings only ever land in the existing `warnings` array / `warn` verdict — this can never create a `block`. It's advisory, not a fabrication check, exactly like the existing `warn_phrases` config channel it sits beside.

`modes/_shared.md` gets a short new section instructing the agent, when a bullet is flagged, to walk the user through it with the same four-way confirmation shape already used for unconfirmed `story-bank.md` figures (keep as-is / make it concrete / mark narrative-only / cut) — never auto-rewrite, never silently ignore.

## Testing

- New `tests/cv-genericity-check.test.mjs` (12 assertions): buzzword detection, task-only bullets across all three bullet formats, no false positives on numbered or already-specific bullets, no false positives on non-bulleted prose, opt-in wiring (`checkGenericity` off by default), warn-never-block, and an end-to-end check against `generate-cover-letter.mjs`'s own `buildHtml()`.
- 8 new cases added to `verify-cv-facts.mjs`'s own `--self-test`.
- Full `node test-all.mjs --quick` run: 7262 passed, 0 new failures. The 5 pre-existing failures (`doctor-tracked-bak-files`, `updater-commit-file-modes`, `updater-drift-detection`, `updater-status-paths`, `updater-upgrade-safety`) reproduce identically on `main` with this branch's changes stashed — an unrelated environment issue where a global git commit-msg hook intercepts those tests' own internal sandbox `git commit` calls.

## Scope check (CONTRIBUTING.md)

Core path, no new mode/data file/config surface — one exported function + one opt-in parameter in an existing file, two mode-doc paragraphs, one new test file. Issue #3623 opened first per the new-feature guideline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds an advisory `Genericity Check` for generated CVs and cover letters.

### User impact

- PDF and cover-letter generation now warns about stock phrases and task-only bullets without digits: `verify-cv-facts.mjs:858-908`.
- Warnings do not block generation: `tests/cv-genericity-check.test.mjs:63-81`.
- Agents must ask whether to keep, clarify, mark narrative-only, or remove flagged content: `modes/_shared.md:251-270`.
- Existing programmatic callers keep the check disabled by default: `verify-cv-facts.mjs:870-898`.
- The CLI enables the check by default and supports `--no-genericity`: `verify-cv-facts.mjs:950-981`.
- Cover-letter validation enables the check: `generate-cover-letter.mjs:327`.
- Specific bullets without a generic opener are not flagged: `tests/cv-genericity-check.test.mjs:50-60`.

### Files changed

- `verify-cv-facts.mjs`
- `generate-cover-letter.mjs`
- `modes/_shared.md`
- `modes/cover.md`
- `modes/pdf.md`
- `tests/cv-genericity-check.test.mjs`
- `lib/context-budget.mjs`: Adds `genericity check` at priority P2: `lib/context-budget.mjs:55-73`.

The requested system files were not changed: `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->