### PR TITLE
fix(scan): do not block Dublin OH as Ireland

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -152,7 +152,10 @@ export function matchedTitleKeywords(title, titleFilter) {
 //     override; for country-level terms that are never a false rejection)
 //   - `always_allow` matches → pass (takes precedence over `block` — lets a
 //     multi-location string like "Remote, Belgium or France" through because
-//     the home region is an option, even though "france" is blocked)
+//     the home region is an option, even though "france" is blocked). When
+//     always_allow names the US as a country (united states / usa / u.s. /
+//     u.s.a.), USPS state names and 2-letter codes are additional always_allow
+//     matches, so block: [Dublin] does not drop "Dublin, OH".
 //   - `block` matches → reject
 //   - `allow` empty → pass (already cleared block)
 //   - `allow` non-empty → must match at least one keyword, OR the TITLE carries
@@ -201,6 +204,78 @@ function compileLocationKeyword(keyword) {
 function compileLocationKeywordList(value) {
   return normalizeKeywordList(value).map(compileLocationKeyword);
 }
+
+// Frozen USPS state-name + abbreviation table. Not a world gazetteer: only
+// consulted when always_allow already names the United States as a country,
+// so EU-targeted configs (no US token) keep their previous semantics.
+const US_COUNTRY_ALWAYS_ALLOW = new Set(['united states', 'usa', 'u.s.', 'u.s.a.']);
+const USPS_STATES = Object.freeze([
+  Object.freeze(['alabama', 'al']),
+  Object.freeze(['alaska', 'ak']),
+  Object.freeze(['arizona', 'az']),
+  Object.freeze(['arkansas', 'ar']),
+  Object.freeze(['california', 'ca']),
+  Object.freeze(['colorado', 'co']),
+  Object.freeze(['connecticut', 'ct']),
+  Object.freeze(['delaware', 'de']),
+  Object.freeze(['florida', 'fl']),
+  Object.freeze(['georgia', 'ga']),
+  Object.freeze(['hawaii', 'hi']),
+  Object.freeze(['idaho', 'id']),
+  Object.freeze(['illinois', 'il']),
+  Object.freeze(['indiana', 'in']),
+  Object.freeze(['iowa', 'ia']),
+  Object.freeze(['kansas', 'ks']),
+  Object.freeze(['kentucky', 'ky']),
+  Object.freeze(['louisiana', 'la']),
+  Object.freeze(['maine', 'me']),
+  Object.freeze(['maryland', 'md']),
+  Object.freeze(['massachusetts', 'ma']),
+  Object.freeze(['michigan', 'mi']),
+  Object.freeze(['minnesota', 'mn']),
+  Object.freeze(['mississippi', 'ms']),
+  Object.freeze(['missouri', 'mo']),
+  Object.freeze(['montana', 'mt']),
+  Object.freeze(['nebraska', 'ne']),
+  Object.freeze(['nevada', 'nv']),
+  Object.freeze(['new hampshire', 'nh']),
+  Object.freeze(['new jersey', 'nj']),
+  Object.freeze(['new mexico', 'nm']),
+  Object.freeze(['new york', 'ny']),
+  Object.freeze(['north carolina', 'nc']),
+  Object.freeze(['north dakota', 'nd']),
+  Object.freeze(['ohio', 'oh']),
+  Object.freeze(['oklahoma', 'ok']),
+  Object.freeze(['oregon', 'or']),
+  Object.freeze(['pennsylvania', 'pa']),
+  Object.freeze(['rhode island', 'ri']),
+  Object.freeze(['south carolina', 'sc']),
+  Object.freeze(['south dakota', 'sd']),
+  Object.freeze(['tennessee', 'tn']),
+  Object.freeze(['texas', 'tx']),
+  Object.freeze(['utah', 'ut']),
+  Object.freeze(['vermont', 'vt']),
+  Object.freeze(['virginia', 'va']),
+  Object.freeze(['washington', 'wa']),
+  Object.freeze(['west virginia', 'wv']),
+  Object.freeze(['wisconsin', 'wi']),
+  Object.freeze(['wyoming', 'wy']),
+]);
+
+// 2-letter codes: comma-state (", OH" / ",OH, USA") or a trailing token
+// ("Dublin OH", Workday URL hint "dublin oh"). Not a generic word-boundary —
+// English "in"/"or"/"me" in "Remote, Belgium or France" must not impersonate
+// Indiana/Oregon/Maine. State *names* still use compileLocationKeyword.
+function compileUsStateAbbrev(abbr) {
+  const escaped = abbr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?:,\\s*${escaped}(?![a-z0-9])|(?:^|[^a-z0-9])${escaped}[^a-z0-9]*$)`);
+  return (lower) => re.test(lower);
+}
+
+const US_STATE_ALWAYS_ALLOW_MATCHERS = USPS_STATES.flatMap(([name, abbr]) => [
+  compileLocationKeyword(name),
+  compileUsStateAbbrev(abbr),
+]);
 
 // Some providers report a rolled-up display string ("5 Locations", "2 Locations")
 // while the canonical URL still names the real primary location. Workday is the
@@ -284,7 +359,15 @@ export function titleSignalsRemote(title) {
 // location-only semantics, which is what the existing unit tests exercise.
 export function buildLocationFilter(locationFilter) {
   if (!locationFilter) return () => true;
-  const alwaysAllow = compileLocationKeywordList(locationFilter.always_allow);
+  const alwaysAllowKeywords = normalizeKeywordList(locationFilter.always_allow);
+  const alwaysAllow = alwaysAllowKeywords.map(compileLocationKeyword);
+  // US-targeted configs list the country in always_allow and foreign cities
+  // in block. "Dublin, OH" does not contain "United States", so without this
+  // expansion block: [Dublin] rejects a real US job. Opt-in on the country
+  // token — configs with no US always_allow entry are unchanged.
+  if (alwaysAllowKeywords.some(k => US_COUNTRY_ALWAYS_ALLOW.has(k))) {
+    alwaysAllow.push(...US_STATE_ALWAYS_ALLOW_MATCHERS);
+  }
   const allow = compileLocationKeywordList(locationFilter.allow);
   const block = compileLocationKeywordList(locationFilter.block);
   const blockHard = compileLocationKeywordList(locationFilter.block_hard);

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -82,7 +82,7 @@
 # location_filter:
 #   # always_allow is checked BEFORE block — keep this list to your home region only
 #   always_allow:
-#     - "United States"   # (replace with your home region)
+#     - "United States"   # also admits City, ST homonyms (Dublin, OH) via USPS states
 #     - "New York"
 #   allow:
 #     - "Remote"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7201,6 +7201,117 @@ try {
     fail('omitting block_hard must preserve the pre-existing always_allow-wins behaviour');
   }
 
+  // Case 9e: US-targeted always_allow + blocked foreign cities must not drop
+  // US homonym cities ("Dublin, OH" is Ohio, not Ireland). State names and
+  // 2-letter codes both count; the foreign counterpart still rejects.
+  const usHomonymFilter = buildLocationFilter({
+    always_allow: ['United States', 'USA'],
+    allow: [],
+    block: ['Dublin', 'Paris', 'London', 'Berlin', 'Manchester', 'Cambridge'],
+  });
+  const usHomonymPass = [
+    ['Dublin, OH', 'abbrev'],
+    ['Dublin, Ohio', 'state name'],
+    ['Paris, TX', 'Paris TX'],
+    ['London, KY', 'London KY'],
+    ['Berlin, NH', 'Berlin NH'],
+    ['Cambridge, MA', 'Cambridge MA'],
+  ];
+  const usHomonymReject = [
+    ['Dublin, Ireland', 'Dublin Ireland'],
+    ['Paris, France', 'Paris France'],
+    ['London, United Kingdom', 'London UK'],
+    ['Berlin, Germany', 'Berlin Germany'],
+    ['Cambridge, UK', 'Cambridge UK'],
+  ];
+  const usHomonymLeaks = usHomonymPass.filter(([loc]) => usHomonymFilter(loc) !== true);
+  const usHomonymMisses = usHomonymReject.filter(([loc]) => usHomonymFilter(loc) !== false);
+  if (usHomonymLeaks.length === 0) {
+    pass('US always_allow treats City, ST homonyms as US (Dublin OH / Paris TX / London KY)');
+  } else {
+    fail(`US city homonym should pass: ${usHomonymLeaks.map(([l]) => l).join('; ')}`);
+  }
+  if (usHomonymMisses.length === 0) {
+    pass('US always_allow still blocks the foreign counterpart (Dublin Ireland / Paris France)');
+  } else {
+    fail(`foreign counterpart should still reject: ${usHomonymMisses.map(([l]) => l).join('; ')}`);
+  }
+
+  // Case 9f: URL hint "City-ST" (Workday) is the same expansion.
+  if (usHomonymFilter('5 Locations', 'https://x.wd1.myworkdayjobs.com/c/job/Dublin-OH/Eng_R1') === true) {
+    pass('US state expansion applies to the URL location hint (Dublin-OH)');
+  } else {
+    fail('Workday URL hint "Dublin-OH" should pass via the USPS abbrev');
+  }
+
+  // Case 9g: genuine always_allow city still passes; block_hard still wins
+  // over the US expansion (country-level, never a false rejection).
+  const usHomonymWithCity = buildLocationFilter({
+    always_allow: ['united states', 'amsterdam'],
+    allow: [],
+    block: ['Dublin', 'Paris', 'London', 'Berlin'],
+    block_hard: ['ireland', 'brazil', 'usa'],
+  });
+  if (usHomonymWithCity('Amsterdam, Netherlands') === true) {
+    pass('genuine always_allow city (Amsterdam, Netherlands) still passes under US expansion');
+  } else {
+    fail('Amsterdam, Netherlands must still pass via always_allow amsterdam');
+  }
+  if (
+    usHomonymWithCity('Dublin, Ireland') === false &&
+    usHomonymWithCity('USA - New York - Malta') === false &&
+    usHomonymWithCity('Porto Alegre, Rio Grande do Sul, Brazil') === false
+  ) {
+    pass('block_hard still wins over US state expansion (Ireland / USA / Brazil)');
+  } else {
+    fail('block_hard must still reject country-level hits when US expansion is active');
+  }
+
+  // Case 9h: no US country token → expansion is off (EU-targeted installs).
+  const euFilter = buildLocationFilter({
+    always_allow: ['belgium', 'brussels', 'amsterdam'],
+    allow: [],
+    block: ['Dublin', 'Paris', 'London'],
+  });
+  if (
+    euFilter('Dublin, OH') === false &&
+    euFilter('Paris, TX') === false &&
+    euFilter('Amsterdam, Netherlands') === true
+  ) {
+    pass('without a US always_allow token, City, ST homonyms stay blocked (EU config unchanged)');
+  } else {
+    fail('EU-targeted always_allow must not grow USPS state matches');
+  }
+
+  // Case 9j: the other documented US country spellings trigger the same expansion.
+  const usDot = buildLocationFilter({ always_allow: ['U.S.'], block: ['Dublin'] });
+  const usDotA = buildLocationFilter({ always_allow: ['U.S.A.'], block: ['Dublin'] });
+  if (usDot('Dublin, OH') === true && usDotA('Dublin, Ohio') === true) {
+    pass('u.s. / u.s.a. always_allow tokens also expand USPS states');
+  } else {
+    fail('u.s. and u.s.a. must trigger the same US homonym rescue as United States');
+  }
+
+  // Case 9i: 2-letter codes do not match inside other words, and English
+  // "or"/"in" in a multi-location string is not Oregon/Indiana. always_allow
+  // is checked before block, so a leak would rescue these rather than reject.
+  const usAbbrevLeakFilter = buildLocationFilter({
+    always_allow: ['united states'],
+    allow: ['united states', 'usa'],
+    block: ['france', 'belgium', 'dublin', 'india'],
+  });
+  if (
+    usAbbrevLeakFilter('Remote, Belgium or France') === false &&
+    usAbbrevLeakFilter('Hyderabad, India') === false &&
+    usAbbrevLeakFilter('Dublin, India') === false &&
+    usAbbrevLeakFilter('Portland, OR') === true &&
+    usAbbrevLeakFilter('Dublin, IN') === true
+  ) {
+    pass('USPS abbrevs do not match inside India / English or-in conjunctions');
+  } else {
+    fail('state abbrevs leaked: IN/OR must not match India or "Belgium or France"');
+  }
+
   // Case 10: all-null/non-string list → empty after normalization (no false rejects)
   const allBadFilter = buildLocationFilter({ block: [null, 42, undefined], allow: ['remote'] });
   if (allBadFilter('Remote') === true) {


### PR DESCRIPTION
## What does this PR do?

`location_filter` word-boundary matching already avoids `India` swallowing `Indiana`, but a **bare city** in `block` is still a whole-word hit everywhere. A US-targeted `portals.yml` typically has `always_allow: [United States, USA, …]`, `block: [Dublin, Paris, London, …]`, and an empty `allow` list. `always_allow` beats `block` only when the location string contains a US country token, so **Dublin, OH** / **Paris, TX** / **London, KY** were rejected as Ireland / France / the UK.

When `always_allow` already names the US as a country (`united states` / `usa` / `u.s.` / `u.s.a.`), USPS state names and 2-letter codes become additional `always_allow` matches (word-boundary for names; comma-state or trailing token for abbrevs, so English `or`/`in` cannot impersonate Oregon/Indiana).

- `Dublin, OH` / `Dublin, Ohio` → pass; `Dublin, Ireland` → still reject
- `Paris, TX` → pass; `Paris, France` → reject
- `Amsterdam, Netherlands` with amsterdam in always_allow still passes
- `block_hard` still wins (country-level, never a false rejection)
- Configs with no US always_allow token are unchanged (EU-targeted installs)

Does not edit user-layer `portals.yml`. No world gazetteer — US homonyms only.

## Related issue

Bug fix, no issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs --quick` and all tests pass (7578 passed, 0 failed, 13 pre-existing warnings)
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)