### PR TITLE
docs(web): give web/ its own AGENTS.md, so Next stops scaffolding a CLAUDE.md

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,65 @@
+# Working in `web/`
+
+The web app is a **view over the user's own files**, not a second engine. Read this
+before changing anything under `web/`.
+
+## The three rules that are not style preferences
+
+1. **Orchestrate the core; never reimplement it.** The CLI already resolves tracker
+   paths, matches tailored CVs and canonicalises statuses: call it, or mirror it
+   behind a parity test. A second implementation of the same rule is how the two
+   halves start disagreeing, and the disagreement is always silent.
+   `web/src/lib/core/` holds the access layer for exactly this.
+
+2. **Markdown is the source of truth.** `data/applications.md`, `cv.md`, `reports/`
+   are canonical; anything else is a derived index. Status changes go through
+   `/api/status`, which delegates to the root `set-status.mjs`. That is the single
+   write path, and it is single on purpose. Never write a user's file from a route
+   that bypasses it.
+
+3. **Nothing is ever submitted automatically.** The apply flow fills in and previews;
+   a human presses send. There is no exception, no flag, and no "just for testing".
+
+## A missing file is not a malformed file
+
+Treating a parse error as "not there yet" is how a user's config gets overwritten
+with the shipped example. Distinguish `ENOENT` from every other failure, and let a
+broken user-layer file surface as an error the user can act on rather than as an
+empty default. (`web/src/lib/portals-config.mjs` is the worked example.)
+
+## Testing
+
+Logic that deserves a test lives in a plain `.mjs` module so `node --test` can import
+it with no build step and no `@/` alias loader. See `tracker-table.mjs`,
+`cv-selection.mjs`, `report-sections.mjs`. A component is not a place to put a rule
+you want to assert.
+
+```
+npm test          # node --test "tests/**/*.test.mjs"
+npm run typecheck # tsc --noEmit
+npm run dev       # the app, reading the sibling career-ops files
+```
+
+Point `CAREER_OPS_ROOT` at a scratch directory when you need data to test against;
+it is how the app finds the user's files, and it keeps your real pipeline out of it.
+
+## Reviews and scope
+
+`web/` is maintained as first-party: functional and correctness fixes are very
+welcome, design and feature proposals are routed to Discussion #156 so the surface
+stays coherent. That is a routing decision, not a judgement on the work.
+
+<!-- The block below is written and re-added by `next dev`. It is committed
+     deliberately: keeping it in the file means Next updates only the marked
+     region and never scaffolds a separate CLAUDE.md, so an agent's instructions
+     here stay reviewable in a diff instead of appearing untracked. -->
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
## The problem, and where it came from

`next dev` writes agent instructions into the project directory. Two untracked files nobody wrote, `web/AGENTS.md` and `web/CLAUDE.md`, appeared under `web/` and were swept into an unrelated PR by a `git add -A`. They were removed from that PR; this is the follow-up that decides what to do about them, in the open rather than as a side effect.

## What I measured

I read `writeAgentFiles` in `next/dist/server/lib/generate-agent-files.js` and then **ran it** against three fixtures, because the branch that matters is not obvious from the docs:

```
neither file exists          → creates BOTH        (this is today)
AGENTS.md exists, no markers → appends its block, keeps every line we wrote,
                               CLAUDE.md "skipped", never created
same, run a second time      → "unchanged"        (idempotent)
```

So the existence of an `AGENTS.md` is what stops `CLAUDE.md` from ever being scaffolded, and Next confines itself to the region between `<!-- BEGIN:nextjs-agent-rules -->` and its end marker.

## Why commit rather than gitignore

I proposed gitignoring both files first, and the measurement changed my mind. Ignoring them hides the same content instead of owning it, leaves `git status` permanently dirty for anyone running `npm run dev`, and would silently block a real `web/CLAUDE.md` if we ever wanted one.

Committing an `AGENTS.md` we wrote is better on every axis: `CLAUDE.md` stops being generated at all, Next's contribution is confined to a marked block that **shows up in a diff when it changes**. That is the actual concern, since it is text a tool writes and an agent then reads as instructions. And the tree is clean from the first `next dev` instead of after every one.

The file is committed with the block already in place, so the first run is `unchanged` rather than a fresh diff.

## The prose

`web/` had no written guidance at all, so this is not filler around a mechanism. The rules that get repeated in review lived only in review comments:

- orchestrate the core, never reimplement it: a second implementation of the same rule is how the two halves start disagreeing, and the disagreement is always silent
- markdown is the source of truth, and `/api/status` to `set-status.mjs` is the single write path
- nothing is ever submitted automatically
- a missing file is not a malformed file, with `portals-config.mjs` as the worked example
- testable logic goes in a plain `.mjs`, not in a component
- `web/` is first-party: correctness fixes welcome, design and feature proposals routed to #156

## Verification

- `writeAgentFiles` run against this exact file: our text preserved in full, block appended, `claudeMd: "skipped"`, second pass `unchanged`.
- Docs-only change: no source, no tests, no behaviour.

---

Opened by the web agent (`career-ops-ui`). `.github/CODEOWNERS:55` makes `/web/ @santifer` the only code owner and `main` requires a code-owner review, so this cannot receive an independent approval and will be merged with `--admin`. Said out loud rather than letting the branch protection look satisfied.
