### PR TITLE
fix(web): deny Write/Bash when evaluating untrusted JDs

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -15329,6 +15329,8 @@ try {
     const required = {
       'claude-invocation.mjs': join(webLib, 'claude-invocation.mjs'),
       'cv-envelope.mjs': join(webLib, 'cv-envelope.mjs'),
+      'report-envelope.mjs': join(webLib, 'report-envelope.mjs'),
+      'report-persist.mjs': join(webLib, 'report-persist.mjs'),
       'run-prompts.mjs': join(webLib, 'run-prompts.mjs'),
       'api/run/route.ts': runRoutePath,
     };
@@ -15341,10 +15343,12 @@ try {
       try {
         invocation = await import(pathToFileURL(required['claude-invocation.mjs']).href);
         prompts = await import(pathToFileURL(required['run-prompts.mjs']).href);
-        // Imported for its side effect of resolving: run-prompts pulls cv-envelope
-        // for CV_ENVELOPE_INSTRUCTION, so a break there would surface here anyway,
-        // but naming it keeps the failure message specific.
+        // Imported for their side effect of resolving: run-prompts pulls
+        // cv-envelope and report-envelope; report-persist is the evaluate
+        // backend writer. Naming them keeps the failure message specific.
         await import(pathToFileURL(required['cv-envelope.mjs']).href);
+        await import(pathToFileURL(required['report-envelope.mjs']).href);
+        await import(pathToFileURL(required['report-persist.mjs']).href);
       } catch (err) {
         fail(`web pdf write-scope modules could not be imported (${err.message}) — the #2185 freeze cannot verify`);
       }
@@ -15428,6 +15432,28 @@ try {
         } else {
           const granted = WRITE_CAPABLE_TOOLS.filter((t) => toolNames(allowed).includes(t));
           fail(`web pdf command line grants write access via ${granted.join(', ')} — an unscoped write grant is the #2185 hole`);
+        }
+
+        // evaluate (and CLI mode names oferta / auto-pipeline) ingest a posting.
+        // Job postings are data, never instructions — Write/Bash on that kind is
+        // the same unscoped grant #2185 closed for pdf.
+        const jdKinds = invocation.UNTRUSTED_JD_KINDS ?? ['evaluate', 'oferta', 'auto-pipeline'];
+        const jdWrite = [];
+        for (const kind of jdKinds) {
+          const jdArgs = claudeCliArgs({ kind, prompt: 'freeze-probe' });
+          const jdAllowed = argValue(jdArgs, '--allowedTools');
+          const jdDenied = argValue(jdArgs, '--disallowedTools');
+          if (grantsWriteCapability({ allowed: jdAllowed, disallowed: jdDenied })) {
+            const granted = WRITE_CAPABLE_TOOLS.filter((t) => toolNames(jdAllowed).includes(t));
+            jdWrite.push(`${kind}:${granted.join(',')}`);
+          }
+          const undeniedJd = WRITE_CAPABLE_TOOLS.filter((t) => !toolNames(jdDenied).includes(t));
+          if (undeniedJd.length) jdWrite.push(`${kind}:undenied:${undeniedJd.join(',')}`);
+        }
+        if (jdWrite.length === 0) {
+          pass('web evaluate/oferta/auto-pipeline command lines grant no write-capable tool');
+        } else {
+          fail(`web untrusted-JD kinds still grant write access (${jdWrite.join('; ')}) — a posting can aim Write/Bash`);
         }
 
         // Denied by name, not merely omitted: --permission-mode acceptEdits exists

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -6,12 +6,14 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveCli } from "@/lib/clis";
-import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr, killMsForKind, timeoutMessage } from "@/lib/run-cli-support.mjs";
+import { accumulateTokens, isFatalGenericStderr, killMsForKind, timeoutMessage } from "@/lib/run-cli-support.mjs";
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates, readLanguageConfig } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf, writeCvHtml, pdfRunOutcome } from "@/lib/pdf-render.mjs";
 import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
+import { createReportEnvelopeFilter } from "@/lib/report-envelope.mjs";
+import { persistEvaluation, evaluateRunOutcome } from "@/lib/report-persist.mjs";
 import { buildPrompt, isShellSafeCompanyName } from "@/lib/run-prompts.mjs";
 import { claudeCliArgs } from "@/lib/claude-invocation.mjs";
 import { acquireTrackerWrite, releaseTrackerWrite } from "@/lib/core/run-registry";
@@ -106,7 +108,7 @@ export async function POST(req: Request) {
   // copies a recorded value instead of inviting a guess — and modes/oferta.md is
   // explicit that a guessed date is worse than an absent one (the POSTED column
   // renders absent as `—`, a wrong date as a fresh req). Unknown URL → undefined
-  // → the prompt writes no segment at all.
+  // → report-persist writes no segment at all.
   const postedAt =
     kind === "evaluate"
       ? readInbox().find((j) => j.url === input)?.postedAt ?? readScanDates().get(input)
@@ -129,23 +131,10 @@ export async function POST(req: Request) {
   // envelope-parsing routes rely on.
   const args = isClaude ? claudeCliArgs({ kind, prompt }) : (spec.streamArgs ?? spec.args)(prompt);
 
-  // For write-needing kinds, snapshot reports/ so we can verify the worker
-  // actually persisted (non-Claude CLIs lack Write auth and silently no-op).
-  // Names, not a count: reserving a number writes reports/NNN-RESERVED.md and the
-  // final report REPLACES it, so the `.md` count is unchanged and a count-delta
-  // gate reported "didn't save a report" for an evaluation that saved fine (#2085).
-  const reportsDir = path.join(careerOpsRoot(), "reports");
-  const reportEntries = () => {
-    try {
-      return fs.readdirSync(reportsDir);
-    } catch {
-      return [];
-    }
-  };
-  const persists = kind === "evaluate";
-  const reportsBefore = persists ? reportEntries() : [];
-  // Tracker-mutating runs hold a write token so a row delete can't race their merge
-  // (tracker.mjs delete doesn't yet share a lock with merge-tracker — see run-registry).
+  // Tracker-mutating runs hold a write token so a row delete can't race their
+  // merge (tracker.mjs delete doesn't yet share a lock with merge-tracker —
+  // see run-registry). evaluate's agent no longer writes; the backend persist
+  // path below still merges the tracker, so the token stays.
   const writeToken = kind === "evaluate" || kind === "pdf" ? acquireTrackerWrite() : null;
 
   // stdin must reach EOF or the CLI waits on piped input that never comes: Codex's
@@ -173,12 +162,12 @@ export async function POST(req: Request) {
   // otherwise a late enqueue onto a closed controller throws uncaught (see #1155).
   let closed = false;
   let killer: ReturnType<typeof setTimeout> | undefined;
-  // pdf-kind's render+mark work (renderPdf, below) keeps running detached even
-  // after the agent child closes — and even after a client disconnect fires
-  // cancel(). Track its promise so cancel() can defer releasing writeToken
-  // until that work actually settles, instead of releasing the tracker-delete
-  // guard while mark-pdf-ready.mjs is still actively writing applications.md.
+  // pdf-kind's render+mark work (renderPdf, below) and evaluate's persist
+  // (persistEval) keep running detached even after the agent child closes —
+  // and even after a client disconnect fires cancel(). Track the promise so
+  // cancel() can defer releasing writeToken until that work actually settles.
   let pdfRenderPromise: Promise<void> | null = null;
+  let evaluatePersistPromise: Promise<void> | null = null;
   let writeTokenReleased = false;
   const releaseWriteTokenOnce = () => {
     if (writeToken !== null && !writeTokenReleased) {
@@ -275,11 +264,11 @@ export async function POST(req: Request) {
           try { controller.close(); } catch { /* */ }
         }
       };
-      // pdf's CV arrives inline in a <<cv-html>> envelope instead of being written
-      // by the agent (#2185). The filter keeps every byte for the backend while
-      // holding the 15-25 KB body out of the run log, which is the agent's
-      // narration — see cv-envelope.mjs.
+      // pdf's CV arrives inline in a <<cv-html>> envelope (#2185); evaluate's
+      // report arrives in a <<report-md>> envelope. The filter keeps every byte
+      // for the backend while holding the body out of the run log.
       const cvFilter = kind === "pdf" ? createCvEnvelopeFilter() : null;
+      const reportFilter = kind === "evaluate" ? createReportEnvelopeFilter() : null;
       // While the agent emits the 15-25 KB <<cv-html>> envelope, cvFilter swallows
       // every byte, so the response stream goes completely silent for as long as
       // the model takes to write the CV — a minute or more. Nothing downstream can
@@ -289,7 +278,8 @@ export async function POST(req: Request) {
       // the stream never idles during the filtered phase. Unknown event types are
       // ignored by the client's switch, so this is safe for older tabs too.
       const sendAgentText = (text: string) => {
-        const visible = cvFilter ? cvFilter.push(text) : text;
+        const filter = cvFilter ?? reportFilter;
+        const visible = filter ? filter.push(text) : text;
         if (visible) send({ type: "text", text: visible });
       };
       /** Surface non-fatal issues in the run log rather than only a server log. */
@@ -369,7 +359,31 @@ export async function POST(req: Request) {
       // interactive approval nobody is present to grant in a headless/web-
       // triggered run (#2172). The tracker is marked ✅ only after a CONFIRMED
       // successful render, not optimistically — same honesty-gate discipline as
-      // the evaluate path below.
+      // persistEval below.
+      const persistEval = async (markdown: string) => {
+        send({ type: "status", label: "Saving report…" });
+        try {
+          const result = await persistEvaluation({
+            spawnFn: spawn,
+            execPath: process.execPath,
+            root: careerOpsRoot(),
+            markdown,
+            url: input,
+            today,
+            postedAt,
+          });
+          if (!result.ok) {
+            send({ type: "error", msg: result.error.slice(0, 200) });
+            return;
+          }
+          sendWarnings(result.warnings);
+          send({ type: "done", tokens: lastTokens, costUsd: lastCostUsd });
+        } catch (e) {
+          send({ type: "error", msg: `Evaluation persist crashed unexpectedly: ${e instanceof Error ? e.message : String(e)}`.slice(0, 200) });
+        } finally {
+          close();
+        }
+      };
       const renderPdf = async (paths: PdfPaths, format: "letter" | "a4") => {
         send({ type: "status", label: "Rendering PDF…" });
         // renderAndMarkPdf is designed to resolve, never throw — but this is
@@ -484,17 +498,33 @@ export async function POST(req: Request) {
           return close();
         }
 
-        const wroteReport = hasNewCompletedReport(reportsBefore, reportEntries());
-        // Honesty gate (#9): a green "done" with a parsed score requires a CLEAN exit,
-        // real output, AND (for evaluations) a report actually written. Anything else
-        // is surfaced — an errored run must never be banked as a confident score.
+        if (kind === "evaluate") {
+          const tail = reportFilter?.flush();
+          if (tail) send({ type: "text", text: tail });
+          const envelope = reportFilter?.result();
+          const outcome = evaluateRunOutcome({
+            envelope,
+            noOutputMessage: noOutputError(),
+            sawError,
+            cleanExit,
+          });
+          if (!outcome.ok) {
+            send({ type: "error", msg: outcome.message });
+          } else if (envelope?.ok !== true) {
+            send({ type: "error", msg: "Internal error: the evaluate run passed its gate with no report to save — please report this." });
+          } else {
+            evaluatePersistPromise = persistEval(envelope.markdown);
+            return;
+          }
+          return close();
+        }
+
+        // Honesty gate (#9): a green "done" with a parsed score requires a CLEAN exit
+        // and real output. Anything else is surfaced — an errored run must never be
+        // banked as a confident score.
         const baseErr = noOutputError();
         if (baseErr) {
           send({ type: "error", msg: baseErr });
-        } else if (persists && !wroteReport) {
-          // The worker ran but never wrote the report/tracker row (e.g. a CLI
-          // without file-write authorization) — surface it instead of a fake score.
-          send({ type: "error", msg: "This evaluation didn't save a report, so it's not in your tracker. Full evaluation is verified on Claude Code." });
         } else if (!cleanExit || sawError) {
           // Produced output (maybe even a report) but did NOT finish cleanly — flag it
           // instead of recording a confident score off a half-finished run. sawError
@@ -513,11 +543,12 @@ export async function POST(req: Request) {
       closed = true;
       if (killer) clearTimeout(killer);
       try { child.kill("SIGTERM"); } catch { /* ignore */ }
-      if (pdfRenderPromise) {
-        // Render/mark keeps running after this client disconnects — wait for
-        // it to settle before releasing the guard, so a concurrent tracker
-        // delete can't race mark-pdf-ready.mjs's still-in-flight write.
-        pdfRenderPromise.finally(releaseWriteTokenOnce);
+      const followup = pdfRenderPromise ?? evaluatePersistPromise;
+      if (followup) {
+        // Render/mark or evaluate persist keeps running after this client
+        // disconnects — wait for it to settle before releasing the guard, so a
+        // concurrent tracker delete can't race the still-in-flight write.
+        followup.finally(releaseWriteTokenOnce);
       } else {
         releaseWriteTokenOnce();
       }

--- a/web/src/lib/claude-invocation.mjs
+++ b/web/src/lib/claude-invocation.mjs
@@ -69,11 +69,17 @@ function scopeFrom(allowed) {
 
 /**
  * The two scopes that exist. `persisting` kinds run the REAL mode and write
- * canonical artifacts (reserve-report-num.mjs / merge-tracker.mjs /
- * verify-portals.mjs), so they need Write + Bash. `readOnly` kinds produce their
- * result through the response stream and need no write tool at all — pdf emits
- * its CV in a `<<cv-html>>` envelope the backend persists (#2185), and research
- * only reports.
+ * canonical artifacts (`verify-portals.mjs` for fix-portal), so they need
+ * Write + Bash. `readOnly` kinds produce their result through the response
+ * stream and need no write tool at all — pdf emits its CV in a `<<cv-html>>`
+ * envelope (#2185) and evaluate emits a `<<report-md>>` envelope; the backend
+ * persists both. research only reports.
+ *
+ * Job postings are data, never instructions (AGENTS.md Untrusted External
+ * Content). evaluate used to share the persisting scope so it could run
+ * reserve-report-num.mjs / merge-tracker.mjs itself; a posting can try to aim
+ * those tools at cv.md. Persistence moved to the backend so evaluate can sit
+ * on the read-only arm with pdf.
  *
  * @type {{persisting: ToolScope, readOnly: ToolScope}}
  */
@@ -82,8 +88,19 @@ export const TOOL_SCOPES = Object.freeze({
   readOnly: scopeFrom("Read,WebFetch,WebSearch,Glob,Grep"),
 });
 
-/** Kinds that legitimately write files. Everything else is read-only. */
-const PERSISTING_KINDS = new Set(["evaluate", "fix-portal"]);
+/**
+ * Kinds that ingest a job posting or URL. They MUST NOT receive Write/Bash:
+ * the JD is untrusted input and `--permission-mode acceptEdits` would
+ * auto-approve an unmentioned write tool. Includes CLI mode names (oferta,
+ * auto-pipeline) so a future /api/run kind of that name cannot quietly inherit
+ * the persisting scope. pdf is here because the report it reads is the same
+ * untrusted posting, already locked down by #2185.
+ */
+export const UNTRUSTED_JD_KINDS = Object.freeze(["pdf", "evaluate", "oferta", "auto-pipeline"]);
+const UNTRUSTED_JD_KIND_SET = new Set(UNTRUSTED_JD_KINDS);
+
+/** Kinds that legitimately write files. Untrusted-JD kinds are excluded even if listed. */
+const PERSISTING_KINDS = new Set(["fix-portal"]);
 
 /**
  * Every kind /api/run dispatches. Exported so guards iterate this rather than a
@@ -96,13 +113,16 @@ export const KNOWN_KINDS = Object.freeze(["pdf", "research", "evaluate", "fix-po
 /**
  * Resolve the tool scope for a worker kind.
  *
- * Unknown kinds get the read-only scope: granting write access to a kind nobody
- * has reviewed is the one unrecoverable default.
+ * Untrusted-JD kinds are always read-only, even if someone later adds them to
+ * PERSISTING_KINDS — granting Write to a kind that ingests a posting is the
+ * hole this module exists to close. Unknown kinds also get read-only: granting
+ * write access to a kind nobody has reviewed is the other unrecoverable default.
  *
  * @param {string} kind - Worker kind ("pdf", "research", "evaluate", …).
  * @returns {ToolScope}
  */
 export function toolScopeFor(kind) {
+  if (UNTRUSTED_JD_KIND_SET.has(kind)) return TOOL_SCOPES.readOnly;
   return PERSISTING_KINDS.has(kind) ? TOOL_SCOPES.persisting : TOOL_SCOPES.readOnly;
 }
 
@@ -138,14 +158,15 @@ export function claudeCliArgs({ kind, prompt }) {
     "--verbose",
     "--include-partial-messages",
     "--permission-mode", "acceptEdits",
-    // pdf only, deliberately. --strict-mcp-config with no --mcp-config loads ZERO
-    // MCP servers, so the tool lists below describe everything the agent can
-    // reach — without it an MCP server from the user's own config could supply a
-    // write tool that appears in neither list. #2185 is about pdf, and applying
-    // this to every kind would silently stop a configured MCP server (e.g. the
-    // optional Canva server) from loading on evaluate/research runs. The same gap
-    // for the other kinds is #2507.
-    ...(kind === "pdf" ? ["--strict-mcp-config"] : []),
+    // Untrusted-JD kinds only. --strict-mcp-config with no --mcp-config loads
+    // ZERO MCP servers, so the tool lists below describe everything the agent
+    // can reach — without it an MCP server from the user's own config could
+    // supply a write tool that appears in neither list. Derived from
+    // UNTRUSTED_JD_KINDS rather than `kind === "pdf"` so evaluate cannot regain
+    // an MCP write path while pdf stays locked. research / fix-portal keep
+    // their MCP access (optional Canva, etc.). Non-Claude CLIs still get no
+    // tool flags from spec.args() — that gap is #2507.
+    ...(UNTRUSTED_JD_KIND_SET.has(kind) ? ["--strict-mcp-config"] : []),
     "--allowedTools", scope.allowed,
     "--disallowedTools", scope.disallowed,
   ];

--- a/web/src/lib/report-envelope.mjs
+++ b/web/src/lib/report-envelope.mjs
@@ -1,0 +1,173 @@
+/**
+ * report-envelope.mjs — the evaluate-mode agent's output channel.
+ *
+ * evaluate used to hand the agent Write/Bash so it could reserve a report
+ * number, write reports/, write a tracker TSV, and run merge-tracker.mjs.
+ * Tool grants are tool-name-only, not path-scoped, so a prompt injection in
+ * the posting (AGENTS.md Untrusted External Content) could redirect a write
+ * at cv.md or a shell at `.env`. Rather than fence those writes, evaluate no
+ * longer grants them: the agent emits the report inline in a `<<report-md>>`
+ * envelope and the BACKEND persists it — the same arc #2185 used for pdf.
+ *
+ * Plain .mjs so this can be unit-tested with `node --test`, no TypeScript
+ * build step. Fail-closed: markers only count on a line of their own, the
+ * FIRST closer wins, more than one envelope is refused rather than guessed.
+ */
+export const OPEN_MARK = "<<report-md>>";
+export const CLOSE_MARK = "<</report-md>>";
+
+const OPENER_SRC = String.raw`^<<report-md>>[ \t]*$`;
+const CLOSER_SRC = String.raw`^<<\/report-md>>[ \t]*$`;
+const OPENER = new RegExp(OPENER_SRC, "gm");
+const CLOSER = new RegExp(CLOSER_SRC, "m");
+const CLOSER_ALL = new RegExp(CLOSER_SRC, "gm");
+
+/**
+ * The envelope contract, as the agent is told it. Lives here beside the parser
+ * so the two cannot drift; run-prompts.mjs interpolates it into the evaluate
+ * prompt.
+ *
+ * Markers are described MID-LINE (inside backticks) rather than shown on their
+ * own lines: `codex exec` echoes its prompt to stdout, and a line-start marker
+ * in that echo parses as a second envelope, failing the run.
+ *
+ * It says "do not save" rather than "you have no write tools": that claim is
+ * only true on Claude Code. The six CLIs invoked via clis.ts's bare args keep
+ * their own default tool access (#2507), and telling an agent something false
+ * about its own capabilities invites it to test the claim.
+ */
+export const REPORT_ENVELOPE_INSTRUCTION =
+  `Do NOT save or edit any file, and do not run reserve-report-num.mjs or merge-tracker.mjs — the platform persists your output for you. Instead OUTPUT the finished report markdown inline, between two marker lines. The first line contains only \`${OPEN_MARK}\`, then the complete report (header, Machine Summary YAML fence, blocks A–G), then a final line containing only \`${CLOSE_MARK}\`. Each marker appears exactly once. Emit the WHOLE report — never abbreviate, summarize, or write "unchanged"; the platform writes exactly these bytes to reports/.`;
+
+/**
+ * @typedef {Object} ReportEnvelope
+ * @property {true} ok
+ * @property {string} markdown - The evaluation report, byte-exact as emitted.
+ */
+
+/**
+ * Extract the evaluation report from an agent's full output.
+ *
+ * @param {string} text - Everything the agent emitted, concatenated.
+ * @returns {ReportEnvelope | {ok: false, error: string}}
+ */
+export function parseReportEnvelope(text) {
+  if (typeof text !== "string") {
+    return { ok: false, error: "No agent output to read a report envelope from." };
+  }
+  const normalized = text.replace(/\r\n/g, "\n");
+
+  const openers = [...normalized.matchAll(OPENER)];
+  if (openers.length === 0) {
+    return { ok: false, error: "The agent emitted no <<report-md>> envelope, so there is no report to save." };
+  }
+  if (openers.length > 1) {
+    return { ok: false, error: `Found ${openers.length} <<report-md>> envelopes; refusing to guess which is the real report.` };
+  }
+
+  const opener = openers[0];
+  const afterOpener = normalized.slice(opener.index + opener[0].length);
+  const closer = CLOSER.exec(afterOpener);
+  if (!closer) {
+    return { ok: false, error: "The <<report-md>> envelope was never closed — the report output is incomplete." };
+  }
+
+  const markdown = afterOpener.slice(0, closer.index).replace(/^\n/, "").replace(/\n$/, "");
+  if (!markdown.trim()) {
+    return { ok: false, error: "The <<report-md>> envelope was empty — no report was written." };
+  }
+  if (!/^#\s/m.test(markdown)) {
+    return { ok: false, error: "The report has no markdown title — the output is incomplete." };
+  }
+  if (!/##\s*Machine Summary/i.test(markdown)) {
+    return { ok: false, error: "The report has no Machine Summary — the tracker row cannot be built from it." };
+  }
+
+  return { ok: true, markdown };
+}
+
+/**
+ * Could `line` still become a marker once more characters arrive?
+ * @param {string} line
+ * @returns {boolean}
+ */
+function couldBecomeMarker(line) {
+  return (
+    OPEN_MARK.startsWith(line) || CLOSE_MARK.startsWith(line) ||
+    line.startsWith(OPEN_MARK) || line.startsWith(CLOSE_MARK)
+  );
+}
+
+/**
+ * First match of `re` in `s` whose line is terminated by a newline.
+ * @param {RegExp} re
+ * @param {string} s
+ * @returns {{start: number, end: number} | null}
+ */
+function completeMarker(re, s) {
+  for (const m of s.matchAll(re)) {
+    const after = m.index + m[0].length;
+    if (s[after] === "\n") return { start: m.index, end: after + 1 };
+  }
+  return null;
+}
+
+/**
+ * Streaming companion to parseReportEnvelope: accumulates the agent's full
+ * output for parsing while keeping the envelope body out of the run log.
+ *
+ * @returns {{push: (chunk: string) => string, flush: () => string, result: () => (ReportEnvelope | {ok: false, error: string})}}
+ */
+export function createReportEnvelopeFilter() {
+  let raw = "";
+  let pending = "";
+  let carry = "";
+  let inBody = false;
+
+  return {
+    push(chunk) {
+      const text = String(chunk ?? "");
+      raw += text;
+      const withCarry = carry + text;
+      carry = withCarry.endsWith("\r") ? "\r" : "";
+      pending += (carry ? withCarry.slice(0, -1) : withCarry).replace(/\r\n/g, "\n");
+      let display = "";
+      for (;;) {
+        if (!inBody) {
+          const opener = completeMarker(OPENER, pending);
+          if (opener) {
+            display += pending.slice(0, opener.start);
+            pending = pending.slice(opener.end);
+            inBody = true;
+            continue;
+          }
+          const tailStart = pending.lastIndexOf("\n") + 1;
+          const cut = couldBecomeMarker(pending.slice(tailStart)) ? tailStart : pending.length;
+          display += pending.slice(0, cut);
+          pending = pending.slice(cut);
+          return display;
+        }
+        const closer = completeMarker(CLOSER_ALL, pending);
+        if (closer) {
+          pending = pending.slice(closer.end);
+          inBody = false;
+          continue;
+        }
+        const tailStart = pending.lastIndexOf("\n") + 1;
+        pending = pending.slice(tailStart);
+        return display;
+      }
+    },
+
+    flush() {
+      const held = inBody ? "" : pending + carry;
+      pending = "";
+      carry = "";
+      return held;
+    },
+
+    result() {
+      return parseReportEnvelope(raw);
+    },
+  };
+}

--- a/web/src/lib/report-persist.mjs
+++ b/web/src/lib/report-persist.mjs
@@ -85,6 +85,13 @@ export function formatScore(raw) {
  * @param {string} markdown
  * @returns {{ok: true, company: string, role: string, score: string, via: string|null} | {ok: false, error: string}}
  */
+const TSV_BREAK = /[\t\r\n]/;
+
+/** Model-derived tracker cells cannot carry TSV control characters. */
+function tsvUnsafe(value) {
+  return typeof value === "string" && TSV_BREAK.test(value);
+}
+
 export function parseReportMeta(markdown) {
   const fence = String(markdown ?? "").match(YAML_FENCE)?.[1] ?? "";
   const title = String(markdown ?? "").match(TITLE_RE);
@@ -97,6 +104,11 @@ export function parseReportMeta(markdown) {
   }
   if (!score) {
     return { ok: false, error: "The report's Machine Summary is missing a numeric score, so the tracker row cannot be built." };
+  }
+  for (const [field, value] of [["company", company], ["role", role], ["score", score], ["via", via]]) {
+    if (tsvUnsafe(value)) {
+      return { ok: false, error: `The report's Machine Summary has a tab or newline in ${field}, so the tracker row cannot be built.` };
+    }
   }
   return { ok: true, company, role, score, via };
 }

--- a/web/src/lib/report-persist.mjs
+++ b/web/src/lib/report-persist.mjs
@@ -1,0 +1,224 @@
+/**
+ * report-persist.mjs — persist a web evaluate run's report + tracker row.
+ *
+ * The evaluate agent used to hold Write + Bash so it could run
+ * reserve-report-num.mjs, write reports/, write a TSV, and merge-tracker.mjs.
+ * Those tools are unscoped, so a posting in its context could aim them anywhere.
+ * The agent now emits the report in a <<report-md>> envelope; this module (a
+ * plain Node process, no CLI sandbox) is the only writer — same split #2185
+ * used for pdf.
+ *
+ * spawnFn / execPath / root are injected so tests substitute a fake child
+ * process and never touch the real allocator or tracker.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/** Lowercase, non-alphanumeric runs -> single hyphen, trimmed. Same rule as pdf-paths.mjs. */
+function slugify(s) {
+  return String(s ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
+const YAML_FENCE = /##\s*Machine Summary\s*\n+```(?:yaml|yml)?\s*\n([\s\S]*?)\n```/i;
+const TITLE_RE = /^#\s+Evaluation:\s+(.+?)\s+(?:—|--|–|-)\s+(.+)$/m;
+
+/**
+ * Did this evaluate run produce a report worth persisting?
+ *
+ * Pure, and here rather than in the route, because it is the decision point
+ * for the backend evaluate pipeline: nothing is written unless this says yes.
+ *
+ * @param {{envelope: object|undefined, noOutputMessage: string|null, sawError: boolean, cleanExit: boolean}} signals
+ * @returns {{ok: true} | {ok: false, message: string}}
+ */
+export function evaluateRunOutcome({ envelope, noOutputMessage, sawError, cleanExit }) {
+  if (noOutputMessage) return { ok: false, message: noOutputMessage };
+  if (envelope?.ok !== true || !cleanExit || sawError) {
+    const why = envelope && envelope.ok === false ? ` (${envelope.error})` : "";
+    return {
+      ok: false,
+      message: `This evaluation didn't produce a report to save, so it isn't in your tracker — re-run it to verify.${why}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Read a YAML scalar from a Machine Summary fence. Quoted or bare; `null` / `~`
+ * / empty → null. Does not parse nested maps — company/role/score/via are
+ * top-level scalars in batch/batch-prompt.md.
+ *
+ * @param {string} block
+ * @param {string} key
+ * @returns {string|null}
+ */
+export function yamlScalar(block, key) {
+  const m = String(block ?? "").match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
+  if (!m) return null;
+  let v = m[1].trim();
+  if (!v || v === "null" || v === "~") return null;
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+    v = v.slice(1, -1);
+  }
+  return v.trim() || null;
+}
+
+/**
+ * Score as the tracker writes it (`X.X/5`). Null if the value is not a number.
+ * @param {string|null} raw
+ * @returns {string|null}
+ */
+export function formatScore(raw) {
+  const s = String(raw ?? "").trim();
+  if (!s) return null;
+  if (/^\d+(?:\.\d+)?\/5$/.test(s)) return s.includes(".") ? s : `${s.slice(0, -2)}.0/5`;
+  const n = Number(s);
+  if (!Number.isFinite(n) || n < 0 || n > 5) return null;
+  return `${n.toFixed(1)}/5`;
+}
+
+/**
+ * Company, role, score, via from the report. Machine Summary wins; the
+ * `# Evaluation: Company — Role` title is the fallback for company/role.
+ *
+ * @param {string} markdown
+ * @returns {{ok: true, company: string, role: string, score: string, via: string|null} | {ok: false, error: string}}
+ */
+export function parseReportMeta(markdown) {
+  const fence = String(markdown ?? "").match(YAML_FENCE)?.[1] ?? "";
+  const title = String(markdown ?? "").match(TITLE_RE);
+  const company = yamlScalar(fence, "company") || title?.[1]?.trim() || null;
+  const role = yamlScalar(fence, "role") || title?.[2]?.trim() || null;
+  const score = formatScore(yamlScalar(fence, "score"));
+  const via = yamlScalar(fence, "via");
+  if (!company || !role) {
+    return { ok: false, error: "The report's Machine Summary is missing company or role, so the tracker row cannot be built." };
+  }
+  if (!score) {
+    return { ok: false, error: "The report's Machine Summary is missing a numeric score, so the tracker row cannot be built." };
+  }
+  return { ok: true, company, role, score, via };
+}
+
+/**
+ * Filename slug for a report. `?` (unknown end employer, #1596) becomes
+ * `confidential` or `confidential-{agency}`. Empty after slugify → `company`.
+ * @param {string} company
+ * @param {string|null} via
+ * @returns {string}
+ */
+export function reportSlug(company, via) {
+  if (company === "?") {
+    const agency = via ? slugify(via) : "";
+    return agency ? `confidential-${agency}` : "confidential";
+  }
+  return slugify(company) || "company";
+}
+
+/**
+ * One tracker-additions TSV line (tab-separated, trailing newline). Always 10
+ * fields with the posting URL last — empty when there is none, never "N/A".
+ * A tagged `via={Agency}` extra sits between notes and URL when present.
+ *
+ * @param {{num: string, today: string, company: string, role: string, score: string, reportFile: string, notes: string, via: string|null, url: string}} row
+ * @returns {string}
+ */
+export function trackerTsvLine({ num, today, company, role, score, reportFile, notes, via, url }) {
+  const fields = [
+    num, today, company, role, "Evaluated", score, "❌",
+    `[${num}](reports/${reportFile})`, notes,
+  ];
+  if (via) fields.push(`via=${via}`);
+  fields.push(url);
+  return `${fields.join("\t")}\n`;
+}
+
+function spawnScript({ spawnFn, execPath, root, script, args = [] }) {
+  return new Promise((resolve) => {
+    const child = spawnFn(execPath, [path.join(root, script), ...args], { cwd: root });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d) => { stdout += d.toString(); });
+    child.stderr?.on("data", (d) => { stderr += d.toString(); });
+    child.on("close", (code) => resolve({ ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() }));
+    child.on("error", (e) => resolve({ ok: false, stdout: "", stderr: `${script} failed to start: ${e.message}` }));
+  });
+}
+
+/**
+ * Reserve a report number, write the report + TSV, merge the tracker, release
+ * the sentinel. Never throws: the caller routes `{ok:false}` through the same
+ * honesty gate as every other evaluate failure.
+ *
+ * @param {{spawnFn: Function, execPath: string, root: string, markdown: string, url: string, today: string, postedAt?: string}} args
+ * @returns {Promise<{ok: true, num: string, reportFile: string, warnings: string[]} | {ok: false, error: string}>}
+ */
+export async function persistEvaluation({ spawnFn, execPath, root, markdown, url, today, postedAt }) {
+  if (!ISO_DATE_RE.test(String(today ?? ""))) {
+    return { ok: false, error: `Invalid evaluation date "${today}" — expected YYYY-MM-DD.` };
+  }
+  const meta = parseReportMeta(markdown);
+  if (!meta.ok) return meta;
+
+  const reserved = await spawnScript({
+    spawnFn, execPath, root, script: "reserve-report-num.mjs",
+  });
+  if (!reserved.ok) {
+    return { ok: false, error: `Could not reserve a report number: ${reserved.stderr || "reserve-report-num.mjs failed"}.` };
+  }
+  const num = reserved.stdout.trim();
+  if (!/^\d{3,}$/.test(num)) {
+    return { ok: false, error: `reserve-report-num.mjs returned an unusable number: "${num}".` };
+  }
+
+  const release = () => spawnScript({
+    spawnFn, execPath, root, script: "reserve-report-num.mjs", args: ["--release", num],
+  });
+
+  const slug = reportSlug(meta.company, meta.via);
+  const reportFile = `${num}-${slug}-${today}.md`;
+  // The backend owns the path. A slug of `..` cannot happen (slugify strips
+  // non-alphanumerics) but a report written outside reports/ would be the
+  // original hole this module exists to close — refuse rather than join.
+  if (path.basename(reportFile) !== reportFile || reportFile.includes("..")) {
+    await release();
+    return { ok: false, error: `Refusing to write report "${reportFile}" — the filename is not a single path segment.` };
+  }
+
+  const reportsDir = path.join(root, "reports");
+  const additionsDir = path.join(root, "batch", "tracker-additions");
+  const reportPath = path.join(reportsDir, reportFile);
+  const tsvPath = path.join(additionsDir, `${num}-${slug}.tsv`);
+  if (path.dirname(reportPath) !== reportsDir || path.dirname(tsvPath) !== additionsDir) {
+    await release();
+    return { ok: false, error: "Refusing to persist outside reports/ or batch/tracker-additions/." };
+  }
+
+  const postingUrl = /^https?:\/\//i.test(String(url ?? "")) ? String(url) : "";
+  const notes = ISO_DATE_RE.test(String(postedAt ?? "")) ? `; posted: ${postedAt}` : "";
+
+  try {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    fs.mkdirSync(additionsDir, { recursive: true });
+    fs.writeFileSync(reportPath, markdown, "utf8");
+    fs.writeFileSync(tsvPath, trackerTsvLine({
+      num, today, company: meta.company, role: meta.role, score: meta.score,
+      reportFile, notes, via: meta.via, url: postingUrl,
+    }), "utf8");
+  } catch (err) {
+    await release();
+    return { ok: false, error: `Could not save the evaluation report: ${err.message}` };
+  }
+
+  const merged = await spawnScript({
+    spawnFn, execPath, root, script: "merge-tracker.mjs",
+  });
+  await release();
+  if (!merged.ok) {
+    return { ok: false, error: `The report was saved but merge-tracker.mjs failed: ${merged.stderr || "non-zero exit"}.` };
+  }
+  const warnings = [];
+  if (merged.stderr) warnings.push(merged.stderr);
+  return { ok: true, num, reportFile, warnings };
+}

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -2,13 +2,15 @@
  * run-prompts.mjs — the prompts /api/run sends each worker kind (#2185).
  *
  * The web ORCHESTRATES the real career-ops engine — it does NOT reimplement it.
- * kind "evaluate" runs the REAL modes/oferta.md and persists the canonical
- * artifacts (A–F report + tracker row) via the SAME scripts the CLI uses
- * (reserve-report-num.mjs → reports/ → batch/tracker-additions/ → merge-tracker.mjs),
- * so a web evaluation is byte-identical to a CLI one (single source of truth, no
- * drift). kind "research" stays read-only.
+ * kind "evaluate" runs the REAL modes/oferta.md scoring and emits the report in
+ * a <<report-md>> envelope; the backend persists it via the SAME scripts the
+ * CLI uses (reserve-report-num.mjs → reports/ → batch/tracker-additions/ →
+ * merge-tracker.mjs). The agent itself holds no Write/Bash — a posting is
+ * untrusted input and must not be able to aim those tools. kind "research"
+ * stays read-only.
  */
 import { CV_ENVELOPE_INSTRUCTION } from "./cv-envelope.mjs";
+import { REPORT_ENVELOPE_INSTRUCTION } from "./report-envelope.mjs";
 
 /**
  * Is this company name safe to interpolate into a shell command inside a prompt?
@@ -48,9 +50,6 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
  * @param {{kind: string, input: string, memory: string, today: string}} args
  * @returns {string}
  */
-/** ISO calendar date, the only form the dashboard's POSTED column parses. */
-const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
-
 export function buildPrompt({ kind, input, memory, today, postedAt, lang }) {
   // AGENTS.md's "Output Language vs Market Modes" composition rule. The CLI
   // picks this up by reading AGENTS.md interactively; a one-shot headless
@@ -102,53 +101,29 @@ If NO slug variant resolves, say so clearly and leave portals.yml unchanged. Nev
 
 End with EXACTLY one final line: VERDICT: {5 if now live, else 1}/5 — {what you changed, ≤12 words}`;
   }
-  // The posting date is INTERPOLATED, not asked for. The scanner wrote it into
-  // pipeline.md from the provider's own `offer.postedAt`; the server already has
-  // it (readScanDates/readInbox) and passes it here, so the agent copies a value
-  // rather than deriving one. modes/oferta.md is explicit that a guessed date is
-  // worse than none — the dashboard's POSTED column renders an absent date as
-  // `—`, and an invented one reports a months-old req as fresh.
-  //
-  // Canonical form, taken from the regex that CONSUMES it (dashboard's
-  // rePostedOn) rather than from prose: its own trailing segment after `; `,
-  // anchored to a separator, ISO `YYYY-MM-DD`. Mid-sentence mentions are
-  // deliberately not metadata there, so this must be a segment or nothing.
-  //
-  // Absent → the empty string, so the row is byte-identical to today's. Same
-  // reason the url field is always written but may be empty: the shape an agent
-  // reliably follows is one unconditional template, and here the CONTENT is
-  // conditional precisely because "write nothing" is the required behaviour.
-  const postedSegment = ISO_DATE_RE.test(String(postedAt ?? "")) ? `; posted: ${postedAt}` : "";
+  // postedAt is owned by the backend persist path (report-persist.mjs), not
+  // interpolated into this prompt. The agent used to copy it into a TSV row it
+  // wrote itself; it no longer writes files. Unused on purpose — the signature
+  // stays so the route keeps passing the scanner date it already resolved.
+  void postedAt;
 
-  // evaluate (default) — run the REAL oferta mode + persist canonically
+  // evaluate (default) — run the REAL oferta mode; the backend persists.
   //
-  // The TSV row carries 10 fields, the 10th being the posting URL that
-  // merge-tracker dedupes on (#1298). The web is a WRITER of that file, not only
-  // a reader: emitting 9 fields stays valid forever, so nothing would ever go
-  // red — every job evaluated from the web would simply sit outside the
-  // URL dedup. Compatible and half-dead at once, which is the failure mode with
-  // no symptom.
-  //
-  // ALWAYS 10 fields, empty when there is no URL, deliberately: an
-  // unconditional template is one an agent follows, "emit 9 or 10 depending"
-  // is one it sometimes forgets. Empty and absent are byte-identical in the
-  // written row (verified against merge-tracker), so the robust instruction
-  // costs nothing. Not "N/A" either — parseTsvExtras drops placeholders
-  // precisely so they can't be misread as the row's LOCATION.
+  // The agent used to be told to run reserve-report-num.mjs / write reports/ /
+  // write a TSV / merge-tracker.mjs, which is why it held Write + Bash. A
+  // posting is untrusted input (AGENTS.md Untrusted External Content) and those
+  // tools are unscoped, so an injected instruction could aim them at cv.md.
+  // Persistence moved to report-persist.mjs; this prompt must never ask for a
+  // write the agent cannot (and must not) perform.
   return `You are running the OFFICIAL career-ops job evaluation, HEADLESS, on the user's own machine. Today is ${today}. Run the REAL career-ops evaluation — do NOT improvise your own scoring.
 
 1. Read ${resolvedLang.evalModeFile} and follow it EXACTLY (blocks A–F, G posting-legitimacy, and the Machine Summary). Ground the fit in THIS person: read cv.md, config/profile.yml and modes/_profile.md. Use WebFetch to read the posting (you are headless — Playwright is unavailable, so use WebFetch and mark the report header "Verification: unconfirmed (batch mode)").
 
-2. Persist the result CANONICALLY so the web and the CLI share ONE source of truth:
-   a. Reserve a report number: run \`node reserve-report-num.mjs\` — its stdout is a 3-digit number (e.g. 035).
-   b. Write the full report to reports/{num}-{company-slug}-${today}.md  (company-slug = company lowercased, non-alphanumerics → hyphens).
-   c. Append ONE row of 10 TAB-separated columns to batch/tracker-additions/{num}-{company-slug}.tsv, in THIS exact order (real \\t tabs, status BEFORE score). ALWAYS write all 10 fields — leave the last one EMPTY if there is no posting URL, never "N/A" or "-":
-      {num}\t${today}\t{Company}\t{Role}\t{CanonicalStatus e.g. Evaluated}\t{score}/5\t❌\t[{num}](reports/{num}-{company-slug}-${today}.md)\t{one-line note}${postedSegment}\t{posting URL, or empty}
-   d. Merge into the tracker: run \`node merge-tracker.mjs\` (it dedupes by company+role+report-num, validates the status, and writes data/applications.md — NEVER edit applications.md by hand).
+2. ${REPORT_ENVELOPE_INSTRUCTION}
 
-3. NEVER submit an application, fill no forms, contact no one. This is evaluation + persistence ONLY.${mem}
+3. NEVER submit an application, fill no forms, contact no one. This is evaluation ONLY.${mem}
 
-After everything above is written and merged, output EXACTLY one final line, nothing after it:
+After the envelope, end with EXACTLY one final line, nothing after it:
 VERDICT: {score}/5 — {reason in 12 words or fewer}
 
 Posting URL: ${input}`;

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -47,7 +47,7 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
  * inline instead of writing it), and a guard that greps route.ts for the marker
  * text matched the route's own comments instead. See test-all.mjs §55.6.
  *
- * @param {{kind: string, input: string, memory: string, today: string}} args
+ * @param {{kind: string, input: string, memory: string, today: string, postedAt?: string, lang?: {output: string, modesDir: string, evalModeFile: string}}} args
  * @returns {string}
  */
 export function buildPrompt({ kind, input, memory, today, postedAt, lang }) {

--- a/web/tests/lib/claude-invocation.test.mjs
+++ b/web/tests/lib/claude-invocation.test.mjs
@@ -18,6 +18,7 @@ import {
   argValue,
   toolNames,
   KNOWN_KINDS,
+  UNTRUSTED_JD_KINDS,
 } from "../../src/lib/claude-invocation.mjs";
 
 test("toolScopeFor: pdf gets no write-capable tool at all", () => {
@@ -88,18 +89,29 @@ test("toolScopeFor: an unknown kind falls back to the read-only scope", () => {
   assert.equal(scope, TOOL_SCOPES.readOnly);
 });
 
-test("toolScopeFor: evaluate and fix-portal keep Write and Bash on purpose", () => {
-  // Given these kinds genuinely run reserve-report-num.mjs / merge-tracker.mjs /
-  // verify-portals.mjs and persist canonical artifacts
-  for (const kind of ["evaluate", "fix-portal"]) {
-    // When resolving their scope
-    const allowed = toolNames(toolScopeFor(kind).allowed);
-
-    // Then they retain write access — this test exists so removing it is a
-    // deliberate act, not an accident
-    assert.ok(allowed.includes("Write"), `${kind} needs Write`);
-    assert.ok(allowed.includes("Bash"), `${kind} needs Bash`);
+test("toolScopeFor: untrusted-JD kinds get no write-capable tool at all", () => {
+  // Given evaluate/oferta/auto-pipeline ingest a posting (data, never
+  // instructions) and pdf already reads that same posting via the report
+  for (const kind of UNTRUSTED_JD_KINDS) {
+    const scope = toolScopeFor(kind);
+    const allowed = toolNames(scope.allowed);
+    const denied = toolNames(scope.disallowed);
+    for (const tool of WRITE_CAPABLE_TOOLS) {
+      assert.ok(!allowed.includes(tool), `${kind} must not allow ${tool}`);
+      assert.ok(denied.includes(tool), `${kind} must explicitly deny ${tool}`);
+    }
+    assert.equal(grantsWriteCapability(scope), false, `${kind} must not grant write`);
   }
+});
+
+test("toolScopeFor: fix-portal keeps Write and Bash on purpose", () => {
+  // Given this kind genuinely runs verify-portals.mjs and edits portals.yml
+  const allowed = toolNames(toolScopeFor("fix-portal").allowed);
+
+  // Then it retains write access — tracker merge / pdf generation live in the
+  // backend, not this scope; removing fix-portal's grant is a deliberate act
+  assert.ok(allowed.includes("Write"), "fix-portal needs Write");
+  assert.ok(allowed.includes("Bash"), "fix-portal needs Bash");
 });
 
 test("toolScopeFor: every kind blocks sub-agents", () => {
@@ -182,15 +194,26 @@ test("claudeCliArgs: loads no MCP servers", () => {
   assert.ok(!args.includes("--mcp-config"), "no MCP server may be loaded");
 });
 
-test("claudeCliArgs: other kinds keep their MCP servers", () => {
-  // Given #2185 is about pdf. Locking MCP config for every kind would silently stop
-  // a user's configured server (the optional Canva one, say) from loading on an
-  // evaluation — a behaviour change the issue never asked for. #2507 covers the
-  // same gap for the other kinds.
-  for (const kind of ["research", "evaluate", "fix-portal"]) {
+test("claudeCliArgs: untrusted-JD kinds load no MCP servers", () => {
+  // Given MCP tools would appear in neither the allow nor the deny list, so a
+  // write tool arriving from the user's MCP config would be invisible to every
+  // check here. evaluate ingests a posting; locking MCP is the same hole pdf
+  // already closed.
+  for (const kind of UNTRUSTED_JD_KINDS) {
+    const args = claudeCliArgs({ kind, prompt: "x" });
+    assert.ok(args.includes("--strict-mcp-config"), `${kind} argv must pass --strict-mcp-config`);
+    assert.ok(!args.includes("--mcp-config"), `${kind}: no MCP server may be loaded`);
+  }
+});
+
+test("claudeCliArgs: research and fix-portal keep their MCP servers", () => {
+  // research investigates the user's own work; fix-portal edits portals.yml.
+  // Neither ingests a posting, so a configured MCP server (optional Canva)
+  // still loads. Non-Claude CLIs remain unfenced — #2507.
+  for (const kind of ["research", "fix-portal"]) {
     assert.ok(
       !claudeCliArgs({ kind, prompt: "x" }).includes("--strict-mcp-config"),
-      `${kind} must not have its MCP config locked down by a pdf-scoped fix`,
+      `${kind} must not have its MCP config locked down by an evaluate/pdf fix`,
     );
   }
 });
@@ -210,12 +233,17 @@ test("claudeCliArgs: carries the prompt and the streaming flags", () => {
   assert.equal(argValue(args, "--permission-mode"), "acceptEdits");
 });
 
-test("claudeCliArgs: evaluate still ships write access", () => {
-  // Given an evaluation, which genuinely persists report + tracker artifacts
-  const allowed = argValue(claudeCliArgs({ kind: "evaluate", prompt: "x" }), "--allowedTools");
+test("claudeCliArgs: evaluate command line grants no write-capable tool", () => {
+  // Given an evaluation, whose agent only scores and emits the report inline
+  const args = claudeCliArgs({ kind: "evaluate", prompt: "x" });
+  const allowed = argValue(args, "--allowedTools");
+  const disallowed = argValue(args, "--disallowedTools");
 
-  // Then its argv keeps write access — so removing it is a deliberate act
-  assert.equal(grantsWriteCapability({ allowed, disallowed: "" }), true);
+  // Then what actually ships grants no write, and denies each one by name
+  assert.equal(grantsWriteCapability({ allowed, disallowed }), false, `allowed=${allowed}`);
+  for (const tool of WRITE_CAPABLE_TOOLS) {
+    assert.ok(toolNames(disallowed).includes(tool), `evaluate argv must deny ${tool}`);
+  }
 });
 
 test("argValue: absent or dangling flags yield an empty string, not a crash", () => {

--- a/web/tests/lib/report-envelope.test.mjs
+++ b/web/tests/lib/report-envelope.test.mjs
@@ -1,0 +1,98 @@
+// Tests for the evaluate-mode report envelope parser. Imports directly from
+// report-envelope.mjs so the test and production code cannot drift.
+//
+// The envelope exists so the evaluate-mode agent needs NO write access: it
+// emits the report inline and the backend persists it. Every case here is a
+// security case as much as a parsing one.
+//
+// Run:  node --test tests/lib/report-envelope.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseReportEnvelope, createReportEnvelopeFilter } from "../../src/lib/report-envelope.mjs";
+
+const SUMMARY = `## Machine Summary
+\`\`\`yaml
+company: Acme
+role: Engineer
+score: 4.2
+\`\`\``;
+
+const REPORT = `# Evaluation: Acme — Engineer
+
+${SUMMARY}
+
+## A) Role Summary
+A role.`;
+
+function envelope(body) {
+  return `<<report-md>>\n${body}\n<</report-md>>`;
+}
+
+test("parseReportEnvelope: extracts markdown from a well-formed envelope", () => {
+  const text = `Scoring done.\n\n${envelope(REPORT)}\n\nVERDICT: 4.2/5 — strong fit`;
+  const result = parseReportEnvelope(text);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.markdown, REPORT);
+});
+
+test("parseReportEnvelope: refuses a missing envelope", () => {
+  const result = parseReportEnvelope("VERDICT: 4.2/5 — no envelope here");
+  assert.equal(result.ok, false);
+  assert.match(result.error, /no <<report-md>> envelope/i);
+});
+
+test("parseReportEnvelope: refuses two envelopes rather than guessing", () => {
+  const result = parseReportEnvelope(`${envelope(REPORT)}\n${envelope(REPORT)}`);
+  assert.equal(result.ok, false);
+  assert.match(result.error, /2 <<report-md>> envelopes/i);
+});
+
+test("parseReportEnvelope: refuses an unclosed envelope", () => {
+  const result = parseReportEnvelope(`<<report-md>>\n${REPORT}\n`);
+  assert.equal(result.ok, false);
+  assert.match(result.error, /never closed/i);
+});
+
+test("parseReportEnvelope: refuses an empty envelope", () => {
+  const result = parseReportEnvelope("<<report-md>>\n\n<</report-md>>");
+  assert.equal(result.ok, false);
+  assert.match(result.error, /empty/i);
+});
+
+test("parseReportEnvelope: refuses a body with no title", () => {
+  const result = parseReportEnvelope(envelope(SUMMARY));
+  assert.equal(result.ok, false);
+  assert.match(result.error, /no markdown title/i);
+});
+
+test("parseReportEnvelope: refuses a body with no Machine Summary", () => {
+  const result = parseReportEnvelope(envelope("# Evaluation: Acme — Engineer\n\nNo YAML."));
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Machine Summary/i);
+});
+
+test("parseReportEnvelope: a mention in prose is not a marker", () => {
+  const text = `Use a <<report-md>> envelope.\n\n${envelope(REPORT)}`;
+  const result = parseReportEnvelope(text);
+  assert.equal(result.ok, true);
+  assert.equal(result.markdown, REPORT);
+});
+
+test("createReportEnvelopeFilter: hides the body from the run log", () => {
+  const filter = createReportEnvelopeFilter();
+  const visible = [
+    filter.push("Working.\n<<report-md>>\n"),
+    filter.push(`${REPORT}\n`),
+    filter.push("<</report-md>>\nVERDICT: 4.2/5 — done\n"),
+  ].join("");
+  const tail = filter.flush();
+
+  assert.ok(!visible.includes("Machine Summary"), "body must not reach the log");
+  assert.match(visible + tail, /Working/);
+  assert.match(visible + tail, /VERDICT: 4.2\/5/);
+  const result = filter.result();
+  assert.equal(result.ok, true);
+  assert.equal(result.markdown, REPORT);
+});

--- a/web/tests/lib/report-persist.test.mjs
+++ b/web/tests/lib/report-persist.test.mjs
@@ -140,6 +140,20 @@ role: Role
   assert.match(meta.error, /score/i);
 });
 
+test("parseReportMeta: tab in company fails closed", () => {
+  const md = REPORT.replace('company: "Acme AI"', 'company: "Acme\tInjected"');
+  const meta = parseReportMeta(md);
+  assert.equal(meta.ok, false);
+  assert.match(meta.error, /tab or newline in company/i);
+});
+
+test("parseReportMeta: tab in via fails closed", () => {
+  const md = REPORT.replace("via: null", 'via: "Hays\tExtra"');
+  const meta = parseReportMeta(md);
+  assert.equal(meta.ok, false);
+  assert.match(meta.error, /tab or newline in via/i);
+});
+
 test("reportSlug: confidential marker for unknown employer", () => {
   assert.equal(reportSlug("Acme AI", null), "acme-ai");
   assert.equal(reportSlug("?", null), "confidential");
@@ -193,6 +207,28 @@ test("persistEvaluation: writes report + TSV, reserves, merges, releases", async
     const scripts = calls.map((c) => basename(c.args[0]) + (c.args.includes("--release") ? " --release" : ""));
     assert.deepEqual(scripts, ["reserve-report-num.mjs", "merge-tracker.mjs", "reserve-report-num.mjs --release"]);
     assert.ok(calls.every((c) => c.opts.cwd === root));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("persistEvaluation: tab in company does not reserve or write a TSV", async () => {
+  const root = mkdtempSync(join(tmpdir(), "co-evalpersist-"));
+  const { spawnFn, calls } = makeRouterSpawn({
+    "reserve-report-num.mjs": { exitCode: 0, stdout: "035\n" },
+    "merge-tracker.mjs": { exitCode: 0 },
+  });
+  const hostile = REPORT.replace('company: "Acme AI"', 'company: "Acme\tInjected"');
+  try {
+    const result = await persistEvaluation({
+      spawnFn, execPath: "node", root, markdown: hostile,
+      url: "https://acme.com/jobs/7", today: "2026-08-04",
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /tab or newline/i);
+    assert.equal(calls.length, 0);
+    assert.equal(existsSync(join(root, "reports")), false);
+    assert.equal(existsSync(join(root, "batch", "tracker-additions")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/web/tests/lib/report-persist.test.mjs
+++ b/web/tests/lib/report-persist.test.mjs
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   evaluateRunOutcome,
@@ -190,7 +190,7 @@ test("persistEvaluation: writes report + TSV, reserves, merges, releases", async
     assert.equal(tsv[8], "; posted: 2026-08-01");
     assert.equal(tsv[9], "https://acme.com/jobs/7");
 
-    const scripts = calls.map((c) => c.args[0].split("/").pop() + (c.args.includes("--release") ? " --release" : ""));
+    const scripts = calls.map((c) => basename(c.args[0]) + (c.args.includes("--release") ? " --release" : ""));
     assert.deepEqual(scripts, ["reserve-report-num.mjs", "merge-tracker.mjs", "reserve-report-num.mjs --release"]);
     assert.ok(calls.every((c) => c.opts.cwd === root));
   } finally {

--- a/web/tests/lib/report-persist.test.mjs
+++ b/web/tests/lib/report-persist.test.mjs
@@ -1,0 +1,248 @@
+// Tests for report-persist.mjs. spawnFn is a fake EventEmitter-based child
+// process — no real reserve-report-num.mjs / merge-tracker.mjs is spawned.
+//
+// Run:  node --test tests/lib/report-persist.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  evaluateRunOutcome,
+  yamlScalar,
+  formatScore,
+  parseReportMeta,
+  reportSlug,
+  trackerTsvLine,
+  persistEvaluation,
+} from "../../src/lib/report-persist.mjs";
+
+function fakeChild({ stdout = "", stderr = "", exitCode = 0, spawnError = null } = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  queueMicrotask(() => {
+    if (spawnError) {
+      child.emit("error", spawnError);
+      return;
+    }
+    if (stdout) child.stdout.emit("data", Buffer.from(stdout));
+    if (stderr) child.stderr.emit("data", Buffer.from(stderr));
+    child.emit("close", exitCode);
+  });
+  return child;
+}
+
+function makeRouterSpawn(routes) {
+  const calls = [];
+  const spawnFn = (execPath, args, opts) => {
+    calls.push({ execPath, args, opts });
+    const scriptPath = args[0];
+    const route = Object.entries(routes).find(([suffix]) => scriptPath.endsWith(suffix));
+    if (!route) throw new Error(`no fake route for ${scriptPath}`);
+    const spec = typeof route[1] === "function" ? route[1](args) : route[1];
+    return fakeChild(spec);
+  };
+  return { spawnFn, calls };
+}
+
+const REPORT = `# Evaluation: Acme AI — Senior Engineer
+
+## Machine Summary
+\`\`\`yaml
+company: "Acme AI"
+role: "Senior Engineer"
+score: 4.2
+via: null
+\`\`\`
+
+## A) Role Summary
+A role.`;
+
+test("evaluateRunOutcome: missing envelope fails closed", () => {
+  const outcome = evaluateRunOutcome({
+    envelope: { ok: false, error: "The agent emitted no <<report-md>> envelope, so there is no report to save." },
+    noOutputMessage: null,
+    sawError: false,
+    cleanExit: true,
+  });
+  assert.equal(outcome.ok, false);
+  assert.match(outcome.message, /no <<report-md>> envelope/);
+});
+
+test("evaluateRunOutcome: clean envelope is ok", () => {
+  const outcome = evaluateRunOutcome({
+    envelope: { ok: true, markdown: REPORT },
+    noOutputMessage: null,
+    sawError: false,
+    cleanExit: true,
+  });
+  assert.equal(outcome.ok, true);
+});
+
+test("yamlScalar: reads quoted, bare, and null", () => {
+  const block = `company: "Acme AI"\nrole: Engineer\nvia: null\nscore: 4.2\n`;
+  assert.equal(yamlScalar(block, "company"), "Acme AI");
+  assert.equal(yamlScalar(block, "role"), "Engineer");
+  assert.equal(yamlScalar(block, "via"), null);
+  assert.equal(yamlScalar(block, "score"), "4.2");
+  assert.equal(yamlScalar(block, "missing"), null);
+});
+
+test("formatScore: normalizes to X.X/5", () => {
+  assert.equal(formatScore("4.2"), "4.2/5");
+  assert.equal(formatScore("4.2/5"), "4.2/5");
+  assert.equal(formatScore("4"), "4.0/5");
+  assert.equal(formatScore("4/5"), "4.0/5");
+  assert.equal(formatScore("nope"), null);
+  assert.equal(formatScore("9"), null);
+  assert.equal(formatScore(""), null);
+  assert.equal(formatScore(null), null);
+});
+
+test("parseReportMeta: Machine Summary wins; title is fallback", () => {
+  const meta = parseReportMeta(REPORT);
+  assert.equal(meta.ok, true);
+  assert.equal(meta.company, "Acme AI");
+  assert.equal(meta.role, "Senior Engineer");
+  assert.equal(meta.score, "4.2/5");
+  assert.equal(meta.via, null);
+});
+
+test("parseReportMeta: title fallback when YAML omits company/role", () => {
+  const md = `# Evaluation: Globex -- Analyst
+
+## Machine Summary
+\`\`\`yaml
+score: 3.5
+\`\`\`
+`;
+  const meta = parseReportMeta(md);
+  assert.equal(meta.ok, true);
+  assert.equal(meta.company, "Globex");
+  assert.equal(meta.role, "Analyst");
+  assert.equal(meta.score, "3.5/5");
+});
+
+test("parseReportMeta: missing score fails", () => {
+  const md = `# Evaluation: Acme — Role
+
+## Machine Summary
+\`\`\`yaml
+company: Acme
+role: Role
+\`\`\`
+`;
+  const meta = parseReportMeta(md);
+  assert.equal(meta.ok, false);
+  assert.match(meta.error, /score/i);
+});
+
+test("reportSlug: confidential marker for unknown employer", () => {
+  assert.equal(reportSlug("Acme AI", null), "acme-ai");
+  assert.equal(reportSlug("?", null), "confidential");
+  assert.equal(reportSlug("?", "Hays"), "confidential-hays");
+  assert.equal(reportSlug("???", null), "company");
+});
+
+test("trackerTsvLine: 10 fields, url last, via tagged when present", () => {
+  const line = trackerTsvLine({
+    num: "035", today: "2026-08-04", company: "Acme", role: "Eng",
+    score: "4.2/5", reportFile: "035-acme-2026-08-04.md", notes: "; posted: 2026-08-01",
+    via: "Hays", url: "https://acme.com/jobs/7",
+  }).trimEnd();
+  const fields = line.split("\t");
+  assert.equal(fields[0], "035");
+  assert.equal(fields[4], "Evaluated");
+  assert.equal(fields[5], "4.2/5");
+  assert.equal(fields[7], "[035](reports/035-acme-2026-08-04.md)");
+  assert.equal(fields[8], "; posted: 2026-08-01");
+  assert.equal(fields[9], "via=Hays");
+  assert.equal(fields[10], "https://acme.com/jobs/7");
+});
+
+test("persistEvaluation: writes report + TSV, reserves, merges, releases", async () => {
+  const root = mkdtempSync(join(tmpdir(), "co-evalpersist-"));
+  const { spawnFn, calls } = makeRouterSpawn({
+    "reserve-report-num.mjs": (args) => args.includes("--release")
+      ? { exitCode: 0 }
+      : { exitCode: 0, stdout: "035\n" },
+    "merge-tracker.mjs": { exitCode: 0 },
+  });
+
+  try {
+    const result = await persistEvaluation({
+      spawnFn, execPath: "node", root, markdown: REPORT,
+      url: "https://acme.com/jobs/7", today: "2026-08-04", postedAt: "2026-08-01",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.num, "035");
+    assert.equal(result.reportFile, "035-acme-ai-2026-08-04.md");
+
+    const reportPath = join(root, "reports", "035-acme-ai-2026-08-04.md");
+    const tsvPath = join(root, "batch", "tracker-additions", "035-acme-ai.tsv");
+    assert.equal(readFileSync(reportPath, "utf8"), REPORT);
+    const tsv = readFileSync(tsvPath, "utf8").trimEnd().split("\t");
+    assert.equal(tsv[2], "Acme AI");
+    assert.equal(tsv[4], "Evaluated");
+    assert.equal(tsv[8], "; posted: 2026-08-01");
+    assert.equal(tsv[9], "https://acme.com/jobs/7");
+
+    const scripts = calls.map((c) => c.args[0].split("/").pop() + (c.args.includes("--release") ? " --release" : ""));
+    assert.deepEqual(scripts, ["reserve-report-num.mjs", "merge-tracker.mjs", "reserve-report-num.mjs --release"]);
+    assert.ok(calls.every((c) => c.opts.cwd === root));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("persistEvaluation: reserve failure does not write files", async () => {
+  const root = mkdtempSync(join(tmpdir(), "co-evalpersist-"));
+  const { spawnFn } = makeRouterSpawn({
+    "reserve-report-num.mjs": { exitCode: 1, stderr: "lock timeout" },
+  });
+  try {
+    const result = await persistEvaluation({
+      spawnFn, execPath: "node", root, markdown: REPORT,
+      url: "https://acme.com/jobs/7", today: "2026-08-04",
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /lock timeout/);
+    assert.equal(existsSync(join(root, "reports")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("persistEvaluation: merge failure still releases the sentinel", async () => {
+  const root = mkdtempSync(join(tmpdir(), "co-evalpersist-"));
+  const { spawnFn, calls } = makeRouterSpawn({
+    "reserve-report-num.mjs": (args) => args.includes("--release")
+      ? { exitCode: 0 }
+      : { exitCode: 0, stdout: "036\n" },
+    "merge-tracker.mjs": { exitCode: 1, stderr: "status not canonical" },
+  });
+  try {
+    const result = await persistEvaluation({
+      spawnFn, execPath: "node", root, markdown: REPORT,
+      url: "https://acme.com/jobs/7", today: "2026-08-04",
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /merge-tracker/);
+    assert.ok(calls.some((c) => c.args.includes("--release")));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("persistEvaluation: refuses a non-ISO today rather than joining it into a path", async () => {
+  const { spawnFn } = makeRouterSpawn({});
+  const result = await persistEvaluation({
+    spawnFn, execPath: "node", root: "/tmp", markdown: REPORT,
+    url: "https://acme.com/jobs/7", today: "../etc",
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Invalid evaluation date/);
+});

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -11,6 +11,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { buildPrompt, isShellSafeCompanyName } from "../../src/lib/run-prompts.mjs";
 import { OPEN_MARK, CLOSE_MARK } from "../../src/lib/cv-envelope.mjs";
+import { OPEN_MARK as REPORT_OPEN, CLOSE_MARK as REPORT_CLOSE } from "../../src/lib/report-envelope.mjs";
 import { grantsWriteCapability, toolScopeFor } from "../../src/lib/claude-invocation.mjs";
 
 const ARGS = { input: "018", memory: "", today: "2026-08-04" };
@@ -159,77 +160,41 @@ test("isShellSafeCompanyName: refuses anything that could close the quote", () =
   assert.equal(isShellSafeCompanyName(undefined), false);
 });
 
-// ── the tracker-additions TSV row (#1298) ───────────────────────────────────
-//
-// The web is a WRITER of batch/tracker-additions/*.tsv, not just a reader of the
-// tracker. merge-tracker accepts 9 fields forever, so a stale template can never
-// go red — it just silently leaves every web-evaluated job out of the URL dedup.
-// Nothing else in this repo can catch that, which is why it is asserted here.
-
-/** The example row the evaluate prompt tells the agent to append. */
-function exampleTsvRow(prompt) {
-  const line = prompt.split("\n").find((l) => l.includes("\t"));
-  assert.ok(line, "the evaluate prompt must contain a literal tab-separated example row");
-  return line.trim().split("\t");
-}
-
-test("buildPrompt: the evaluate prompt's TSV row carries all 10 fields, url last", () => {
-  // Given an evaluate run
-  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-04" });
-  const fields = exampleTsvRow(prompt);
-
-  // Then the row has the 10 fields merge-tracker reads, with the posting URL last
-  assert.equal(fields.length, 10, `expected 10 tab-separated fields, got ${fields.length}: ${JSON.stringify(fields)}`);
-  assert.match(fields[9], /posting URL/i, "the 10th field must be the posting URL");
-  // ...and the prose agrees, so the agent is not told "9" while shown 10
-  assert.match(prompt, /10 TAB-separated columns/);
-});
-
-test("buildPrompt: the evaluate prompt demands an EMPTY url field, never a placeholder", () => {
-  // Given merge-tracker's parseTsvExtras drops "N/A"/"-" precisely so they can't
-  // be misread as the row's LOCATION, and an unconditional template is one an
-  // agent actually follows
+test("buildPrompt: the evaluate prompt asks for the envelope and forbids saving", () => {
   const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-04" });
 
-  // Then the instruction says to write all 10 fields and leave the last empty
-  assert.match(prompt, /ALWAYS write all 10 fields/i);
-  assert.match(prompt, /EMPTY if there is no posting URL/i);
-  assert.match(prompt, /never "N\/A"/i);
+  assert.ok(prompt.includes(REPORT_OPEN), "evaluate prompt must name the opening marker");
+  assert.ok(prompt.includes(REPORT_CLOSE), "evaluate prompt must name the closing marker");
+  assert.match(prompt, /Do NOT save or edit any file/i);
 });
 
-// ── the posted: segment (#2692) ─────────────────────────────────────────────
-//
-// The dashboard's POSTED column parses this out of the tracker's Notes cell.
-// The date is interpolated by the server from what the scanner recorded, never
-// requested from the agent: modes/oferta.md is explicit that a guessed date is
-// worse than an absent one, because the column renders absent as `—` and would
-// render an invented one as a fresh requisition.
+test("buildPrompt: the evaluate prompt does not claim the agent has no write tools", () => {
+  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-04" });
 
-test("buildPrompt: a known posting date becomes its own trailing segment", () => {
-  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-14", postedAt: "2026-08-07" });
-  const fields = exampleTsvRow(prompt);
-
-  assert.equal(fields.length, 10, "the row must still carry all 10 fields");
-  // Canonical form, from the regex that CONSUMES it: separator-anchored `; `,
-  // label, colon, ISO date. A mid-sentence mention is deliberately not metadata.
-  assert.match(fields[8], /; posted: 2026-08-07$/);
+  assert.ok(!/no file-writing tools/i.test(prompt), "must not assert a capability the agent may have");
+  assert.ok(!/you have no .*tools/i.test(prompt), "must not assert a capability the agent may have");
 });
 
-test("buildPrompt: no known date writes NO segment, never a guess", () => {
-  for (const postedAt of [undefined, null, "", "unknown", "7 Aug 2026", "2026-8-7", "1999-01-01"]) {
-    const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-14", postedAt });
-    const fields = exampleTsvRow(prompt);
-    assert.equal(fields.length, 10, `field count changed for ${JSON.stringify(postedAt)}`);
-    assert.ok(!/posted:/.test(fields[8]), `wrote a posted segment for ${JSON.stringify(postedAt)}: ${fields[8]}`);
-  }
+test("buildPrompt: the evaluate prompt never tells the agent to persist files", () => {
+  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-04" });
+
+  assert.ok(!/node reserve-report-num/.test(prompt), "evaluate prompt must not ask the agent to reserve a number");
+  assert.ok(!/node merge-tracker/.test(prompt), "evaluate prompt must not ask the agent to merge the tracker");
+  assert.ok(!/Write the full report to/.test(prompt), "evaluate prompt must not ask for a report file write");
+  assert.ok(!prompt.includes("\t"), "evaluate prompt must not carry a TSV template the agent would write");
 });
 
-test("buildPrompt: the row without a date is byte-identical to before the feature", () => {
-  // The segment is the ONLY difference between the two prompts, so a run with no
-  // recorded date cannot drift from what the CLI has always produced.
+test("buildPrompt: evaluate is read-only by tools as well as by instruction", () => {
+  assert.equal(grantsWriteCapability(toolScopeFor("evaluate")), false);
+  assert.match(buildPrompt({ kind: "evaluate", ...ARGS }), /Do NOT save or edit any file/i);
+});
+
+test("buildPrompt: postedAt does not change the evaluate prompt", () => {
+  // The scanner date is owned by report-persist.mjs. Putting it in the prompt
+  // would re-invite the agent to write a TSV row it no longer writes.
   const withDate = buildPrompt({ kind: "evaluate", input: "u", memory: "", today: "2026-08-14", postedAt: "2026-08-07" });
   const without = buildPrompt({ kind: "evaluate", input: "u", memory: "", today: "2026-08-14" });
-  assert.equal(withDate.replace("; posted: 2026-08-07", ""), without);
+  assert.equal(withDate, without);
 });
 
 // ── language.modes_dir / language.output ─────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Job postings are data, never instructions (`AGENTS.md` Untrusted External Content). `/api/run` evaluate still granted Claude `Write`/`Bash` (pdf already did not). A JD could try to induce file writes or a shell.

Evaluate now shares pdf's read-only tool arm. The agent emits the report in a `<<report-md>>` envelope; the backend persists via `reserve-report-num.mjs` / `merge-tracker.mjs`. `fix-portal` keeps Write/Bash. `oferta` / `auto-pipeline` are pinned to the same read-only scope so a future `/api/run` kind of that name cannot inherit persisting tools.

## Related issue

Untrusted-JD tool lockdown on Claude evaluate. Leftover: **#2507** — non-Claude `/api/run` still gets no tool flags (`spec.args(prompt)` only). That is per-CLI sandboxing (open PR #2941); not boiled in here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] Focused tests pass (`node --test` on `claude-invocation`, `run-prompts`, `report-envelope`, `report-persist` — 65 pass). `node test-all.mjs` not re-run in this worktree (web `node_modules` absent).
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## Tests

- `UNTRUSTED_JD_KINDS` (`pdf`, `evaluate`, `oferta`, `auto-pipeline`) allow no Write/Bash and pass `--strict-mcp-config`
- `fix-portal` still allows Write/Bash
- evaluate prompt forbids saving; backend persist writes report + TSV + merge
- `test-all.mjs` §55.6 freeze extended to untrusted-JD kinds

## Residual risk

- Non-Claude CLIs remain unrestricted on this route (**#2507** / #2941).
- Persistence now depends on the agent emitting a well-formed envelope with Machine Summary; a malformed report fails closed instead of writing via the agent.