### PR TITLE
docs(signatures): add @violetsea555 (via #2634)

### DIFF
--- a/SIGNATURES.md
+++ b/SIGNATURES.md
@@ -152,3 +152,4 @@ public commit with a stated reason.
 - @fabdull1 | 2026-09-02 | "No time to waste" | id:250269279 | src:https://github.com/career-ops-hq/career-ops/discussions/3630 | n:104
 - @zyxc2024 | 2026-09-02 | id:194247172 | src:https://github.com/career-ops-hq/career-ops/discussions/3625 | n:105
 - @9jaswag | Chuks Opia | 2026-09-02 | id:8125356 | src:https://github.com/career-ops-hq/career-ops/discussions/3663 | n:106
+- @violetsea555 | violet | 2026-08-08 | "If a system rejects you, you have the right to know it was a system." | id:88992496 | src:https://github.com/career-ops-hq/career-ops/pull/2634 | n:107


### PR DESCRIPTION
Lands the manifesto signature from #2634 at the current end of the ledger (n:107), with @violetsea555 as co-author. Her PR conflicted after 36 web-button signatures; the file promises the PR route carries the same credit, so this keeps that promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9mnb6ho4JQLJMm4HVSTcR