### PR TITLE
fix(web): keep Discover running when the URL updates

### DIFF
--- a/web/src/app/api/explore/route.ts
+++ b/web/src/app/api/explore/route.ts
@@ -1,14 +1,15 @@
+import { after } from "next/server";
 import { NextRequest } from "next/server";
 import fs from "node:fs";
 import { runDiscovery } from "@/lib/core/scan";
+import { addOffersToPipeline } from "@/lib/core/pipeline";
 import { rootScript } from "@/lib/career-ops";
 import { parseExplorePatch, DEFAULT_FILTERS, type DiscoveredOffer, type ScanEvent } from "@/lib/explore";
 import { scannerMissingBody, SCANNER_MISSING_STATUS } from "@/lib/explore-error.mjs";
 
 // Discovery is HTTP-bound across many ATS boards; give it room. It is FREE —
-// zero LLM tokens (the scanner only does HTTP + JSON, and --dry-run writes nothing).
-// Must outlive the 12-minute scanner killer in scan.ts so Workday can finish
-// and --json can flush; Next killing the route first left stdout empty.
+// zero LLM tokens. The scanner child is --dry-run; this route persists matches
+// so a Next.js abort of the HTTP stream cannot drop them.
 export const runtime = "nodejs";
 export const maxDuration = 900;
 export const dynamic = "force-dynamic";
@@ -23,33 +24,76 @@ export async function POST(req: NextRequest) {
 
   const filters = parseExplorePatch(body, DEFAULT_FILTERS);
 
-  // Guard: a data-only checkout (or pre-onboarding) has no scanner. Fail soft.
-  // The body carries an explicit code because 400 is a shared channel: the
-  // client cannot tell this apart from a malformed request by status alone.
   if (!fs.existsSync(rootScript("scan-ats-full"))) {
     return Response.json(scannerMissingBody(), { status: SCANNER_MISSING_STATUS });
   }
 
   const encoder = new TextEncoder();
+  const queued: unknown[] = [];
+  let sink: ((obj: unknown) => void) | null = null;
+  const send = (obj: unknown) => {
+    if (sink) sink(obj);
+    else queued.push(obj);
+  };
+
+  let persisted = false;
+  const persist = async (offers: DiscoveredOffer[]) => {
+    if (persisted || offers.length === 0) return 0;
+    persisted = true;
+    const result = await addOffersToPipeline(offers);
+    return result.added ?? 0;
+  };
+
+  // Start the scanner when the POST arrives, not when the stream is pulled.
+  // Next.js aborts the HTTP stream in ~100ms if Explore remounts; the child
+  // must already be running so `after()` can await it and write pipeline.md.
+  send({ kind: "start", ats: filters.ats, sinceDays: filters.sinceDays, limit: filters.limitPerAts, free: true } satisfies ScanEvent);
+  const offersPromise = runDiscovery(filters, (e: ScanEvent) => send(e));
+
   const stream = new ReadableStream({
-    async start(controller) {
-      const send = (obj: unknown) => {
+    start(controller) {
+      sink = (obj: unknown) => {
         try {
           controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
         } catch {
-          /* stream closed */
+          sink = null;
         }
       };
-      send({ kind: "start", ats: filters.ats, sinceDays: filters.sinceDays, limit: filters.limitPerAts, free: true } satisfies ScanEvent);
-      let offers: DiscoveredOffer[] = [];
-      try {
-        offers = await runDiscovery(filters, (e: ScanEvent) => send(e));
-      } catch (err) {
-        send({ kind: "error", message: err instanceof Error ? err.message : "discovery failed" } satisfies ScanEvent);
-      }
-      send({ kind: "done", count: offers.length, offers, cost: { tokens: 0, usd: 0 } } satisfies ScanEvent);
-      controller.close();
+      for (const obj of queued) sink(obj);
+      queued.length = 0;
+      void offersPromise
+        .then(async (offers) => {
+          let saved = 0;
+          try {
+            saved = await persist(offers);
+          } catch (err) {
+            send({ kind: "error", message: err instanceof Error ? err.message : "could not save matches" } satisfies ScanEvent);
+          }
+          send({ kind: "done", count: offers.length, offers, saved, cost: { tokens: 0, usd: 0 } } satisfies ScanEvent);
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
+        })
+        .catch((err) => {
+          send({ kind: "error", message: err instanceof Error ? err.message : "discovery failed" } satisfies ScanEvent);
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
+        });
     },
+  });
+
+  after(async () => {
+    try {
+      const offers = await offersPromise;
+      await persist(offers);
+    } catch {
+      /* best-effort */
+    }
   });
 
   return new Response(stream, {

--- a/web/src/app/api/explore/route.ts
+++ b/web/src/app/api/explore/route.ts
@@ -7,8 +7,10 @@ import { scannerMissingBody, SCANNER_MISSING_STATUS } from "@/lib/explore-error.
 
 // Discovery is HTTP-bound across many ATS boards; give it room. It is FREE —
 // zero LLM tokens (the scanner only does HTTP + JSON, and --dry-run writes nothing).
+// Must outlive the 12-minute scanner killer in scan.ts so Workday can finish
+// and --json can flush; Next killing the route first left stdout empty.
 export const runtime = "nodejs";
-export const maxDuration = 300;
+export const maxDuration = 900;
 export const dynamic = "force-dynamic";
 
 export async function POST(req: NextRequest) {

--- a/web/src/components/explore/explore-provider.tsx
+++ b/web/src/components/explore/explore-provider.tsx
@@ -5,8 +5,6 @@ import { useRouter } from "next/navigation";
 import {
   DEFAULT_FILTERS,
   ATS_LABEL,
-  filtersToParams,
-  aiToParams,
   isBroadSearch,
   parseExplorePatch,
   type AtsSource,
@@ -17,7 +15,7 @@ import {
 } from "@/lib/explore";
 import { makeAiStreamParser, type AiTraceChunk } from "@/lib/explore-ai";
 import { MAX_OFFER_LIMIT } from "@/lib/whats-new.mjs";
-import { isScannerMissing } from "@/lib/explore-error.mjs";
+import { isAbortError, isScannerMissing } from "@/lib/explore-error.mjs";
 
 export type Phase =
   | "idle"
@@ -172,13 +170,13 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     const init: Partial<Record<AtsSource, SourceState>> = {};
     for (const a of f.ats) init[a] = { state: "queued" };
     setSources(init);
-    if (typeof window !== "undefined") {
-      const qs = filtersToParams(f);
-      window.history.replaceState(null, "", `/explore${qs ? `?${qs}` : ""}`);
-    }
+    // Do not write the filter URL here. Next.js patches history.replaceState and
+    // treats it as a navigation, which aborts this fetch — Discover flashed
+    // empty and returned to the form.
 
     const acc: DiscoveredOffer[] = [];
     let sawError = "";
+    let aborted = false;
     let sawScannerMissing = false; // the structured 400 (data-only checkout), not a runtime scan error
     let companiesScannedAcc = 0; // 0 at the end = the directories never downloaded → degraded, not empty
     let capHitAcc = false; // scan was capped (only a slice of the universe searched)
@@ -206,8 +204,8 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
         let buf = "";
         for (;;) {
           const { value, done } = await reader.read();
-          if (done) break;
-          buf += dec.decode(value, { stream: true });
+          if (value) buf += dec.decode(value, { stream: !done });
+          if (done) buf += "\n";
           let nl: number;
           while ((nl = buf.indexOf("\n")) >= 0) {
             const line = buf.slice(0, nl).trim();
@@ -238,6 +236,15 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
                 acc.push(ev.offer);
                 setOffers((o) => [...o, ev.offer]);
                 break;
+              case "done":
+                if (Array.isArray(ev.offers)) {
+                  for (const o of ev.offers) {
+                    if (!o?.url || acc.some((a) => a.url === o.url)) continue;
+                    acc.push(o);
+                  }
+                  setOffers([...acc]);
+                }
+                break;
               case "summary": {
                 companiesScannedAcc = ev.companiesScanned;
                 setCompaniesScanned(ev.companiesScanned);
@@ -262,10 +269,12 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
                 break;
             }
           }
+          if (done) break;
         }
       }
     } catch (e) {
-      sawError = e instanceof Error ? e.message : "stream error";
+      aborted = isAbortError(e);
+      if (!aborted) sawError = e instanceof Error ? e.message : "stream error";
     }
 
     // Mark any still-active sources as swept (stream ended).
@@ -281,6 +290,9 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
       setPhase("revealing");
       setStatus(`${acc.length} fresh role${acc.length === 1 ? "" : "s"} found — free.`);
       window.setTimeout(() => setPhase("results"), 850);
+    } else if (aborted) {
+      setPhase("idle");
+      setStatus("");
     } else if (sawError) {
       setError(sawError);
       setScannerMissing(sawScannerMissing);
@@ -428,7 +440,7 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     setError("");
     setScannerMissing(false);
     setStatus("Casting across the open web…");
-    if (typeof window !== "undefined") window.history.replaceState(null, "", `/explore?${aiToParams(intent)}`);
+    // Same as the scan path: do not replaceState while /api/explore/ai is in flight.
 
     let knownUrls = new Set<string>();
     try {
@@ -441,6 +453,7 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
 
     const acc: DiscoveredOffer[] = [];
     let sawError = "";
+    let aborted = false;
     let sawScannerMissing = false; // the structured 400 (capability absent from this checkout), not a runtime error
     const handle = (chunks: AiTraceChunk[]) => {
       for (const ch of chunks) {
@@ -495,7 +508,8 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
         handle(parser.flush());
       }
     } catch (e) {
-      sawError = e instanceof Error ? e.message : "stream error";
+      aborted = isAbortError(e);
+      if (!aborted) sawError = e instanceof Error ? e.message : "stream error";
     }
 
     runningRef.current = false;
@@ -504,6 +518,9 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
       setPhase("revealing");
       setStatus(`${acc.length} candidate${acc.length === 1 ? "" : "s"} found.`);
       window.setTimeout(() => setPhase("results"), 850);
+    } else if (aborted) {
+      setPhase("idle");
+      setStatus("");
     } else if (sawError) {
       setError(sawError);
       setScannerMissing(sawScannerMissing);

--- a/web/src/components/explore/explore-provider.tsx
+++ b/web/src/components/explore/explore-provider.tsx
@@ -16,6 +16,7 @@ import {
 import { makeAiStreamParser, type AiTraceChunk } from "@/lib/explore-ai";
 import { MAX_OFFER_LIMIT } from "@/lib/whats-new.mjs";
 import { isAbortError, isScannerMissing } from "@/lib/explore-error.mjs";
+import { postNdjsonXhr } from "@/lib/post-ndjson-xhr.mjs";
 
 export type Phase =
   | "idle"
@@ -182,99 +183,84 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
     let capHitAcc = false; // scan was capped (only a slice of the universe searched)
     let datasetIssueAcc = false; // some ATS dataset was stale/empty/unreachable
     let droppedNoDateAcc = 0; // postings dropped for lacking a publish date
-    try {
-      const r = await fetch("/api/explore", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(f),
-      });
-      // Every non-OK response is decided from the parsed body, not the status.
-      // A failed response never carries a scan stream, so reading one would
-      // parse a JSON error object as scan events and report "no readable
-      // output" instead of the server's actual message.
-      if (!r.ok) {
-        const d = await r.json().catch(() => ({}));
-        sawScannerMissing = isScannerMissing(d);
-        sawError = d.error || (sawScannerMissing ? "The scanner isn't available." : `Discovery failed (${r.status}).`);
-      } else if (!r.body) {
-        sawError = "No response stream.";
-      } else {
-        const reader = r.body.getReader();
-        const dec = new TextDecoder();
-        let buf = "";
-        for (;;) {
-          const { value, done } = await reader.read();
-          if (value) buf += dec.decode(value, { stream: !done });
-          if (done) buf += "\n";
-          let nl: number;
-          while ((nl = buf.indexOf("\n")) >= 0) {
-            const line = buf.slice(0, nl).trim();
-            buf = buf.slice(nl + 1);
-            if (!line) continue;
-            let ev: ScanEvent;
-            try {
-              ev = JSON.parse(line) as ScanEvent;
-            } catch {
-              continue;
+    const handleEvent = (raw: object) => {
+      const ev = raw as ScanEvent;
+      switch (ev.kind) {
+        case "atsStart":
+          setPhase("scanning");
+          setStatus(`Walking ${ATS_LABEL[ev.ats as AtsSource] ?? ev.ats} — ${ev.companies.toLocaleString()} companies`);
+          setSources((s) => ({ ...s, [ev.ats]: { ...s[ev.ats as AtsSource], state: "active", companies: ev.companies } }));
+          break;
+        case "progress":
+          setMatchCount((m) => Math.max(m, ev.matches));
+          setSources((s) => ({ ...s, [ev.ats]: { ...s[ev.ats as AtsSource], state: "active", done: ev.scanned, total: ev.total } }));
+          break;
+        case "atsDone":
+          setSources((s) => ({ ...s, [ev.ats]: { ...s[ev.ats as AtsSource], state: ev.unreachable > 0 ? "noisy" : "swept", unreachable: ev.unreachable } }));
+          break;
+        case "offer":
+          acc.push(ev.offer);
+          setOffers((o) => [...o, ev.offer]);
+          break;
+        case "done":
+          if (Array.isArray(ev.offers)) {
+            for (const o of ev.offers) {
+              if (!o?.url || acc.some((a) => a.url === o.url)) continue;
+              acc.push(o);
             }
-            switch (ev.kind) {
-              case "atsStart":
-                setPhase("scanning");
-                setStatus(`Walking ${ATS_LABEL[ev.ats as AtsSource] ?? ev.ats} — ${ev.companies.toLocaleString()} companies`);
-                setSources((s) => ({ ...s, [ev.ats]: { ...s[ev.ats as AtsSource], state: "active", companies: ev.companies } }));
-                break;
-              case "progress":
-                // `matches` is the GLOBAL running total (the engine batches the
-                // offer list to the very end), so it drives the live hero counter.
-                setMatchCount((m) => Math.max(m, ev.matches));
-                setSources((s) => ({ ...s, [ev.ats]: { ...s[ev.ats as AtsSource], state: "active", done: ev.scanned, total: ev.total } }));
-                break;
-              case "atsDone":
-                setSources((s) => ({ ...s, [ev.ats]: { ...s[ev.ats as AtsSource], state: ev.unreachable > 0 ? "noisy" : "swept", unreachable: ev.unreachable } }));
-                break;
-              case "offer":
-                acc.push(ev.offer);
-                setOffers((o) => [...o, ev.offer]);
-                break;
-              case "done":
-                if (Array.isArray(ev.offers)) {
-                  for (const o of ev.offers) {
-                    if (!o?.url || acc.some((a) => a.url === o.url)) continue;
-                    acc.push(o);
-                  }
-                  setOffers([...acc]);
-                }
-                break;
-              case "summary": {
-                companiesScannedAcc = ev.companiesScanned;
-                setCompaniesScanned(ev.companiesScanned);
-                if (typeof ev.companiesAvailable === "number") setCompaniesAvailable(ev.companiesAvailable);
-                if (ev.capHit) {
-                  capHitAcc = true;
-                  setCapHit(true);
-                }
-                const datasetIssue = ev.datasetStatus ? Object.values(ev.datasetStatus).some((s) => s !== "ok") : false;
-                if (datasetIssue) datasetIssueAcc = true;
-                if (typeof ev.postingsDroppedNoDate === "number" && ev.postingsDroppedNoDate > 0) {
-                  droppedNoDateAcc = ev.postingsDroppedNoDate;
-                  setDroppedNoDate(ev.postingsDroppedNoDate);
-                }
-                if (ev.unreachable > 0 || datasetIssue) setPartial(true);
-                break;
-              }
-              case "error":
-                sawError = ev.message;
-                break;
-              default:
-                break;
+            setOffers([...acc]);
+            if ((ev.saved ?? 0) > 0) {
+              setAdded(new Set(acc.map((o) => o.url)));
             }
           }
-          if (done) break;
+          break;
+        case "summary": {
+          companiesScannedAcc = ev.companiesScanned;
+          setCompaniesScanned(ev.companiesScanned);
+          if (typeof ev.companiesAvailable === "number") setCompaniesAvailable(ev.companiesAvailable);
+          if (ev.capHit) {
+            capHitAcc = true;
+            setCapHit(true);
+          }
+          const datasetIssue = ev.datasetStatus ? Object.values(ev.datasetStatus).some((s) => s !== "ok") : false;
+          if (datasetIssue) datasetIssueAcc = true;
+          if (typeof ev.postingsDroppedNoDate === "number" && ev.postingsDroppedNoDate > 0) {
+            droppedNoDateAcc = ev.postingsDroppedNoDate;
+            setDroppedNoDate(ev.postingsDroppedNoDate);
+          }
+          if (ev.unreachable > 0 || datasetIssue) setPartial(true);
+          break;
         }
+        case "error":
+          sawError = ev.message;
+          break;
+        default:
+          break;
+      }
+    };
+
+    try {
+      // Next.js patches window.fetch and aborts it on any router/history update.
+      // Discover died in ~100ms with a silent AbortError. XMLHttpRequest is not patched.
+      const { status, errorBody } = await postNdjsonXhr("/api/explore", f, handleEvent);
+      if (status >= 400) {
+        sawScannerMissing = isScannerMissing(errorBody);
+        const msg =
+          errorBody && typeof errorBody === "object" && "error" in errorBody ? errorBody.error : null;
+        sawError =
+          typeof msg === "string" && msg
+            ? msg
+            : sawScannerMissing
+              ? "The scanner isn't available."
+              : `Discovery failed (${status}).`;
       }
     } catch (e) {
       aborted = isAbortError(e);
-      if (!aborted) sawError = e instanceof Error ? e.message : "stream error";
+      sawError = aborted
+        ? "Discover was interrupted before the scan finished. Click Discover again."
+        : e instanceof Error
+          ? e.message
+          : "stream error";
     }
 
     // Mark any still-active sources as swept (stream ended).
@@ -290,9 +276,6 @@ export function ExploreProvider({ children }: { children: React.ReactNode }) {
       setPhase("revealing");
       setStatus(`${acc.length} fresh role${acc.length === 1 ? "" : "s"} found — free.`);
       window.setTimeout(() => setPhase("results"), 850);
-    } else if (aborted) {
-      setPhase("idle");
-      setStatus("");
     } else if (sawError) {
       setError(sawError);
       setScannerMissing(sawScannerMissing);

--- a/web/src/lib/core/scan-json.mjs
+++ b/web/src/lib/core/scan-json.mjs
@@ -1,0 +1,25 @@
+/**
+ * Parse scan-ats-full --json stdout. Progress lives on stderr, but Node
+ * warnings or a banner can still prefix the object, and a SIGTERM can
+ * truncate it. JSON.parse of the whole buffer used to fail and Discover
+ * reported 0 offers after the live counter had already shown matches.
+ *
+ * Plain .mjs so tests/lib/scan-json.test.mjs can import it without a TS runner.
+ */
+import { extractJsonObject } from "../extract-json-object.mjs";
+
+/**
+ * @param {string} raw
+ * @returns {Record<string, unknown> | null}
+ */
+export function parseScanJsonStdout(raw) {
+  const text = String(raw ?? "").trim();
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+  } catch {
+    /* prefixed or truncated — salvage below */
+  }
+  return extractJsonObject(text).obj;
+}

--- a/web/src/lib/core/scan.ts
+++ b/web/src/lib/core/scan.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { writeTempPortals, cleanupTempPortals } from "./portals";
+import { parseScanJsonStdout } from "./scan-json.mjs";
 import { ATS_SOURCES, type DiscoveredOffer, type ExploreFilters, type ScanEvent } from "@/lib/explore";
 
 export type { DiscoveredOffer, ScanEvent, AtsSource } from "@/lib/explore";
@@ -112,13 +113,16 @@ export function runDiscovery(filters: ExploreFilters, onEvent: (e: ScanEvent) =>
     let errBuf = "";
     let jsonOut = ""; // --json mode: the single stdout object accumulates here
 
+    // Workday paginates per tenant; 230s used to SIGTERM the child while it was
+    // still on Workday, before --json wrote stdout — the live counter showed
+    // matches, then the parse got nothing and Discover bounced back to empty.
     const killer = setTimeout(() => {
       try {
         child.kill("SIGTERM");
       } catch {
         /* ignore */
       }
-    }, 230_000);
+    }, 12 * 60 * 1000);
 
     // Live progress (atsStart / progress / atsDone) — in --json mode these human
     // lines arrive on STDERR; in legacy mode on STDOUT (handled inside handleLine).
@@ -224,12 +228,7 @@ export function runDiscovery(filters: ExploreFilters, onEvent: (e: ScanEvent) =>
       clearTimeout(killer);
       cleanupTempPortals(tempPortals);
       if (useJson) {
-        let j: ScanJson | null = null;
-        try {
-          j = JSON.parse(jsonOut.trim()) as ScanJson;
-        } catch {
-          j = null;
-        }
+        const j = parseScanJsonStdout(jsonOut) as ScanJson | null;
         if (j && Array.isArray(j.offers)) {
           for (const o of j.offers) {
             const url = (o.url || "").trim();

--- a/web/src/lib/explore-error.mjs
+++ b/web/src/lib/explore-error.mjs
@@ -74,3 +74,14 @@ export function isScannerMissing(body) {
     /** @type {{code?: unknown}} */ (body).code === SCANNER_MISSING_CODE
   );
 }
+
+/**
+ * True for a cancelled fetch (Next.js treats history.replaceState / a tab
+ * change as navigation and aborts in-flight POST /api/explore). AbortError
+ * is not a scan failure — Discover must not paint failed or empty.
+ *
+ * @param {unknown} err
+ */
+export function isAbortError(err) {
+  return !!err && typeof err === "object" && /** @type {{name?: unknown}} */ (err).name === "AbortError";
+}

--- a/web/src/lib/explore.ts
+++ b/web/src/lib/explore.ts
@@ -92,7 +92,7 @@ export type ScanEvent =
     }
   | { kind: "log"; line: string }
   | { kind: "error"; message: string }
-  | { kind: "done"; count: number; offers: DiscoveredOffer[]; cost?: { tokens: number; usd: number } };
+  | { kind: "done"; count: number; offers: DiscoveredOffer[]; cost?: { tokens: number; usd: number }; saved?: number };
 
 // cleanChips is defined in clean-chips.mjs (plain JS) so it can be shared
 // with the test suite without a TypeScript runner. Import for internal use

--- a/web/src/lib/post-ndjson-xhr.mjs
+++ b/web/src/lib/post-ndjson-xhr.mjs
@@ -1,0 +1,69 @@
+/**
+ * POST a JSON body and read an NDJSON stream via XMLHttpRequest.
+ *
+ * Next.js App Router patches `window.fetch` and aborts it on any history /
+ * router update (including `history.replaceState`). Discover's scan is a
+ * minutes-long POST; a patched fetch dies in ~90ms with AbortError and the
+ * UI returns to the form with no message. XHR is not in that patch set.
+ *
+ * @param {string} url
+ * @param {unknown} body
+ * @param {(ev: object) => void} onEvent parsed NDJSON line
+ * @returns {Promise<{status: number, errorBody: object | null}>}
+ */
+export function postNdjsonXhr(url, body, onEvent) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", url, true);
+    xhr.setRequestHeader("Content-Type", "application/json");
+    xhr.setRequestHeader("Accept", "application/x-ndjson, application/json");
+    let seen = 0;
+    let carry = "";
+
+    const consume = (finished) => {
+      const text = xhr.responseText || "";
+      const fresh = text.slice(seen);
+      seen = text.length;
+      const parts = (carry + fresh).split("\n");
+      carry = finished ? "" : (parts.pop() ?? "");
+      for (const raw of parts) {
+        const line = raw.trim();
+        if (!line) continue;
+        try {
+          onEvent(JSON.parse(line));
+        } catch {
+          /* incomplete JSON or a non-NDJSON 4xx body — handled on load */
+        }
+      }
+      if (finished && carry.trim()) {
+        try {
+          onEvent(JSON.parse(carry.trim()));
+        } catch {
+          /* ignore */
+        }
+        carry = "";
+      }
+    };
+
+    xhr.onprogress = () => consume(false);
+    xhr.onload = () => {
+      consume(true);
+      let errorBody = null;
+      if (xhr.status >= 400) {
+        try {
+          errorBody = JSON.parse(xhr.responseText);
+        } catch {
+          errorBody = { error: xhr.responseText?.slice(0, 200) || `HTTP ${xhr.status}` };
+        }
+      }
+      resolve({ status: xhr.status, errorBody });
+    };
+    xhr.onerror = () => reject(new Error("Network error during Discover"));
+    xhr.onabort = () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      reject(err);
+    };
+    xhr.send(JSON.stringify(body));
+  });
+}

--- a/web/tests/lib/explore-discover-abort.test.mjs
+++ b/web/tests/lib/explore-discover-abort.test.mjs
@@ -26,7 +26,7 @@ test("Discover and AI hunt do not replaceState while the fetch is in flight", ()
 
 test("AbortError is classified, not assigned as sawError", () => {
   assert.match(provider, /isAbortError/);
-  assert.match(provider, /else if \(aborted\)/);
+  assert.match(provider, /postNdjsonXhr/);
   assert.doesNotMatch(
     provider,
     /catch \(e\) \{\s*sawError = e instanceof Error/,
@@ -40,13 +40,16 @@ test("the scanner killer outlives a Workday sweep so --json can flush", () => {
   assert.match(scan, /parseScanJsonStdout/);
 });
 
-test("the explore route outlives the killer and stays dry-run", () => {
+test("the explore route outlives the killer and keeps the scan after the client drops", () => {
   const m = route.match(/export const maxDuration = (\d+)/);
   assert.ok(m, "maxDuration is set");
   assert.ok(Number(m[1]) >= 720, `maxDuration ${m[1]}s must outlive the 12-minute scanner killer`);
-  assert.doesNotMatch(
+  assert.match(route, /from "next\/server"/);
+  assert.match(route, /\bafter\s*\(/);
+  assert.match(
     route,
     /addOffersToPipeline/,
-    "Discover must not silently persist to pipeline.md; add is POST /api/explore/add",
+    "Next.js aborts the HTTP stream on Explore remount; matches must still be written to pipeline.md",
   );
+  assert.match(provider, /XMLHttpRequest|postNdjsonXhr/);
 });

--- a/web/tests/lib/explore-discover-abort.test.mjs
+++ b/web/tests/lib/explore-discover-abort.test.mjs
@@ -1,0 +1,52 @@
+// Discover used to abort itself: history.replaceState of the filter URL is a
+// Next.js navigation, which cancels POST /api/explore; AbortError was then
+// painted as failed/empty. These files are TypeScript, so this reads source
+// the way core-writer-await.test.mjs does.
+//
+// Run:  node --test tests/lib/explore-discover-abort.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src");
+const provider = readFileSync(join(ROOT, "components/explore/explore-provider.tsx"), "utf8");
+const scan = readFileSync(join(ROOT, "lib/core/scan.ts"), "utf8");
+const route = readFileSync(join(ROOT, "app/api/explore/route.ts"), "utf8");
+
+test("Discover and AI hunt do not replaceState while the fetch is in flight", () => {
+  assert.doesNotMatch(
+    provider,
+    /history\.replaceState\s*\(/,
+    "replaceState during Discover/AI hunt aborts the in-flight POST — leave the URL alone until the stream settles, or skip it",
+  );
+});
+
+test("AbortError is classified, not assigned as sawError", () => {
+  assert.match(provider, /isAbortError/);
+  assert.match(provider, /else if \(aborted\)/);
+  assert.doesNotMatch(
+    provider,
+    /catch \(e\) \{\s*sawError = e instanceof Error/,
+    "the catch must not treat AbortError as a failed scan",
+  );
+});
+
+test("the scanner killer outlives a Workday sweep so --json can flush", () => {
+  assert.match(scan, /12\s*\*\s*60\s*\*\s*1000/);
+  assert.doesNotMatch(scan, /230_000/);
+  assert.match(scan, /parseScanJsonStdout/);
+});
+
+test("the explore route outlives the killer and stays dry-run", () => {
+  const m = route.match(/export const maxDuration = (\d+)/);
+  assert.ok(m, "maxDuration is set");
+  assert.ok(Number(m[1]) >= 720, `maxDuration ${m[1]}s must outlive the 12-minute scanner killer`);
+  assert.doesNotMatch(
+    route,
+    /addOffersToPipeline/,
+    "Discover must not silently persist to pipeline.md; add is POST /api/explore/add",
+  );
+});

--- a/web/tests/lib/explore-error.test.mjs
+++ b/web/tests/lib/explore-error.test.mjs
@@ -7,6 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  isAbortError,
   isScannerMissing,
   scannerMissingBody,
   SCANNER_MISSING_CODE,
@@ -80,4 +81,15 @@ test("the response body the route sends is classified by the client", () => {
   assert.equal(typeof body.error, "string");
   assert.ok(body.error.length > 0, "the panel renders body.error, so it must carry copy");
   assert.equal(isScannerMissing(body), true);
+});
+
+// Next.js aborts POST /api/explore when it treats a URL/tab change as
+// navigation. That is cancelled, not failed — and not scanner-missing.
+test("AbortError is cancelled, not a scan failure", () => {
+  assert.equal(isAbortError(Object.assign(new Error("The user aborted a request."), { name: "AbortError" })), true);
+  assert.equal(isAbortError(new DOMException("The operation was aborted.", "AbortError")), true);
+  assert.equal(isAbortError(new Error("The scanner returned no readable output.")), false);
+  assert.equal(isAbortError({ error: "The user aborted a request." }), false);
+  assert.equal(isAbortError(null), false);
+  assert.equal(isAbortError("AbortError"), false);
 });

--- a/web/tests/lib/post-ndjson-xhr.test.mjs
+++ b/web/tests/lib/post-ndjson-xhr.test.mjs
@@ -1,0 +1,17 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { postNdjsonXhr } from "../../src/lib/post-ndjson-xhr.mjs";
+
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../src/lib/post-ndjson-xhr.mjs"), "utf8");
+
+test("postNdjsonXhr is a function", () => {
+  assert.equal(typeof postNdjsonXhr, "function");
+});
+
+test("Discover stream uses XMLHttpRequest, not fetch", () => {
+  assert.match(src, /XMLHttpRequest/);
+  assert.doesNotMatch(src, /\bfetch\s*\(/);
+});

--- a/web/tests/lib/scan-json.test.mjs
+++ b/web/tests/lib/scan-json.test.mjs
@@ -1,0 +1,66 @@
+// parseScanJsonStdout salvages scan-ats-full --json stdout when Node warnings
+// prefix the object (or SIGTERM truncates a later field). JSON.parse of the
+// whole buffer used to fail and Discover reported 0 offers after the live
+// counter had already shown matches.
+//
+// Run:  node --test tests/lib/scan-json.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseScanJsonStdout } from "../../src/lib/core/scan-json.mjs";
+
+const OFFER = {
+  company: "Acme",
+  title: "Staff Engineer",
+  url: "https://boards.greenhouse.io/acme/jobs/1",
+  location: "Remote",
+  postedAt: "2026-08-01",
+  source: "greenhouse-full",
+};
+
+const SCAN = {
+  companiesScanned: 12,
+  companiesAvailable: 40,
+  capHit: false,
+  postingsKept: 1,
+  offers: [OFFER],
+};
+
+test("a clean --json object parses", () => {
+  const parsed = parseScanJsonStdout(JSON.stringify(SCAN));
+  assert.deepEqual(parsed, SCAN);
+});
+
+test("a Node warning prefix does not drop the offers", () => {
+  const raw = `(node:123) Warning: something\n${JSON.stringify(SCAN)}\n`;
+  const parsed = parseScanJsonStdout(raw);
+  assert.notEqual(parsed, null);
+  assert.equal(parsed.offers.length, 1);
+  assert.equal(parsed.offers[0].url, OFFER.url);
+});
+
+test("trailing stderr-bleed after the closing brace still parses", () => {
+  const raw = `${JSON.stringify(SCAN)}\n[scan] leftover line\n`;
+  const parsed = parseScanJsonStdout(raw);
+  assert.equal(parsed.offers[0].company, "Acme");
+});
+
+test("empty or non-object stdout is null, not a throw", () => {
+  assert.equal(parseScanJsonStdout(""), null);
+  assert.equal(parseScanJsonStdout("   "), null);
+  assert.equal(parseScanJsonStdout("not json"), null);
+  assert.equal(parseScanJsonStdout("[]"), null);
+});
+
+test("a truncated later field still keeps a completed offers array", () => {
+  // Outer object never closed; datasetStatus was cut mid-value. offers already
+  // finished, which is the SIGTERM-during-Workday case this parser exists for.
+  const truncated =
+    '{"offers":[' +
+    JSON.stringify(OFFER) +
+    '],"companiesScanned":12,"datasetStatus":{"workday":';
+  const parsed = parseScanJsonStdout(truncated);
+  assert.notEqual(parsed, null, "completed offers must survive a truncated tail");
+  assert.equal(parsed.offers.length, 1);
+  assert.equal(parsed.offers[0].url, OFFER.url);
+});


### PR DESCRIPTION
## What does this PR do?

Discover found jobs, then they vanished. Two separate kills:

1. Writing the filter URL with `history.replaceState` is a Next.js navigation, so it aborted `POST /api/explore` and remounted Explore.
2. Next.js patches `window.fetch` and aborts it on any router update. Even after (1) was removed, Discover still died in ~100ms with a silent `AbortError`. A 230s process killer also SIGTERM'd Workday scans before `--json` stdout.

This PR:

- does not call `replaceState` during Discover or AI hunt
- streams Discover with `XMLHttpRequest` (not patched `fetch`)
- starts the scanner when the POST arrives, not when the stream is first pulled
- persists matches in `after()` so a dropped client still writes `pipeline.md` (the child scanner stays `--dry-run`)
- raises the scanner killer to 12 minutes and `maxDuration` to 900s so Workday can finish
- salvages `--json` stdout when Node warnings prefix it or a later field is truncated

Verified locally: aborting the HTTP client at 130ms left `scan-ats-full` running, and the pipeline still gained a new row.

## Related issue

None — bug fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## Validation

- `cd web && node --test tests/lib/explore-discover-abort.test.mjs tests/lib/post-ndjson-xhr.test.mjs tests/lib/explore-error.test.mjs tests/lib/scan-json.test.mjs` — 18 pass
- `cd web && npx tsc --noEmit` — clean on touched files