### PR TITLE
fix(gmail): skip page assets so logos stop landing as job leads

### DIFF
--- a/plugins/gmail/_helpers.mjs
+++ b/plugins/gmail/_helpers.mjs
@@ -21,6 +21,13 @@ export function extractUrls(body) {
   return [...new Set(urls)];
 }
 
+/** File types that are page furniture (logos, webfonts, media), never a posting. */
+const ASSET_EXT_RE =
+  /\.(jpe?g|png|gif|svg|webp|avif|ico|bmp|tiff?|css|js|mjs|woff2?|ttf|otf|eot|mp4|webm|mp3|wav)(\?|#|$)/i;
+
+/** Subdomains that only ever serve static files. */
+const ASSET_HOST_PREFIXES = ['cdn.', 'static.', 'assets.', 'img.', 'images.', 'media.'];
+
 /**
  * Is a URL clean and relevant (not a click tracker, unsubscribe link, or pixel)?
  * @param {string} url
@@ -37,6 +44,17 @@ export function isCleanUrl(url) {
       'linkedin.com/legal', 'linkedin.com/help', 'linkedin.com/settings',
     ];
     if (badKeywords.some(kw => lowerUrl.includes(kw))) return false;
+    // Page assets, not postings. Job-alert emails embed one company logo per job,
+    // and those URLs pass every check above: https, no tracker keyword, hosted on
+    // the board's own domain. They land in the pipeline as untitled "job leads" you
+    // have to click to discover are 160x160 PNGs. Extension check first (query
+    // string included, since CDNs append cache-busters), then the CMS upload paths
+    // and asset subdomains that serve files without one.
+    const host = u.hostname.toLowerCase();
+    if (ASSET_EXT_RE.test(u.pathname + u.search)) return false;
+    if (/\/(wp-content|wp-includes)\//i.test(u.pathname)) return false;
+    if (host === 'fonts.googleapis.com' || host === 'fonts.gstatic.com') return false;
+    if (ASSET_HOST_PREFIXES.some(prefix => host.startsWith(prefix))) return false;
     return u.protocol === 'https:';
   } catch {
     return false;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -17687,6 +17687,50 @@ try {
   }
 }
 
+console.log('\n74. gmail: isCleanUrl() drops page assets');
+try {
+  const { isCleanUrl } = await import(pathToFileURL(join(ROOT, 'plugins', 'gmail', '_helpers.mjs')).href);
+
+  // The bug: job-alert emails embed a company logo per job. These reached the
+  // pipeline as untitled "job leads" because they are https, carry no tracker
+  // keyword, and sit on the board's own domain.
+  const assets = [
+    'https://80000hours.org/wp-content/uploads/2023/11/acme-160x160.jpeg',
+    'https://example.com/logo.svg?v=2',              // cache-buster after the extension
+    'https://example.com/hero.PNG',                  // extension case is not significant
+    'https://cdn.example.com/anything',              // asset subdomain, no extension
+    'https://images.example.com/x',
+    'https://fonts.googleapis.com/css2?family=Inter', // webfont CSS has no extension
+    'https://example.com/wp-includes/js/x',
+  ];
+  const bad = assets.filter(isCleanUrl);
+  if (bad.length === 0) pass('isCleanUrl() rejects logos, webfonts and asset hosts');
+  else fail(`isCleanUrl() let ${bad.length} asset URL(s) through: ${bad.join(', ')}`);
+
+  // Regression guard: real postings must survive. "gh_src=js" and "/static-site/"
+  // are the shapes most likely to trip a naive asset filter.
+  const postings = [
+    'https://boards.greenhouse.io/acme/jobs/4384681009?gh_src=js',
+    'https://jobs.ashbyhq.com/acme/abc-123',
+    'https://jobs.lever.co/acme/b71cd010-d3cf-446c-80fa',
+    'https://careers.example.com/static-site-engineer',
+    'https://example.com/jobs/senior-media-buyer',
+  ];
+  const lost = postings.filter(u => !isCleanUrl(u));
+  if (lost.length === 0) pass('isCleanUrl() still accepts real job postings');
+  else fail(`isCleanUrl() wrongly rejected: ${lost.join(', ')}`);
+
+  // Pre-existing behaviour must not regress.
+  if (!isCleanUrl('http://example.com/jobs/1') && !isCleanUrl('https://example.com/click/track')
+      && !isCleanUrl('not a url')) {
+    pass('isCleanUrl() keeps rejecting http, trackers and malformed input');
+  } else {
+    fail('isCleanUrl() regressed on http / tracker / malformed input');
+  }
+} catch (e) {
+  fail(`gmail isCleanUrl tests crashed: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();


### PR DESCRIPTION
## The bug

Job-alert emails embed one company logo per posting. Those image URLs pass every check in `isCleanUrl()` — they are `https`, carry no tracker keyword, and are served from the board's own domain — so the ingest files each one as an untitled `Job lead (email)`:

```
- [ ] https://example.org/wp-content/uploads/2023/11/some-company-160x160.jpeg |  | Job lead (email)
- [ ] https://example.org/wp-content/uploads/2019/06/another-org-160x160.png   |  | Job lead (email)
```

You only find out it is a 160×160 PNG after clicking it.

## How much

On one install: **193 rows over 26 days, 23% of everything the gmail ingest had produced**, still arriving at roughly 11 a day.

```
gmail-ingest rows           828
  of which image files      193   (all from a single alert sender)
```

They all came from one job-board newsletter, so any alert email that illustrates its listings will do the same.

## The fix

Three checks in `isCleanUrl()`, cheapest first:

1. **Extension**, matched against `pathname + search` — CDNs append cache-busters, so `logo.svg?v=2` has to be caught too.
2. **`/wp-content/` and `/wp-includes/`** — WordPress serves uploads from these regardless of extension.
3. **Asset subdomains** (`cdn.`, `static.`, `assets.`, `img.`, `images.`, `media.`) and **webfont hosts** — `fonts.googleapis.com/css2?family=Inter` has no extension at all.

The extension list and host prefixes are module constants, so the regex compiles once rather than per URL.

## Tests

New section 74 in `test-all.mjs`:

- assets that must be dropped, including case-varied `hero.PNG` and the extension-less `cdn.` / webfont shapes
- **real postings that must survive** — `?gh_src=js` and `/static-site-engineer` are the two shapes most likely to trip a naive asset filter, so both are in the guard
- the pre-existing `http:` / tracker / malformed-input rejections, so this does not regress them

`node test-all.mjs` on this branch: **7691 passed, 0 failed**, 14 warnings (all pre-existing — no Go compiler in env, no user data, and the repo's own `funding.json` / `HIRED.md`).

## Scope

`isCleanUrl()` only. No behaviour change for any URL that is not a static file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)