### PR TITLE
fix(web): persist inbox Skip to pipeline.md

### DIFF
--- a/web/src/app/api/inbox/skip/route.ts
+++ b/web/src/app/api/inbox/skip/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import fs from "node:fs";
+import path from "node:path";
+import { careerOpsRoot } from "@/lib/career-ops";
+import { setInboxSkip } from "@/lib/inbox-skip.mjs";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Inbox Skip/undo: flip `- [ ]` ↔ `- [x]` on the matching data/pipeline.md row.
+// This is NOT /api/status — Home DecisionCard Skip writes a tracker Discarded
+// status; the inbox is the pipeline checklist.
+
+const ERROR_HTTP: Record<string, number> = {
+  "invalid-url": 400,
+  "unmatched": 404,
+  "not-found": 404,
+  "busy": 409,
+};
+
+const ERROR_MSG: Record<string, string> = {
+  "invalid-url": "url must be an http(s) posting URL",
+  "unmatched": "no pipeline row for that URL",
+  "not-found": "pipeline.md not found",
+  "busy": "The pipeline is being written right now (CLI or another tab). Try again.",
+};
+
+export async function POST(req: Request) {
+  let body: { url?: unknown; done?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "bad json" }, { status: 400 });
+  }
+
+  const url = typeof body.url === "string" ? body.url : "";
+  if (body.done !== undefined && typeof body.done !== "boolean") {
+    return NextResponse.json({ error: "done must be a boolean" }, { status: 400 });
+  }
+  const done = body.done !== false;
+
+  const root = careerOpsRoot();
+  const file = path.join(root, "data", "pipeline.md");
+  const lockModule = path.join(root, "pipeline-lock.mjs");
+  if (!fs.existsSync(lockModule)) {
+    return NextResponse.json(
+      { error: "inbox skip needs the career-ops scripts; this root has data only", code: "core-script-missing" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const result = await setInboxSkip(file, url, done, { lockModule });
+    if (!result.ok) {
+      const code = result.error;
+      return NextResponse.json(
+        { error: ERROR_MSG[code] ?? "skip failed", code },
+        {
+          status: ERROR_HTTP[code] ?? 400,
+          ...(code === "busy" ? { headers: { "Retry-After": "5" } } : {}),
+        },
+      );
+    }
+    return NextResponse.json({ ok: true, done, matched: result.matched, changed: result.changed });
+  } catch {
+    return NextResponse.json({ error: "write failed" }, { status: 500 });
+  }
+}

--- a/web/src/components/inbox/inbox-triage.tsx
+++ b/web/src/components/inbox/inbox-triage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Undo2 } from "lucide-react";
 import { useJobs } from "@/components/jobs/job-store";
 import type { InboxJob } from "@/lib/career-ops";
@@ -22,7 +23,10 @@ const BATCH = 20;
 // it; only "Score shortlist" spends tokens. 🔴 The shell is agnostic to what makes a
 // role relevant — order is freshness with a single documented plug point.
 export function InboxTriage({ inbox }: { inbox: InboxJob[] }) {
+  const router = useRouter();
   const { jobs, startJob } = useJobs();
+  // Serialize skip/undo per URL so a fast Undo cannot lose the race to Skip.
+  const skipChain = useRef(new Map<string, Promise<void>>());
 
   // facets
   const [within, setWithin] = useState<number | null>(null);
@@ -45,13 +49,19 @@ export function InboxTriage({ inbox }: { inbox: InboxJob[] }) {
       const s = localStorage.getItem(SHORTLIST_KEY);
       if (s) setShortlist(JSON.parse(s));
       const h = localStorage.getItem(HIDDEN_KEY);
-      if (h) setHidden(JSON.parse(h));
+      if (h) {
+        const parsed = JSON.parse(h) as unknown;
+        const urls = Array.isArray(parsed) ? parsed.filter((u): u is string => typeof u === "string") : [];
+        const pending = new Set(inbox.map((j) => j.url));
+        setHidden(urls.filter((u) => pending.has(u)));
+      }
       const c = localStorage.getItem(CONFIG_KEY);
       setHasCli(!!(c && JSON.parse(c).cliId));
     } catch {
       /* ignore */
     }
     setLoaded(true);
+    // First SSR inbox only — later refreshes prune via the inbox effect below.
   }, []);
   useEffect(() => {
     if (loaded) try { localStorage.setItem(SHORTLIST_KEY, JSON.stringify(shortlist)); } catch { /* quota */ }
@@ -59,6 +69,15 @@ export function InboxTriage({ inbox }: { inbox: InboxJob[] }) {
   useEffect(() => {
     if (loaded) try { localStorage.setItem(HIDDEN_KEY, JSON.stringify(hidden)); } catch { /* quota */ }
   }, [hidden, loaded]);
+  // After SSR refresh, pipeline.md [x] rows are already gone from `inbox`.
+  // Drop them from the localStorage cache so "N hidden" does not linger.
+  useEffect(() => {
+    const pending = new Set(inbox.map((j) => j.url));
+    setHidden((h) => {
+      const next = h.filter((u) => pending.has(u));
+      return next.length === h.length ? h : next;
+    });
+  }, [inbox]);
   // auto-dismiss the undo toast
   useEffect(() => {
     if (!undo) return;
@@ -135,13 +154,44 @@ export function InboxTriage({ inbox }: { inbox: InboxJob[] }) {
 
   const isShortlisted = (url: string) => shortlist.some((s) => s.url === url);
 
+  const persistSkip = (url: string, done: boolean) => {
+    const prev = skipChain.current.get(url) ?? Promise.resolve();
+    const next = prev
+      .then(async () => {
+        const res = await fetch("/api/inbox/skip", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url, done }),
+        });
+        if (!res.ok) throw new Error("skip write failed");
+        router.refresh();
+      })
+      .catch(() => {
+        if (done) setHidden((h) => h.filter((u) => u !== url));
+      });
+    skipChain.current.set(url, next);
+    return next;
+  };
+
   const save = (job: InboxJob) => {
     if (isShortlisted(job.url)) return;
     setShortlist((s) => [...s, { url: job.url, company: job.company, role: job.role }]);
   };
   const skip = (job: InboxJob) => {
     setHidden((h) => (h.includes(job.url) ? h : [...h, job.url]));
-    setUndo({ label: `Skipped ${job.company}`, fn: () => setHidden((h) => h.filter((u) => u !== job.url)) });
+    setUndo({
+      label: `Skipped ${job.company}`,
+      fn: () => {
+        setHidden((h) => h.filter((u) => u !== job.url));
+        void persistSkip(job.url, false);
+      },
+    });
+    void persistSkip(job.url, true);
+  };
+  const restoreHidden = () => {
+    const urls = hidden;
+    setHidden([]);
+    for (const url of urls) void persistSkip(url, false);
   };
   const toggleSelect = (url: string) =>
     setSelected((s) => {
@@ -206,7 +256,7 @@ export function InboxTriage({ inbox }: { inbox: InboxJob[] }) {
           {capped ? "Fresh — worth a look" : anyFacet ? `${filtered.length} match${filtered.length === 1 ? "" : "es"}` : "All roles"}
         </p>
         {hiddenCount > 0 && (
-          <button type="button" onClick={() => setHidden([])} className="text-xs text-faint transition-colors hover:text-foreground">
+          <button type="button" onClick={restoreHidden} className="text-xs text-faint transition-colors hover:text-foreground">
             {hiddenCount} hidden · restore
           </button>
         )}

--- a/web/src/lib/inbox-skip.mjs
+++ b/web/src/lib/inbox-skip.mjs
@@ -1,0 +1,170 @@
+/**
+ * Persist inbox Skip/undo by flipping the `data/pipeline.md` checkbox for one
+ * posting URL. localStorage is only a cache; this is the file write.
+ *
+ * The URL is a matcher, never a filesystem path. Only the checkbox on matching
+ * Pending rows changes — company/role and every other line stay byte-identical.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+const MAX_URL_LEN = 2048;
+const CHECKBOX_LINE = /^(\s*-\s*)\[([ xX])\](.*)$/;
+const PENDING_HEADING = /^##\s+(Pending|Pendientes)\s*$/i;
+
+/**
+ * Accept only a real http(s) posting URL. Anything else (relative paths,
+ * file:/javascript:/data:, newlines) is refused so a Skip cannot be turned
+ * into a write outside pipeline.md.
+ *
+ * @param {unknown} raw
+ * @returns {string | null} trimmed URL, or null when it is not a posting URL
+ */
+export function postingUrl(raw) {
+  if (typeof raw !== "string") return null;
+  const s = raw.trim();
+  if (!s || s.length > MAX_URL_LEN) return null;
+  if (/[\0\r\n]/.test(s)) return null;
+  let u;
+  try {
+    u = new URL(s);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+  if (!u.hostname) return null;
+  if (u.username || u.password) return null;
+  return s;
+}
+
+/**
+ * Job URL on a pipeline checkbox line — same first-cell rule as readInbox,
+ * with the scan.mjs fallback of "first http(s) URL" for legacy `#NNN | url` rows.
+ *
+ * @param {string} rest text after `- [ ]` / `- [x]`
+ * @returns {string | null}
+ */
+export function jobUrlFromRest(rest) {
+  const first = rest.split("|")[0].trim();
+  if (/^https?:\/\//i.test(first)) return first;
+  const m = rest.match(/https?:\/\/[^\s|]+/);
+  return m ? m[0] : null;
+}
+
+function pendingRange(lines) {
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (PENDING_HEADING.test(t)) {
+      start = i + 1;
+      continue;
+    }
+    if (start !== -1 && t.startsWith("## ")) {
+      return { start, end: i };
+    }
+  }
+  if (start !== -1) return { start, end: lines.length };
+  return null; // no Pending heading → every line is a candidate
+}
+
+function inRange(i, range) {
+  return !range || (i >= range.start && i < range.end);
+}
+
+/**
+ * Flip `- [ ]` ↔ `- [x]` on Pending rows whose job URL equals `url`.
+ *
+ * @param {string} text pipeline.md contents
+ * @param {string} url posting URL already accepted by postingUrl()
+ * @param {boolean} done true = Skip (`[x]`), false = undo (`[ ]`)
+ * @returns {{ ok: true, text: string, matched: number, changed: number } | { ok: false, error: string }}
+ */
+export function applyInboxSkip(text, url, done) {
+  const parsed = postingUrl(url);
+  if (!parsed) return { ok: false, error: "invalid-url" };
+
+  const nl = text.includes("\r\n") ? "\r\n" : "\n";
+  const endedWithNl = /\r?\n$/.test(text);
+  const lines = text.split(/\r?\n/);
+  if (endedWithNl && lines[lines.length - 1] === "") lines.pop();
+
+  const range = pendingRange(lines);
+  const want = done ? "x" : " ";
+  let matched = 0;
+  let changed = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!inRange(i, range)) continue;
+    const m = lines[i].match(CHECKBOX_LINE);
+    if (!m) continue;
+    const rest = m[3];
+    const jobUrl = jobUrlFromRest(rest);
+    if (jobUrl !== parsed) continue;
+    matched += 1;
+    const currentlyDone = m[2].toLowerCase() === "x";
+    if (currentlyDone === done) continue;
+    lines[i] = `${m[1]}[${want}]${rest}`;
+    changed += 1;
+  }
+
+  if (matched === 0) return { ok: false, error: "unmatched" };
+  return {
+    ok: true,
+    text: lines.join(nl) + (endedWithNl ? nl : ""),
+    matched,
+    changed,
+  };
+}
+
+function atomicWrite(file, content) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp-${process.pid}-${randomUUID()}`;
+  fs.writeFileSync(tmp, content, "utf8");
+  fs.renameSync(tmp, file);
+}
+
+/**
+ * Read-modify-write `pipeline.md` under the core pipeline lock when available.
+ *
+ * @param {string} pipelinePath absolute path to data/pipeline.md
+ * @param {string} url
+ * @param {boolean} done
+ * @param {{ lockModule?: string, timeoutMs?: number }} [options]
+ */
+export async function setInboxSkip(pipelinePath, url, done, options = {}) {
+  const parsed = postingUrl(url);
+  if (!parsed) return { ok: false, error: "invalid-url" };
+
+  const run = () => {
+    let md;
+    try {
+      md = fs.readFileSync(pipelinePath, "utf8");
+    } catch (err) {
+      if (err && err.code === "ENOENT") return { ok: false, error: "not-found" };
+      throw err;
+    }
+    const result = applyInboxSkip(md, parsed, done);
+    if (!result.ok) return result;
+    if (result.changed > 0) atomicWrite(pipelinePath, result.text);
+    return result;
+  };
+
+  const lockModule = options.lockModule;
+  if (!lockModule) return run();
+
+  const mod = await import(/* webpackIgnore: true */ pathToFileURL(lockModule).href);
+  if (typeof mod.withPipelineLock !== "function") {
+    throw new Error("pipeline-lock.mjs has no withPipelineLock");
+  }
+  try {
+    return await mod.withPipelineLock(pipelinePath, run, {
+      timeoutMs: options.timeoutMs ?? (Number(process.env.CAREER_OPS_WEB_LOCK_TIMEOUT_MS) || 5_000),
+      retryMs: 50,
+    });
+  } catch (err) {
+    if (err && err.name === "LockTimeoutError") return { ok: false, error: "busy" };
+    throw err;
+  }
+}

--- a/web/src/lib/inbox-skip.mjs
+++ b/web/src/lib/inbox-skip.mjs
@@ -40,17 +40,15 @@ export function postingUrl(raw) {
 }
 
 /**
- * Job URL on a pipeline checkbox line — same first-cell rule as readInbox,
- * with the scan.mjs fallback of "first http(s) URL" for legacy `#NNN | url` rows.
+ * Job URL on a pipeline checkbox line — the first `|` cell, same rule as
+ * readInbox. The whole cell must be an http(s) posting URL; a substring
+ * elsewhere on the line is not a match.
  *
  * @param {string} rest text after `- [ ]` / `- [x]`
  * @returns {string | null}
  */
 export function jobUrlFromRest(rest) {
-  const first = rest.split("|")[0].trim();
-  if (/^https?:\/\//i.test(first)) return first;
-  const m = rest.match(/https?:\/\/[^\s|]+/);
-  return m ? m[0] : null;
+  return postingUrl(rest.split("|")[0]);
 }
 
 function pendingRange(lines) {

--- a/web/tests/lib/inbox-skip.test.mjs
+++ b/web/tests/lib/inbox-skip.test.mjs
@@ -1,0 +1,168 @@
+// Inbox Skip must persist by checking data/pipeline.md, not only localStorage.
+//
+// applyInboxSkip / setInboxSkip flip `- [ ]` ↔ `- [x]` for one posting URL and
+// leave every other line byte-identical. The URL is a matcher, never a path.
+//
+// Run (from web/, as `npm test` does):  node --test tests/lib/inbox-skip.test.mjs
+// From the repo root:                   node --test web/tests/lib/inbox-skip.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(HERE, "..", "..", "src", "lib", "inbox-skip.mjs");
+const CORE = process.env.CAREER_OPS_ROOT || path.join(HERE, "..", "..", "..");
+const LOCK = path.join(CORE, "pipeline-lock.mjs");
+const HAS_LOCK = fs.existsSync(LOCK);
+
+const { postingUrl, applyInboxSkip, setInboxSkip } = await import(pathToFileURL(SRC).href);
+
+const FIXTURE = [
+  "# Pipeline — Pending URLs",
+  "",
+  "Paste job URLs below.",
+  "",
+  "## Pending",
+  "",
+  "- [ ] https://boards.greenhouse.io/acme/jobs/1 | Acme | Staff Engineer | Remote | posted: 2026-08-01",
+  "- [ ] https://jobs.lever.co/beta/2 | Beta | Platform Engineer | NYC",
+  "- [x] https://ats.example.com/old | OldCo | Already done",
+  "",
+  "## Processed",
+  "",
+  "- [x] https://done.example.com/x | DoneCo | PM",
+  "- [ ] https://jobs.lever.co/beta/2 | Beta | should not flip (processed duplicate)",
+  "",
+].join("\n");
+
+const ACME = "https://boards.greenhouse.io/acme/jobs/1";
+const BETA = "https://jobs.lever.co/beta/2";
+const DONE = "https://done.example.com/x";
+
+function linesOf(text) {
+  return text.split("\n");
+}
+
+test("postingUrl accepts http(s) and refuses path traversal / non-http", () => {
+  assert.equal(postingUrl("https://boards.greenhouse.io/acme/jobs/1"), ACME);
+  assert.equal(postingUrl("  http://example.com/a  "), "http://example.com/a");
+  assert.equal(postingUrl("../data/applications.md"), null);
+  assert.equal(postingUrl("/etc/passwd"), null);
+  assert.equal(postingUrl("file:///etc/passwd"), null);
+  assert.equal(postingUrl("javascript:alert(1)"), null);
+  assert.equal(postingUrl("data:text/plain,hi"), null);
+  assert.equal(postingUrl("https://example.com/job\n- [x] https://evil.example"), null);
+  assert.equal(postingUrl("https://user:pass@example.com/job"), null);
+  assert.equal(postingUrl(""), null);
+  assert.equal(postingUrl(null), null);
+});
+
+test("skip one URL checks that line and leaves every other line unchanged", () => {
+  const result = applyInboxSkip(FIXTURE, BETA, true);
+  assert.equal(result.ok, true);
+  assert.equal(result.matched, 1);
+  assert.equal(result.changed, 1);
+
+  const before = linesOf(FIXTURE);
+  const after = linesOf(result.text);
+  assert.equal(after.length, before.length);
+  for (let i = 0; i < before.length; i++) {
+    if (before[i].includes(BETA) && before[i].startsWith("- [ ] https://jobs.lever.co/beta/2 | Beta | Platform")) {
+      assert.equal(
+        after[i],
+        "- [x] https://jobs.lever.co/beta/2 | Beta | Platform Engineer | NYC",
+      );
+    } else {
+      assert.equal(after[i], before[i], `line ${i} must stay unchanged`);
+    }
+  }
+});
+
+test("undo restores the checkbox to [ ]", () => {
+  const skipped = applyInboxSkip(FIXTURE, BETA, true);
+  assert.equal(skipped.ok, true);
+  const undone = applyInboxSkip(skipped.text, BETA, false);
+  assert.equal(undone.ok, true);
+  assert.equal(undone.text, FIXTURE);
+});
+
+test("already-skipped row is idempotent and does not rewrite neighbors", () => {
+  const once = applyInboxSkip(FIXTURE, BETA, true);
+  const twice = applyInboxSkip(once.text, BETA, true);
+  assert.equal(twice.ok, true);
+  assert.equal(twice.changed, 0);
+  assert.equal(twice.text, once.text);
+});
+
+test("Processed-section rows are not flipped, even with the same URL", () => {
+  const skipped = applyInboxSkip(FIXTURE, BETA, true);
+  const processed = linesOf(skipped.text).find((l) => l.includes("should not flip"));
+  assert.equal(processed, "- [ ] https://jobs.lever.co/beta/2 | Beta | should not flip (processed duplicate)");
+});
+
+test("unmatched URL is refused without rewriting the file", () => {
+  const result = applyInboxSkip(FIXTURE, "https://nobody.example/jobs/9", true);
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "unmatched");
+});
+
+test("invalid URL never matches", () => {
+  assert.equal(applyInboxSkip(FIXTURE, "../data/pipeline.md", true).error, "invalid-url");
+  assert.equal(applyInboxSkip(FIXTURE, "file:///tmp/pipeline.md", true).error, "invalid-url");
+});
+
+test("does not invent company/role — only the checkbox character changes", () => {
+  const result = applyInboxSkip(FIXTURE, ACME, true);
+  const line = linesOf(result.text).find((l) => l.includes("boards.greenhouse.io/acme"));
+  assert.equal(
+    line,
+    "- [x] https://boards.greenhouse.io/acme/jobs/1 | Acme | Staff Engineer | Remote | posted: 2026-08-01",
+  );
+});
+
+test("a URL that only appears under Processed does not match as inbox Skip", () => {
+  const result = applyInboxSkip(FIXTURE, DONE, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "unmatched");
+});
+
+test("setInboxSkip writes the fixture file, then undo restores it", { skip: HAS_LOCK ? false : "pipeline-lock.mjs not resolvable" }, async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-skip-"));
+  const file = path.join(dir, "pipeline.md");
+  fs.writeFileSync(file, FIXTURE);
+  try {
+    const skipped = await setInboxSkip(file, BETA, true, { lockModule: LOCK, timeoutMs: 5_000 });
+    assert.equal(skipped.ok, true);
+    const afterSkip = fs.readFileSync(file, "utf8");
+    assert.match(afterSkip, /^- \[x\] https:\/\/jobs\.lever\.co\/beta\/2 \| Beta \| Platform Engineer \| NYC$/m);
+    assert.match(afterSkip, /^- \[ \] https:\/\/boards\.greenhouse\.io\/acme\/jobs\/1 /m);
+    assert.match(afterSkip, /^- \[x\] https:\/\/ats\.example\.com\/old /m);
+    assert.match(afterSkip, /^- \[x\] https:\/\/done\.example\.com\/x /m);
+    assert.match(afterSkip, /should not flip \(processed duplicate\)/);
+    assert.equal(afterSkip.split("\n").length, FIXTURE.split("\n").length);
+
+    const undone = await setInboxSkip(file, BETA, false, { lockModule: LOCK, timeoutMs: 5_000 });
+    assert.equal(undone.ok, true);
+    assert.equal(fs.readFileSync(file, "utf8"), FIXTURE);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("setInboxSkip refuses an unmatched URL and leaves the file untouched", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-skip-miss-"));
+  const file = path.join(dir, "pipeline.md");
+  fs.writeFileSync(file, FIXTURE);
+  try {
+    const result = await setInboxSkip(file, "https://nobody.example/jobs/9", true);
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "unmatched");
+    assert.equal(fs.readFileSync(file, "utf8"), FIXTURE);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/web/tests/lib/inbox-skip.test.mjs
+++ b/web/tests/lib/inbox-skip.test.mjs
@@ -21,6 +21,18 @@ const HAS_LOCK = fs.existsSync(LOCK);
 
 const { postingUrl, applyInboxSkip, setInboxSkip } = await import(pathToFileURL(SRC).href);
 
+const ACME = "https://boards.greenhouse.io/acme/jobs/1";
+const BETA = "https://jobs.lever.co/beta/2";
+const DONE = "https://done.example.com/x";
+
+const ACME_PENDING = `- [ ] ${ACME} | Acme | Staff Engineer | Remote | posted: 2026-08-01`;
+const ACME_SKIPPED = `- [x] ${ACME} | Acme | Staff Engineer | Remote | posted: 2026-08-01`;
+const BETA_PENDING = `- [ ] ${BETA} | Beta | Platform Engineer | NYC`;
+const BETA_SKIPPED = `- [x] ${BETA} | Beta | Platform Engineer | NYC`;
+const OLD_DONE = "- [x] https://ats.example.com/old | OldCo | Already done";
+const DONE_PROCESSED = `- [x] ${DONE} | DoneCo | PM`;
+const BETA_PROCESSED = `- [ ] ${BETA} | Beta | should not flip (processed duplicate)`;
+
 const FIXTURE = [
   "# Pipeline — Pending URLs",
   "",
@@ -28,20 +40,34 @@ const FIXTURE = [
   "",
   "## Pending",
   "",
-  "- [ ] https://boards.greenhouse.io/acme/jobs/1 | Acme | Staff Engineer | Remote | posted: 2026-08-01",
-  "- [ ] https://jobs.lever.co/beta/2 | Beta | Platform Engineer | NYC",
-  "- [x] https://ats.example.com/old | OldCo | Already done",
+  ACME_PENDING,
+  BETA_PENDING,
+  OLD_DONE,
   "",
   "## Processed",
   "",
-  "- [x] https://done.example.com/x | DoneCo | PM",
-  "- [ ] https://jobs.lever.co/beta/2 | Beta | should not flip (processed duplicate)",
+  DONE_PROCESSED,
+  BETA_PROCESSED,
   "",
 ].join("\n");
 
-const ACME = "https://boards.greenhouse.io/acme/jobs/1";
-const BETA = "https://jobs.lever.co/beta/2";
-const DONE = "https://done.example.com/x";
+const SKIPPED_FIXTURE = [
+  "# Pipeline — Pending URLs",
+  "",
+  "Paste job URLs below.",
+  "",
+  "## Pending",
+  "",
+  ACME_PENDING,
+  BETA_SKIPPED,
+  OLD_DONE,
+  "",
+  "## Processed",
+  "",
+  DONE_PROCESSED,
+  BETA_PROCESSED,
+  "",
+].join("\n");
 
 function linesOf(text) {
   return text.split("\n");
@@ -66,16 +92,14 @@ test("skip one URL checks that line and leaves every other line unchanged", () =
   assert.equal(result.ok, true);
   assert.equal(result.matched, 1);
   assert.equal(result.changed, 1);
+  assert.equal(result.text, SKIPPED_FIXTURE);
 
   const before = linesOf(FIXTURE);
   const after = linesOf(result.text);
   assert.equal(after.length, before.length);
   for (let i = 0; i < before.length; i++) {
-    if (before[i].includes(BETA) && before[i].startsWith("- [ ] https://jobs.lever.co/beta/2 | Beta | Platform")) {
-      assert.equal(
-        after[i],
-        "- [x] https://jobs.lever.co/beta/2 | Beta | Platform Engineer | NYC",
-      );
+    if (before[i] === BETA_PENDING) {
+      assert.equal(after[i], BETA_SKIPPED);
     } else {
       assert.equal(after[i], before[i], `line ${i} must stay unchanged`);
     }
@@ -100,8 +124,10 @@ test("already-skipped row is idempotent and does not rewrite neighbors", () => {
 
 test("Processed-section rows are not flipped, even with the same URL", () => {
   const skipped = applyInboxSkip(FIXTURE, BETA, true);
-  const processed = linesOf(skipped.text).find((l) => l.includes("should not flip"));
-  assert.equal(processed, "- [ ] https://jobs.lever.co/beta/2 | Beta | should not flip (processed duplicate)");
+  assert.equal(
+    linesOf(skipped.text).find((l) => l === BETA_PROCESSED),
+    BETA_PROCESSED,
+  );
 });
 
 test("unmatched URL is refused without rewriting the file", () => {
@@ -117,11 +143,20 @@ test("invalid URL never matches", () => {
 
 test("does not invent company/role — only the checkbox character changes", () => {
   const result = applyInboxSkip(FIXTURE, ACME, true);
-  const line = linesOf(result.text).find((l) => l.includes("boards.greenhouse.io/acme"));
   assert.equal(
-    line,
-    "- [x] https://boards.greenhouse.io/acme/jobs/1 | Acme | Staff Engineer | Remote | posted: 2026-08-01",
+    linesOf(result.text).find((l) => l === ACME_SKIPPED),
+    ACME_SKIPPED,
   );
+});
+
+test("a URL that is only a substring of another row's URL cell does not match", () => {
+  const trap = `- [ ] ${new URL("https://evil.example/https://jobs.lever.co/beta/2").href} | Evil | Trap`;
+  const real = BETA_PENDING;
+  const text = ["## Pending", "", trap, real, ""].join("\n");
+  const result = applyInboxSkip(text, BETA, true);
+  assert.equal(result.ok, true);
+  assert.equal(result.matched, 1);
+  assert.equal(result.text, ["## Pending", "", trap, BETA_SKIPPED, ""].join("\n"));
 });
 
 test("a URL that only appears under Processed does not match as inbox Skip", () => {
@@ -138,12 +173,7 @@ test("setInboxSkip writes the fixture file, then undo restores it", { skip: HAS_
     const skipped = await setInboxSkip(file, BETA, true, { lockModule: LOCK, timeoutMs: 5_000 });
     assert.equal(skipped.ok, true);
     const afterSkip = fs.readFileSync(file, "utf8");
-    assert.match(afterSkip, /^- \[x\] https:\/\/jobs\.lever\.co\/beta\/2 \| Beta \| Platform Engineer \| NYC$/m);
-    assert.match(afterSkip, /^- \[ \] https:\/\/boards\.greenhouse\.io\/acme\/jobs\/1 /m);
-    assert.match(afterSkip, /^- \[x\] https:\/\/ats\.example\.com\/old /m);
-    assert.match(afterSkip, /^- \[x\] https:\/\/done\.example\.com\/x /m);
-    assert.match(afterSkip, /should not flip \(processed duplicate\)/);
-    assert.equal(afterSkip.split("\n").length, FIXTURE.split("\n").length);
+    assert.equal(afterSkip, SKIPPED_FIXTURE);
 
     const undone = await setInboxSkip(file, BETA, false, { lockModule: LOCK, timeoutMs: 5_000 });
     assert.equal(undone.ok, true);


### PR DESCRIPTION
## What does this PR do?

Inbox Skip only wrote the URL to `localStorage` (`career-ops:hidden`). `data/pipeline.md` stayed `- [ ]`, so a refresh in another browser, the CLI, or after clearing site data showed the job again.

Skip and undo now `POST /api/inbox/skip`, which flips `- [ ]` ↔ `- [x]` on the matching Pending row under the existing pipeline lock. `router.refresh()` then re-reads the file. localStorage stays an optimistic cache, not the source of truth.

This is not Home `DecisionCard` Skip — that path writes tracker `Discarded` via `/api/status`.

## Related issue

Bug fix, no issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node --test web/tests/lib/inbox-skip.test.mjs` (11 pass)
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)