### PR TITLE
fix(pdf): run the fact gate before rendering a CV

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -4,7 +4,7 @@
  * generate-pdf.mjs — HTML → PDF via Playwright
  *
  * Usage:
- *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages]
+ *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages] [--skip-fact-check]
  *   node career-ops/generate-pdf.mjs --batch=<manifest.json> [--format=letter|a4] [--allow-reorder] [--max-pages=N] [--strict-pages]
  *
  * --batch renders every document in a JSON manifest (an array of
@@ -1087,6 +1087,7 @@ function updatePDFManifest(reportNum, pdfPath, htmlPath, format) {
  */
 async function generatePDF() {
   const args = process.argv.slice(2);
+  let skipFactCheck = false;
 
   // Parse arguments
   let inputPath, outputPath, format = 'a4', reportNum = '', allowReorder = false;
@@ -1106,6 +1107,8 @@ async function generatePDF() {
       allowReorder = true;
     } else if (arg === '--strict-pages') {
       strictPages = true;
+    } else if (arg === '--skip-fact-check') {
+      skipFactCheck = true;
     } else if (!inputPath) {
       inputPath = arg;
     } else if (!outputPath) {
@@ -1211,6 +1214,32 @@ async function generatePDF() {
   if (totalReplacements > 0) {
     const breakdown = Object.entries(normalized.replacements).map(([k, v]) => `${k}=${v}`).join(', ');
     console.log(`🧹 ATS normalization: ${totalReplacements} replacements (${breakdown})`);
+  }
+
+  // Fact gate. generate-cover-letter.mjs already blocks on assertFacts before
+  // importing Playwright, on the reasoning that a failed gate must not leave a
+  // misleading artifact behind. A tailored CV is the same class of document and
+  // carries the numbers a reader acts on, but the CV path enforced the gate only
+  // as an instructed step in the mode prompts — so a programmatic caller (a
+  // bridge, a script, a batch run) rendered inflated metrics in silence. Gate the
+  // normalized HTML, which is the document that actually prints.
+  if (!skipFactCheck && cvMarkdown) {
+    // Imported lazily, INSIDE the guard. A static import is resolved at module
+    // load whether or not this branch runs, and the page-budget/batch suites copy
+    // generate-pdf.mjs alone into a temp workspace — a static import of a sibling
+    // that isn't copied made every one of those suites die with
+    // ERR_MODULE_NOT_FOUND before reaching the behaviour under test. Those
+    // fixtures also ship no cv.md, so this branch is never entered there. If the
+    // module is genuinely missing in a real workspace this throws and the render
+    // fails, which is the correct direction to fail for a fact gate.
+    const { assertFacts } = await import('./verify-cv-facts.mjs');
+    const factCheck = assertFacts(html, { label: basename(inputPath) });
+    if (factCheck.verdict === 'warn') {
+      console.warn(`⚠️  CV fact check warning: ${basename(inputPath)}`);
+      for (const phrase of factCheck.warnings) console.warn(`  - advisory phrase: ${phrase}`);
+    } else {
+      console.log('✅ Fact check passed');
+    }
   }
 
   return renderHtmlToPdf(html, outputPath, {


### PR DESCRIPTION
## Problem

`generate-cover-letter.mjs` calls `assertFacts` **before** it imports Playwright, on the reasoning that a failed gate must not leave a misleading artifact on disk.

The CV path does not. There, the gate is an instructed step inside the mode prompts — so anything that calls `generate-pdf.mjs` directly (a script, a batch run, another tool) renders inflated metrics in silence and writes a PDF that looks finished. The prompt-level instruction protects the interactive path and nothing else.

## Fix

Gate the normalized HTML — the document that actually prints — before `renderHtmlToPdf`, mirroring the cover-letter path. `--skip-fact-check` is added for callers that genuinely want the old behaviour.

## Demonstrated, not assumed

Against a `cv.md` saying `800 users` and an HTML claiming `9000 users`, on current `main`:

| | result |
|---|---|
| **unpatched** | `✅ PDF generated` — 19KB artifact written, no warning |
| **patched** | `❌ Fact check failed … metric-like claims absent from sources: 9000 users`, no artifact left behind |

## One subtlety worth keeping in the diff

The `assertFacts` import is **lazy and inside the guard**, not at module top level. `generate-pdf-page-budget`, `generate-pdf-batch` and `generate-pdf-workspace-root` copy `generate-pdf.mjs` alone into a temp workspace; a static import of a sibling that was not copied made all three die with `ERR_MODULE_NOT_FOUND` before reaching the behaviour under test. Those fixtures also ship no `cv.md`, so the branch is never entered there.

If the module is genuinely missing in a real workspace the import throws and the render fails — the correct direction for a fact gate to fail.

## Testing

- `generate-pdf-batch`, `generate-pdf-page-budget`, `generate-pdf-workspace-root`, `cover-fact-gate` — all pass **identically with and without** the patch (1/1 each, verified both ways on `1696bec`)
- `node verify-cv-facts.mjs --self-test` → **70 passed, 0 failed**

Pairs naturally with the `METRIC_NOUNS` education PR, but is independent of it — either can land alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbizGUzukKv4Ef66TpEJpx