### PR TITLE
fix(calibrate): detect tracker columns from the file lines, not the header string

### DIFF
--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -212,10 +212,9 @@ export function computeCalibration(rows, journals, opts = {}) {
 
 // --- Filesystem assembly --------------------------------------------------
 
-function loadTrackerRows(appsFile) {
+export function loadTrackerRows(appsFile) {
   const lines = readFileSync(appsFile, 'utf-8').split(/\r?\n/);
-  const headerLine = lines.find((l) => isHeaderRow(l));
-  const colmap = headerLine ? resolveColumns(headerLine) : undefined;
+  const colmap = resolveColumns(lines);
   const rows = [];
   for (const line of lines) {
     if (!line.trim().startsWith('|') || isHeaderRow(line) || isSeparatorRow(line)) continue;

--- a/tests/calibrate-columns.test.mjs
+++ b/tests/calibrate-columns.test.mjs
@@ -1,0 +1,45 @@
+// tests/calibrate-columns.test.mjs — calibrate must read the tracker through
+// the detected column layout. resolveColumns() takes the file's lines; handed
+// the header STRING it iterates characters, finds no header, and falls back to
+// the legacy fixed layout — so a tracker with an inserted column (Location,
+// #2274) reads Score from the wrong cell and calibrate reports "0 resolved".
+import { pass, fail, ROOT, rmSync } from './helpers.mjs';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\ncalibrate — tracker column detection');
+
+const { loadTrackerRows } = await import(pathToFileURL(join(ROOT, 'calibrate.mjs')).href);
+
+const dir = mkdtempSync(join(tmpdir(), 'co-calibrate-'));
+try {
+  const withLocation = join(dir, 'applications.md');
+  writeFileSync(withLocation, [
+    '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|----------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-01-01 | Acme | Backend | Remote | 4.4/5 | Rejected | ✅ | [1](../reports/001-acme-2026-01-01.md) | - |',
+    '| 2 | 2026-01-02 | Beta | Backend | Berlin | 3.1/5 | Interview | ❌ | [2](../reports/002-beta-2026-01-02.md) | - |',
+    '',
+  ].join('\n'));
+  const rows = loadTrackerRows(withLocation);
+  if (rows.length === 2 && rows[0].score === 4.4 && rows[0].status === 'Rejected' && rows[1].score === 3.1 && rows[1].status === 'Interview') {
+    pass('a tracker with an inserted Location column is read through the detected layout');
+  } else {
+    fail(`inserted-column tracker parsed as ${JSON.stringify(rows)}`);
+  }
+
+  const legacy = join(dir, 'legacy.md');
+  writeFileSync(legacy, [
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 7 | 2026-01-03 | Gamma | Backend | 3.8/5 | Offer | ✅ | [7](../reports/007-gamma-2026-01-03.md) | - |',
+    '',
+  ].join('\n'));
+  const one = loadTrackerRows(legacy);
+  if (one.length === 1 && one[0].num === 7 && one[0].score === 3.8 && one[0].status === 'Offer') pass('the plain 9-column tracker still parses');
+  else fail(`legacy tracker parsed as ${JSON.stringify(one)}`);
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

`calibrate.mjs` reads the tracker through `resolveColumns()`, which takes the file's **lines** and detects the header layout. `loadTrackerRows()` handed it the header **string**: iterated character by character, no character is a header, so it always fell back to the legacy fixed layout. Any tracker whose columns are not the fixed 9 in the fixed order (a `Location` column, the #2274 layout; a localized header with columns moved) reads Score from the wrong cell — the row's status becomes the score cell, the score becomes `null`, and calibrate reports `0 resolved` with exit 0. Nothing looked wrong on the plain 9-column tracker, which is why it went unnoticed.

Fix: pass `lines` (and drop the now-unused `headerLine` lookup — `resolveColumns()` already falls back to the legacy map when no header matches). `loadTrackerRows` is now exported so the regression test can target it directly.

## Test

`tests/calibrate-columns.test.mjs` (auto-discovered): a tracker with `Location` inserted after `Role` parses to `score 4.4 / status Rejected`; the plain 9-column tracker still parses. Reverting the fix turns the first assertion red — `{"score":null,"status":"4.4/5"}` — while the second stays green. `node calibrate.mjs --self-test` unchanged; `node test-all.mjs --quick` passes.
