### PR TITLE
fix(fact-gate): count education and training nouns as metrics

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -51,6 +51,15 @@ const METRIC_NOUNS = [
   'machines', 'devices', 'instruments', 'vehicles', 'units', 'locations',
   'acres', 'hectares', 'shifts', 'rounds', 'inspections', 'audits', 'incidents',
   'alarms', 'tickets',
+  // Education and training, for the same reason as the headcount block above.
+  // 'students' and 'staff' were already here, but the nouns an education or
+  // L&D CV actually inflates were not: how many people were put through a
+  // program and how many sites it covered. "Trained 900+ candidates across 60
+  // schools" against a source saying 250 and 20 passed the gate in silence.
+  'candidates', 'trainees', 'learners', 'participants', 'attendees',
+  'graduates', 'alumni', 'teachers', 'instructors', 'educators', 'faculty',
+  'schools', 'districts', 'campuses', 'classrooms', 'programs', 'programmes',
+  'workshops', 'assessments', 'exams',
 ];
 // How many words may sit between a number and the noun it counts. The same
 // regex parses the generated CV and the sources, so the window is symmetric by


### PR DESCRIPTION
## Problem

`METRIC_NOUNS` already carries `students` and `staff`, but not the nouns an education, training or L&D CV inflates in practice: `candidates`, `trainees`, `learners`, `graduates`, `teachers`, `schools`, `districts`, `campuses`, `workshops`, `assessments`.

So a generated CV claiming *"trained 900+ candidates across 60 schools"* passes the gate against a `cv.md` that says 250 and 20 — the exact failure the gate exists to prevent, in the document class it is most often run on.

Observed directly while testing the sibling PR on this fork: an inflated education CV came back `verdict: 'warn'` (advisory phrases) rather than a metric block, because none of the nouns carrying the numbers were recognised as metrics at all.

## Fix

Nine lines: extend `METRIC_NOUNS` with the education and training block. No logic change — the same symmetric parse now sees the numbers.

## Why upstream rather than a downstream patch

The list's own comment already argues for coverage beyond software:

> Headcount outside software. The list above counts users, engineers and repos, so a CV in operations, facilities, healthcare, education or the trades produced NO claim for the one number those CVs actually inflate.

This finishes that thought for the education case rather than introducing a new idea, and every downstream user in education inherits the hole today.

## Testing

- `node verify-cv-facts.mjs --self-test` → **70 passed, 0 failed**
- Applies cleanly to current `main` (`1696bec`); confirmed the nouns are still absent upstream before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbizGUzukKv4Ef66TpEJpx