### PR TITLE
fix(analyze-patterns): stop counting Applied as positive

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -16,6 +16,7 @@
 import { readFileSync, existsSync, realpathSync, writeFileSync, symlinkSync, rmSync } from 'fs';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
+import { isMainModule } from './lib/is-main-module.mjs';
 import { load as yamlLoad } from 'js-yaml';
 import { resolveColumns, parseTrackerRow, normalizeVia } from './tracker-parse.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
@@ -104,11 +105,17 @@ function normalizeStatus(raw) {
   return ALIASES[clean] || clean;
 }
 
-function classifyOutcome(status) {
+export function classifyOutcome(status) {
   const s = normalizeStatus(status);
   // 'hired' is the strongest positive outcome — a landed job. It must not fall
   // through to the 'pending' default, which would drag conversion rates down.
-  if (['hired', 'interview', 'offer', 'responded', 'applied'].includes(s)) return 'positive';
+  if (['hired', 'interview', 'offer', 'responded'].includes(s)) return 'positive';
+  // 'applied' is SENT, not successful — no recorded answer yet. It gets its
+  // own bucket so it can sit in the conversion DENOMINATOR without inflating
+  // the numerator; counting it as positive reports the user's own sending
+  // activity back at them as traction. Mirrors ADVANCED_STATUSES, which already
+  // excludes 'applied' for the vendor/via channel-yield analysis.
+  if (s === 'applied') return 'awaiting';
   if (['rejected', 'discarded'].includes(s)) return 'negative';
   if (['skip'].includes(s)) return 'self_filtered';
   return 'pending'; // evaluated
@@ -134,6 +141,51 @@ function discardableBase(enriched) {
 // contribute a blocker and must not pad the denominator.
 function gapBearingBase(enriched) {
   return enriched.filter(e => e.report?.gaps?.length > 0).length;
+}
+
+// Outcome buckets a breakdown row carries. Kept in one place so a new bucket
+// cannot be added to classifyOutcome without every counter learning about it —
+// `entry[outcome]++` on a missing key silently writes NaN.
+export const OUTCOME_BUCKETS = ['positive', 'negative', 'self_filtered', 'pending', 'awaiting'];
+
+// Sample floors for the prescriptive recommendations. Small on purpose: they
+// do not claim statistical confidence, they stop a single row from becoming
+// an instruction ("avoid X", "set the threshold at Y").
+const MIN_SUBMITTED_FOR_RECOMMENDATION = 2;
+const MIN_DECIDED_FOR_AVOID = 2;
+const MIN_POSITIVE_SCORES_FOR_THRESHOLD = 3;
+
+/** A zeroed counter row for the per-segment breakdowns. */
+export function newOutcomeCounts() {
+  const row = { total: 0 };
+  for (const bucket of OUTCOME_BUCKETS) row[bucket] = 0;
+  return row;
+}
+
+/**
+ * Rates for one breakdown row.
+ *
+ * `conversionRate` divides by SUBMITTED (positive + negative + awaiting), never
+ * by `total`: `total` also counts Evaluated rows that were never sent, so
+ * dividing by it answers "what share of the evaluated pile did I apply to",
+ * which is not a conversion rate.
+ *
+ * `decidedRate` is the stricter reading — of the applications with a recorded
+ * outcome (positive or negative), how many advanced. It is `null` (not 0)
+ * when nothing is decided yet, so an untested segment reads as "no data"
+ * instead of "0%". `decided` is returned as a count so callers gate on facts
+ * rather than on a rounded percentage.
+ */
+export function withOutcomeRates(data) {
+  const submitted = data.positive + data.negative + data.awaiting;
+  const decided = data.positive + data.negative;
+  return {
+    ...data,
+    submitted,
+    decided,
+    conversionRate: submitted > 0 ? Math.round((data.positive / submitted) * 100) : 0,
+    decidedRate: decided > 0 ? Math.round((data.positive / decided) * 100) : null,
+  };
 }
 
 // Statuses that count as a submitted application for channel-yield analysis
@@ -453,6 +505,9 @@ requirement_importance:
   for (const alias of ['contratado', 'contratada', 'accepted', 'accept']) {
     if (normalizeStatus(alias) !== 'hired') failures.push(`hired: normalizeStatus('${alias}') → ${normalizeStatus(alias)}, expected 'hired'`);
   }
+  // Outcome buckets and rate helpers are covered by
+  // tests/analyze-patterns-outcomes.test.mjs (unit + end-to-end fixture).
+
   if (!ADVANCED_STATUSES.has('hired')) failures.push('hired: ADVANCED_STATUSES must include hired (a hire advanced past screening)');
   if (!SUBMITTED_STATUSES.has('hired')) failures.push('hired: SUBMITTED_STATUSES must include hired (a hire was submitted)');
   if (!FUNNEL_ORDER.includes('hired')) failures.push('hired: FUNNEL_ORDER must include hired so it prints in the funnel');
@@ -1058,7 +1113,7 @@ function analyze() {
   }
 
   // --- Score comparison by outcome ---
-  const scoresByOutcome = { positive: [], negative: [], self_filtered: [], pending: [] };
+  const scoresByOutcome = Object.fromEntries(OUTCOME_BUCKETS.map((b) => [b, []]));
   for (const e of enriched) {
     if (e.score > 0) scoresByOutcome[e.outcome].push(e.score);
   }
@@ -1074,26 +1129,24 @@ function analyze() {
     };
   };
 
-  const scoreComparison = {
-    positive: scoreStats(scoresByOutcome.positive),
-    negative: scoreStats(scoresByOutcome.negative),
-    self_filtered: scoreStats(scoresByOutcome.self_filtered),
-    pending: scoreStats(scoresByOutcome.pending),
-  };
+  // Same bucket list as the counters and metadata, so a bucket cannot exist in
+  // one output and be missing from another.
+  const scoreComparison = Object.fromEntries(
+    OUTCOME_BUCKETS.map((bucket) => [bucket, scoreStats(scoresByOutcome[bucket])])
+  );
 
   // --- Archetype breakdown ---
   const archetypeMap = new Map();
   for (const e of enriched) {
     const arch = e.report?.archetype || 'Unknown';
-    if (!archetypeMap.has(arch)) archetypeMap.set(arch, { total: 0, positive: 0, negative: 0, self_filtered: 0, pending: 0 });
+    if (!archetypeMap.has(arch)) archetypeMap.set(arch, newOutcomeCounts());
     const entry = archetypeMap.get(arch);
     entry.total++;
     entry[e.outcome]++;
   }
   const archetypeBreakdown = [...archetypeMap.entries()].map(([archetype, data]) => ({
     archetype,
-    ...data,
-    conversionRate: data.total > 0 ? Math.round((data.positive / data.total) * 100) : 0,
+    ...withOutcomeRates(data),
   })).sort((a, b) => b.total - a.total);
 
   // --- Blocker / discard-reason / technology analysis ---
@@ -1111,30 +1164,28 @@ function analyze() {
   const remoteMap = new Map();
   for (const e of enriched) {
     const policy = e.remoteBucket;
-    if (!remoteMap.has(policy)) remoteMap.set(policy, { total: 0, positive: 0, negative: 0, self_filtered: 0, pending: 0 });
+    if (!remoteMap.has(policy)) remoteMap.set(policy, newOutcomeCounts());
     const entry = remoteMap.get(policy);
     entry.total++;
     entry[e.outcome]++;
   }
   const remotePolicy = [...remoteMap.entries()].map(([policy, data]) => ({
     policy,
-    ...data,
-    conversionRate: data.total > 0 ? Math.round((data.positive / data.total) * 100) : 0,
+    ...withOutcomeRates(data),
   })).sort((a, b) => b.total - a.total);
 
   // --- Company size breakdown ---
   const sizeMap = new Map();
   for (const e of enriched) {
     const size = e.companySize;
-    if (!sizeMap.has(size)) sizeMap.set(size, { total: 0, positive: 0, negative: 0, self_filtered: 0, pending: 0 });
+    if (!sizeMap.has(size)) sizeMap.set(size, newOutcomeCounts());
     const entry = sizeMap.get(size);
     entry.total++;
     entry[e.outcome]++;
   }
   const companySizeBreakdown = [...sizeMap.entries()].map(([size, data]) => ({
     size,
-    ...data,
-    conversionRate: data.total > 0 ? Math.round((data.positive / data.total) * 100) : 0,
+    ...withOutcomeRates(data),
   })).sort((a, b) => b.total - a.total);
 
   // --- ATS vendor / channel analysis (algorithmic-monoculture aware) ---
@@ -1204,13 +1255,22 @@ function analyze() {
   const viaChannelAnalysis = buildViaChannelAnalysis(submitted, isAdvanced);
 
   // --- Score threshold analysis ---
+  // 'positive' no longer includes bare Applied rows, so the floor is the lowest
+  // score that actually got traction — a smaller, more honest sample. A single
+  // Responded at 5.0 must not become "set the threshold at 5/5": the range is
+  // always reported, the prescription waits for a minimum sample.
   const positiveScores = scoresByOutcome.positive.filter(s => s > 0);
   const minPositiveScore = positiveScores.length > 0 ? Math.min(...positiveScores) : 0;
+  const thresholdSufficient = positiveScores.length >= MIN_POSITIVE_SCORES_FOR_THRESHOLD;
   const scoreThreshold = {
     recommended: minPositiveScore > 0 ? Math.floor(minPositiveScore * 10) / 10 : 3.5,
-    reasoning: positiveScores.length > 0
-      ? `Lowest score among positive outcomes is ${minPositiveScore}. No applications below this score led to progress.`
-      : 'Not enough positive outcome data to determine threshold.',
+    sampleSize: positiveScores.length,
+    sufficientSample: thresholdSufficient,
+    reasoning: positiveScores.length === 0
+      ? 'Not enough positive outcome data to determine threshold.'
+      : thresholdSufficient
+        ? `Lowest score among ${positiveScores.length} positive outcomes is ${minPositiveScore}. No applications below this score led to progress.`
+        : `Lowest score among positive outcomes so far is ${minPositiveScore}, but only ${positiveScores.length} positive outcome(s) carry a score (${MIN_POSITIVE_SCORES_FOR_THRESHOLD} needed before this is a threshold).`,
     positiveRange: positiveScores.length > 0
       ? `${Math.min(...positiveScores)} - ${Math.max(...positiveScores)}`
       : 'N/A',
@@ -1242,32 +1302,40 @@ function analyze() {
     });
   }
 
-  // Score threshold recommendation
-  if (minPositiveScore > 3.0) {
+  // Score threshold recommendation — only once enough positive outcomes carry
+  // a score; below the floor the threshold is an observation, not an action.
+  if (thresholdSufficient && minPositiveScore > 3.0) {
     recommendations.push({
       action: `Set minimum score threshold at ${scoreThreshold.recommended}/5 before generating PDFs`,
-      reasoning: `No positive outcomes below ${minPositiveScore}/5. Scores below this are wasted effort.`,
+      reasoning: `None of the ${positiveScores.length} positive outcomes scored below ${minPositiveScore}/5.`,
       impact: 'medium',
     });
   }
 
-  // Best archetype recommendation
-  const bestArchetype = archetypeBreakdown.filter(a => a.total >= 2).sort((a, b) => b.conversionRate - a.conversionRate)[0];
+  // Best archetype recommendation. Gated on `submitted`, not `total`: a segment
+  // of rows that were evaluated and never sent has no conversion to speak of,
+  // and gating on `total` let it reach the recommendation as if it did.
+  const bestArchetype = archetypeBreakdown.filter(a => a.submitted >= MIN_SUBMITTED_FOR_RECOMMENDATION).sort((a, b) => b.conversionRate - a.conversionRate)[0];
   if (bestArchetype && bestArchetype.conversionRate > 0) {
     recommendations.push({
       action: `Double down on "${bestArchetype.archetype}" roles (${bestArchetype.conversionRate}% conversion rate)`,
-      reasoning: `${bestArchetype.positive} of ${bestArchetype.total} applications in this archetype led to positive outcomes.`,
+      reasoning: `${bestArchetype.positive} of ${bestArchetype.submitted} applications sent in this archetype led to positive outcomes.`,
       impact: 'medium',
     });
   }
 
   // Remote policy recommendation
   const bestRemote = remotePolicy.filter(r => r.total >= 2).sort((a, b) => b.conversionRate - a.conversionRate)[0];
-  const worstRemote = remotePolicy.filter(r => r.total >= 2 && r.conversionRate === 0)[0];
+  // "0% conversion" is only a claim once something was actually DECIDED — a
+  // bucket of applications still awaiting a reply is silence, not a rejection.
+  // Gate on the COUNTS, not on the rounded rate: 1 positive out of 201 decided
+  // rounds to 0% yet is not "none advanced", and 1 negative + 1 awaiting is a
+  // single data point, not a pattern.
+  const worstRemote = remotePolicy.filter(r => r.positive === 0 && r.decided >= MIN_DECIDED_FOR_AVOID)[0];
   if (worstRemote) {
     recommendations.push({
-      action: `Avoid "${worstRemote.policy}" roles (0% conversion across ${worstRemote.total} applications)`,
-      reasoning: `None of the ${worstRemote.total} applications with "${worstRemote.policy}" policy led to progress.`,
+      action: `Avoid "${worstRemote.policy}" roles (0 of ${worstRemote.decided} decided outcomes advanced, ${worstRemote.submitted} sent)`,
+      reasoning: `None of the ${worstRemote.decided} decided applications with "${worstRemote.policy}" policy led to progress.`,
       impact: 'medium',
     });
   }
@@ -1319,12 +1387,11 @@ function analyze() {
       total: enriched.length,
       dateRange: { from: dates[0], to: dates[dates.length - 1] },
       analysisDate: new Date().toISOString().split('T')[0],
-      byOutcome: {
-        positive: enriched.filter(e => e.outcome === 'positive').length,
-        negative: enriched.filter(e => e.outcome === 'negative').length,
-        self_filtered: enriched.filter(e => e.outcome === 'self_filtered').length,
-        pending: enriched.filter(e => e.outcome === 'pending').length,
-      },
+      // Built from OUTCOME_BUCKETS so a new bucket cannot be added to
+      // classifyOutcome and then quietly go missing from the summary.
+      byOutcome: Object.fromEntries(
+        OUTCOME_BUCKETS.map((bucket) => [bucket, enriched.filter(e => e.outcome === bucket).length])
+      ),
     },
     funnel,
     scoreComparison,
@@ -1392,7 +1459,9 @@ function printSummary(result) {
   console.log('\nREMOTE POLICY');
   console.log('-'.repeat(40));
   for (const r of remotePolicy) {
-    console.log(`  ${r.policy.padEnd(20)} ${String(r.total).padStart(2)} total, ${r.positive} positive (${r.conversionRate}%)`);
+    // A segment nobody has answered yet prints n/a, not 0%: silence is not a result.
+    const decidedLabel = r.decidedRate === null ? 'n/a' : `${r.decidedRate}%`;
+    console.log(`  ${r.policy.padEnd(20)} ${String(r.submitted).padStart(2)} sent, ${r.awaiting} awaiting, ${r.positive} positive of ${r.decided} decided (${decidedLabel})`);
   }
 
   // Tech gaps
@@ -1461,16 +1530,21 @@ function printSummary(result) {
 }
 
 // --- Run ---
-if (args.includes('--self-test')) {
-  runSelfTest();
+// Guarded so the module can be imported for its pure helpers without running an
+// analysis and printing JSON to stdout. Same idiom as followup-cadence.mjs,
+// which stats.mjs already imports.
+if (isMainModule(import.meta.url)) {
+  if (args.includes('--self-test')) {
+    runSelfTest();
+  }
+
+  const result = analyze();
+
+  if (summaryMode) {
+    printSummary(result);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+
+  if (result.error) process.exit(1);
 }
-
-const result = analyze();
-
-if (summaryMode) {
-  printSummary(result);
-} else {
-  console.log(JSON.stringify(result, null, 2));
-}
-
-if (result.error) process.exit(1);

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -110,14 +110,14 @@ export function classifyOutcome(status) {
   // 'hired' is the strongest positive outcome — a landed job. It must not fall
   // through to the 'pending' default, which would drag conversion rates down.
   if (['hired', 'interview', 'offer', 'responded'].includes(s)) return 'positive';
-  // 'applied' is SENT, not successful — no recorded answer yet. It gets its
-  // own bucket so it can sit in the conversion DENOMINATOR without inflating
-  // the numerator; counting it as positive reports the user's own sending
-  // activity back at them as traction. Mirrors ADVANCED_STATUSES, which already
-  // excludes 'applied' for the vendor/via channel-yield analysis.
+  // 'applied' is SENT, not answered: denominator only, never the numerator.
+  // Mirrors ADVANCED_STATUSES, which already excludes it.
   if (s === 'applied') return 'awaiting';
-  if (['rejected', 'discarded'].includes(s)) return 'negative';
-  if (['skip'].includes(s)) return 'self_filtered';
+  if (s === 'rejected') return 'negative';
+  // Withdrawn by the candidate or the posting died: neither a submission the
+  // canonical funnel counts (stats.mjs) nor an employer decision.
+  if (s === 'discarded') return 'discarded';
+  if (s === 'skip') return 'self_filtered';
   return 'pending'; // evaluated
 }
 
@@ -133,7 +133,7 @@ export function classifyOutcome(status) {
 // the base only dilutes the share. Must stay in lockstep with the filter that
 // guards the discard-reason harvest loop.
 function discardableBase(enriched) {
-  return enriched.filter(e => e.outcome === 'self_filtered' || e.outcome === 'negative').length;
+  return enriched.filter(e => REASON_BEARING.has(e.outcome)).length;
 }
 
 // Entries that actually carry gaps, i.e. the ones a blocker can be extracted
@@ -146,13 +146,17 @@ function gapBearingBase(enriched) {
 // Outcome buckets a breakdown row carries. Kept in one place so a new bucket
 // cannot be added to classifyOutcome without every counter learning about it —
 // `entry[outcome]++` on a missing key silently writes NaN.
-export const OUTCOME_BUCKETS = ['positive', 'negative', 'self_filtered', 'pending', 'awaiting'];
+export const OUTCOME_BUCKETS = ['positive', 'awaiting', 'negative', 'discarded', 'self_filtered', 'pending'];
+// Buckets whose rows can carry a skip/discard reason or a blocker: the base for
+// discard-reason shares and the source of blocker / tech-gap harvesting.
+const REASON_BEARING = new Set(['negative', 'discarded', 'self_filtered']);
 
 // Sample floors for the prescriptive recommendations. Small on purpose: they
 // do not claim statistical confidence, they stop a single row from becoming
 // an instruction ("avoid X", "set the threshold at Y").
-const MIN_SUBMITTED_FOR_RECOMMENDATION = 2;
-const MIN_DECIDED_FOR_AVOID = 2;
+// A prescription ("double down", "avoid") needs at least this many DECIDED
+// outcomes — employer silence is not evidence in either direction.
+const MIN_DECIDED_FOR_RECOMMENDATION = 2;
 const MIN_POSITIVE_SCORES_FOR_THRESHOLD = 3;
 
 /** A zeroed counter row for the per-segment breakdowns. */
@@ -163,18 +167,11 @@ export function newOutcomeCounts() {
 }
 
 /**
- * Rates for one breakdown row.
- *
- * `conversionRate` divides by SUBMITTED (positive + negative + awaiting), never
- * by `total`: `total` also counts Evaluated rows that were never sent, so
- * dividing by it answers "what share of the evaluated pile did I apply to",
- * which is not a conversion rate.
- *
- * `decidedRate` is the stricter reading — of the applications with a recorded
- * outcome (positive or negative), how many advanced. It is `null` (not 0)
- * when nothing is decided yet, so an untested segment reads as "no data"
- * instead of "0%". `decided` is returned as a count so callers gate on facts
- * rather than on a rounded percentage.
+ * Rates for one breakdown row. `conversionRate` divides by SUBMITTED, never by
+ * `total` (which also counts Evaluated rows never sent). `decidedRate` divides
+ * by the rows with a recorded outcome and is `null`, not 0, while nothing is
+ * decided. `decided` ships as a count so callers gate on facts, not on a
+ * rounded percentage.
  */
 export function withOutcomeRates(data) {
   const submitted = data.positive + data.negative + data.awaiting;
@@ -188,11 +185,81 @@ export function withOutcomeRates(data) {
   };
 }
 
-// Statuses that count as a submitted application for channel-yield analysis
-// (drop 'evaluated' = never applied, 'skip' = self-filtered). 'hired' counts —
-// a landed job was, by definition, submitted. Module-scoped so the self-test
+/** Group entries by a key, count outcomes, attach rates. Largest bucket first. */
+function breakdownBy(enriched, labelKey, keyOf) {
+  const map = new Map();
+  for (const e of enriched) {
+    const k = keyOf(e);
+    if (!map.has(k)) map.set(k, newOutcomeCounts());
+    const row = map.get(k);
+    row.total++;
+    row[e.outcome]++;
+  }
+  return [...map.entries()]
+    .map(([label, data]) => ({ [labelKey]: label, ...withOutcomeRates(data) }))
+    .sort((a, b) => b.total - a.total);
+}
+
+/**
+ * The segment worth doubling down on: highest decidedRate among rows with
+ * enough DECIDED outcomes. Ranking by conversionRate would let "1 positive +
+ * 1 awaiting" (50%) outrank "5 positive + 15 awaiting" (25%). A rate that
+ * rounds to 0% (1 of 201) is not a lane to double down on.
+ */
+export function bestDecidedSegment(rows) {
+  return rows
+    .filter(r => r.decided >= MIN_DECIDED_FOR_RECOMMENDATION && r.decidedRate > 0)
+    .sort((a, b) => b.decidedRate - a.decidedRate || b.decided - a.decided)[0] || null;
+}
+
+/**
+ * The segment to avoid: nothing advanced across enough DECIDED outcomes, the
+ * most evidence first. Gate on counts, not the rounded rate: 1 positive of 201
+ * decided rounds to 0% and is not "none advanced"; 1 negative + 1 awaiting is
+ * a data point, not a pattern.
+ */
+export function worstDecidedSegment(rows) {
+  return rows
+    .filter(r => r.positive === 0 && r.decided >= MIN_DECIDED_FOR_RECOMMENDATION)
+    .sort((a, b) => b.decided - a.decided)[0] || null;
+}
+
+/**
+ * Score floor from decided outcomes. The lowest positive score is always
+ * reported as an observation; it becomes a recommended threshold only when
+ * enough positives carry a score AND at least one rejected application scored
+ * below it — "nothing below X advanced" is vacuous when nothing below X was
+ * ever decided.
+ */
+export function scoreThresholdFrom(positiveScoresRaw, negativeScoresRaw) {
+  const positive = positiveScoresRaw.filter(s => s > 0);
+  const negative = negativeScoresRaw.filter(s => s > 0);
+  const min = positive.length > 0 ? Math.min(...positive) : 0;
+  const rejectedBelow = negative.filter(s => s < min).length;
+  const sufficient = positive.length >= MIN_POSITIVE_SCORES_FOR_THRESHOLD;
+  const prescribe = sufficient && rejectedBelow > 0;
+  let reasoning;
+  if (positive.length === 0) reasoning = 'No positive outcome carries a score yet.';
+  else if (!sufficient) reasoning = `Lowest score among positive outcomes so far is ${min}, but only ${positive.length} positive outcome(s) carry a score (${MIN_POSITIVE_SCORES_FOR_THRESHOLD} needed before this is a threshold).`;
+  else if (!prescribe) reasoning = `Lowest score among ${positive.length} positive outcomes is ${min}, but no rejected application scored below it — nothing shows that lower scores fail.`;
+  else reasoning = `None of the ${positive.length} positive outcomes scored below ${min}, and ${rejectedBelow} rejected application(s) did.`;
+  return {
+    recommended: prescribe ? Math.floor(min * 10) / 10 : null,
+    observedMinimum: min > 0 ? min : null,
+    sampleSize: positive.length,
+    sufficientSample: sufficient,
+    rejectedBelow,
+    reasoning,
+    positiveRange: positive.length > 0 ? `${min} - ${Math.max(...positive)}` : 'N/A',
+  };
+}
+
+// Statuses that count as a submitted application for channel-yield analysis.
+// 'evaluated' was never sent, 'skip' is self-filtered, and 'discarded' (withdrawn
+// or the posting closed) proves neither a submission nor an answer — the same
+// set stats.mjs uses for its canonical funnel. Module-scoped so the self-test
 // can assert membership and the channel-yield pass and self-test share one set.
-const SUBMITTED_STATUSES = new Set(['applied', 'responded', 'interview', 'offer', 'hired', 'rejected', 'discarded']);
+const SUBMITTED_STATUSES = new Set(['applied', 'responded', 'interview', 'offer', 'hired', 'rejected']);
 
 // Statuses that count as "advanced past screening" — STRICTER than
 // outcome=='positive': a bare 'applied' (submitted, no reply yet) does NOT
@@ -505,8 +572,14 @@ requirement_importance:
   for (const alias of ['contratado', 'contratada', 'accepted', 'accept']) {
     if (normalizeStatus(alias) !== 'hired') failures.push(`hired: normalizeStatus('${alias}') → ${normalizeStatus(alias)}, expected 'hired'`);
   }
-  // Outcome buckets and rate helpers are covered by
-  // tests/analyze-patterns-outcomes.test.mjs (unit + end-to-end fixture).
+  // Every submitted status must land in exactly one outcome bucket, and every
+  // bucket must be a declared one — a status added to one list and not the other
+  // would silently vanish from the rates.
+  for (const st of SUBMITTED_STATUSES) {
+    const bucket = classifyOutcome(st);
+    if (!['positive', 'negative', 'awaiting'].includes(bucket)) failures.push(`buckets: '${st}' classifies as '${bucket}', so submitted counts would disagree with the channel-yield pass`);
+  }
+  if (classifyOutcome('Discarded') !== 'discarded' || SUBMITTED_STATUSES.has('discarded')) failures.push('discarded: withdrawn/closed rows must be their own bucket and not count as submitted');
 
   if (!ADVANCED_STATUSES.has('hired')) failures.push('hired: ADVANCED_STATUSES must include hired (a hire advanced past screening)');
   if (!SUBMITTED_STATUSES.has('hired')) failures.push('hired: SUBMITTED_STATUSES must include hired (a hire was submitted)');
@@ -586,14 +659,18 @@ requirement_importance:
     failures.push(`geo blocker aggregation returned ${JSON.stringify(geoBlocker)} against base ${blockerSignals.blockerBase}, expected 2/2 (100%)`);
   }
 
-  // Repeated technology mentions across one report count once per entry.
-  const techSignals = buildPatternSignals([{ outcome: 'negative', notes: '', report: { gaps: [
-    { description: 'Java is required', severity: 'hard' },
-    { description: 'Production Java and Go experience', severity: 'hard' },
-  ] } }]);
+  // Repeated technology mentions across one report count once per entry, and a
+  // withdrawn/closed ('discarded') row is harvested like a rejected one.
+  const techSignals = buildPatternSignals([
+    { outcome: 'negative', notes: '', report: { gaps: [
+      { description: 'Java is required', severity: 'hard' },
+      { description: 'Production Java and Go experience', severity: 'hard' },
+    ] } },
+    { outcome: 'discarded', notes: '', report: { gaps: [{ description: 'Java is required', severity: 'hard' }] } },
+  ]);
   const javaGap = techSignals.techStackGaps.find(g => g.skill === 'Java');
-  if (javaGap?.frequency !== 1) {
-    failures.push(`technology deduplication returned ${JSON.stringify(javaGap)}, expected Java frequency 1`);
+  if (javaGap?.frequency !== 2) {
+    failures.push(`technology harvest returned ${JSON.stringify(javaGap)}, expected Java frequency 2 (one negative + one discarded row)`);
   }
 
   // Empty populations must expose zero bases and no NaN-bearing stats.
@@ -987,7 +1064,7 @@ function buildPatternSignals(enriched) {
 
   const discardReasonCounts = new Map();
   for (const e of enriched) {
-    if (e.outcome !== 'self_filtered' && e.outcome !== 'negative') continue;
+    if (!REASON_BEARING.has(e.outcome)) continue;
     const notesMatch = (e.notes || '').match(/(?:DISCARD|SKIP):\s*([^,;\n]+)/gi);
     if (!notesMatch) continue;
     const entryReasons = new Set();
@@ -1010,7 +1087,7 @@ function buildPatternSignals(enriched) {
 
   const stackGapCounts = new Map();
   for (const e of enriched) {
-    if (e.outcome !== 'negative' && e.outcome !== 'self_filtered') continue;
+    if (!REASON_BEARING.has(e.outcome)) continue;
     if (!e.report?.gaps) continue;
     const entryTechs = new Set();
     for (const gap of e.report.gaps) {
@@ -1095,12 +1172,13 @@ function analyze() {
     };
   });
 
-  // Count entries beyond "Evaluated"
-  const beyondEvaluated = enriched.filter(e => e.normalizedStatus !== 'evaluated');
-  if (beyondEvaluated.length < MIN_THRESHOLD) {
+  // The floor counts applications actually SENT: a tracker of skipped and
+  // withdrawn rows has no outcomes to learn from.
+  const sent = enriched.filter(e => SUBMITTED_STATUSES.has(e.normalizedStatus));
+  if (sent.length < MIN_THRESHOLD) {
     return {
-      error: `Not enough data: ${beyondEvaluated.length}/${MIN_THRESHOLD} applications beyond "Evaluated". Keep applying and come back later.`,
-      current: beyondEvaluated.length,
+      error: `Not enough data: ${sent.length}/${MIN_THRESHOLD} applications sent. Keep applying and come back later.`,
+      current: sent.length,
       threshold: MIN_THRESHOLD,
     };
   }
@@ -1129,25 +1207,11 @@ function analyze() {
     };
   };
 
-  // Same bucket list as the counters and metadata, so a bucket cannot exist in
-  // one output and be missing from another.
   const scoreComparison = Object.fromEntries(
     OUTCOME_BUCKETS.map((bucket) => [bucket, scoreStats(scoresByOutcome[bucket])])
   );
 
-  // --- Archetype breakdown ---
-  const archetypeMap = new Map();
-  for (const e of enriched) {
-    const arch = e.report?.archetype || 'Unknown';
-    if (!archetypeMap.has(arch)) archetypeMap.set(arch, newOutcomeCounts());
-    const entry = archetypeMap.get(arch);
-    entry.total++;
-    entry[e.outcome]++;
-  }
-  const archetypeBreakdown = [...archetypeMap.entries()].map(([archetype, data]) => ({
-    archetype,
-    ...withOutcomeRates(data),
-  })).sort((a, b) => b.total - a.total);
+  const archetypeBreakdown = breakdownBy(enriched, 'archetype', e => e.report?.archetype || 'Unknown');
 
   // --- Blocker / discard-reason / technology analysis ---
   // Shared with --self-test so fixtures exercise the production aggregation.
@@ -1160,33 +1224,9 @@ function analyze() {
     discardReasonRecommendation,
   } = buildPatternSignals(enriched);
 
-  // --- Remote policy breakdown ---
-  const remoteMap = new Map();
-  for (const e of enriched) {
-    const policy = e.remoteBucket;
-    if (!remoteMap.has(policy)) remoteMap.set(policy, newOutcomeCounts());
-    const entry = remoteMap.get(policy);
-    entry.total++;
-    entry[e.outcome]++;
-  }
-  const remotePolicy = [...remoteMap.entries()].map(([policy, data]) => ({
-    policy,
-    ...withOutcomeRates(data),
-  })).sort((a, b) => b.total - a.total);
+  const remotePolicy = breakdownBy(enriched, 'policy', e => e.remoteBucket);
 
-  // --- Company size breakdown ---
-  const sizeMap = new Map();
-  for (const e of enriched) {
-    const size = e.companySize;
-    if (!sizeMap.has(size)) sizeMap.set(size, newOutcomeCounts());
-    const entry = sizeMap.get(size);
-    entry.total++;
-    entry[e.outcome]++;
-  }
-  const companySizeBreakdown = [...sizeMap.entries()].map(([size, data]) => ({
-    size,
-    ...withOutcomeRates(data),
-  })).sort((a, b) => b.total - a.total);
+  const companySizeBreakdown = breakdownBy(enriched, 'size', e => e.companySize);
 
   // --- ATS vendor / channel analysis (algorithmic-monoculture aware) ---
   // Motivation: Bommasani et al., "Algorithmic Monocultures in Hiring" (FAccT
@@ -1255,26 +1295,7 @@ function analyze() {
   const viaChannelAnalysis = buildViaChannelAnalysis(submitted, isAdvanced);
 
   // --- Score threshold analysis ---
-  // 'positive' no longer includes bare Applied rows, so the floor is the lowest
-  // score that actually got traction — a smaller, more honest sample. A single
-  // Responded at 5.0 must not become "set the threshold at 5/5": the range is
-  // always reported, the prescription waits for a minimum sample.
-  const positiveScores = scoresByOutcome.positive.filter(s => s > 0);
-  const minPositiveScore = positiveScores.length > 0 ? Math.min(...positiveScores) : 0;
-  const thresholdSufficient = positiveScores.length >= MIN_POSITIVE_SCORES_FOR_THRESHOLD;
-  const scoreThreshold = {
-    recommended: minPositiveScore > 0 ? Math.floor(minPositiveScore * 10) / 10 : 3.5,
-    sampleSize: positiveScores.length,
-    sufficientSample: thresholdSufficient,
-    reasoning: positiveScores.length === 0
-      ? 'Not enough positive outcome data to determine threshold.'
-      : thresholdSufficient
-        ? `Lowest score among ${positiveScores.length} positive outcomes is ${minPositiveScore}. No applications below this score led to progress.`
-        : `Lowest score among positive outcomes so far is ${minPositiveScore}, but only ${positiveScores.length} positive outcome(s) carry a score (${MIN_POSITIVE_SCORES_FOR_THRESHOLD} needed before this is a threshold).`,
-    positiveRange: positiveScores.length > 0
-      ? `${Math.min(...positiveScores)} - ${Math.max(...positiveScores)}`
-      : 'N/A',
-  };
+  const scoreThreshold = scoreThresholdFrom(scoresByOutcome.positive, scoresByOutcome.negative);
 
   // --- Generate recommendations ---
   const recommendations = [];
@@ -1302,36 +1323,24 @@ function analyze() {
     });
   }
 
-  // Score threshold recommendation — only once enough positive outcomes carry
-  // a score; below the floor the threshold is an observation, not an action.
-  if (thresholdSufficient && minPositiveScore > 3.0) {
+  if (scoreThreshold.recommended !== null && scoreThreshold.recommended > 3.0) {
     recommendations.push({
       action: `Set minimum score threshold at ${scoreThreshold.recommended}/5 before generating PDFs`,
-      reasoning: `None of the ${positiveScores.length} positive outcomes scored below ${minPositiveScore}/5.`,
+      reasoning: scoreThreshold.reasoning,
       impact: 'medium',
     });
   }
 
-  // Best archetype recommendation. Gated on `submitted`, not `total`: a segment
-  // of rows that were evaluated and never sent has no conversion to speak of,
-  // and gating on `total` let it reach the recommendation as if it did.
-  const bestArchetype = archetypeBreakdown.filter(a => a.submitted >= MIN_SUBMITTED_FOR_RECOMMENDATION).sort((a, b) => b.conversionRate - a.conversionRate)[0];
-  if (bestArchetype && bestArchetype.conversionRate > 0) {
+  const bestArchetype = bestDecidedSegment(archetypeBreakdown);
+  if (bestArchetype) {
     recommendations.push({
-      action: `Double down on "${bestArchetype.archetype}" roles (${bestArchetype.conversionRate}% conversion rate)`,
-      reasoning: `${bestArchetype.positive} of ${bestArchetype.submitted} applications sent in this archetype led to positive outcomes.`,
+      action: `Double down on "${bestArchetype.archetype}" roles (${bestArchetype.decidedRate}% of decided outcomes advanced, ${bestArchetype.conversionRate}% of all sent)`,
+      reasoning: `${bestArchetype.positive} of ${bestArchetype.decided} decided applications in this archetype advanced (${bestArchetype.awaiting} still awaiting a reply).`,
       impact: 'medium',
     });
   }
 
-  // Remote policy recommendation
-  const bestRemote = remotePolicy.filter(r => r.total >= 2).sort((a, b) => b.conversionRate - a.conversionRate)[0];
-  // "0% conversion" is only a claim once something was actually DECIDED — a
-  // bucket of applications still awaiting a reply is silence, not a rejection.
-  // Gate on the COUNTS, not on the rounded rate: 1 positive out of 201 decided
-  // rounds to 0% yet is not "none advanced", and 1 negative + 1 awaiting is a
-  // single data point, not a pattern.
-  const worstRemote = remotePolicy.filter(r => r.positive === 0 && r.decided >= MIN_DECIDED_FOR_AVOID)[0];
+  const worstRemote = worstDecidedSegment(remotePolicy);
   if (worstRemote) {
     recommendations.push({
       action: `Avoid "${worstRemote.policy}" roles (0 of ${worstRemote.decided} decided outcomes advanced, ${worstRemote.submitted} sent)`,
@@ -1382,16 +1391,19 @@ function analyze() {
   // Date range
   const dates = enriched.map(e => e.date).filter(Boolean).sort();
 
+  const byOutcome = Object.fromEntries(
+    OUTCOME_BUCKETS.map((bucket) => [bucket, enriched.filter(e => e.outcome === bucket).length])
+  );
+
   return {
     metadata: {
       total: enriched.length,
       dateRange: { from: dates[0], to: dates[dates.length - 1] },
       analysisDate: new Date().toISOString().split('T')[0],
-      // Built from OUTCOME_BUCKETS so a new bucket cannot be added to
-      // classifyOutcome and then quietly go missing from the summary.
-      byOutcome: Object.fromEntries(
-        OUTCOME_BUCKETS.map((bucket) => [bucket, enriched.filter(e => e.outcome === bucket).length])
-      ),
+      byOutcome,
+      // The same rates as every breakdown row, over the whole tracker — the
+      // one honest place to quote "X% of what I sent advanced".
+      outcomeRates: withOutcomeRates({ total: enriched.length, ...byOutcome }),
     },
     funnel,
     scoreComparison,
@@ -1466,7 +1478,7 @@ function printSummary(result) {
 
   // Tech gaps
   if (techStackGaps.length > 0) {
-    console.log('\nTOP TECH STACK GAPS (negative outcomes)');
+    console.log('\nTOP TECH STACK GAPS (negative / discarded outcomes)');
     console.log('-'.repeat(40));
     for (const g of techStackGaps.slice(0, 10)) {
       console.log(`  ${g.skill.padEnd(20)} ${g.frequency}x`);
@@ -1475,7 +1487,7 @@ function printSummary(result) {
 
   // Discard reasons
   if (discardReasonStats && discardReasonStats.length > 0) {
-    console.log(`\nTOP DISCARD / SKIP REASONS (of ${result.discardReasonBase} self-filtered/negative entries)`);
+    console.log(`\nTOP DISCARD / SKIP REASONS (of ${result.discardReasonBase} self-filtered / discarded / negative entries)`);
     console.log('-'.repeat(40));
     for (const d of discardReasonStats.slice(0, 10)) {
       console.log(`  ${d.reason.padEnd(30)} ${String(d.frequency).padStart(2)}x (${d.percentage}%)`);
@@ -1512,7 +1524,14 @@ function printSummary(result) {
   }
 
   // Score threshold
-  console.log(`\nSCORE THRESHOLD: ${scoreThreshold.recommended}/5`);
+  // A threshold is printed only when one was actually earned (see
+  // scoreThresholdFrom); a sufficient sample with nothing rejected below the
+  // floor is still an observation.
+  if (scoreThreshold.recommended !== null) {
+    console.log(`\nSCORE THRESHOLD: ${scoreThreshold.recommended}/5`);
+  } else {
+    console.log(`\nSCORE OBSERVATION: lowest positive ${scoreThreshold.observedMinimum ?? 'n/a'}/5 (n=${scoreThreshold.sampleSize}; not a threshold yet)`);
+  }
   console.log(`  ${scoreThreshold.reasoning}`);
 
   // Recommendations
@@ -1529,10 +1548,7 @@ function printSummary(result) {
   console.log('');
 }
 
-// --- Run ---
-// Guarded so the module can be imported for its pure helpers without running an
-// analysis and printing JSON to stdout. Same idiom as followup-cadence.mjs,
-// which stats.mjs already imports.
+// --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (isMainModule(import.meta.url)) {
   if (args.includes('--self-test')) {
     runSelfTest();

--- a/modes/patterns.md
+++ b/modes/patterns.md
@@ -38,11 +38,11 @@ Parse the JSON output. It contains:
 |-----|----------|
 | `metadata` | Total entries, date range, analysis date, counts by outcome |
 | `funnel` | Count per status stage (evaluated, applied, interview, offer, etc.) |
-| `scoreComparison` | Avg/min/max score per outcome group (positive, negative, self_filtered, pending) |
-| `archetypeBreakdown` | Per-archetype: total, positive, negative, self_filtered, conversion rate |
+| `scoreComparison` | Avg/min/max score per outcome group (positive, negative, awaiting, self_filtered, pending) |
+| `archetypeBreakdown` | Per-archetype: total, submitted, positive, negative, awaiting, self_filtered, conversionRate, decidedRate |
 | `blockerAnalysis` | Most frequent hard blockers: geo-restriction, stack-mismatch, seniority, onsite; each `percentage` is a share of `blockerBase` |
 | `blockerBase` | Entries carrying a non-empty gaps array — the denominator for `blockerAnalysis[].percentage` |
-| `remotePolicy` | Per-policy bucket: total, positive, negative, conversion rate |
+| `remotePolicy` | Per-policy bucket: total, submitted, positive, negative, awaiting, conversionRate, decidedRate |
 | `companySizeBreakdown` | Per-size bucket: startup, scaleup, enterprise |
 | `vendorAnalysis` | ATS channel analysis: per-vendor advance rate + coverage (see below) |
 | `viaChannelAnalysis` | Via channel analysis (#1596): per-agency advance rate + agency-vs-direct aggregate (see below) |
@@ -157,7 +157,7 @@ Write the report to `reports/pattern-analysis-{YYYY-MM-DD}.md`.
 
 **Applications analyzed:** {total}
 **Date range:** {from} to {to}
-**Outcomes:** {positive} positive, {negative} negative, {self_filtered} self-filtered, {pending} pending
+**Outcomes:** {positive} positive, {awaiting} awaiting a reply, {negative} negative, {self_filtered} self-filtered, {pending} not sent
 
 ---
 
@@ -177,13 +177,16 @@ Show each status with count and percentage of total. Use a simple table:
 |---------|-----------|-----|-----|-------|
 | Positive | X.X/5 | X.X | X.X | X |
 | Negative | ... | | | |
+| Awaiting | ... | | | |
 | Self-filtered | ... | | | |
 | Pending | ... | | | |
 
 ## Archetype Performance
 
-Table with each archetype, total applications, positive outcomes, conversion rate.
+Table with each archetype, applications **sent** (`submitted`), positive outcomes, `conversionRate` and `decidedRate`.
 Highlight the best-performing archetype and the worst.
+
+Read the two rates as different questions. `conversionRate` = positives over everything sent, so a segment where most applications are still unanswered reads low by construction. `decidedRate` = positives over the applications the employer has actually answered, and is `null` while nothing is decided — report that as "no data yet", never as 0%.
 
 ## Top Blockers
 
@@ -194,6 +197,8 @@ gap-bearing entries, not the share of all applications.
 ## Remote Policy Patterns
 
 Table showing conversion rate by remote policy bucket (global, regional, geo-restricted, hybrid/onsite).
+
+**Never call a segment bad on `conversionRate` alone.** A bucket whose applications are all still unanswered shows a low `conversionRate` and a `null` `decidedRate` — that is silence, not rejection, and retiring a lane on it is how a working channel gets dropped. State `0%` as a negative signal only when `positive` is 0 **and** `decided` is at least 2, and name the decided count alongside it.
 
 ## Tech Stack Gaps
 
@@ -228,7 +233,7 @@ Example:
 > **Pattern Analysis Complete** (24 applications, Apr 7-8)
 >
 > Key findings:
-> - Geo-restricted roles are 0% conversion (7 of 24) -- stop evaluating US/Canada-only postings
+> - Geo-restricted roles: 0 of 7 **decided** applications advanced -- stop evaluating US/Canada-only postings
 > - Regional/global remote roles convert at 57-67% -- these are your sweet spot
 > - No positive outcomes below 4.2/5 -- consider this your score floor
 >
@@ -257,7 +262,8 @@ For reference, outcomes are classified as:
 
 | Status | Outcome |
 |--------|---------|
-| Interview, Offer, Responded, Applied | **Positive** (invested effort or got traction) |
+| Interview, Offer, Responded, Hired | **Positive** (the employer moved it forward) |
+| Applied | **Awaiting** (sent, no answer yet — counts in the conversion denominator, never as a success) |
 | Rejected, Discarded | **Negative** (company said no or offer closed) |
 | SKIP, NO APLICAR | **Self-filtered** (user decided not to apply) |
-| Evaluated | **Pending** (no action taken yet) |
+| Evaluated | **Pending** (never sent) |

--- a/modes/patterns.md
+++ b/modes/patterns.md
@@ -17,7 +17,7 @@ When interview sessions are available, it also reads *what the candidate actuall
 
 ## Minimum Threshold
 
-Before running analysis, check: does `data/applications.md` have at least 5 entries with status beyond "Evaluated" (i.e., Applied, Responded, Interview, Offer, Rejected, Discarded, SKIP)?
+Before running analysis, check: does `data/applications.md` have at least 5 entries that were actually sent (Applied, Responded, Interview, Offer, Hired, Rejected)? SKIP and Discarded rows are not submissions and do not count toward the floor.
 
 If not, tell the user:
 > "Not enough data yet -- {N}/5 applications have progressed beyond evaluation. Keep applying and come back when you have more outcomes to analyze."
@@ -36,20 +36,20 @@ Parse the JSON output. It contains:
 
 | Key | Contents |
 |-----|----------|
-| `metadata` | Total entries, date range, analysis date, counts by outcome |
+| `metadata` | Total entries, date range, analysis date, counts by outcome, and `outcomeRates` — the whole tracker through the same `submitted` / `decided` denominators as every breakdown row |
 | `funnel` | Count per status stage (evaluated, applied, interview, offer, etc.) |
-| `scoreComparison` | Avg/min/max score per outcome group (positive, negative, awaiting, self_filtered, pending) |
-| `archetypeBreakdown` | Per-archetype: total, submitted, positive, negative, awaiting, self_filtered, conversionRate, decidedRate |
+| `scoreComparison` | Avg/min/max score per outcome group (positive, awaiting, negative, discarded, self_filtered, pending) |
+| `archetypeBreakdown` | Per-archetype: total, submitted, decided, positive, awaiting, negative, discarded, self_filtered, conversionRate, decidedRate |
 | `blockerAnalysis` | Most frequent hard blockers: geo-restriction, stack-mismatch, seniority, onsite; each `percentage` is a share of `blockerBase` |
 | `blockerBase` | Entries carrying a non-empty gaps array — the denominator for `blockerAnalysis[].percentage` |
-| `remotePolicy` | Per-policy bucket: total, submitted, positive, negative, awaiting, conversionRate, decidedRate |
+| `remotePolicy` | Per-policy bucket: same columns as `archetypeBreakdown` |
 | `companySizeBreakdown` | Per-size bucket: startup, scaleup, enterprise |
 | `vendorAnalysis` | ATS channel analysis: per-vendor advance rate + coverage (see below) |
 | `viaChannelAnalysis` | Via channel analysis (#1596): per-agency advance rate + agency-vs-direct aggregate (see below) |
-| `scoreThreshold` | Recommended minimum score + reasoning |
-| `techStackGaps` | Most frequent tech gaps in negative outcomes |
+| `scoreThreshold` | `recommended` (null until `sufficientSample`), `observedMinimum`, `sampleSize`, `sufficientSample`, reasoning |
+| `techStackGaps` | Most frequent tech gaps in negative / discarded outcomes |
 | `discardReasonStats` | User-committed skip/discard reasons; each `percentage` is a share of `discardReasonBase` |
-| `discardReasonBase` | Self-filtered or negative entries — the denominator for `discardReasonStats[].percentage` and its recommendation threshold |
+| `discardReasonBase` | Self-filtered, discarded or negative entries — the denominator for `discardReasonStats[].percentage` and its recommendation threshold |
 | `recommendations` | Top 5 actionable items with reasoning and impact level |
 
 If the script returns `error`, display the error message and exit.
@@ -183,10 +183,9 @@ Show each status with count and percentage of total. Use a simple table:
 
 ## Archetype Performance
 
-Table with each archetype, applications **sent** (`submitted`), positive outcomes, `conversionRate` and `decidedRate`.
-Highlight the best-performing archetype and the worst.
+Table with each archetype: `submitted`, `decided`, positive, `decidedRate` (lead with it) and `conversionRate`. Highlight the best-performing archetype and the worst.
 
-Read the two rates as different questions. `conversionRate` = positives over everything sent, so a segment where most applications are still unanswered reads low by construction. `decidedRate` = positives over the applications the employer has actually answered, and is `null` while nothing is decided — report that as "no data yet", never as 0%.
+`conversionRate` = positives over everything sent, so a mostly-unanswered segment reads low by construction. `decidedRate` = positives over the applications with a recorded outcome, and is `null` while nothing is decided — report that as "no data yet", never 0%. Never divide by `metadata.total`: it counts evaluated rows that were never sent; the whole-tracker rates live in `metadata.outcomeRates`.
 
 ## Top Blockers
 
@@ -198,15 +197,15 @@ gap-bearing entries, not the share of all applications.
 
 Table showing conversion rate by remote policy bucket (global, regional, geo-restricted, hybrid/onsite).
 
-**Never call a segment bad on `conversionRate` alone.** A bucket whose applications are all still unanswered shows a low `conversionRate` and a `null` `decidedRate` — that is silence, not rejection, and retiring a lane on it is how a working channel gets dropped. State `0%` as a negative signal only when `positive` is 0 **and** `decided` is at least 2, and name the decided count alongside it.
+**Never call a segment bad on `conversionRate` alone** — an all-awaiting bucket shows a low rate and a `null` `decidedRate`, which is silence, not rejection. Call `0%` negative only when `positive` is 0 and `decided` >= 2, and name the decided count.
 
 ## Tech Stack Gaps
 
-List of most common missing skills in negative/self-filtered outcomes with frequency.
+List of most common missing skills in negative / discarded / self-filtered outcomes with frequency.
 
 ## Recommended Score Threshold
 
-State the data-driven minimum score and reasoning.
+State the data-driven minimum score and reasoning. When `sufficientSample` is false, `recommended` is `null`: report `observedMinimum` as an observation over `sampleSize` outcome(s) and do not offer to persist it.
 
 ## Targeting Signal (interview sessions)
 
@@ -225,7 +224,7 @@ Number the top recommendations (from the script output). For each:
 ## Step 3 — Present Summary
 
 Show the user a condensed version with:
-1. One-line stat summary (X applications, Y% applied, Z% positive outcome)
+1. One-line stat summary from `metadata.outcomeRates` (X sent, Y decided, Z% of decided advanced) — never a share of `metadata.total`
 2. Top 3 findings (most impactful patterns)
 3. Link to full report
 
@@ -245,7 +244,7 @@ Ask the user if they want to act on any recommendations:
 
 > "Want me to apply any of these recommendations? I can:
 > - Update `portals.yml` to filter out geo-restricted roles
-> - Set a score threshold in `_profile.md` for PDF generation
+> - Set a score threshold in `_profile.md` for PDF generation (only when `scoreThreshold.sufficientSample` is true)
 > - Adjust archetype targeting based on what's converting
 > - Realign targeting from the session signal — add the under-targeted archetype X to `modes/_profile.md` and reweight `portals.yml` `title_filter.positive` (if Step 1b ran)
 >
@@ -264,6 +263,7 @@ For reference, outcomes are classified as:
 |--------|---------|
 | Interview, Offer, Responded, Hired | **Positive** (the employer moved it forward) |
 | Applied | **Awaiting** (sent, no answer yet — counts in the conversion denominator, never as a success) |
-| Rejected, Discarded | **Negative** (company said no or offer closed) |
+| Rejected | **Negative** (the employer said no) |
+| Discarded | **Discarded** (you withdrew, or the posting closed — not an employer decision, not a proven submission; counts in neither `submitted` nor `decided`) |
 | SKIP, NO APLICAR | **Self-filtered** (user decided not to apply) |
 | Evaluated | **Pending** (never sent) |

--- a/tests/analyze-patterns-outcomes.test.mjs
+++ b/tests/analyze-patterns-outcomes.test.mjs
@@ -1,0 +1,233 @@
+// tests/analyze-patterns-outcomes.test.mjs — outcome classification and the
+// conversion denominators in analyze-patterns.mjs.
+//
+// These two are tested together because they fail together: counting a sent-
+// but-unanswered application as a positive outcome AND dividing by a `total`
+// that includes never-sent rows both push the reported conversion rate away
+// from what the employer actually did. On a small or healthy tracker the wrong
+// and right readings look similar; they diverge once a real pile of unanswered
+// applications accumulates, which is exactly when someone reads the number to
+// decide where to aim next.
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nanalyze-patterns — outcome classification & conversion denominators');
+
+const { classifyOutcome, newOutcomeCounts, withOutcomeRates } =
+  await import(pathToFileURL(join(ROOT, 'analyze-patterns.mjs')).href);
+
+// --- classifyOutcome ---------------------------------------------------------
+
+const OUTCOMES = [
+  ['Applied', 'awaiting', 'sent, no answer yet'],
+  ['Responded', 'positive', 'the employer answered'],
+  ['Interview', 'positive', 'advanced past screening'],
+  ['Offer', 'positive', 'offer in hand'],
+  ['Hired', 'positive', 'landed the job'],
+  ['Rejected', 'negative', 'the employer said no'],
+  ['Discarded', 'negative', 'dropped or the posting died'],
+  ['SKIP', 'self_filtered', 'never sent, by our own choice'],
+  ['Evaluated', 'pending', 'scored, not sent'],
+];
+
+let ok = true;
+for (const [status, expected, why] of OUTCOMES) {
+  const got = classifyOutcome(status);
+  if (got !== expected) { fail(`classifyOutcome('${status}') → '${got}', expected '${expected}' (${why})`); ok = false; }
+}
+if (ok) pass('classifyOutcome maps every canonical status to its outcome bucket');
+
+// Spanish aliases run through the same normalization; 'aplicado' must not be a
+// positive either, or the bug simply reappears for Spanish-language trackers.
+if (classifyOutcome('aplicado') === 'awaiting' && classifyOutcome('enviada') === 'awaiting') {
+  pass("localized 'applied' aliases resolve to 'awaiting', not 'positive'");
+} else {
+  fail(`aplicado → '${classifyOutcome('aplicado')}', enviada → '${classifyOutcome('enviada')}'`);
+}
+
+// --- every bucket exists on a counter row ------------------------------------
+// `entry[outcome]++` on a key the row does not define writes NaN and poisons
+// the whole breakdown silently, so the two must be kept in lockstep.
+const row = newOutcomeCounts();
+const missing = [...new Set(OUTCOMES.map(([s]) => classifyOutcome(s)))].filter((b) => !(b in row));
+if (missing.length === 0) pass('newOutcomeCounts() defines every bucket classifyOutcome can return');
+else fail(`newOutcomeCounts() is missing buckets: ${missing.join(', ')}`);
+
+if (row.total === 0 && Object.values(row).every((v) => v === 0)) pass('newOutcomeCounts() starts zeroed');
+else fail(`newOutcomeCounts() = ${JSON.stringify(row)}`);
+
+// --- withOutcomeRates --------------------------------------------------------
+// 25 rows in the segment, of which only 10 were ever sent: 1 advanced,
+// 1 rejected, 8 still silent. Conversion is 1/10, not 1/25 and not 9/10.
+const mixed = withOutcomeRates({ ...newOutcomeCounts(), total: 25, positive: 1, negative: 1, awaiting: 8, pending: 15 });
+if (mixed.submitted === 10) pass('submitted counts positive + negative + awaiting (never-sent rows excluded)');
+else fail(`submitted → ${mixed.submitted}, expected 10`);
+
+if (mixed.conversionRate === 10) pass('conversionRate divides by submitted, not by total');
+else fail(`conversionRate → ${mixed.conversionRate}, expected 10 (dividing by total would give 4)`);
+
+if (mixed.decidedRate === 50) pass('decidedRate divides by decided outcomes only');
+else fail(`decidedRate → ${mixed.decidedRate}, expected 50`);
+
+// A segment nobody has answered yet is "no data", not "0% — avoid this".
+// Reporting 0 here is how a promising lane gets retired on silence alone.
+const silent = withOutcomeRates({ ...newOutcomeCounts(), total: 3, awaiting: 3 });
+if (silent.decidedRate === null) pass('decidedRate is null while nothing is decided, not 0');
+else fail(`decidedRate on an all-awaiting segment → ${silent.decidedRate}, expected null`);
+
+// An untouched segment must not divide by zero.
+const empty = withOutcomeRates(newOutcomeCounts());
+if (empty.submitted === 0 && empty.conversionRate === 0 && empty.decidedRate === null) {
+  pass('an empty segment yields 0 submitted, 0% conversion and a null decidedRate');
+} else {
+  fail(`empty segment → ${JSON.stringify({ s: empty.submitted, c: empty.conversionRate, d: empty.decidedRate })}`);
+}
+
+// The all-positive case must still read as 100%, so the fix cannot be mistaken
+// for "always deflate the number".
+const perfect = withOutcomeRates({ ...newOutcomeCounts(), total: 2, positive: 2 });
+if (perfect.conversionRate === 100 && perfect.decidedRate === 100) pass('a fully-converting segment still reads 100%');
+else fail(`perfect segment → conversion ${perfect.conversionRate}%, decided ${perfect.decidedRate}%`);
+
+// `decided` is a count on the row, because the recommendation gates must read
+// facts, not a rounded percentage: 1 advance out of 201 decided rounds to 0%
+// and is still not "none advanced".
+const lopsided = withOutcomeRates({ ...newOutcomeCounts(), total: 201, positive: 1, negative: 200 });
+if (lopsided.decided === 201 && lopsided.decidedRate === 0) pass('decided is exposed as a count next to the rounded decidedRate');
+else fail(`lopsided segment → decided ${lopsided.decided}, decidedRate ${lopsided.decidedRate}`);
+
+// --- end to end through analyze() --------------------------------------------
+// The helpers above can be right while a breakdown still divides by `total`, or
+// while metadata forgets a bucket, or while a recommendation gate reads the
+// rounded rate. Only a real run over a real tracker catches that, so build one.
+const work = mkdtempSync(join(tmpdir(), 'cops-ap-outcomes-'));
+mkdirSync(join(work, 'data'));
+mkdirSync(join(work, 'reports'));
+
+const GLOBAL = 'Fully remote, hiring worldwide';
+const GEO = 'US-only remote';
+const HYBRID = 'Hybrid, 3 days a week in the office';
+// [num, status, score, archetype, remote]
+// Bucket sizes are load-bearing: remote-policy rows are sorted by `total`, and
+// only the FIRST bucket that passes the "avoid" gate becomes a recommendation.
+// hybrid/onsite (1 rejection + 4 unanswered) is deliberately the LARGEST
+// bucket, so a gate that wrongly reads its rounded 0% as "none advanced" would
+// pick it ahead of the legitimately-avoidable geo-restricted bucket — and the
+// assertion below can tell the two gates apart.
+const ROWS = [
+  [1,  'Applied',   '4.0', 'AI Engineer', GLOBAL],
+  [2,  'Applied',   '3.5', 'AI Engineer', GLOBAL],
+  [3,  'Responded', '4.2', 'AI Engineer', GLOBAL],
+  [4,  'Rejected',  '3.8', 'AI Engineer', GEO],
+  [5,  'Evaluated', '4.5', 'AI Engineer', GLOBAL],
+  [6,  'Rejected',  '3.0', 'Backend',     GEO],
+  [7,  'Applied',   '3.6', 'Backend',     GEO],
+  [8,  'Rejected',  '3.2', 'Backend',     HYBRID],
+  [9,  'Applied',   '3.4', 'Backend',     HYBRID],
+  [10, 'Applied',   '3.3', 'Backend',     HYBRID],
+  [11, 'Applied',   '3.1', 'Backend',     HYBRID],
+  [12, 'Applied',   '3.7', 'Backend',     HYBRID],
+];
+const trackerLines = [
+  '# Applications Tracker', '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+];
+for (const [num, status, score, archetype, remote] of ROWS) {
+  const file = `${String(num).padStart(3, '0')}-co${num}-2026-01-01.md`;
+  writeFileSync(join(work, 'reports', file), [
+    `# Evaluation: Co${num} — ${archetype}`, '',
+    '## Machine Summary', '',
+    '```yaml',
+    `company: "Co${num}"`,
+    `role: "${archetype}"`,
+    `score: ${score}`,
+    `archetype: "${archetype}"`,
+    `remote: "${remote}"`,
+    '```', '',
+  ].join('\n'));
+  trackerLines.push(`| ${num} | 2026-01-01 | Co${num} | ${archetype} | ${score}/5 | ${status} | ❌ | [${num}](../reports/${file}) | fixture |`);
+}
+writeFileSync(join(work, 'data', 'applications.md'), trackerLines.join('\n') + '\n');
+
+let result = null;
+try {
+  const stdout = execFileSync(NODE, [join(ROOT, 'analyze-patterns.mjs'), '--min-threshold', '1'], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    env: { ...process.env, CAREER_OPS_ROOT: work },
+  });
+  result = JSON.parse(stdout);
+} catch (e) {
+  fail(`analyze-patterns.mjs did not produce JSON over the fixture tracker: ${(e.stderr || e.message || '').toString().slice(0, 300)}`);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}
+
+if (result) {
+  const buckets = ['positive', 'negative', 'self_filtered', 'pending', 'awaiting'];
+  const byOutcome = result.metadata?.byOutcome || {};
+  if (JSON.stringify(Object.keys(byOutcome).sort()) === JSON.stringify([...buckets].sort())) pass('metadata.byOutcome carries exactly the five outcome buckets');
+  else fail(`metadata.byOutcome keys = ${Object.keys(byOutcome).join(',')}`);
+  if (byOutcome.awaiting === 7 && byOutcome.positive === 1 && byOutcome.negative === 3 && byOutcome.pending === 1) {
+    pass('seven Applied rows land in awaiting; the one Responded row is the only positive');
+  } else {
+    fail(`byOutcome = ${JSON.stringify(byOutcome)}`);
+  }
+
+  if (JSON.stringify(Object.keys(result.scoreComparison || {}).sort()) === JSON.stringify([...buckets].sort())
+      && result.scoreComparison.awaiting?.count === 7) {
+    pass('scoreComparison has an awaiting group with the seven Applied scores');
+  } else {
+    fail(`scoreComparison = ${JSON.stringify(result.scoreComparison)}`);
+  }
+
+  const ai = (result.archetypeBreakdown || []).find((a) => a.archetype === 'AI Engineer');
+  // 5 rows, 4 sent (2 awaiting, 1 positive, 1 negative), 1 never sent.
+  if (ai && ai.total === 5 && ai.submitted === 4 && ai.awaiting === 2 && ai.decided === 2
+      && ai.conversionRate === 25 && ai.decidedRate === 50) {
+    pass('archetype breakdown: 1 of 4 sent converted → 25%, not 3 of 5 "positive" → 60%');
+  } else {
+    fail(`AI Engineer archetype row = ${JSON.stringify(ai)}`);
+  }
+
+  const geo = (result.remotePolicy || []).find((r) => r.policy === 'geo-restricted');
+  const hybrid = (result.remotePolicy || []).find((r) => r.policy === 'hybrid/onsite');
+  const globalRow = (result.remotePolicy || []).find((r) => r.policy === 'global remote');
+  if (geo && geo.submitted === 3 && geo.decided === 2 && geo.positive === 0 && geo.decidedRate === 0
+      && hybrid && hybrid.submitted === 5 && hybrid.decided === 1 && hybrid.decidedRate === 0
+      && globalRow && globalRow.submitted === 3 && globalRow.decided === 1 && globalRow.decidedRate === 100) {
+    pass('remote policy rows expose submitted / decided / decidedRate per bucket');
+  } else {
+    fail(`remote rows = ${JSON.stringify({ geo, hybrid, globalRow })}`);
+  }
+
+  const actions = (result.recommendations || []).map((r) => r.action);
+  const avoid = actions.filter((a) => a.startsWith('Avoid '));
+  if (avoid.length === 1 && /geo-restricted/.test(avoid[0]) && /0 of 2 decided/.test(avoid[0])) {
+    pass('"Avoid" fires for the bucket with 2 decided losses and names the decided count');
+  } else {
+    fail(`Avoid recommendations = ${JSON.stringify(avoid)}`);
+  }
+  if (!avoid.some((a) => /hybrid/.test(a))) pass('"Avoid" does NOT fire on 1 rejection + 4 unanswered applications (decided < 2)');
+  else fail('"Avoid" fired for hybrid/onsite on a single decided outcome');
+
+  const doubleDown = actions.find((a) => a.startsWith('Double down'));
+  if (doubleDown && /AI Engineer/.test(doubleDown) && /\(25% conversion rate\)/.test(doubleDown)) {
+    pass('"Double down" quotes the submitted-based rate (25%), not the total-based 60%');
+  } else {
+    fail(`Double down recommendation = ${JSON.stringify(doubleDown)}`);
+  }
+
+  const st = result.scoreThreshold || {};
+  if (st.sampleSize === 1 && st.sufficientSample === false && st.recommended === 4.2
+      && !actions.some((a) => /Set minimum score threshold/.test(a))) {
+    pass('one scored positive outcome is reported as an observation, not turned into a threshold recommendation');
+  } else {
+    fail(`scoreThreshold = ${JSON.stringify(st)}; actions = ${JSON.stringify(actions)}`);
+  }
+}

--- a/tests/analyze-patterns-outcomes.test.mjs
+++ b/tests/analyze-patterns-outcomes.test.mjs
@@ -17,7 +17,7 @@ import { pathToFileURL } from 'url';
 
 console.log('\nanalyze-patterns — outcome classification & conversion denominators');
 
-const { classifyOutcome, newOutcomeCounts, withOutcomeRates } =
+const { classifyOutcome, newOutcomeCounts, withOutcomeRates, OUTCOME_BUCKETS, bestDecidedSegment, worstDecidedSegment, scoreThresholdFrom } =
   await import(pathToFileURL(join(ROOT, 'analyze-patterns.mjs')).href);
 
 // --- classifyOutcome ---------------------------------------------------------
@@ -29,7 +29,7 @@ const OUTCOMES = [
   ['Offer', 'positive', 'offer in hand'],
   ['Hired', 'positive', 'landed the job'],
   ['Rejected', 'negative', 'the employer said no'],
-  ['Discarded', 'negative', 'dropped or the posting died'],
+  ['Discarded', 'discarded', 'withdrawn or the posting died — not an employer decision'],
   ['SKIP', 'self_filtered', 'never sent, by our own choice'],
   ['Evaluated', 'pending', 'scored, not sent'],
 ];
@@ -44,7 +44,7 @@ if (ok) pass('classifyOutcome maps every canonical status to its outcome bucket'
 // Spanish aliases run through the same normalization; 'aplicado' must not be a
 // positive either, or the bug simply reappears for Spanish-language trackers.
 if (classifyOutcome('aplicado') === 'awaiting' && classifyOutcome('enviada') === 'awaiting') {
-  pass("localized 'applied' aliases resolve to 'awaiting', not 'positive'");
+  pass("Spanish 'applied' aliases resolve to 'awaiting', not 'positive'");
 } else {
   fail(`aplicado → '${classifyOutcome('aplicado')}', enviada → '${classifyOutcome('enviada')}'`);
 }
@@ -101,6 +101,49 @@ if (lopsided.decided === 201 && lopsided.decidedRate === 0) pass('decided is exp
 else fail(`lopsided segment → decided ${lopsided.decided}, decidedRate ${lopsided.decidedRate}`);
 
 // --- end to end through analyze() --------------------------------------------
+// --- recommendation selectors ---------------------------------------------
+// Both prescriptions gate on DECIDED outcomes: employer silence is evidence in
+// neither direction, and the list order (largest `total` first) must not decide
+// which segment gets named.
+const seg = (label, positive, negative, awaiting, pending = 0) =>
+  ({ label, ...withOutcomeRates({ total: positive + negative + awaiting + pending, positive, negative, awaiting, discarded: 0, self_filtered: 0, pending }) });
+
+const quietLane = seg('quiet', 3, 1, 10);              // 3 of 4 decided advanced (75%), 21% of everything sent
+const loudLane = seg('loud', 5, 5, 0);                 // 5 of 10 decided advanced (50%), 50% of everything sent
+if (bestDecidedSegment([loudLane, quietLane])?.label === 'quiet') pass('"double down" ranks by decidedRate (75% of 4 beats 50% of 10), not by conversionRate (which would pick the loud lane)');
+else fail(`bestDecidedSegment picked ${JSON.stringify(bestDecidedSegment([loudLane, quietLane]))}`);
+if (bestDecidedSegment([seg('rare', 1, 200, 0)]) === null) pass('"double down" skips a lane whose decided rate rounds to 0% (1 of 201 is not a pattern to lean into)');
+else fail('bestDecidedSegment prescribed a 0% lane');
+const oneDecided = seg('niche', 1, 0, 1);              // 1 positive + 1 awaiting: 100% decided, n=1
+if (bestDecidedSegment([oneDecided]) === null) pass('"double down" needs at least 2 decided outcomes (one employer answer is not a pattern)');
+else fail('bestDecidedSegment prescribed on a single decided outcome');
+
+const bigQuiet = seg('hybrid', 0, 2, 0, 14);           // total 16, decided 2
+const smallLoud = seg('geo', 0, 6, 0);                 // total 6, decided 6
+if (worstDecidedSegment([bigQuiet, smallLoud])?.label === 'geo') pass('"avoid" names the segment with the most decided losses, not the largest total');
+else fail(`worstDecidedSegment picked ${JSON.stringify(worstDecidedSegment([bigQuiet, smallLoud]))}`);
+if (worstDecidedSegment([seg('x', 0, 1, 4)]) === null) pass('"avoid" needs at least 2 decided outcomes (1 rejection + 4 unanswered is not a pattern)');
+else fail('worstDecidedSegment fired on a single rejection');
+if (worstDecidedSegment([seg('y', 1, 200, 0)]) === null) pass('"avoid" reads the positive count, not a rounded 0% rate (1 of 201 advanced)');
+else fail('worstDecidedSegment fired on 1 positive of 201 decided');
+
+// --- score threshold ----------------------------------------------------------
+// The lowest positive score is an observation; it is a threshold only when the
+// sample is big enough AND something decided below it actually failed.
+const thin = scoreThresholdFrom([4.2], [3.8, 3.0]);
+if (thin.recommended === null && thin.observedMinimum === 4.2 && thin.sufficientSample === false) pass('one positive score is an observation, never a threshold');
+else fail(`thin sample → ${JSON.stringify(thin)}`);
+const vacuous = scoreThresholdFrom([4.2, 4.4, 4.6], [4.5, 4.8]);
+if (vacuous.recommended === null && vacuous.sufficientSample === true && vacuous.rejectedBelow === 0 && /no rejected application scored below/.test(vacuous.reasoning)) {
+  pass('three positives with no rejection below the floor stay an observation ("nothing below X advanced" would be vacuous)');
+} else {
+  fail(`vacuous floor → ${JSON.stringify(vacuous)}`);
+}
+const earned = scoreThresholdFrom([4.25, 4.4, 4.6], [3.8, 4.5, 3.0]);
+if (earned.recommended === 4.2 && earned.rejectedBelow === 2 && /2 rejected application\(s\) did/.test(earned.reasoning)) pass('three positives and two rejections below the floor earn a recommended threshold (floored to 0.1)');
+else fail(`earned floor → ${JSON.stringify(earned)}`);
+
+// --- end-to-end over a fixture tracker ---------------------------------------
 // The helpers above can be right while a breakdown still divides by `total`, or
 // while metadata forgets a bucket, or while a recommendation gate reads the
 // rounded rate. Only a real run over a real tracker catches that, so build one.
@@ -112,12 +155,8 @@ const GLOBAL = 'Fully remote, hiring worldwide';
 const GEO = 'US-only remote';
 const HYBRID = 'Hybrid, 3 days a week in the office';
 // [num, status, score, archetype, remote]
-// Bucket sizes are load-bearing: remote-policy rows are sorted by `total`, and
-// only the FIRST bucket that passes the "avoid" gate becomes a recommendation.
-// hybrid/onsite (1 rejection + 4 unanswered) is deliberately the LARGEST
-// bucket, so a gate that wrongly reads its rounded 0% as "none advanced" would
-// pick it ahead of the legitimately-avoidable geo-restricted bucket — and the
-// assertion below can tell the two gates apart.
+// hybrid/onsite = 1 rejection + 4 unanswered + 1 withdrawn: the largest bucket by
+// total, ONE decided outcome — "avoid" must skip it and name geo-restricted (2).
 const ROWS = [
   [1,  'Applied',   '4.0', 'AI Engineer', GLOBAL],
   [2,  'Applied',   '3.5', 'AI Engineer', GLOBAL],
@@ -131,6 +170,7 @@ const ROWS = [
   [10, 'Applied',   '3.3', 'Backend',     HYBRID],
   [11, 'Applied',   '3.1', 'Backend',     HYBRID],
   [12, 'Applied',   '3.7', 'Backend',     HYBRID],
+  [13, 'Discarded', '3.9', 'Backend',     HYBRID],
 ];
 const trackerLines = [
   '# Applications Tracker', '',
@@ -155,28 +195,42 @@ for (const [num, status, score, archetype, remote] of ROWS) {
 writeFileSync(join(work, 'data', 'applications.md'), trackerLines.join('\n') + '\n');
 
 let result = null;
+let summary = '';
+let gated = null;
 try {
-  const stdout = execFileSync(NODE, [join(ROOT, 'analyze-patterns.mjs'), '--min-threshold', '1'], {
+  const run = (...flags) => execFileSync(NODE, [join(ROOT, 'analyze-patterns.mjs'), ...flags], {
     encoding: 'utf-8',
     timeout: 60000,
     env: { ...process.env, CAREER_OPS_ROOT: work },
   });
-  result = JSON.parse(stdout);
+  result = JSON.parse(run('--min-threshold', '1'));
+  summary = run('--min-threshold', '1', '--summary');
+  // Below the floor the script prints its JSON and exits 1.
+  try { run('--min-threshold', '12'); } catch (e) { gated = JSON.parse(e.stdout || 'null'); }
 } catch (e) {
-  fail(`analyze-patterns.mjs did not produce JSON over the fixture tracker: ${(e.stderr || e.message || '').toString().slice(0, 300)}`);
+  fail(`analyze-patterns.mjs did not run over the fixture tracker: ${(e.stderr || e.message || '').toString().slice(0, 300)}`);
 } finally {
   rmSync(work, { recursive: true, force: true });
 }
 
+if (gated && gated.error && gated.current === 11 && gated.threshold === 12) pass('the data floor counts sent applications only (11 of 13 rows: not the Evaluated or Discarded ones)');
+else fail(`--min-threshold 12 over 11 sent rows → ${JSON.stringify(gated)}`);
+
 if (result) {
-  const buckets = ['positive', 'negative', 'self_filtered', 'pending', 'awaiting'];
+  const buckets = OUTCOME_BUCKETS;
   const byOutcome = result.metadata?.byOutcome || {};
-  if (JSON.stringify(Object.keys(byOutcome).sort()) === JSON.stringify([...buckets].sort())) pass('metadata.byOutcome carries exactly the five outcome buckets');
+  if (JSON.stringify(Object.keys(byOutcome)) === JSON.stringify(buckets)) pass('metadata.byOutcome carries exactly the declared outcome buckets, in lifecycle order');
   else fail(`metadata.byOutcome keys = ${Object.keys(byOutcome).join(',')}`);
-  if (byOutcome.awaiting === 7 && byOutcome.positive === 1 && byOutcome.negative === 3 && byOutcome.pending === 1) {
-    pass('seven Applied rows land in awaiting; the one Responded row is the only positive');
+  if (byOutcome.awaiting === 7 && byOutcome.positive === 1 && byOutcome.negative === 3 && byOutcome.discarded === 1 && byOutcome.pending === 1) {
+    pass('seven Applied rows land in awaiting, the Discarded row in discarded; the one Responded row is the only positive');
   } else {
     fail(`byOutcome = ${JSON.stringify(byOutcome)}`);
+  }
+  const rates = result.metadata?.outcomeRates || {};
+  if (rates.submitted === 11 && rates.decided === 4 && rates.conversionRate === 9 && rates.decidedRate === 25) {
+    pass('metadata.outcomeRates quotes the whole tracker through the same denominators (1 of 11 sent, 1 of 4 decided)');
+  } else {
+    fail(`metadata.outcomeRates = ${JSON.stringify(rates)}`);
   }
 
   if (JSON.stringify(Object.keys(result.scoreComparison || {}).sort()) === JSON.stringify([...buckets].sort())
@@ -199,11 +253,17 @@ if (result) {
   const hybrid = (result.remotePolicy || []).find((r) => r.policy === 'hybrid/onsite');
   const globalRow = (result.remotePolicy || []).find((r) => r.policy === 'global remote');
   if (geo && geo.submitted === 3 && geo.decided === 2 && geo.positive === 0 && geo.decidedRate === 0
-      && hybrid && hybrid.submitted === 5 && hybrid.decided === 1 && hybrid.decidedRate === 0
+      && hybrid && hybrid.total === 6 && hybrid.submitted === 5 && hybrid.decided === 1 && hybrid.discarded === 1 && hybrid.decidedRate === 0
       && globalRow && globalRow.submitted === 3 && globalRow.decided === 1 && globalRow.decidedRate === 100) {
-    pass('remote policy rows expose submitted / decided / decidedRate per bucket');
+    pass('remote policy rows expose submitted / decided / decidedRate per bucket, and a Discarded row is neither submitted nor decided');
   } else {
     fail(`remote rows = ${JSON.stringify({ geo, hybrid, globalRow })}`);
+  }
+  const sizes = result.companySizeBreakdown || [];
+  if (sizes.length === 1 && 'size' in sizes[0] && sizes[0].submitted === 11 && sizes[0].decided === 4 && sizes[0].decidedRate === 25) {
+    pass('company-size breakdown uses the same denominators (the fixture has one size bucket)');
+  } else {
+    fail(`companySizeBreakdown = ${JSON.stringify(sizes)}`);
   }
 
   const actions = (result.recommendations || []).map((r) => r.action);
@@ -217,17 +277,27 @@ if (result) {
   else fail('"Avoid" fired for hybrid/onsite on a single decided outcome');
 
   const doubleDown = actions.find((a) => a.startsWith('Double down'));
-  if (doubleDown && /AI Engineer/.test(doubleDown) && /\(25% conversion rate\)/.test(doubleDown)) {
-    pass('"Double down" quotes the submitted-based rate (25%), not the total-based 60%');
+  if (doubleDown && /AI Engineer/.test(doubleDown) && /50% of decided outcomes advanced, 25% of all sent/.test(doubleDown)) {
+    pass('"Double down" names AI Engineer (1 of 2 decided) and quotes both rates, never the total-based 60%');
   } else {
     fail(`Double down recommendation = ${JSON.stringify(doubleDown)}`);
   }
 
   const st = result.scoreThreshold || {};
-  if (st.sampleSize === 1 && st.sufficientSample === false && st.recommended === 4.2
+  if (st.sampleSize === 1 && st.sufficientSample === false && st.recommended === null && st.observedMinimum === 4.2
       && !actions.some((a) => /Set minimum score threshold/.test(a))) {
-    pass('one scored positive outcome is reported as an observation, not turned into a threshold recommendation');
+    pass('one scored positive outcome yields an observedMinimum, a null recommended threshold and no threshold recommendation');
   } else {
     fail(`scoreThreshold = ${JSON.stringify(st)}; actions = ${JSON.stringify(actions)}`);
+  }
+  if (/SCORE OBSERVATION: lowest positive 4.2\/5 \(n=1; not a threshold yet\)/.test(summary) && !/SCORE THRESHOLD/.test(summary)) {
+    pass('--summary withholds the SCORE THRESHOLD headline on a 1-outcome sample and prints it as an observation');
+  } else {
+    fail(`--summary threshold lines = ${JSON.stringify((summary.match(/SCORE [A-Z]+.*/g) || []))}`);
+  }
+  if (/hybrid\/onsite\s+5 sent, 4 awaiting, 0 positive of 1 decided \(0%\)/.test(summary)) {
+    pass('--summary remote row prints sent / awaiting / positive-of-decided per bucket');
+  } else {
+    fail(`--summary remote rows = ${JSON.stringify((summary.match(/^\s+(global remote|geo-restricted|hybrid\/onsite).*/gm) || []))}`);
   }
 }


### PR DESCRIPTION
## What does this PR do?

`analyze-patterns.mjs` counted `Applied` — an application merely sent — as a positive outcome, so every conversion rate, the score threshold and the "double down / avoid" recommendations reported the user's own sending activity back as traction. This PR gives sent-but-unanswered rows their own `awaiting` bucket, divides every rate by what was actually sent (`submitted`) or actually answered (`decided`), and gates every prescription on decided outcomes. Same class of defect as #2783 (rate denominators counting rows that could never contribute).

## Related issue

None — bug fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (bug fix — exempt)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

---

## Reproduction (fixture in the test)

13 tracker rows: 7 Applied, 1 Responded, 3 Rejected, 1 Discarded, 1 Evaluated.

| | before | after |
| --- | --- | --- |
| `metadata.byOutcome.positive` | 8 | 1 |
| AI Engineer archetype (2 Applied, 1 Responded, 1 Rejected, 1 Evaluated) | 60% "conversion" (3 of 5 rows) | 25% of sent, 50% of decided |
| `SCORE THRESHOLD` headline | `3.1/5` (lowest *Applied* score) | withheld — `SCORE OBSERVATION: lowest positive 4.2/5 (n=1; not a threshold yet)` |
| "Double down" | fired on the archetype with the most Applied rows | fires only with ≥2 decided outcomes, ranked by `decidedRate` |
| "Avoid" | could name a lane on rounded 0% with one rejection | needs `positive === 0` and ≥2 decided, names the lane with the most decided losses |

## What changes

- **Buckets** (`OUTCOME_BUCKETS`, lifecycle order): `positive` · `awaiting` (Applied) · `negative` (Rejected) · `discarded` (withdrawn or the posting closed — neither a proven submission nor an employer decision, the same reading as `stats.mjs`'s canonical funnel) · `self_filtered` · `pending`.
- **Rates** (`withOutcomeRates`, one helper for every breakdown and for `metadata.outcomeRates`): `submitted = positive + negative + awaiting`, `decided = positive + negative`, `conversionRate = positive / submitted`, `decidedRate = positive / decided` (`null`, not 0, while nothing is decided). The three breakdown loops are one `breakdownBy()`.
- **Prescriptions** (`bestDecidedSegment`, `worstDecidedSegment`): both need ≥2 decided outcomes; "double down" ranks by `decidedRate` (ranking by `conversionRate` lets 1 positive + 1 awaiting outrank 5 positive + 15 awaiting), "avoid" ranks by decided losses (the list is ordered by `total`, and `[0]` used to name the lane with the least evidence).
- **Score floor** (`scoreThresholdFrom`): the lowest positive score is always an `observedMinimum`; it becomes `recommended` only with ≥3 scored positives *and* at least one rejection below it — "nothing below X advanced" is vacuous when nothing below X was decided.
- **Data floor** (`--min-threshold`): counts applications sent, not "anything beyond Evaluated" (five SKIP rows used to pass it). `Discarded` leaves `SUBMITTED_STATUSES` for the vendor/via channel-yield pass too.
- `modes/patterns.md`: the new fields, both rates and which to lead with, the `discarded` row, and Step 4 offers to persist a threshold only when `sufficientSample`.

`awaiting`, `discarded`, `submitted`, `decided`, `decidedRate`, `observedMinimum`, `sampleSize`, `sufficientSample`, `rejectedBelow` and `metadata.outcomeRates` are new keys. `positive`, `negative`, `conversionRate`, `scoreComparison`, `scoreThreshold.recommended` and the recommendation set change value on purpose. Inside the repository the only consumer of these keys is `modes/patterns.md` (updated); the script prints JSON to stdout, so external readers are not enumerable.

## Tests

`tests/analyze-patterns-outcomes.test.mjs` (34 assertions): classification of every canonical status and the Spanish aliases; `withOutcomeRates` denominators; the two selectors (floor, ranking key, rounded-0% guards); `scoreThresholdFrom` (thin sample, vacuous floor, earned floor); and an end-to-end run over the fixture tracker asserting `byOutcome`, `outcomeRates`, `scoreComparison`, all three breakdowns, both recommendations, the threshold observation, the `--summary` wording and the sent-only data floor. `--self-test` gains the bucket-partition invariant and a `discarded` row in the tech-gap harvest.

Eleven mutants killed (bucket, denominators, each selector's floor and ranking key, the threshold guards, the data floor, `Discarded` back into `negative` or into `SUBMITTED_STATUSES`); each compiles, reddens only its named assertion, leaves the rest green.

## Known gap, separate PR

`normalizeStatus` keeps a private alias map with no Turkish, so a `modes/tr/` tracker classifies every row as `pending` today. Pre-existing; the fix is routing through `resolveCanonicalState` from `tracker-utils.mjs` like the other status readers do, and belongs in its own PR.
