### PR TITLE
fix(verify-cv-facts): a proposed plan horizon is not a metric claim (#3655)

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -212,7 +212,7 @@ export function foldDigits(text) {
 }
 
 /** Remove HTML, basic LaTeX commands, and excess whitespace from document text. */
-export function stripMarkup(text) {
+export function stripMarkup(text, { keepLineBreaks = false } = {}) {
   return foldDigits(String(text))
     .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
     .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
@@ -233,7 +233,11 @@ export function stripMarkup(text) {
     .replace(/\\[a-zA-Z]+\*?(?:\[[^\]]*\])?(?:\{([^}]*)\})?/g, ' $1 ')
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&')
-    .replace(/\s+/g, ' ')
+    // keepLineBreaks preserves a newline as a CLAUSE boundary for the plan-horizon
+    // scan. Horizontal whitespace still collapses, and every claim pattern spans a
+    // newline through `\s`, so extraction is unaffected either way.
+    .replace(keepLineBreaks ? /[^\S\n]+/g : /\s+/g, ' ')
+    .replace(/ *\n+ */g, keepLineBreaks ? '\n' : ' ')
     .trim();
 }
 
@@ -405,15 +409,112 @@ export function delegatedAuthorshipClaims(targetText, sourceText) {
   ));
 }
 
+// A PLAN HORIZON is the window a candidate proposes to work in, and it asserts
+// nothing about the past:
+//
+//   "I'd welcome the chance to talk through how I'd approach the first 90 days"
+//
+// The time units it uses belong in METRIC_NOUNS -- "cut deployment time to 2
+// days" and "saved 20 hours a week" are exactly the claims this gate exists to
+// check -- so the stock cover-letter closing above was extracted as the claim
+// "90 days" and reported as unsupported. No source can ever evidence a proposal,
+// so the only remedy was an allow_metrics entry per phrasing, and every fresh
+// wording came back red.
+//
+// Two signals are required together, and each alone would silence a real claim:
+//
+//   - a horizon LEAD adjacent to the number ("the first", "my next"). Alone it
+//     would swallow "revenue grew in the first 12 months", a past-tense claim.
+//   - a FORWARD marker in the same sentence: one of the four modals that frame
+//     a proposal (would, will, shall, should), a contracted 'd/'ll, or an
+//     explicit intent verb. Ability and possibility modals (can, could, may,
+//     might) are deliberately out, since they frame what is possible rather
+//     than what is planned. Alone this half would swallow "I would bring 20
+//     years of experience", where the number is a real claim inside a
+//     hypothetical sentence.
+//
+// CLAUSE-scoped on purpose. Document-scoped, one conditional courtesy line
+// would silence every time-unit claim in the letter; sentence-scoped, a marker in
+// a later clause ("...in the first 99 months, and I would be glad to repeat it")
+// silences a fabricated PAST number, which is the direction this gate exists to
+// prevent. A newline ends a clause, so a soft-wrapped letter cannot join two.
+const TIME_NOUNS = new Set(['days', 'weeks', 'months', 'years', 'hours', 'minutes', 'seconds']);
+const HORIZON_LEAD_RE = /\b(?:the|my|our|your)?\s*(?:first|next)\s+$/i;
+// `'d` is "had" as often as "would", so it only counts when the verb after it is
+// not a past participle. The -ed test is a heuristic: an irregular participle
+// ("I'd built the first 12 months") still reads as a marker, which is why the
+// clause scope below carries the weight rather than this test alone.
+const FORWARD_MARKER_RE = /\b(?:would|will|shall|should)\b|['\u2019]d\b(?!\s+[A-Za-z]+ed\b)|['\u2019]ll\b|\b(?:plan|plans|planning|intend|intends)\s+to\b|\bgoing to\b|\blooking forward\b/i;
+
+/**
+ * The CLAUSE of `text` containing `index`.
+ *
+ * Bounded by `. ! ? , ; :` and by a newline, so a marker in a neighbouring
+ * clause cannot reach the number: "grew in the first 99 months, and I would be
+ * glad to repeat it" keeps its claim, and so does the same pair soft-wrapped
+ * across two lines. A separator BETWEEN DIGITS is not a boundary, or the clause
+ * around "1.5 years" would end inside the number and lose its own marker.
+ *
+ * @param {string} text
+ * @param {number} index
+ * @returns {string}
+ */
+function clauseAround(text, index) {
+  const isBoundary = (i) => {
+    const c = text[i];
+    if (c === '\n') return true;
+    if (c !== '.' && c !== '!' && c !== '?' && c !== ',' && c !== ';' && c !== ':') return false;
+    return !(/\d/.test(text[i - 1] ?? '') && /\d/.test(text[i + 1] ?? ''));
+  };
+  const isSentenceEnd = (i) => {
+    const c = text[i];
+    if (c === '\n') return true;
+    if (c !== '.' && c !== '!' && c !== '?') return false;
+    return !(/\d/.test(text[i - 1] ?? '') && /\d/.test(text[i + 1] ?? ''));
+  };
+  let start = 0;
+  for (let i = index - 1; i >= 0; i--) if (isBoundary(i)) { start = i + 1; break; }
+  let end = text.length;
+  for (let i = index; i < text.length; i++) if (isBoundary(i)) { end = i; break; }
+  // A clause opened by a coordinator continues the one before it, and a plan
+  // stated once governs both halves: "I'd approach the first 90 days by
+  // listening, and the first 30 days by shipping". The lookback stops at a
+  // SENTENCE end, so it can never reach across "…first 99 months. I would…".
+  if (/^\s*(?:and|or|then|plus)\b/i.test(text.slice(start, end))) {
+    let sentenceStart = 0;
+    for (let i = start - 1; i >= 0; i--) if (isSentenceEnd(i)) { sentenceStart = i + 1; break; }
+    return text.slice(sentenceStart, end);
+  }
+  return text.slice(start, end);
+}
+
+/**
+ * Count-claim matches in `clean`, minus the ones that assert nothing.
+ *
+ * Shared by metricClaims and diagnoseCoverage so the two cannot disagree about
+ * whether a document contained a readable count.
+ *
+ * @param {string} clean
+ * @returns {RegExpMatchArray[]}
+ */
+function countMatches(clean) {
+  COUNT_CLAIM_RE.lastIndex = 0;
+  return [...clean.matchAll(COUNT_CLAIM_RE)].filter((match) => {
+    if (!TIME_NOUNS.has(match[2].toLowerCase())) return true;
+    const lead = clean.slice(Math.max(0, match.index - 40), match.index);
+    if (!HORIZON_LEAD_RE.test(lead)) return true;
+    return !FORWARD_MARKER_RE.test(clauseAround(clean, match.index));
+  });
+}
+
 /** Extract metric-like claims that require source evidence. */
 export function metricClaims(text) {
-  const clean = stripMarkup(text);
+  const clean = stripMarkup(text, { keepLineBreaks: true });
   const claims = new Set();
   for (const pattern of SIMPLE_CLAIM_PATTERNS) {
     for (const match of clean.matchAll(pattern)) claims.add(normalizeClaim(match[0]));
   }
-  COUNT_CLAIM_RE.lastIndex = 0;
-  for (const match of clean.matchAll(COUNT_CLAIM_RE)) {
+  for (const match of countMatches(clean)) {
     const noun = match[2].toLowerCase();
     claims.add(normalizeClaim(`${match[1]} ${NOUN_SYNONYMS.get(noun) ?? noun}`));
   }
@@ -521,6 +622,11 @@ function countShapedSpans(text) {
 export function diagnoseCoverage(targetText) {
   const spans = countShapedSpans(targetText);
   if (spans.length < 2) return null;
+  // RAW matches on purpose. This asks "could the extractor read any count here?",
+  // which is about the noun lexicon, not about whether a count was later judged a
+  // proposal. Reading the filtered set made a letter whose only counts were plan
+  // horizons report "none matched the metric extractor, whose noun list is
+  // English-only" -- a false warn blaming the lexicon for counts it had read fine.
   COUNT_CLAIM_RE.lastIndex = 0;
   const recognized = [...stripMarkup(String(targetText ?? '')).matchAll(COUNT_CLAIM_RE)];
   if (recognized.length > 0) return null;
@@ -739,6 +845,65 @@ function runSelfTest() {
   equal('and its 2-modifier paraphrase agrees', claimsOf('~5 Cloud Run deployments'), '5 deployments');
   // A number is a hard barrier for the chain, so two counts stay separate.
   equal('two counts in one sentence stay distinct', claimsOf('8 years supporting 40 engineers'), '40 engineers | 8 years');
+
+  // A proposed plan horizon is not a claim about the past (#3655). Time units
+  // belong in METRIC_NOUNS, so the stock cover-letter closing was extracted as a
+  // metric and reported as invented, and no source could ever evidence it.
+  equal('a proposed plan horizon is not a claim',
+    claimsOf("I'd welcome the chance to talk through how I'd approach the first 90 days."), '');
+  equal('the same closing in the fuller phrasing',
+    claimsOf('I would welcome a conversation about the first 90 days.'), '');
+  equal('an end-to-end audit stops reporting it',
+    auditClaims("I'd approach the first 90 days by listening.", 'No numbers here.').invented, []);
+  // Both halves are required, and each alone would silence a real claim.
+  equal('a past-tense window behind the same lead is still a claim',
+    claimsOf('Revenue grew in the first 12 months.'), '12 months');
+  equal('a forward-looking sentence keeps a claim with no horizon lead',
+    claimsOf('I would bring 20 years of experience.'), '20 years');
+  equal('an ordinary time metric is untouched',
+    claimsOf('Cut deployment time to 2 days.'), '2 days');
+  // The marker must be in the SAME sentence, or one conditional courtesy line
+  // would silence every time-unit claim in the document.
+  equal('a marker in a neighbouring sentence does not reach',
+    claimsOf('I would be glad to help. Revenue grew in the first 12 months.'), '12 months');
+  // Scoped to time units on purpose: a count of anything else is still a count.
+  equal('a non-time noun behind the same construction is unaffected',
+    claimsOf("I'd start with the first 3 teams."), '3 teams');
+  // The marker need not be first person: a plan is still a plan when the letter
+  // frames it around the reader, or drops the pronoun entirely.
+  equal('a bare modal is a forward marker too',
+    claimsOf('My first 90 days would centre on the pipeline.'), '');
+  equal('a reader-facing plan question is one as well',
+    claimsOf('How would you approach the first 90 days?'), '');
+  equal('and a proposal framed with should',
+    claimsOf('Glad to talk through how the first 90 days should go.'), '');
+  // Ability is not a plan: "could" frames what is possible, not what is proposed.
+  equal('an ability modal is not a forward marker',
+    claimsOf('Revenue could be traced to the first 12 months.'), '12 months');
+  // Review of #3656: the filter was wider than the description, and in the
+  // direction the gate exists to prevent. A marker anywhere in the sentence let
+  // a fabricated PAST number through, so the marker must share the number's
+  // CLAUSE, and a line break ends one.
+  equal('a marker in a later clause does not suppress',
+    claimsOf('Revenue grew in the first 99 months, and I would be glad to repeat it.'), '99 months');
+  equal('a soft-wrapped line does not join two clauses',
+    claimsOf('I would be glad to help\nRevenue grew in the first 99 months'), '99 months');
+  // "'d" is "had" as often as "would"; a past-perfect claim is not a plan.
+  equal('a past-perfect contraction is not a forward marker',
+    claimsOf("I'd completed the migration in the first 12 months."), '12 months');
+  equal("but 'd before a base verb still is", claimsOf("I'd approach the first 90 days."), '');
+  // A decimal is not a sentence boundary. Splitting inside "1.5" put the marker
+  // outside the number's own clause, so a real plan horizon stayed a claim.
+  equal('a decimal horizon is still a plan', claimsOf('My first 1.5 years would focus on the pipeline.'), '');
+  // ...and the VERDICT, not just `invented`: routing diagnoseCoverage through the
+  // filtered matches turned a false block into a false warn whose message blamed
+  // the English-only noun list for counts that were English and recognized.
+  const verdictOf = (t) => {
+    const r = verifyFacts(t, { sourcePaths: [], configPath: '/nonexistent' });
+    return `${r.verdict}${r.coverage ? ' +' + r.coverage.reason : ''}`;
+  };
+  equal('two plan horizons do not trigger a coverage warning',
+    verdictOf("I'd approach the first 90 days by listening, and the first 30 days by shipping."), 'pass');
   equal(
     'allow_metrics override',
     auditClaims('Reached 94,772 users', source, { allow_metrics: ['94,772 users'] }).invented,


### PR DESCRIPTION
Fixes #3655.

The standard cover-letter closing is extracted as a metric claim and reported as unsupported, because `days`, `weeks`, `months` and `hours` are in `METRIC_NOUNS` and nothing distinguishes a **plan horizon** from a past-tense achievement:

| sentence | before | after |
|---|---|---|
| `I would welcome the chance to talk through how I'd approach the first 90 days.` | **`90 days`** | (no claim) |
| `My first 90 days would centre on the pipeline.` | **`90 days`** | (no claim) |
| `Cut deployment time to 2 days.` | `2 days` | `2 days` |
| `Revenue grew in the first 12 months.` | `12 months` | `12 months` |

The first two assert nothing. A proposed onboarding window is not a fact any source can evidence, so no source ever will, and the only way to clear it was an `allow_metrics` entry per phrasing. Every fresh wording came back red. That is the same expensive direction as #3414: a gate that flags a line the candidate wrote in good faith is one they learn to override.

## Not "drop the noun"

Time units belong in `METRIC_NOUNS`. Row 3 above is exactly the inflatable claim this gate exists to catch, and #2279's fixtures rely on time units. Deleting them would trade a false positive for a silent gap, which is the worse direction.

The distinction is tense and stance, not the noun, so a time-unit count is dropped only when **two signals appear together**:

- a **horizon lead** adjacent to the number (`the first`, `my next`)
- a **forward marker** in the same sentence (`would`, `will`, `shall`, `should`, `'d`, `'ll`, `plan to`, `intend to`, `going to`, `looking forward`)

Neither is sufficient, and the self-test pins why. The lead alone silences row 4. The marker alone silences `I would bring 20 years of experience`, where the number is a real claim inside a hypothetical sentence.

Three scope decisions, each with a test:

- **Sentence-scoped, not document-scoped.** One conditional courtesy line would otherwise silence every time metric in the letter.
- **Time units only.** `I'd start with the first 3 teams` still yields `3 teams`. A count of anything else is still a count.
- **Ability modals stay out.** `can`, `could`, `may`, `might` frame what is possible, not what is planned, so `Revenue could be traced to the first 12 months` keeps its claim.

`diagnoseCoverage` reads through the same helper, so it cannot disagree with `metricClaims` about whether a document contained a readable count.

## Verification

Self-test goes 70 to 82. Reverting only the filter, assertions kept:

```
FAIL: a proposed plan horizon is not a claim
FAIL: the same closing in the fuller phrasing
FAIL: an end-to-end audit stops reporting it
FAIL: a bare modal is a forward marker too
FAIL: a reader-facing plan question is one as well
FAIL: and a proposal framed with should
```

The five assertions that pin the other direction pass before and after, so an over-broad filter cannot land quietly.

`node test-all.mjs` is green: 7689 passed, 0 failed, and the 13 warnings are the pre-existing set on a fresh checkout (no user data, maintainer names in tracked files), none of them from the fact gate.

Measured against a local corpus of 200 generated documents, before and after:

- the phantom claim disappears from **67** of them, and `12 months` from 2 more
- **2 documents are unblocked outright**, and the count blocked solely by a time-unit claim goes 4 to 2
- **nothing is newly blocked, and no document gains a claim**

One deliberate gap, stated rather than implied: a present-tense plan with no modal (`my first 90 days centre on X`) is still extracted, because the only remaining signal is tense. Three documents in that corpus still report `90 days` after the change: one is a question about the employer's market using `the last 90 days`, which is not a plan horizon, and two are notes files that quote the gate's own output.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] This is a bug fix, which CONTRIBUTING exempts from issue-first. An issue was opened anyway (#3655) because the fix is a judgement call about which signal to read, and that is worth discussing separately from the code.
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data). Every example is a fictional sentence.
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`verify-cv-facts.mjs` now ignores proposed time-based plan horizons, such as “the first 90 days,” when the same clause contains a forward marker. It continues to report genuine past-tense time metrics and non-time counts.

The change also:

- Shares count extraction between `metricClaims()` and `diagnoseCoverage()`.
- Scopes forward-marker detection to the relevant clause.
- Handles punctuation, newlines, decimal numbers, and coordinated clauses.
- Adds regression tests for plan horizons and guard cases.
- Updates `stripMarkup()` to optionally preserve line breaks.

## User impact

Proposed onboarding plans no longer produce false unsupported-metric warnings. Existing metric checks remain active for claims such as “Cut deployment time to 2 days.”

## Files changed

- `verify-cv-facts.mjs`: extraction logic, coverage diagnosis, and regression tests.
- No changes to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->