### PR TITLE
fix(web): never type a generated answer into a visa or salary field

### DIFF
--- a/web/src/lib/apply/sensitive-questions.mjs
+++ b/web/src/lib/apply/sensitive-questions.mjs
@@ -1,0 +1,120 @@
+/**
+ * sensitive-questions.mjs - the questions this system never answers for the user.
+ *
+ * Legal, visa, work-authorization, salary and demographic questions are the
+ * candidate's own to answer. That has always been the rule, and until now it
+ * rested entirely on the planner honouring one bullet in its prompt and setting
+ * needs_confirmation on those fields. That is the planner agreeing to refuse.
+ *
+ * A planner that returns needs_confirmation:false instead - a refusal arriving
+ * as a fluent, confident, entirely invented sentence about the candidate's
+ * immigration status or pay - had its value used: typed into a real employer's
+ * form, or written into a report and re-read before the next application. A
+ * prompt instruction is not an enforcement point.
+ *
+ * So the rule is a predicate, tested, applied at every point where a generated
+ * answer could reach a field. It is the same defense-in-depth the apply flow
+ * already applied to legal consent checkboxes, generalized from one bespoke
+ * regex at one call site to one policy every caller shares. Callers must not
+ * re-implement it; a second copy is a second thing to forget.
+ *
+ * The list leans deliberately wide. A false positive costs the candidate one
+ * answer they were going to write themselves anyway. A false negative is an
+ * invented answer about their immigration status sent to an employer, and it
+ * looks exactly like a real one until after it has been sent.
+ *
+ * Plain .mjs and no imports, same reason as extract-json-object.mjs: `web/`'s
+ * test runner is `node --test tests/**\/*.test.mjs`, so a .ts file or one
+ * reaching through the `@/` alias cannot be tested at all.
+ */
+
+/**
+ * @typedef {"visa" | "work-authorization" | "salary" | "demographic" | "legal" | "consent"} SensitiveCategory
+ */
+
+/**
+ * Category patterns, in the order they are tried.
+ *
+ * No `g` flag on any of them, deliberately: a `g` regex carries `lastIndex`
+ * between `.test()` calls, so a shared module-level pattern would start matching
+ * every other question. That failure is silent and intermittent, which is the
+ * worst possible shape for a guard whose whole job is to never miss one.
+ *
+ * @type {Array<{category: SensitiveCategory, pattern: RegExp}>}
+ */
+export const SENSITIVE_PATTERNS = [
+  {
+    // Immigration status. "sponsor" carries the near-universal phrasing "will you
+    // now or in the future require sponsorship for employment".
+    category: "visa",
+    pattern:
+      /\b(visas?|sponsorship|sponsor|immigration|work permits?|h-?1-?b|tn visa|green card|citizenship|citizen of|nationality|residency status|permanent resident)\b/i,
+  },
+  {
+    // Right to work. Written as prefixes rather than whole words because the
+    // forms spell it a dozen ways ("authorised", "authorization", "authorized").
+    category: "work-authorization",
+    pattern:
+      /(\bwork authoris|\bwork authoriz|\bemployment authoris|\bemployment authoriz|\bauthoris(?:ed|ation) to work|\bauthoriz(?:ed|ation) to work|\blegally (?:able|entitled|authoris|authoriz)|\bright to work\b|\beligib(?:le|ility) to work)/i,
+  },
+  {
+    // Pay. "compensation" is included knowing it also catches a question about
+    // designing someone else's comp plan; that answer is one the candidate can
+    // write, and the alternative is an invented salary expectation.
+    category: "salary",
+    pattern:
+      /\b(salary|salaries|compensation|remuneration|current pay|expected pay|desired pay|pay expectation|pay range|expected rate|desired rate|rate expectation|hourly rate|day rate|equity expectation|bonus expectation)\b/i,
+  },
+  {
+    // Protected characteristics, plus the self-identification blocks that carry
+    // them. Accommodation and medical questions sit here for the same reason.
+    category: "demographic",
+    pattern:
+      /\b(gender|sex|race|racial|ethnicity|ethnic|disabilit(?:y|ies)|veterans?|sexual orientation|pronouns|marital status|religion|religious|date of birth|birth ?date|your age|age range|age group|how old are you|eeoc?|equal (?:employment )?opportunity|protected (?:veteran|class)|self-?identif|reasonable accommodation|medical condition|pregnan)/i,
+  },
+  {
+    // Background and legal history.
+    category: "legal",
+    pattern:
+      /\b(criminal|convicted|convictions?|felony|felonies|misdemeanou?rs?|background check|drug (?:test|screen)|security clearance|clearance level|non-?compete|non-?disclosure|nda|terminated for cause|arrested|lawsuits?|litigation)\b/i,
+  },
+  {
+    // Consent and agreement. An affirmative acceptance is the human's to give,
+    // never the system's. This category is what the apply flow's original
+    // consent-checkbox regex covered, and it must stay a superset of it: a
+    // checkbox labelled only "Terms *" was caught by that regex's bare `terms`.
+    //
+    // The lookbehind is what makes keeping that word affordable. This predicate
+    // now runs on free-text questions too, and "In terms of impact, what are you
+    // proudest of?" is an ordinary question that must stay draftable. Excluding
+    // the one idiom keeps the label coverage without eating the question.
+    category: "consent",
+    pattern:
+      /\b(i (?:have )?read|i agree|i consent|i accept|consent to|privacy (?:notice|policy|statement)|(?<!\bin )terms\b|gdpr|data protection)\b/i,
+  },
+];
+
+/**
+ * Which sensitive category a question or field label falls into, if any.
+ *
+ * @param {string} text The question or label as the employer wrote it.
+ * @returns {SensitiveCategory | null} The category, or null when nothing matches.
+ */
+export function sensitiveCategory(text) {
+  const s = String(text ?? "");
+  if (!s.trim()) return null;
+  for (const { category, pattern } of SENSITIVE_PATTERNS) {
+    if (pattern.test(s)) return category;
+  }
+  return null;
+}
+
+/**
+ * Whether this question or field must never be auto-answered.
+ *
+ * @param {string} text The question or label as the employer wrote it.
+ * @returns {boolean}
+ */
+export function isSensitiveQuestion(text) {
+  return sensitiveCategory(text) !== null;
+}

--- a/web/src/lib/apply/session.ts
+++ b/web/src/lib/apply/session.ts
@@ -3,6 +3,7 @@ import { extractForm, type ApplyField, type ExtractedForm } from "./extract";
 import { parseGreenhouse, fetchGreenhouseSchema } from "./greenhouse";
 import { statusBlock, dismissConsent, tryApplyTrigger, dropNewTabs, classifyEmpty, captchaWarning, multiStepInfo, verifyFill, type ApplyIssue } from "./diagnose";
 import { agentInterpretForm } from "./agent-interpret";
+import { isSensitiveQuestion } from "./sensitive-questions.mjs";
 
 /** The frame with the most interactive controls — where the agentic interpreter
  *  should look when deterministic extraction found nothing usable. */
@@ -417,11 +418,23 @@ export async function fillSession(
     const value = (raw ?? "").toString();
     if (!meta || value === "") continue;
     if (meta.type === "file") continue; // handled above (CV) — never auto-fill other uploads
-    // Defense-in-depth: NEVER auto-tick a legal consent/agreement checkbox — the
-    // human must affirmatively accept. (The planner already flags these
-    // needs_confirmation; this guarantees it even if it slips.)
-    if (meta.type === "checkbox" && /\b(i (have )?read|i agree|i consent|i accept|consent to|privacy notice|terms|gdpr|data protection)\b/i.test(meta.label || "")) {
-      steps.push({ fieldId: fid, label: `${meta.label} — you confirm`, ok: false, thumb: undefined });
+    // Defense-in-depth: NEVER put a generated answer into a legal, visa,
+    // work-authorization, salary or demographic field. The human answers those.
+    //
+    // The planner is told to refuse them and to return needs_confirmation, but
+    // that is the planner agreeing to refuse. A planner that instead returns a
+    // fluent, confident, entirely invented sentence about the candidate's
+    // immigration status sets needs_confirmation false, and the only thing then
+    // standing between that value and a real employer's form was the
+    // `value === ""` check above. An invented answer is not an empty one.
+    //
+    // Was a regex matching consent-worded CHECKBOX labels only. The same
+    // reasoning covers every field type, and the shared predicate states it once
+    // so the policy has one home instead of one per call site. Consent wording
+    // is still covered: it is the predicate's `consent` category, unchanged in
+    // meaning.
+    if (isSensitiveQuestion(meta.label || "")) {
+      steps.push({ fieldId: fid, label: `${meta.label} (yours to answer)`, ok: false, thumb: undefined });
       continue;
     }
     let ok = false;

--- a/web/tests/lib/sensitive-questions.test.mjs
+++ b/web/tests/lib/sensitive-questions.test.mjs
@@ -1,0 +1,120 @@
+// The one guarantee this system makes that a candidate cannot check for
+// themselves: legal, visa, work-authorization, salary and demographic questions
+// are never auto-answered.
+//
+// Before this module, that guarantee was a single bullet in the planner prompt
+// plus a needs_confirmation flag on the reply. Both are the planner agreeing to
+// refuse. A planner that instead returns a fluent, confident, entirely invented
+// sentence about the candidate's immigration status sets needs_confirmation
+// false, and the value was used: typed into a real employer's form, or stored
+// on the report and re-read before the next application.
+//
+// So the assertions here are about a value never reaching a field at all. They
+// are deliberately lopsided: the false-positive cases cost one answer the
+// candidate types themselves, the false-negative case is a fabricated visa
+// answer sent to an employer.
+//
+// Run:  node --test tests/lib/sensitive-questions.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSensitiveQuestion, sensitiveCategory, SENSITIVE_PATTERNS } from "../../src/lib/apply/sensitive-questions.mjs";
+
+/** Real phrasings, taken from the shapes application forms actually use. */
+const MUST_REFUSE = [
+  ["visa", "Will you now or in the future require sponsorship for employment visa status?"],
+  ["visa", "Are you a citizen of the United Kingdom?"],
+  ["visa", "Do you hold a green card?"],
+  ["visa", "What is your nationality?"],
+  ["work-authorization", "Are you legally authorized to work in the United States?"],
+  ["work-authorization", "Do you have the right to work in Germany?"],
+  ["work-authorization", "Please confirm your eligibility to work in this location."],
+  ["work-authorization", "Employment authorisation status?"],
+  ["salary", "What are your salary expectations for this role?"],
+  ["salary", "Desired compensation"],
+  ["salary", "What is your current pay?"],
+  ["salary", "Expected hourly rate"],
+  ["demographic", "What is your gender?"],
+  ["demographic", "Do you identify as a protected veteran?"],
+  ["demographic", "Please self-identify your race and ethnicity."],
+  ["demographic", "Do you have a disability?"],
+  ["demographic", "What is your date of birth?"],
+  ["demographic", "Do you require a reasonable accommodation?"],
+  ["legal", "Have you ever been convicted of a felony?"],
+  ["legal", "Are you willing to undergo a background check?"],
+  ["legal", "Do you hold an active security clearance?"],
+  ["legal", "Are you bound by a non-compete agreement?"],
+  ["consent", "I agree to the privacy policy and terms of service."],
+  ["consent", "I consent to the processing of my data under GDPR."],
+  // A bare "Terms *" checkbox, which the apply flow's original consent regex
+  // caught with a bare `terms`. This category has to stay a superset of it.
+  ["consent", "Terms *"],
+];
+
+/** Ordinary free-text questions. Answering these is the whole point. */
+const MUST_ALLOW = [
+  "Describe a workflow you have meaningfully changed using AI. Under 150 words.",
+  "Why do you want to work here?",
+  "What is the most impactful thing you have built?",
+  "Tell us about a time you disagreed with a decision and what you did.",
+  "How do you approach code review on a team of eight?",
+  "What would your first 90 days look like?",
+  // "in terms of" is ordinary English and must not be read as a consent label,
+  // even though the consent category has to keep the bare word "terms" to cover
+  // a checkbox labelled only "Terms *".
+  "In terms of impact, what are you proudest of?",
+  "How do you think about trade-offs in terms of cost and speed?",
+];
+
+test("every question a form uses to ask something protected is refused", () => {
+  for (const [category, question] of MUST_REFUSE) {
+    assert.equal(
+      sensitiveCategory(question),
+      category,
+      `must be refused as ${category}: ${question}`,
+    );
+  }
+});
+
+test("ordinary free-text questions are still draftable", () => {
+  for (const question of MUST_ALLOW) {
+    assert.equal(sensitiveCategory(question), null, `must stay draftable: ${question}`);
+  }
+});
+
+test("matching ignores case and punctuation around the phrase", () => {
+  assert.ok(isSensitiveQuestion("SALARY EXPECTATIONS?"));
+  assert.ok(isSensitiveQuestion("...visa sponsorship required?"));
+  assert.ok(isSensitiveQuestion("Your age?"));
+});
+
+test("a whole word is required, so an innocent substring is not a refusal", () => {
+  // The cost of getting this wrong is not symmetric with a miss, but a predicate
+  // that fires on any question containing "sex" inside "sexagenarian" or "nda"
+  // inside "agenda" would refuse most of the form and teach the user to ignore
+  // the label.
+  assert.equal(sensitiveCategory("What is on the agenda for your first week?"), null);
+  assert.equal(sensitiveCategory("Describe how you manage a large backlog."), null);
+  assert.equal(sensitiveCategory("How do you leverage telemetry?"), null);
+});
+
+test("no pattern carries the g flag", () => {
+  // A `g` regex keeps `lastIndex` between .test() calls. Shared at module scope,
+  // that makes the guard match every OTHER question - silently, intermittently,
+  // and only in the direction that lets a sensitive question through.
+  for (const { category, pattern } of SENSITIVE_PATTERNS) {
+    assert.equal(pattern.global, false, `${category} pattern must not be global`);
+  }
+});
+
+test("the predicate is stable across repeated calls on the same question", () => {
+  // The regression the test above guards against, stated as behaviour.
+  const q = "Will you now or in the future require visa sponsorship?";
+  for (let i = 0; i < 5; i += 1) assert.equal(isSensitiveQuestion(q), true, `call ${i + 1}`);
+});
+
+test("empty and non-string input is not sensitive, and does not throw", () => {
+  for (const bad of ["", "   ", null, undefined, 42, {}, []]) {
+    assert.equal(sensitiveCategory(bad), null, `${JSON.stringify(bad)} must be null`);
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Makes the "never auto-fill legal / visa / work-authorization / salary / demographic fields" rule something the code enforces, on the path that types into a real employer's form.

Today that rule rests on two things, and both of them are the planner agreeing to refuse:

- one bullet in `buildAnswerPrompt` telling it never to fill those fields
- `needs_confirmation` on its reply

Neither is an enforcement point. Trace what happens when a planner declines to refuse and returns a fluent, confident, entirely invented sentence about the candidate's immigration status with `needs_confirmation: false`:

1. `api/apply/prefill` emits the planner's **raw** object (it does not normalise it)
2. `apply-provider` reads `value` out of it into the answers map
3. `session.ts` `fillFields` fills anything whose value is not the empty string

So the only thing standing between an invented visa answer and a real application is that the planner happened to return `""`. An invented answer is not an empty one.

## The guard that already existed was right, just too narrow

`session.ts` had one deterministic check, on consent-worded **checkbox** labels, and its comment states the reasoning exactly:

> Defense-in-depth: NEVER auto-tick a legal consent/agreement checkbox. (The planner already flags these `needs_confirmation`; this guarantees it even if it slips.)

That reasoning was never checkbox-specific. This PR generalises it: one tested predicate, applied to every field type, before any value is entered. A match sends the field back to the human instead of filling it.

`sensitive-questions.mjs` covers six categories: visa, work-authorization, salary, demographic, legal, consent.

## Notes on the shape

- **The consent category is a strict superset of the regex it replaces.** A checkbox labelled only `Terms *` was caught by that regex's bare `terms`, so the word stays. A lookbehind excludes `in terms of`, so an ordinary question ("In terms of impact, what are you proudest of?") is not swept up. Both directions are pinned by tests.
- **No pattern carries the `g` flag, and a test says so.** A shared module-level `g` regex carries `lastIndex` between `.test()` calls and starts matching every *other* field, silently and intermittently, in the one direction that lets a sensitive field through.
- **The list leans wide on purpose.** A false positive costs the candidate one answer they were going to write themselves. A false negative is a fabricated answer about their immigration status sent to an employer, and it looks exactly like a real one until after it has been sent.
- **Plain `.mjs` with no imports**, following `extract-json-object.mjs` (#3142): `web/`'s runner is `node --test tests/**/*.test.mjs`, so a `.ts` file or one reaching through the `@/` alias cannot be tested at all. `session.ts` imports `playwright-core`, which is exactly why the predicate cannot live there and be tested.

Nothing here submits anything. The human still reviews every field, and now also answers the ones that were always theirs.

## Related issues

Refs #2994.

Found while reviewing **#2998**, which adds an Application Questions panel and its route. That PR carries an identical copy of `web/src/lib/apply/sensitive-questions.mjs` and applies it to the panel and `/api/answers`; this PR applies the same module to the apply flow. **The two are independent and can merge in either order** — the file is byte-identical on both branches, so git resolves the add/add without a conflict. Whichever lands second contributes only its own call site.

Opened separately rather than folded into #2998 on the reasoning in that PR's thread: the apply flow is a different surface from the report panel, and this is the more dangerous of the two (a report is a local file; a form is an application). It deserves its own review rather than riding along with a UI feature.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass (7701 passed, 0 failed)
- [x] `web`: `pnpm test` 471 passed, 0 failed · `tsc --noEmit` clean · `pnpm build` clean
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (system-layer files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
