### PR TITLE
fix(web): show inbox rows that are only a URL

### DIFF
--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -6,6 +6,7 @@ import { parseApplications } from "@/lib/tracker-table.mjs";
 // One definition of the `{n}-RESERVED.md` convention, shared with
 // run-cli-support.mjs — see report-files.mjs for why it lives there.
 import { isReservedReportFile } from "@/lib/report-files.mjs";
+import { parseInboxMarkdown } from "@/lib/inbox-parse.mjs";
 import { resolvePdfIndexPath } from "@/lib/core/pdf-index";
 // Pure parser, no I/O — shared with the apply flow's CV resolver so the two
 // don't drift into two different definitions of "which report does this
@@ -58,51 +59,11 @@ function read(rel: string): string | null {
 
 export type InboxJob = { url: string; company: string; role: string; location?: string; compensation?: string; done: boolean; postedAt?: string };
 
-/** A pipeline-row segment like `posted: 2026-07-14`, `trust: 62 stale` or
- *  `note: …` — the core appends these LABELED segments after whatever
- *  positional shape a row has (3/4/5 columns), so a naive positional reader
- *  would misread them as location/compensation on short rows. Any
- *  `word:`-prefixed segment is treated as labeled (forward-compatible with
- *  labels the core hasn't invented yet). */
-const LABELED_SEGMENT = /^([a-z][a-z_-]*):\s*(.*)$/i;
-
-/** Parse data/pipeline.md — `- [ ] URL | Company | Role [| Location [| Compensation]] [| label: …]*`.
- *  Positional split for the first columns (the optional 4th `location` #1015
- *  and 5th `compensation` #1017 must NOT bleed into `role`); labeled segments
- *  (posted:/trust:/note:/…) are filtered out of positional assignment wherever
- *  they appear and surfaced when useful (posted: → postedAt). Unknown labels
- *  and further trailing columns are ignored gracefully. */
+/** Parse data/pipeline.md — see parseInboxMarkdown in inbox-parse.mjs.
+ *  Accepts the documented 1/3/4/5-column shapes plus URL|company; labeled
+ *  segments (posted:/trust:/note:/…) never occupy positional columns. */
 export function readInbox(): InboxJob[] {
-  const md = read("data/pipeline.md");
-  if (!md) return [];
-  const jobs: InboxJob[] = [];
-  for (const line of md.split("\n")) {
-    const m = line.match(/^\s*-\s*\[([ xX])\]\s*(.+)$/);
-    if (!m) continue;
-    const all = m[2].split("|").map((s) => s.trim());
-    const labels = new Map<string, string>();
-    const parts: string[] = [];
-    for (const [i, seg] of all.entries()) {
-      // the URL cell can contain a colon-y value but is always position 0
-      const lm = i >= 3 ? seg.match(LABELED_SEGMENT) : null;
-      if (lm) labels.set(lm[1].toLowerCase(), lm[2].trim());
-      else parts.push(seg);
-    }
-    if (parts.length < 3 || !parts[0]) continue; // need at least url | company | role
-    const posted = labels.get("posted");
-    jobs.push({
-      done: m[1].toLowerCase() === "x",
-      url: parts[0],
-      company: parts[1],
-      role: parts[2],
-      location: parts[3] || undefined, // optional 4th column (#1015)
-      compensation: parts[4] || undefined, // optional 5th column (#1017); 6th+ ignored
-      // the row's own posting date (scan.mjs `posted:` label) — a more direct
-      // freshness signal than the scan-history join, which stays as fallback
-      postedAt: posted && /^\d{4}-\d{2}-\d{2}$/.test(posted) ? posted : undefined,
-    });
-  }
-  return jobs;
+  return parseInboxMarkdown(read("data/pipeline.md"));
 }
 
 /**

--- a/web/src/lib/inbox-parse.mjs
+++ b/web/src/lib/inbox-parse.mjs
@@ -1,0 +1,63 @@
+/**
+ * inbox-parse.mjs — pipeline.md inbox row parser for the web read path.
+ *
+ * Plain .mjs (same pattern as report-files.mjs) so career-ops.ts and
+ * `node --test` share one definition. modes/pipeline.md documents 1-column
+ * (bare URL), 3/4/5-column, and labeled `posted:`/`trust:`/`note:`/`rank:`
+ * shapes; CLI writers also emit URL-only pending rows and processed
+ * `#NNN | URL | …` rows. Requiring three positional cells dropped those.
+ */
+
+/** A pipeline-row segment like `posted: 2026-07-14`, `trust: 62 stale` or
+ *  `note: …` — the core appends these LABELED segments after whatever
+ *  positional shape a row has (1/3/4/5 columns), so a naive positional reader
+ *  would misread them as company/role/location/compensation on short rows. Any
+ *  `word:`-prefixed segment is treated as labeled (forward-compatible with
+ *  labels the core hasn't invented yet). */
+const LABELED_SEGMENT = /^([a-z][a-z_-]*):\s*(.*)$/i;
+const HTTP_URL = /^https?:\/\//i;
+
+/**
+ * Parse `data/pipeline.md` markdown into inbox jobs.
+ *
+ * `- [ ] URL | Company | Role [| Location [| Compensation]] [| label: …]*`
+ * plus the shorter documented shapes: bare URL, URL|company, and processed
+ * `- [x] #NNN | URL | Company | Role | …`. The http(s) cell is the URL even
+ * when a report-number prefix sits in front of it. Missing company/role stay
+ * empty strings — never invented. Non-http cells with no URL are skipped.
+ *
+ * @param {string | null | undefined} md
+ * @returns {Array<{url: string, company: string, role: string, location?: string, compensation?: string, done: boolean, postedAt?: string}>}
+ */
+export function parseInboxMarkdown(md) {
+  if (!md) return [];
+  const jobs = [];
+  for (const line of md.split("\n")) {
+    const m = line.match(/^\s*-\s*\[([ xX])\]\s*(.+)$/);
+    if (!m) continue;
+    const all = m[2].split("|").map((s) => s.trim());
+    const urlIndex = all.findIndex((seg) => HTTP_URL.test(seg));
+    if (urlIndex < 0) continue;
+    const labels = new Map();
+    const positional = [];
+    for (let i = urlIndex + 1; i < all.length; i++) {
+      const seg = all[i];
+      const lm = seg.match(LABELED_SEGMENT);
+      if (lm) labels.set(lm[1].toLowerCase(), lm[2].trim());
+      else positional.push(seg);
+    }
+    const posted = labels.get("posted");
+    jobs.push({
+      done: m[1].toLowerCase() === "x",
+      url: all[urlIndex],
+      company: positional[0] ?? "",
+      role: positional[1] ?? "",
+      location: positional[2] || undefined, // optional 4th column (#1015)
+      compensation: positional[3] || undefined, // optional 5th column (#1017); 6th+ ignored
+      // the row's own posting date (scan.mjs `posted:` label) — a more direct
+      // freshness signal than the scan-history join, which stays as fallback
+      postedAt: posted && /^\d{4}-\d{2}-\d{2}$/.test(posted) ? posted : undefined,
+    });
+  }
+  return jobs;
+}

--- a/web/tests/lib/inbox-parse.test.mjs
+++ b/web/tests/lib/inbox-parse.test.mjs
@@ -1,0 +1,101 @@
+// Tests for parseInboxMarkdown() — the web Pipeline inbox reader.
+// Imports inbox-parse.mjs directly so the test and production path cannot drift.
+//
+// Run:  node --test tests/lib/inbox-parse.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseInboxMarkdown } from "../../src/lib/inbox-parse.mjs";
+
+const URL = "https://example.com/job/1";
+
+test("full URL | Company | Role row still parses", () => {
+  const jobs = parseInboxMarkdown(`- [ ] ${URL} | Acme | Engineer`);
+  assert.equal(jobs.length, 1);
+  assert.deepEqual(jobs[0], {
+    done: false,
+    url: URL,
+    company: "Acme",
+    role: "Engineer",
+    location: undefined,
+    compensation: undefined,
+    postedAt: undefined,
+  });
+});
+
+test("bare checkbox URL row is kept, not skipped", () => {
+  const jobs = parseInboxMarkdown(`- [ ] ${URL}`);
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].url, URL);
+  assert.equal(jobs[0].company, "");
+  assert.equal(jobs[0].role, "");
+  assert.equal(jobs[0].done, false);
+});
+
+test("URL | company without a role is kept", () => {
+  const jobs = parseInboxMarkdown(`- [ ] ${URL} | Acme`);
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].url, URL);
+  assert.equal(jobs[0].company, "Acme");
+  assert.equal(jobs[0].role, "");
+});
+
+test("labeled posted: segment still maps to postedAt on a full row", () => {
+  const jobs = parseInboxMarkdown(
+    `- [ ] ${URL} | Acme | Engineer | Remote (US) | posted: 2026-07-14`,
+  );
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].company, "Acme");
+  assert.equal(jobs[0].role, "Engineer");
+  assert.equal(jobs[0].location, "Remote (US)");
+  assert.equal(jobs[0].postedAt, "2026-07-14");
+  assert.equal(jobs[0].compensation, undefined);
+});
+
+test("labeled posted: still works on a bare URL row", () => {
+  const jobs = parseInboxMarkdown(`- [ ] ${URL} | posted: 2026-07-14`);
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].url, URL);
+  assert.equal(jobs[0].company, "");
+  assert.equal(jobs[0].role, "");
+  assert.equal(jobs[0].postedAt, "2026-07-14");
+});
+
+test("location and compensation stay positional on a 5-column row", () => {
+  const jobs = parseInboxMarkdown(
+    `- [ ] ${URL} | Acme | Engineer | Remote (US) | 180000-220000 USD`,
+  );
+  assert.equal(jobs[0].location, "Remote (US)");
+  assert.equal(jobs[0].compensation, "180000-220000 USD");
+});
+
+test("non-http junk is skipped", () => {
+  const md = [
+    "- [ ] not-a-url | Acme | Engineer",
+    "- [ ] ftp://example.com/job/1 | Acme | Engineer",
+    "- [ ] local:jds/acme.md | Acme | Engineer",
+    "- a prose line with https://example.com/job/1 in it",
+    "",
+  ].join("\n");
+  assert.deepEqual(parseInboxMarkdown(md), []);
+});
+
+test("processed #NNN | URL row keeps the http URL, not the report number", () => {
+  const jobs = parseInboxMarkdown(
+    `- [x] #143 | ${URL} | Acme | Engineer | 4.2/5 | PDF ✅`,
+  );
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].done, true);
+  assert.equal(jobs[0].url, URL);
+  assert.equal(jobs[0].company, "Acme");
+  assert.equal(jobs[0].role, "Engineer");
+});
+
+test("processed #NNN | URL without company/role still keeps the URL", () => {
+  const jobs = parseInboxMarkdown(`- [x] #-- | ${URL}`);
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].done, true);
+  assert.equal(jobs[0].url, URL);
+  assert.equal(jobs[0].company, "");
+  assert.equal(jobs[0].role, "");
+});


### PR DESCRIPTION
The web Pipeline inbox skipped valid `data/pipeline.md` rows that were only a URL.

`readInbox()` required `URL | Company | Role` (`parts.length < 3`). CLI / scan writers and hand-pasted inbox lines often emit:

```
- [ ] https://boards.greenhouse.io/acme/jobs/123
```

Those rows never appeared, so the inbox could look empty while `pipeline.md` had jobs.

## Change
- Parse the documented 1/3/4/5-column shapes, plus `URL | company`.
- `url` is required and must be `http(s)`.
- Missing company/role stay empty strings — no invented names.
- Labeled segments (`posted:`, `trust:`, `note:`, …) still work on short rows, including bare URLs.
- Small extra: processed `- [x] #NNN | URL | …` rows now take the http(s) cell as the URL instead of the report number.

Parser lives in `web/src/lib/inbox-parse.mjs` so `node --test` can import it; `readInbox()` is a thin wrapper.

## Tests
`cd web && node --test tests/lib/inbox-parse.test.mjs` — 9 pass, including:
- full `URL | Company | Role`
- bare URL
- labeled `posted:`
- skip non-http junk
- processed `#NNN | URL`

## Residual
- Processed trailing `Score/5` / `PDF ✅/❌` still land in optional location/compensation. Pending inbox filters `done`, so this is not user-visible there. A dedicated processed-row schema would be a larger redesign.
- Strikethrough expired rows (`- [x] ~~URL | Company | Role~~`) are still skipped; parsing through `~~` needs its own pass.