### PR TITLE
fix: honor CAREER_OPS_DATA_DIR in web and scan writes

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1985,7 +1985,7 @@ export async function appendToScanHistory(offers, date, status = 'added') {
 
 // ── Company blacklist (#1742) ───────────────────────────────────────
 
-const BLACKLIST_PATH = 'data/blacklist.md';
+const BLACKLIST_PATH = path.join(DATA_ROOT, 'data/blacklist.md');
 
 /**
  * Parse the user's do-not-apply list (data/blacklist.md, user layer, opt-in).
@@ -2034,7 +2034,7 @@ export function loadBlacklist(filePath = BLACKLIST_PATH) {
 
 // ── Scan-run persistence (#1604) ────────────────────────────────────
 
-const SCAN_RUNS_PATH = 'data/scan-runs.tsv';
+const SCAN_RUNS_PATH = path.join(DATA_ROOT, 'data/scan-runs.tsv');
 
 // One row of run counters per non-dry scan — today these numbers are printed
 // once in the summary and lost when the terminal scrolls. Full ISO timestamp
@@ -2107,7 +2107,7 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
 
 // ── Portal health persistence (#1744) ───────────────────────────────
 
-const PORTAL_HEALTH_PATH = 'data/portal-health.tsv';
+const PORTAL_HEALTH_PATH = path.join(DATA_ROOT, 'data/portal-health.tsv');
 export const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
 
 // Locked (portal-health-lock.mjs) so a concurrent read-modify-write of this

--- a/tests/portal-health-path.test.mjs
+++ b/tests/portal-health-path.test.mjs
@@ -1,21 +1,18 @@
 // tests/portal-health-path.test.mjs — appendPortalHealth()/loadPortalHealth()
-// must resolve their default path against process.cwd(), not the directory
-// scan.mjs lives in.
+// must resolve their default path against DATA_ROOT, not cwd and not the
+// directory scan.mjs lives in.
 //
-// Every sibling data path in scan.mjs (SCAN_HISTORY_PATH, PIPELINE_PATH,
-// APPLICATIONS_PATH, BLACKLIST_PATH, SCAN_RUNS_PATH) is a bare cwd-relative
-// string. PORTAL_HEALTH_PATH used to be the one exception, resolved via
-// path.dirname(fileURLToPath(import.meta.url)) -- the script's own directory.
-// Any invocation with a sandboxed cwd (a test run, a temp dir, a CI checkout)
-// still wrote fixture rows straight into the real data/portal-health.tsv of
-// whatever checkout happens to own scan.mjs, polluting real pipeline data with
-// test fixtures.
+// SCAN_HISTORY_PATH / PIPELINE_PATH / APPLICATIONS_PATH already join DATA_ROOT.
+// PORTAL_HEALTH_PATH used to be a bare cwd-relative `data/portal-health.tsv`,
+// so a run with cwd ≠ DATA_ROOT (CAREER_OPS_DATA_DIR) wrote where stats.mjs
+// does not read. Earlier still, it was resolved via import.meta.url — the
+// script's own directory — and sandboxed tests polluted the real checkout.
 //
-// This spawns a real child process with cwd pinned to a temp dir that is NOT
-// the directory scan.mjs lives in, then calls appendPortalHealth() with no
-// filePath argument -- the exact call scan.mjs's own production code path
-// makes. The row must land under the given cwd, and the script's own
-// directory must be provably untouched.
+// This spawns a real child with CAREER_OPS_DATA_DIR pinned to a temp dir and
+// cwd pinned to a *different* temp dir, then calls appendPortalHealth() with
+// no filePath argument — the exact call scan.mjs's own production path makes.
+// The row must land under DATA_ROOT, not cwd, and the script's own directory
+// must be provably untouched.
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
 import { spawnSync } from 'child_process';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
@@ -25,10 +22,11 @@ import { pathToFileURL } from 'url';
 import { randomUUID } from 'crypto';
 import { applyScriptDirGuard } from './portal-health-guard.mjs';
 
-console.log('\nscan.mjs — portal-health.tsv resolves against cwd, not script dir');
+console.log('\nscan.mjs — portal-health.tsv resolves against DATA_ROOT, not cwd');
 
 const scanUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan.mjs')).href);
-const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-'));
+const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-root-'));
+const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-cwd-'));
 
 // The script's own directory is ROOT in this checkout -- the same directory
 // the pre-fix bug always resolved to regardless of the cwd it was given.
@@ -50,8 +48,14 @@ try {
     await mod.appendPortalHealth([{ timestamp: '2026-01-01T00:00:00.000Z', company: ${JSON.stringify(marker)}, status: 'reachable' }]);
   `;
 
+  const childEnv = { ...process.env };
+  delete childEnv.CAREER_OPS_ROOT;
+  delete childEnv.CAREER_OPS_DATA_DIR;
+  childEnv.CAREER_OPS_DATA_DIR = dataRoot;
+
   const res = spawnSync(NODE, ['--input-type=module', '-e', script], {
     cwd: sandboxCwd,
+    env: childEnv,
     encoding: 'utf-8',
     timeout: 30000,
   });
@@ -59,15 +63,21 @@ try {
   if (res.error || res.status !== 0) {
     fail(`appendPortalHealth() child process failed: ${res.error?.message || res.stderr}`);
   } else {
-    pass('appendPortalHealth() runs cleanly with a sandbox cwd');
+    pass('appendPortalHealth() runs cleanly with cwd ≠ CAREER_OPS_DATA_DIR');
   }
 
-  // 1. The row lands under the cwd the process was given, not the script dir.
-  const sandboxHealthPath = join(sandboxCwd, 'data', 'portal-health.tsv');
-  if (existsSync(sandboxHealthPath) && readFileSync(sandboxHealthPath, 'utf-8').includes(marker)) {
-    pass('the fixture row is written under the sandbox cwd');
+  // 1. The row lands under DATA_ROOT, not the sandbox cwd and not the script dir.
+  const dataRootHealthPath = join(dataRoot, 'data', 'portal-health.tsv');
+  const cwdHealthPath = join(sandboxCwd, 'data', 'portal-health.tsv');
+  if (existsSync(dataRootHealthPath) && readFileSync(dataRootHealthPath, 'utf-8').includes(marker)) {
+    pass('the fixture row is written under DATA_ROOT');
   } else {
-    fail(`expected ${sandboxHealthPath} to contain the fixture row, it does not`);
+    fail(`expected ${dataRootHealthPath} to contain the fixture row, it does not`);
+  }
+  if (!existsSync(cwdHealthPath)) {
+    pass('the fixture row is not written under the sandbox cwd');
+  } else {
+    fail(`portal-health leaked to cwd (${cwdHealthPath}) — DATA_ROOT split-brain regression`);
   }
 
   // 2. The script's own directory -- the real user-layer data dir in a normal
@@ -83,6 +93,7 @@ try {
     fail(`the sandboxed run wrote into the script's own directory (${scriptDirHealthPath}) -- this is the cwd-resolution regression`);
   }
 } finally {
+  rmSync(dataRoot, { recursive: true, force: true });
   rmSync(sandboxCwd, { recursive: true, force: true });
   // Defensive cleanup, matching the pattern in tests/scan-no-targets.test.mjs
   // and tests/intake-mutex.test.mjs -- never observed to trigger once the path

--- a/tests/scan-data-root-paths.test.mjs
+++ b/tests/scan-data-root-paths.test.mjs
@@ -1,0 +1,129 @@
+// tests/scan-data-root-paths.test.mjs — scan.mjs blacklist + scan-runs defaults
+// must resolve under DATA_ROOT, not cwd.
+//
+// SCAN_HISTORY_PATH / PIPELINE_PATH already join(DATA_ROOT, …). BLACKLIST_PATH
+// and SCAN_RUNS_PATH were bare `data/…` strings, so a run with cwd ≠ DATA_ROOT
+// (the documented CAREER_OPS_DATA_DIR case) wrote scan-runs where stats.mjs
+// does not read them, and missed data/blacklist.md in the data root.
+//
+// Spawns a child: DATA_ROOT is a module-level constant, so an in-process
+// import would see this process's env, not the lane under test. Callers that
+// pass an explicit filePath keep that override (loadBlacklist(filePath = …)).
+import { pass, fail, NODE, ROOT, rmSync } from './helpers.mjs';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+
+console.log('\nscan.mjs — blacklist and scan-runs resolve under DATA_ROOT, not cwd');
+
+const scanUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-scan-dataroot-'));
+const otherCwd = mkdtempSync(join(tmpdir(), 'career-ops-scan-cwd-'));
+const overrideDir = mkdtempSync(join(tmpdir(), 'career-ops-scan-override-'));
+
+mkdirSync(join(dataRoot, 'data'), { recursive: true });
+mkdirSync(join(otherCwd, 'data'), { recursive: true });
+writeFileSync(
+  join(dataRoot, 'data', 'blacklist.md'),
+  [
+    '| Company | Since | Scope | Reason |',
+    '|---------|-------|-------|--------|',
+    '| Data Root Co | 2026-01-01 | all | fixture |',
+    '',
+  ].join('\n'),
+  'utf-8',
+);
+const overridePath = join(overrideDir, 'blacklist.md');
+writeFileSync(
+  overridePath,
+  [
+    '| Company | Since | Scope | Reason |',
+    '|---------|-------|-------|--------|',
+    '| Override Co | 2026-01-01 | all | explicit |',
+    '',
+  ].join('\n'),
+  'utf-8',
+);
+
+const SCANNER_PATH_VARS = [
+  'CAREER_OPS_PORTALS',
+  'CAREER_OPS_PROFILE',
+  'CAREER_OPS_PIPELINE',
+  'CAREER_OPS_SCAN_HISTORY',
+  'CAREER_OPS_ROOT',
+  'CAREER_OPS_DATA_DIR',
+];
+
+try {
+  const script = `
+    const mod = await import(${scanUrl});
+    const fromRoot = [...mod.loadBlacklist().keys()];
+    const fromOverride = [...mod.loadBlacklist(${JSON.stringify(overridePath)}).keys()];
+    mod.appendScanRunSummary({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      status: 'completed',
+      companies: 1, boards: 1, found: 0,
+      filteredTitle: 0, filteredTier: 0, filteredLocation: 0, filteredPostingAge: 0,
+      filteredSalary: 0, filteredContent: 0, filteredCooldown: 0,
+      dupes: 0, newAdded: 0, errors: 0,
+      filteredBlacklist: 0, filteredVisa: 0, filteredPostedDate: 0,
+      filteredCountryEligibility: 0,
+    });
+    console.log(JSON.stringify({ fromRoot, fromOverride }));
+  `;
+
+  const childEnv = { ...process.env };
+  for (const name of SCANNER_PATH_VARS) delete childEnv[name];
+  childEnv.CAREER_OPS_DATA_DIR = dataRoot;
+
+  const res = spawnSync(NODE, ['--input-type=module', '-e', script], {
+    cwd: otherCwd,
+    env: childEnv,
+    encoding: 'utf-8',
+    timeout: 30000,
+  });
+
+  if (res.error || res.status !== 0) {
+    fail(`scan.mjs DATA_ROOT child failed: ${res.error?.message || res.stderr}`);
+  } else {
+    pass('scan.mjs loads with cwd ≠ CAREER_OPS_DATA_DIR');
+  }
+
+  let payload = { fromRoot: [], fromOverride: [] };
+  try {
+    payload = JSON.parse((res.stdout || '').trim().split('\n').at(-1));
+  } catch {
+    fail(`scan.mjs DATA_ROOT child did not print JSON (${JSON.stringify(res.stdout)})`);
+  }
+
+  if (payload.fromRoot.length === 1 && payload.fromRoot[0] === 'datarootco') {
+    pass('loadBlacklist() default reads DATA_ROOT/data/blacklist.md, not cwd');
+  } else {
+    fail(`loadBlacklist() default missed DATA_ROOT blacklist; keys=${JSON.stringify(payload.fromRoot)}`);
+  }
+
+  if (payload.fromOverride.length === 1 && payload.fromOverride[0] === 'overrideco') {
+    pass('loadBlacklist(filePath) still honors an explicit override');
+  } else {
+    fail(`loadBlacklist(filePath) override broken; keys=${JSON.stringify(payload.fromOverride)}`);
+  }
+
+  const rootRuns = join(dataRoot, 'data', 'scan-runs.tsv');
+  const cwdRuns = join(otherCwd, 'data', 'scan-runs.tsv');
+  if (existsSync(rootRuns) && readFileSync(rootRuns, 'utf-8').includes('2026-01-01T00:00:00.000Z')) {
+    pass('appendScanRunSummary() default writes DATA_ROOT/data/scan-runs.tsv');
+  } else {
+    fail(`expected ${rootRuns} to contain the fixture row`);
+  }
+  if (!existsSync(cwdRuns)) {
+    pass('appendScanRunSummary() default does not write cwd/data/scan-runs.tsv');
+  } else {
+    fail(`scan-runs leaked to cwd (${cwdRuns}) — DATA_ROOT split-brain regression`);
+  }
+} finally {
+  rmSync(dataRoot, { recursive: true, force: true });
+  rmSync(otherCwd, { recursive: true, force: true });
+  rmSync(overrideDir, { recursive: true, force: true });
+}

--- a/web/README.md
+++ b/web/README.md
@@ -61,8 +61,9 @@ npx tsc --noEmit     # typecheck
 npm run build        # production build
 ```
 
-Set `CAREER_OPS_ROOT=/path/to/checkout` in `web/.env.local` to point the app at
-a different career-ops directory (useful for testing against sample data).
+Set `CAREER_OPS_ROOT` or `CAREER_OPS_DATA_DIR` in `web/.env.local` to point the
+app at a different career-ops directory (useful for testing against sample data).
+Same pair the CLI honors; `CAREER_OPS_ROOT` wins if both are set.
 
 ### Tests
 

--- a/web/src/lib/career-ops-root.mjs
+++ b/web/src/lib/career-ops-root.mjs
@@ -1,0 +1,23 @@
+/**
+ * career-ops-root.mjs — resolve the career-ops "home" (cv.md, data/, reports/).
+ *
+ * Plain .mjs so web/tests can import it with `node --test` and no TypeScript
+ * build step (same pattern as pdf-paths.mjs / report-files.mjs).
+ *
+ * Env pair matches core's getCareerOpsRoot(): CAREER_OPS_ROOT ||
+ * CAREER_OPS_DATA_DIR. The no-env default stays cwd/.. because Next runs from
+ * web/; core's default is path-resolver's __dirname (the repo root). Do not
+ * call getCareerOpsRoot() here — that would change the web default.
+ */
+import path from "node:path";
+
+/**
+ * Absolute path to the career-ops data root the web app should read.
+ *
+ * @returns {string}
+ */
+export function careerOpsRoot() {
+  const env = process.env.CAREER_OPS_ROOT?.trim() || process.env.CAREER_OPS_DATA_DIR?.trim();
+  if (env) return path.resolve(env);
+  return path.resolve(process.cwd(), "..");
+}

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -13,7 +13,8 @@ import { resolvePdfIndexPath } from "@/lib/core/pdf-index";
 import { pdfIndexEntryForReport } from "@/lib/apply/cv-selection.mjs";
 
 // CAREER_OPS_ROOT || CAREER_OPS_DATA_DIR, else cwd/.. — see career-ops-root.mjs.
-export { careerOpsRoot } from "@/lib/career-ops-root.mjs";
+import { careerOpsRoot } from "@/lib/career-ops-root.mjs";
+export { careerOpsRoot };
 
 /**
  * Absolute path to a core root script (e.g. doctor, verify-portals). The `.mjs`

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -12,18 +12,8 @@ import { resolvePdfIndexPath } from "@/lib/core/pdf-index";
 // index row belong to" (#2599, #2008 review).
 import { pdfIndexEntryForReport } from "@/lib/apply/cv-selection.mjs";
 
-/**
- * Resolve the career-ops "home" — the directory holding the user's sibling
- * files (cv.md, data/, reports/). In production the web/ app lives inside the
- * career-ops checkout, so the home is its parent (..). Dev overrides via
- * CAREER_OPS_ROOT to read the user's real (gitignored) data from a separate
- * checkout — see web/.env.local.
- */
-export function careerOpsRoot(): string {
-  const env = process.env.CAREER_OPS_ROOT?.trim();
-  if (env) return env;
-  return path.resolve(process.cwd(), "..");
-}
+// CAREER_OPS_ROOT || CAREER_OPS_DATA_DIR, else cwd/.. — see career-ops-root.mjs.
+export { careerOpsRoot } from "@/lib/career-ops-root.mjs";
 
 /**
  * Absolute path to a core root script (e.g. doctor, verify-portals). The `.mjs`

--- a/web/tests/lib/career-ops-root.test.mjs
+++ b/web/tests/lib/career-ops-root.test.mjs
@@ -1,0 +1,63 @@
+// Tests for careerOpsRoot() using Node's built-in test runner.
+// Imports directly from career-ops-root.mjs (the single source of truth) so the
+// test and production code can never drift out of sync.
+//
+// Run:  node --test tests/lib/career-ops-root.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { careerOpsRoot } from "../../src/lib/career-ops-root.mjs";
+
+const ENV_NAMES = ["CAREER_OPS_ROOT", "CAREER_OPS_DATA_DIR"];
+
+function withEnv(vars, fn) {
+  const saved = Object.fromEntries(ENV_NAMES.map((n) => [n, process.env[n]]));
+  try {
+    for (const n of ENV_NAMES) {
+      if (vars[n] === undefined) delete process.env[n];
+      else process.env[n] = vars[n];
+    }
+    return fn();
+  } finally {
+    for (const n of ENV_NAMES) {
+      if (saved[n] === undefined) delete process.env[n];
+      else process.env[n] = saved[n];
+    }
+  }
+}
+
+test("no env: default is cwd/.., not path-resolver's repo-root default", () => {
+  withEnv({}, () => {
+    assert.equal(careerOpsRoot(), path.resolve(process.cwd(), ".."));
+  });
+});
+
+test("CAREER_OPS_DATA_DIR alone is honored (absolute)", () => {
+  const dataDir = path.join(os.tmpdir(), "career-ops-data-dir-fixture");
+  withEnv({ CAREER_OPS_DATA_DIR: dataDir }, () => {
+    assert.equal(careerOpsRoot(), path.resolve(dataDir));
+  });
+});
+
+test("CAREER_OPS_DATA_DIR relative path is resolved against cwd", () => {
+  withEnv({ CAREER_OPS_DATA_DIR: "some-data" }, () => {
+    assert.equal(careerOpsRoot(), path.resolve("some-data"));
+  });
+});
+
+test("CAREER_OPS_ROOT still wins when both env vars are set", () => {
+  const root = path.join(os.tmpdir(), "career-ops-root-fixture");
+  const dataDir = path.join(os.tmpdir(), "career-ops-data-dir-fixture");
+  withEnv({ CAREER_OPS_ROOT: root, CAREER_OPS_DATA_DIR: dataDir }, () => {
+    assert.equal(careerOpsRoot(), path.resolve(root));
+  });
+});
+
+test("blank CAREER_OPS_ROOT falls through to CAREER_OPS_DATA_DIR", () => {
+  const dataDir = path.join(os.tmpdir(), "career-ops-data-dir-fallback");
+  withEnv({ CAREER_OPS_ROOT: "  ", CAREER_OPS_DATA_DIR: dataDir }, () => {
+    assert.equal(careerOpsRoot(), path.resolve(dataDir));
+  });
+});


### PR DESCRIPTION
## Why

Setting only `CAREER_OPS_DATA_DIR` (the documented core data-root override) made web and some scan writes use a different tree than `scan` / `doctor` / `stats`.

## What

- Web `careerOpsRoot()` now uses `CAREER_OPS_ROOT || CAREER_OPS_DATA_DIR` (absolute, or resolved against cwd). No-env default stays `cwd/..` because Next runs from `web/` — it does **not** call core `getCareerOpsRoot()`, whose default is path-resolver `__dirname`.
- `scan.mjs` joins `BLACKLIST_PATH`, `SCAN_RUNS_PATH`, and `PORTAL_HEALTH_PATH` to `DATA_ROOT`, matching pipeline/scan-history. Explicit `filePath` overrides (`loadBlacklist(filePath = BLACKLIST_PATH)`, etc.) still work.

## Tests

- `web/tests/lib/career-ops-root.test.mjs` — DATA_DIR alone, ROOT wins, relative resolve, cwd/.. default
- `tests/scan-data-root-paths.test.mjs` — blacklist + scan-runs under DATA_ROOT when cwd differs; explicit blacklist path still honored
- `tests/portal-health-path.test.mjs` — same DATA_ROOT contract for portal-health (stats.mjs already reads it from DATA_ROOT)

No user-layer files.