### PR TITLE
fix(merge-tracker): a corporate-suffix variant is the same employer (#3665)

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -140,7 +140,10 @@ function normalizeStatusKey(status) {
 // True legal-entity suffixes, stripped repeatedly (chained) since a name can
 // legitimately carry more than one ("Acme Holdings Inc." → "acme holdings").
 // These are unambiguous enough that removing several in a row is safe.
-const LEGAL_SUFFIXES = [
+// Exported so merge-tracker.mjs can share the vocabulary rather than keep a
+// second copy of it: a private list there is exactly the identity drift #2445
+// set out to remove.
+export const LEGAL_SUFFIXES = [
   'incorporated', 'inc', 'corporation', 'corp', 'company', 'co',
   'limited', 'ltd', 'llc', 'llp', 'lp', 'plc',
 ];
@@ -151,7 +154,7 @@ const LEGAL_SUFFIXES = [
 // chaining their removal risks collapsing two different companies to the
 // same key. Stripped at most once, and only after legal suffixes are gone —
 // never chained with each other or with LEGAL_SUFFIXES.
-const GENERIC_DESCRIPTORS = [
+export const GENERIC_DESCRIPTORS = [
   'group', 'holdings', 'technologies', 'technology', 'solutions',
   'canada', 'international',
 ];

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -22,7 +22,11 @@ import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { parsePdfIndex } from './find.mjs';
-import { LEGACY_COLMAP, detectColumns, isHeaderRow, resolveScoreStatus, normalizeVia, SEPARATOR_ROW_RE } from './tracker-parse.mjs';
+import { LEGACY_COLMAP, detectColumns, isHeaderRow, resolveScoreStatus, normalizeVia, normalizeTextKey, SEPARATOR_ROW_RE } from './tracker-parse.mjs';
+// Corporate-form vocabulary, shared with invite-match.mjs rather than copied,
+// for the same reason normalizeCompany lives in tracker-utils: a second private
+// list is how company identity drifts between scripts (#2445, #3665).
+import { LEGAL_SUFFIXES, GENERIC_DESCRIPTORS } from './invite-match.mjs';
 import { resolveTrackerPath, resolveWorkspaceRoot, resolvePdfIndexPath, trackerLockDirFor, acquireTrackerLock, writeFileAtomic, normalizeCompany, cell } from './tracker-utils.mjs';
 // Canonical posting-URL key. Kept in its own module so scan.mjs / scan-history
 // can adopt the same key later without the definitions drifting.
@@ -309,6 +313,65 @@ function companiesMatch(a, b) {
   const key = normalizeCompany(String(a));
   if (key !== normalizeCompany(String(b))) return false;
   return key !== '' || String(a).trim() === String(b).trim();
+}
+
+// Words that name a legal form or a generic business descriptor rather than the
+// employer. Both lists come from invite-match.mjs; the union is safe here in a
+// way chaining them there is not, because the prefix rule below never lets two
+// names disagree on a substantive token.
+const CORPORATE_FORM_WORDS = new Set([...LEGAL_SUFFIXES, ...GENERIC_DESCRIPTORS]);
+
+// A one-token stem carries almost no identity, and a two-letter one is usually
+// an initialism that several unrelated employers share. Refusing them costs the
+// duplicate row that exists today; accepting them risks deleting a real one.
+const MIN_STEM_CHARS = 3;
+
+/**
+ * True when two company cells are the same employer written with a different
+ * corporate suffix ("Acme" vs "Acme Technologies Inc.").
+ *
+ * normalizeCompany() folds case, punctuation and width but not corporate
+ * forms, so a suffix variant of one employer never reaches the fuzzy
+ * company+role tier and the same opening is written twice (#3665). This is the
+ * narrow second tier that closes that, used ONLY where the role title already
+ * fuzzy-matches and neither a req-number nor an employer-board URL has proved
+ * the rows distinct. The exact tier above is untouched.
+ *
+ * The rule is a token PREFIX plus a corporate-form tail, not a stripped key.
+ * Stripping suffixes before comparing looks equivalent and is not: it maps
+ * "Acme Solutions" and "Acme Technologies" to the same "acme", which folds two
+ * genuinely different employers and deletes one row. Requiring the shorter name
+ * to be a prefix of the longer makes that structurally impossible, since
+ * neither of those is a prefix of the other. It also means an extra token that
+ * is NOT a corporate form ("Acme Robotics") still reads as a different
+ * employer, which is the conservative direction: over-merging is unrecoverable
+ * here (dedup-tracker.mjs drops the losing line, and applications.md is
+ * gitignored with no backup), while under-merging leaves a duplicate row the
+ * user can already see.
+ *
+ * Tokens come from normalizeTextKey(name, ' ') so this shares the Unicode,
+ * NFKC and Turkish dotted-I handling every other identity key uses (#2445,
+ * #2736) instead of a private strip. Scripts written without spaces produce a
+ * single token and never match here, so CJK corporate forms are unaffected and
+ * remain #2570's subject.
+ *
+ * @param {string} a - Company cell from one side of the comparison.
+ * @param {string} b - Company cell from the other side.
+ * @returns {boolean} True when the two cells name the same employer under a
+ *   different corporate form.
+ */
+function companiesMatchIgnoringCorporateForm(a, b) {
+  const ta = normalizeTextKey(a, ' ').split(' ').filter(Boolean);
+  const tb = normalizeTextKey(b, ' ').split(' ').filter(Boolean);
+  const [stem, full] = ta.length <= tb.length ? [ta, tb] : [tb, ta];
+  // Equal lengths are either the exact tier's business or a genuine
+  // disagreement on a substantive token. An empty stem is the blind-employer
+  // `?` marker and every other punctuation-only cell, which must never match a
+  // named employer.
+  if (stem.length === 0 || stem.length === full.length) return false;
+  if (stem.join('').length < MIN_STEM_CHARS) return false;
+  if (stem.some((token, i) => token !== full[i])) return false;
+  return full.slice(stem.length).every(token => CORPORATE_FORM_WORDS.has(token));
 }
 
 /**
@@ -1211,7 +1274,14 @@ for (const file of tsvFiles) {
       // the #1524 req-number guard, and the tier where an unkeyed addition is
       // also held back from claiming a row whose posting is known.
       if (urlBlocksHeuristic(app)) return false;
-      if (!companiesMatch(app.company, addition.company)) return false;
+      // Corporate-form variants of one employer are accepted HERE and nowhere
+      // else (#3665). The tiers above match on a report or entry number, which
+      // is an identity claim on its own, so a wider company match there would
+      // let sequence drift across two employers write to the wrong row. This
+      // tier already requires a fuzzy role match, and the req-number and URL
+      // guards below and above still get to prove the rows distinct.
+      if (!companiesMatch(app.company, addition.company)
+          && !companiesMatchIgnoringCorporateForm(app.company, addition.company)) return false;
       if (!roleFuzzyMatch(addition.role, app.role)) return false;
       // Cross-channel guard (#1596): unknown-employer rows (`?`) all normalize
       // to the same empty company key, but the same role via two DIFFERENT

--- a/tests/merge-tracker-company-suffix.test.mjs
+++ b/tests/merge-tracker-company-suffix.test.mjs
@@ -1,0 +1,170 @@
+// tests/merge-tracker-company-suffix.test.mjs — corporate-suffix company variants.
+//
+// One employer reaches the tracker under two spellings ("Acme" from one board,
+// "Acme Technologies" from the next). normalizeCompany() folds case and
+// punctuation but not corporate suffixes, so the fuzzy company+role tier never
+// fired and a duplicate row was written (#3665).
+//
+// Every case drives the REAL merge-tracker.mjs CLI against a temp tracker via
+// the CAREER_OPS_TRACKER / CAREER_OPS_ADDITIONS env hooks: the merge path is
+// where the bug lives, so the resulting rows are what proves the fix. The
+// over-merge guards below matter more than the fix itself, because folding two
+// rows is destructive and splitting them is only untidy.
+import { pass, fail } from './helpers.mjs';
+import assert from 'node:assert';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MERGE = join(HERE, '..', 'merge-tracker.mjs');
+const ok = (name, fn) => { try { fn(); pass(name); } catch (e) { fail(`${name} — ${e.message}`); } };
+
+const HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |';
+const SEP = '|---|---|---|---|---|---|---|---|---|';
+
+function makeEnv() {
+  const base = mkdtempSync(join(tmpdir(), 'merge-suffix-test-'));
+  const dataDir = join(base, 'data');
+  const addDir = join(base, 'additions');
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(addDir, { recursive: true });
+  return { base, addDir, tracker: join(dataDir, 'applications.md') };
+}
+function writeTracker(env, rows) {
+  writeFileSync(env.tracker, ['# Applications Tracker', '', HEADER, SEP, ...rows, ''].join('\n'));
+}
+function addTsv(env, name, cols) {
+  writeFileSync(join(env.addDir, name), cols.join('\t'));
+}
+function runMerge(env, args = []) {
+  return execFileSync('node', [MERGE, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, CAREER_OPS_TRACKER: env.tracker, CAREER_OPS_ADDITIONS: env.addDir },
+  });
+}
+function trackerRows(env) {
+  return readFileSync(env.tracker, 'utf-8').split('\n')
+    .filter(l => l.startsWith('|') && !/^\|[\s|:-]+\|\s*$/.test(l) && !/^\|\s*#\s*\|/.test(l));
+}
+const cleanup = (env) => rmSync(env.base, { recursive: true, force: true });
+
+// One row plus one addition, with row and report numbers deliberately different
+// on the two sides so tiers 1 and 2 cannot fire and only the fuzzy company+role
+// tier is left to decide.
+function mergeOne({ existingCompany, existingRole, existingNotes = 'n',
+                    addCompany, addRole, addNotes = 'n' }) {
+  const env = makeEnv();
+  try {
+    writeTracker(env, [
+      `| 1 | 2026-06-01 | ${existingCompany} | ${existingRole} | 4.0/5 | Evaluated | ❌ | [1](reports/1-a.md) | ${existingNotes} |`,
+    ]);
+    addTsv(env, '2-b.tsv', ['2', '2026-06-03', addCompany, addRole, 'Evaluated', '4.1/5', '❌', '[2](reports/2-b.md)', addNotes]);
+    runMerge(env);
+    return trackerRows(env);
+  } finally { cleanup(env); }
+}
+
+console.log('\nmerge-tracker — corporate-suffix company variants (#3665)');
+
+ok('THE BUG: a generic-descriptor variant of one employer merges into its row', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme Technologies', existingRole: 'Director of Marketing',
+    addCompany: 'Acme', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 1, `expected the row to be UPDATED, got ${rows.length} rows (duplicate)`);
+  assert.ok(rows[0].includes('4.1/5'), 're-eval score written through');
+});
+
+ok('THE BUG: a legal-suffix variant merges too, and chains', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme', existingRole: 'Director of Marketing',
+    addCompany: 'Acme Holdings Inc.', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 1, `expected 1 row, got ${rows.length}`);
+});
+
+ok('THE OVER-MERGE GUARD: two employers sharing a stem stay two rows', () => {
+  // Both names end in a word from the descriptor vocabulary, so any rule that
+  // strips descriptors before comparing keys folds these to the same "acme"
+  // and destroys one row. Neither name is a prefix of the other, which is the
+  // property the tier is built on.
+  const rows = mergeOne({
+    existingCompany: 'Acme Solutions', existingRole: 'Director of Marketing',
+    addCompany: 'Acme Technologies', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 2, 'a shared stem is not a shared employer');
+});
+
+ok('THE OVER-MERGE GUARD: an extra word that is not a corporate form stays distinct', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme', existingRole: 'Director of Marketing',
+    addCompany: 'Acme Robotics', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 2, '"Robotics" is part of the name, not a legal form');
+});
+
+ok('THE OVER-MERGE GUARD: a stem under three characters is refused', () => {
+  // A deliberate miss. Two characters is weak identity, and the cost of
+  // refusing is the duplicate row that exists today anyway.
+  const rows = mergeOne({
+    existingCompany: 'AB', existingRole: 'Director of Marketing',
+    addCompany: 'AB Inc.', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 2, 'short stems fall through to the previous behavior');
+});
+
+ok('req-number mismatch still proves two postings apart (#1524 precedence)', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme Technologies', existingRole: 'Director of Marketing', existingNotes: 'req R-1001',
+    addCompany: 'Acme', addRole: 'Director of Marketing', addNotes: 'req R-1002',
+  });
+  assert.equal(rows.length, 2, 'the wider company match must not outrank a req mismatch');
+});
+
+ok('an employer-board URL mismatch still proves two postings apart', () => {
+  const env = makeEnv();
+  try {
+    const H = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL |';
+    const S = '|---|---|---|---|---|---|---|---|---|---|';
+    writeFileSync(env.tracker, ['# Applications Tracker', '', H, S,
+      '| 1 | 2026-06-01 | Acme Technologies | Director of Marketing | 4.0/5 | Evaluated | ❌ | [1](reports/1-a.md) | n | https://boards.greenhouse.io/acme/jobs/7001 |', ''].join('\n'));
+    addTsv(env, '2-b.tsv', ['2', '2026-06-03', 'Acme', 'Director of Marketing', 'Evaluated', '4.1/5', '❌', '[2](reports/2-b.md)', 'n', 'https://boards.greenhouse.io/acme/jobs/7002']);
+    runMerge(env);
+    assert.equal(trackerRows(env).length, 2, 'two requisitions on the employer board stay two rows');
+  } finally { cleanup(env); }
+});
+
+ok('a role that does not fuzzy-match is unaffected by the wider company match', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme Technologies', existingRole: 'Director of Marketing',
+    addCompany: 'Acme', addRole: 'Staff Accountant',
+  });
+  assert.equal(rows.length, 2, 'the tier still requires the role to match');
+});
+
+ok('CONTROL: exact company match still merges, unchanged', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme', existingRole: 'Director of Marketing',
+    addCompany: 'Acme', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 1, 'the existing exact tier is untouched');
+});
+
+ok('CONTROL: unrelated employers still stay apart', () => {
+  const rows = mergeOne({
+    existingCompany: 'Globex', existingRole: 'Director of Marketing',
+    addCompany: 'Initech', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 2);
+});
+
+ok('CONTROL: a blind-employer row cannot reach the tier (empty stem)', () => {
+  const rows = mergeOne({
+    existingCompany: '?', existingRole: 'Director of Marketing',
+    addCompany: 'Acme Ltd', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 2, 'an unknown employer never matches a named one');
+});


### PR DESCRIPTION
## What does this PR do?

Teaches the fuzzy company plus role tier in `merge-tracker.mjs` that "Acme" and "Acme Technologies Inc." are one employer, so an opening that reaches the tracker from two boards under two spellings updates its row instead of adding a second one. The exact-match tier and the two tiers above it are unchanged.

## Related issue

Closes #3665

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The change

`normalizeCompany()` is `normalizeTextKey()`, which folds case, punctuation and width but not corporate forms, so `Acme` keys to `acme` and `Acme Technologies` keys to `acmetechnologies`. Boards disagree about the legal form constantly, so the tier that exists precisely to catch a re-listing never fired for that pair.

The new tier runs only inside the fuzzy match, after `urlBlocksHeuristic` and before the req-number guard, so it sees a pair whose role title already matches and where neither an employer-board URL nor a requisition ID has proved the rows distinct. The report-number and entry-number tiers keep exact company equality on purpose: those match on an identity claim of their own, and sequence drift between report files and tracker rows is common enough that a wider company match there would let one employer's addition write to another's row.

The rule is a token prefix plus a corporate-form tail, not a stripped key:

```js
normalizeTextKey('Acme Solutions', ' ')     // 'acme solutions'
normalizeTextKey('Acme Technologies', ' ')  // 'acme technologies'
```

Stripping the descriptor before comparing maps both of those to `acme`. That folds two genuinely different employers, and folding is unrecoverable here: `dedup-tracker.mjs` promotes the most advanced status onto the keeper and then drops the losing line, taking its score, date, report link, PDF flag and URL with it, out of a file that is gitignored with no backup. Requiring the shorter name to be a prefix of the longer makes that case structurally impossible, since neither is a prefix of the other. An extra token that is not a corporate form (`Acme Robotics`) also still reads as a different employer, and a stem shorter than three characters falls through to today's behavior, which loses `AB` against `AB Inc.` and is the direction I would rather miss in.

Tokens come from `normalizeTextKey(name, ' ')` rather than a private strip, so the NFKC, any-script and Turkish dotted-I handling from #2445 and #2736 is shared. Scripts written without spaces produce a single token and never reach the prefix rule, so CJK corporate forms are untouched and stay #2570's subject.

The vocabulary is imported from `invite-match.mjs` (`LEGAL_SUFFIXES` and `GENERIC_DESCRIPTORS`, now exported) rather than copied. A second private list is the identity drift #2445 set out to remove. Taking the union of the two lists is safe here in a way chaining them is not inside `normalizeCompanyName()`, because the prefix rule never lets two names disagree on a substantive token.

`normalizeCompanyName()` itself is unchanged, and so is every existing caller of it.

## Interaction with #3653

None in behavior, and they are complementary. #3653 stops an aggregator URL from short-circuiting the fuzzy tier; this stops the company key from failing once that tier is allowed to run. A pair that is both cross-listed on an aggregator and spelled differently needs both.

This branch is cut from `main` at `2e33ea86` and does not contain #3653. The two touch `merge-tracker.mjs` in different places (#3653 at `urlDiffers`, around line 1150, plus `url-key.mjs`; this one at the import block, at `companiesMatch`, and at the company check inside the fuzzy tier). The only overlap is the import block at the top of the file, where #3653 adds `isAggregatorUrl` to the `url-key.mjs` line and this adds `normalizeTextKey` to the `tracker-parse.mjs` line two lines above it. Whichever merges second may want a one-line rebase there. Happy to rebase this onto #3653 if you would rather land them in that order.

## How it was verified

New suite `tests/merge-tracker-company-suffix.test.mjs`, auto-discovered under `tests/`, driving the real `merge-tracker.mjs` CLI against a temp tracker through the `CAREER_OPS_TRACKER` and `CAREER_OPS_ADDITIONS` hooks, in the shape `tests/merge-tracker-url-dedup.test.mjs` already uses. Every fixture is a placeholder name.

Against unfixed `main` the two duplicate cases fail and the guards pass:

```
merge-tracker — corporate-suffix company variants (#3665)
  ❌ THE BUG: a generic-descriptor variant of one employer merges into its row — expected the row to be UPDATED, got 2 rows (duplicate)
  ❌ THE BUG: a legal-suffix variant merges too, and chains — expected 1 row, got 2
  ✅ THE OVER-MERGE GUARD: two employers sharing a stem stay two rows
  ✅ THE OVER-MERGE GUARD: an extra word that is not a corporate form stays distinct
  ✅ THE OVER-MERGE GUARD: a stem under three characters is refused
  ✅ req-number mismatch still proves two postings apart (#1524 precedence)
  ✅ an employer-board URL mismatch still proves two postings apart
  ✅ a role that does not fuzzy-match is unaffected by the wider company match
  ✅ CONTROL: exact company match still merges, unchanged
  ✅ CONTROL: unrelated employers still stay apart
  ✅ CONTROL: a blind-employer row cannot reach the tier (empty stem)
```

Guards that pass before and after prove nothing on their own, so I also ran them against the obvious wrong implementation, `companiesMatchIgnoringCorporateForm` replaced by an equality test on `normalizeCompanyName()`. That version passes both bug cases and fails two guards:

```
  ✅ THE BUG: a generic-descriptor variant of one employer merges into its row
  ✅ THE BUG: a legal-suffix variant merges too, and chains
  ❌ THE OVER-MERGE GUARD: two employers sharing a stem stay two rows — a shared stem is not a shared employer
  ❌ THE OVER-MERGE GUARD: a stem under three characters is refused — short stems fall through to the previous behavior
```

Full `node test-all.mjs`: 7735 passed, 0 failed, 13 warnings, all of which are the pre-existing ones on `main` (funding.json and HIRED.md name matches, the intentional fixture warnings in the merge and font suites). Also smoke-tested `merge-tracker.mjs` with no flags, `--migrate` and `--backfill-urls` after the new import, since `invite-match.mjs` has top-level argument handling; it is behind `isMainModule`, so nothing changes.

## Not in this PR, on purpose

The same key is compared for exact equality in two more places, and both are described in #3665: `dedup-tracker.mjs` line 333 cannot group the pair, and `verify-pipeline.mjs` Check 2 reports "No exact duplicates found" on a tracker that holds it. I left them out because this one is prevention while those are cleanup and reporting, because `dedup-tracker.mjs` deletes a row and deserves its own review, and because what the health check should say about a suffix variant is a wording decision rather than a code one. Say the word on the issue and I will send either or both, and move the helper into `tracker-utils.mjs` next to `normalizeCompany` if you want more than one caller.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)
