### PR TITLE
fix(scan): URL location hint must supplement a location, never substitute for one

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -234,7 +234,13 @@ export function locationHintFromUrl(url) {
   }
   // "Hyderabad-Telangana-India" → "hyderabad telangana india" so multi-word
   // block keywords like "united arab emirates" can still match.
-  return segment.replace(/[-_+]+/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase();
+  const normalized = segment.replace(/[-_+]+/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase();
+  // An all-digit segment is an opaque posting id, never a place — Microsoft
+  // (.../job/1970393556874927) and Netflix (.../job/790298014263) both use this
+  // shape. Returning '' says "no hint" instead of "a hint that can never match
+  // any keyword".
+  if (/^[\d ]+$/.test(normalized)) return '';
+  return normalized;
 }
 
 // Some ATSs report the hiring office as the location even when the role is
@@ -293,9 +299,27 @@ export function buildLocationFilter(locationFilter) {
 
   return (location, url, title) => {
     const lower = typeof location === 'string' ? location.trim().toLowerCase() : '';
+    // No structured location → pass, and do NOT consult the URL hint.
+    //
+    // The hint SUPPLEMENTS a location, it never substitutes for one. It exists
+    // to recover the real place behind a rolled-up display string ("5
+    // Locations"), which is by definition non-empty — so restricting it to a
+    // non-empty location keeps every case it was built for.
+    //
+    // Letting it stand in for an absent location inverts the filter's own
+    // "don't penalize missing data" discipline, because the post-`/job/`
+    // segment is only a place on SOME boards. On builtin.com the URL shape is
+    // `/job/{title-slug}/{id}`, so the hint is the JOB TITLE: non-empty, so the
+    // early return never fired, and matching a title against a list of cities
+    // and countries fails, so the row was rejected — a near-total silent drop
+    // for that board, with nothing logged.
+    //
+    // The converse case, an empty location with a genuinely place-like hint,
+    // does not occur: a board that encodes a place in the URL reports one in
+    // the structured field too. So nothing this filter previously rejected on
+    // real evidence starts passing.
+    if (lower === '') return true;
     const hint = locationHintFromUrl(url);
-    // Nothing to judge on either field → pass (don't penalize missing data).
-    if (lower === '' && hint === '') return true;
     const matches = (m) => (lower !== '' && m(lower)) || (hint !== '' && m(hint));
     // `block_hard` is the ONE tier always_allow cannot override. It exists because
     // a European city name can be a whole word inside a non-European location, so

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7306,6 +7306,50 @@ try {
     fail(`URL hint normalization wrong: got "${locationHintFromUrl('https://x.wd1.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1')}"`);
   }
 
+  // Case 19b: an EMPTY location is never rejected on a URL hint alone. The hint
+  // supplements a location, it never substitutes for one — the post-`/job/`
+  // segment is only a place on some boards. builtin.com's URL shape is
+  // `/job/{title-slug}/{id}`, so its hint is the job title; before this guard a
+  // non-empty title slug defeated the "no data → pass" early return and every
+  // builtin row without a "remote"-ish title was silently dropped.
+  if (
+    urlFilter('', 'https://builtin.com/job/senior-hpc-platform-engineer/10960569') === true &&
+    urlFilter(undefined, 'https://builtin.com/job/staff-backend-engineer/123') === true
+  ) {
+    pass('an empty location passes regardless of the URL — a title-slug hint can no longer reject it');
+  } else {
+    fail('empty location + a /job/{title-slug}/ URL must pass (hint supplements, never substitutes)');
+  }
+
+  // Case 19c: the same guard is deliberately blind to WHY the location is empty,
+  // so a place-like hint cannot reject an empty location either. This is the
+  // accepted trade-off: a board that encodes a place in its URL reports one in
+  // the structured field too, so the pairing does not arise in practice.
+  if (urlFilter('', 'https://x.wd5.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1') === true) {
+    pass('an empty location passes even when the URL names a blocked place (documented trade-off)');
+  } else {
+    fail('empty location must pass even with a place-like blocked hint');
+  }
+
+  // Case 19d: the rolled-up case the hint was built for is untouched — its
+  // display string is non-empty, which is exactly when the hint still applies.
+  if (urlFilter('5 Locations', 'https://kyndryl.wd5.myworkdayjobs.com/careers/job/Hyderabad-Telangana-India/Network-Engineer_R-65193-1') === false) {
+    pass('the motivating "5 Locations" + India case still rejects (non-empty location keeps the hint live)');
+  } else {
+    fail('the URL-hint feature must keep working for rolled-up display strings');
+  }
+
+  // Case 19e: an all-digit segment is an opaque posting id, not a place.
+  if (
+    locationHintFromUrl('https://apply.careers.microsoft.com/careers/job/1970393556874927') === '' &&
+    locationHintFromUrl('https://explore.jobs.netflix.net/careers/job/790298014263') === '' &&
+    locationHintFromUrl('https://x.wd1.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1') === 'hyderabad telangana india'
+  ) {
+    pass('locationHintFromUrl returns "" for an all-numeric job segment but still reads a real place');
+  } else {
+    fail(`numeric job-id segments should yield no hint: got "${locationHintFromUrl('https://apply.careers.microsoft.com/careers/job/1970393556874927')}"`);
+  }
+
   // Case 20: omitting the url argument preserves the original location-only behaviour
   if (urlFilter('Bengaluru, India') === false && urlFilter('Austin, TX') === true) {
     pass('calling the filter without a url keeps original location-only semantics');


### PR DESCRIPTION
## What does this PR do?

`buildLocationFilter` consulted the URL location hint even when the structured
location was EMPTY. The hint is meant to SUPPLEMENT a location, never to
substitute for one, and the path segment after `/job/` is only a place on some
boards — so where it isn't, a non-empty hint defeated the "nothing to judge →
pass" early return and rows were rejected on evidence that was never a location.

`locationHintFromUrl` reads that segment to recover the real place behind a
rolled-up display string like `"5 Locations"`, which no `block` keyword can
otherwise match. That part is sound and this PR keeps it working.

The failure case: on builtin.com the URL shape is `/job/{title-slug}/{id}`, so
the hint is the JOB TITLE. Being non-empty, it defeated the early return, and
matching a job title against a list of cities and countries fails — so the row
was rejected. The filter's own "don't penalize missing data" discipline was
inverted into a near-total silent drop for that board, with nothing logged. On a
sample page of 25 rows the only survivors were the ones whose title happened to
contain the word "remote".

Details:

- When the structured location is empty, pass and do not consult the hint. The
  motivating case is untouched, because a rolled-up display string is by
  definition non-empty — which is exactly when the hint still applies.
- Return no hint for an all-digit segment, which is a posting id and can never
  be a place. Microsoft and Netflix both use that URL shape.
- Nothing previously rejected on real evidence starts passing. The converse case
  — an empty location with a genuinely place-like hint — does not arise in
  practice: a board that encodes a place in its URL reports one in the structured
  field too. Case 19c pins that trade-off as an explicit test so the choice is
  visible rather than accidental.

Known limitation, deliberately out of scope: when a location IS present, a
title-slug hint can still match `block` and drop a valid row — a job title
containing a region word. Fixing that needs a way to know whether a board's URLs
encode a location at all, which is a provider-contract change rather than a
filter fix.

Four new cases in section 19 (`19b`—`19e`) cover the empty-location pass, the
documented trade-off, the preserved `"5 Locations"` behaviour, and numeric
segments. `node test-all.mjs` on this branch: **7690 passed, 0 failed**, against
`main` at 1696bec (which is 7686 passed, 0 failed on its own).

## Related issue

None — bug fix, sent straight in per CONTRIBUTING.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156) — not claimed either way; I have not read the roadmap discussion
