### PR TITLE
fix(tests): skip nested checkouts by marker, not by the name .git (#3499)

### DIFF
--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -21,11 +21,11 @@
  * re-diverge the next time one of them learned about a directory.
  */
 
-import { readdirSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 /**
- * Directories excluded from the walk.
+ * Directories excluded from the walk BY NAME.
  *
  * `.git` and `node_modules` are not repository source. `output`, `data`,
  * `coverage` and `test-results` hold generated or user content, so including
@@ -33,8 +33,57 @@ import { join } from 'path';
  * run — a clean clone and a working install would disagree about how many
  * files were checked, and a stray `.mjs` dropped in `output/` could fail the
  * lint of a repository whose source is fine.
+ *
+ * A name is not enough to keep git's storage out on its own — see
+ * `isNestedCheckout` below, which the walk also consults.
  */
 export const SKIP_DIRS = new Set(['.git', 'node_modules', 'output', 'data', 'coverage', 'test-results']);
+
+/**
+ * Is `dir` a checkout of its own, rather than a subdirectory of this one?
+ *
+ * `SKIP_DIRS` drops a directory *named* `.git`, which is the whole of git's
+ * storage in a normal clone — and none of it in a linked worktree, which marks
+ * itself with a `.git` FILE pointing at the parent's gitdir. So the one
+ * exclusion meant to keep git out of the walk slid straight past a worktree and
+ * the walkers descended into a complete second copy of the repository, at
+ * whatever commit that worktree happened to sit on: 1097 files reported in a
+ * 576-file checkout (#3499).
+ *
+ * The consequences differed per consumer, which is what made it hard to see.
+ * The syntax gates silently checked ~2x the files and reported a count that
+ * depended on whether the developer had a worktree open;
+ * `tests/local-today-gates.test.mjs` failed outright, naming *correct* source
+ * files as violations because the stale copies predated the convention;
+ * `tests/main-guard-convention.test.mjs` passed, because the stale copy
+ * happened to satisfy that particular convention. A contributor got a red suite
+ * for a commit they did not write, or a green one that checked the wrong tree —
+ * the exact "gate covering a file set nobody chose" failure this module exists
+ * to remove (#3306, #3388, #3411, #3419).
+ *
+ * Detecting the marker rather than the name is both narrower and broader than
+ * blanket-ignoring `.claude/worktrees/` (Claude Code's default location, which
+ * is how this was found): it holds for a worktree placed anywhere, and it costs
+ * nothing for a checkout that has none.
+ *
+ * Any `.git` entry counts, of either type. A `.git` file is a linked worktree
+ * or a submodule; a `.git` directory below the root is a nested independent
+ * clone. All three are somebody else's source tree that happens to sit inside
+ * this one, and none of them is a file this repository's gates should be
+ * grading.
+ *
+ * NOT applied to the walk root. The root's own `.git` is what makes it the
+ * repository, and this predicate is deliberately blind to how the root is
+ * stored — running the gate from inside a linked worktree (`.git` is a file
+ * there too) must check that worktree's source, not skip all of it and report a
+ * passing scan of nothing.
+ *
+ * @param {string} dir - Absolute path to a directory found below the walk root.
+ * @returns {boolean} True if `dir` carries its own git marker.
+ */
+export function isNestedCheckout(dir) {
+  return existsSync(join(dir, '.git'));
+}
 
 /**
  * Every `.mjs` file under `root`, recursively, sorted by full path.
@@ -81,8 +130,10 @@ export function collectMjsFiles(root) {
       // neither should make the walk recurse unpredictably.
       if (entry.isSymbolicLink()) continue;
       const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full, false);
-      else if (entry.name.endsWith('.mjs')) files.push(full);
+      if (entry.isDirectory()) {
+        if (isNestedCheckout(full)) continue;
+        walk(full, false);
+      } else if (entry.name.endsWith('.mjs')) files.push(full);
     }
   };
   walk(root, true);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -57,7 +57,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 import { pass, fail, warn, run, lastRunFailure, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, DEFAULT_SCRIPT_TIMEOUT_MS, getBash, toBashPath, hermeticGitEnv } from './tests/helpers.mjs';
 import { flagValue, hasFlag } from './lib/cli-flags.mjs';
-import { collectMjsFiles } from './lib/mjs-files.mjs';
+import { collectMjsFiles, isNestedCheckout } from './lib/mjs-files.mjs';
 
 /**
  * Read a repo-relative text file as UTF-8.
@@ -413,6 +413,14 @@ try {
     if (dirname(src) === ROOT && exclude.includes(name)) return;
     const stat = statSync(src);
     if (stat.isDirectory()) {
+      // A linked worktree is a whole second checkout of this repo and carries a
+      // `.git` FILE, not a directory, so the name-based exclusion above never
+      // fires on one (#3499). Copying it doubles this section's copy cost and
+      // seeds the throwaway tree with a stale duplicate of every script.
+      // Skipped below the root ONLY: `src === ROOT` on the first call, and
+      // ROOT's own `.git` is legitimately a file when the suite is being run
+      // FROM a worktree — testing it there would copy nothing at all.
+      if (src !== ROOT && isNestedCheckout(src)) return;
       mkdirSync(dest, { recursive: true });
       for (const entry of readdirSync(src)) {
         copyDirSync(join(src, entry), join(dest, entry), exclude);

--- a/tests/local-today-gates.test.mjs
+++ b/tests/local-today-gates.test.mjs
@@ -26,6 +26,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { localToday } from '../lib/local-today.mjs';
+import { isNestedCheckout } from '../lib/mjs-files.mjs';
 import { shouldDedupScanHistoryRow } from '../scan.mjs';
 import { parseScanHistory, detectReposts } from '../detect-reposts.mjs';
 
@@ -511,6 +512,13 @@ function sourceFiles(dir, acc = []) {
     if (entry.isDirectory()) {
       if (/^(node_modules|\.git|\.next|coverage|dist|build)$/.test(entry.name)) continue;
       if (entry.name.startsWith('.tmp-script-test-')) continue;
+      // ...and so would git's OWN scratch copy of the repo. The `\.git` above
+      // matches a directory NAME, which a linked worktree does not have — it
+      // marks itself with a `.git` file. This gate read the worktree's stale
+      // sources as repo source and failed, naming files that are correct on the
+      // branch under test (#3499). Same hazard as the line above it, different
+      // author of the second copy.
+      if (isNestedCheckout(join(dir, entry.name))) continue;
       sourceFiles(join(dir, entry.name), acc);
     } else if (entry.name.endsWith('.mjs') && !entry.name.endsWith('.test.mjs')) {
       acc.push(join(dir, entry.name));

--- a/tests/main-guard-convention.test.mjs
+++ b/tests/main-guard-convention.test.mjs
@@ -29,6 +29,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { isMainModule } from '../lib/is-main-module.mjs';
+import { isNestedCheckout } from '../lib/mjs-files.mjs';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -212,6 +213,14 @@ function walk(dir, out = []) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
       if (SKIP_DIRS.has(entry.name)) continue;
+      // A linked worktree is a second checkout of this repo at some other
+      // commit, and `.git` in SKIP_DIRS does not catch one — it marks itself
+      // with a `.git` FILE (#3499). The dot-prefix skip above happens to cover
+      // Claude Code's default `.claude/worktrees/`, but nothing keeps a
+      // worktree there; one at `wt/` would put a stale copy of every entrypoint
+      // under enforcement, and this gate would grade source the branch does not
+      // contain — passing or failing on the age of somebody's worktree.
+      if (isNestedCheckout(full)) continue;
       walk(full, out);
     } else if (entry.name.endsWith('.mjs')) {
       out.push(full);

--- a/tests/mjs-files.test.mjs
+++ b/tests/mjs-files.test.mjs
@@ -26,7 +26,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { collectMjsFiles, SKIP_DIRS } from '../lib/mjs-files.mjs';
+import { collectMjsFiles, isNestedCheckout, SKIP_DIRS } from '../lib/mjs-files.mjs';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -91,6 +91,86 @@ test('the syntax gate reaches past the repository root', () => {
   // 'web/ test discovery contract' check already uses instead of hardcoding it.
   if (existsSync(join(ROOT, 'web'))) {
     assert.ok(files.some((f) => f.startsWith('web/')), 'web/ must be inside the gate when present');
+  }
+});
+
+test('a nested checkout is not walked as this repository\u2019s source', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'co-mjs-files-'));
+  try {
+    writeFileSync(join(dir, 'real.mjs'), '');
+
+    // A linked worktree, exactly as git writes one: a `.git` FILE holding a
+    // gitdir pointer. The `.git` entry in SKIP_DIRS matches a NAME, so it never
+    // fires here, and the walk used to descend into the whole second checkout —
+    // 1097 files reported in a 576-file repo (#3499).
+    mkdirSync(join(dir, 'wt'));
+    writeFileSync(join(dir, 'wt', '.git'), 'gitdir: /elsewhere/.git/worktrees/wt\n');
+    writeFileSync(join(dir, 'wt', 'stale.mjs'), '');
+    mkdirSync(join(dir, 'wt', 'tests'));
+    writeFileSync(join(dir, 'wt', 'tests', 'deep.mjs'), '');
+
+    // A nested independent clone marks itself with a `.git` DIRECTORY. SKIP_DIRS
+    // drops git's storage there but not the working tree beside it, so the same
+    // second-copy hazard applies.
+    mkdirSync(join(dir, 'clone', '.git'), { recursive: true });
+    writeFileSync(join(dir, 'clone', 'other.mjs'), '');
+
+    const rel = collectMjsFiles(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, '/'));
+
+    assert.deepEqual(rel, ['real.mjs'],
+      `only this checkout's source is walked, got: ${rel.join(', ')}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the walk root is exempt, so running from inside a worktree still checks it', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'co-mjs-files-'));
+  try {
+    // The root's own `.git` is what makes it the repository, and in a linked
+    // worktree it is a file — the same marker the predicate skips on below the
+    // root. Applying it to the root would return [] and the syntax gate would
+    // report "0 .mjs files" and pass, having checked nothing: strictly worse
+    // than the bug it fixes, and the same shape as #3419.
+    writeFileSync(join(dir, '.git'), 'gitdir: /elsewhere/.git/worktrees/self\n');
+    writeFileSync(join(dir, 'source.mjs'), '');
+    mkdirSync(join(dir, 'lib'));
+    writeFileSync(join(dir, 'lib', 'nested.mjs'), '');
+
+    const rel = collectMjsFiles(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, '/'));
+
+    assert.deepEqual(rel, ['lib/nested.mjs', 'source.mjs']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('isNestedCheckout detects the marker, of either type, and nothing else', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'co-mjs-files-'));
+  try {
+    mkdirSync(join(dir, 'worktree'));
+    writeFileSync(join(dir, 'worktree', '.git'), 'gitdir: /elsewhere\n');
+    mkdirSync(join(dir, 'clone', '.git'), { recursive: true });
+    mkdirSync(join(dir, 'plain'));
+
+    assert.equal(isNestedCheckout(join(dir, 'worktree')), true, 'a .git file is a linked worktree or submodule');
+    assert.equal(isNestedCheckout(join(dir, 'clone')), true, 'a .git directory is an independent clone');
+    assert.equal(isNestedCheckout(join(dir, 'plain')), false, 'an ordinary subdirectory is source');
+    assert.equal(isNestedCheckout(join(dir, 'does-not-exist')), false, 'a missing directory is not a checkout');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the private repo walkers consult the shared predicate, not their own rule', () => {
+  // lib/mjs-files.mjs exists so two walkers cannot drift about what "every
+  // file" means; the same reasoning applies to what "not our source" means.
+  // These three suites keep private walkers because each filters differently
+  // (.test.mjs, dot-dirs, SKIP_DIRS sets), so they import the predicate rather
+  // than the collector — but a fourth hand-rolled `.git` rule is the drift.
+  for (const caller of ['tests/local-today-gates.test.mjs', 'tests/main-guard-convention.test.mjs', 'test-all.mjs']) {
+    const src = readFileSync(join(ROOT, caller), 'utf-8');
+    assert.match(src, /isNestedCheckout\(/, `${caller} must skip nested checkouts via lib/mjs-files.mjs (#3499)`);
   }
 });
 

--- a/tests/mjs-files.test.mjs
+++ b/tests/mjs-files.test.mjs
@@ -170,7 +170,20 @@ test('the private repo walkers consult the shared predicate, not their own rule'
   // than the collector — but a fourth hand-rolled `.git` rule is the drift.
   for (const caller of ['tests/local-today-gates.test.mjs', 'tests/main-guard-convention.test.mjs', 'test-all.mjs']) {
     const src = readFileSync(join(ROOT, caller), 'utf-8');
-    assert.match(src, /isNestedCheckout\(/, `${caller} must skip nested checkouts via lib/mjs-files.mjs (#3499)`);
+
+    // The IMPORT is the assertion, not the call. Matching `isNestedCheckout(`
+    // anywhere in the file is satisfied by a local `const isNestedCheckout =
+    // () => false` — a hand-rolled re-implementation wearing the shared name,
+    // which is precisely the drift this test exists to catch, passing as proof
+    // against itself. Pinning the import binds the name to the one definition.
+    assert.match(
+      src,
+      /import\s*\{[^}]*\bisNestedCheckout\b[^}]*\}\s*from\s*'\.{1,2}\/lib\/mjs-files\.mjs'/,
+      `${caller} must import isNestedCheckout FROM lib/mjs-files.mjs, not re-implement it (#3499)`,
+    );
+    // ...and still use it: an unused import satisfies the check above while the
+    // walk descends into every nested checkout exactly as before.
+    assert.match(src, /isNestedCheckout\(/, `${caller} must actually call isNestedCheckout (#3499)`);
   }
 });
 


### PR DESCRIPTION
## What does this PR do?

Repo-walking helpers here skip a directory *named* `.git`. A linked worktree has no `.git` directory — it marks itself with a `.git` **file** pointing at the parent's gitdir — so the one exclusion meant to keep git's storage out of the walk slides straight past a worktree, and the walkers descend into a complete second copy of the repository at whatever commit it happens to sit on. This detects the marker instead of the name.

`lib/mjs-files.mjs` reported **1252 files in a 626-file checkout**. What made it hard to see is that the consequence differed per consumer:

- the syntax gates silently checked ~2× the files, reporting a count that depended on whether the developer had a worktree open;
- `tests/local-today-gates.test.mjs` **failed outright**, naming *correct* source as violations because the stale copies predated the convention;
- `tests/main-guard-convention.test.mjs` **passed** — only because the stale copy happened to satisfy that particular convention.

So a contributor got a red suite for a commit they didn't write, or a green one that graded the wrong tree. That is the same "gate silently covering a file set nobody chose" failure `lib/mjs-files.mjs` was written to remove (#3306, #3388, #3411, #3419).

### The fix

`isNestedCheckout()` in `lib/mjs-files.mjs`, consulted by the walk. It tests for a `.git` entry of **either type**: a file is a linked worktree or submodule, a directory below the root is a nested independent clone. All are somebody else's source tree sitting inside this one.

**Never applied to the walk ROOT.** This repo is frequently checked out *as* a worktree, whose own `.git` is a file — testing the root would return `[]`, and the syntax gate would report "0 .mjs files" and pass, having checked nothing. That is the exact #3419 failure shape and strictly worse than the bug being fixed. Pinned by its own test.

**Shape chosen:** the three private walkers import the *predicate*, not the collector. Each filters differently (`.test.mjs` exclusion, dot-dir skip, divergent `SKIP_DIRS` sets), so they can't share the walk — but a fourth hand-rolled `.git` rule is exactly the drift this module exists to prevent, so a test now pins that all three consult it.

`test-all.mjs`'s scratch-copy walker gets the same skip; it was copying an entire second checkout into the throwaway tree on every run.

### Scope

The issue listed ten walkers; **four needed the fix.** `doctor.mjs`, `agent-inbox-tests.mjs`, `tests/helpers.mjs` and `tests/generate-pdf-page-budget.test.mjs` don't recurse from the repo root. `plugin-audit.mjs` walks a user-named plugin directory, where the predicate would be actively **wrong** — a plugin installed as a git clone should still be audited. The tenth, `tests/mjs-files.test.mjs`, is the collector's own test file and carries the new cases.

### Note on #3563 (no longer part of this PR)

This originally also carried the `web/` fix for #3563. That landed independently on `main` while this PR was open, so the rebase takes `main`'s version and this branch no longer touches it. #3563 is closed; nothing here is needed for it.

## Related issue

Fixes #3499

**Follow-up, deliberately not in this PR:** #3762 — `test-all.mjs`'s `discoverTests()` walks a nested worktree placed under `tests/` and *executes* its suites. Found by @luochen211 in review here. It anchors at `ROOT/tests` rather than `ROOT`, so it falls outside this PR's set, and fixing it properly means auditing the whole subtree-anchored walker class plus reworking the by-name drift gate.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Verification

| | before | after |
|---|---|---|
| `collectMjsFiles`, worktree present | **2× the tree** | 653 |
| `collectMjsFiles`, no worktree | 653 | 653 |

(Measured 1252 vs 626 at the commit this was written against; `main` has grown since.)

The count is now checkout-independent, which is the invariant the module's header claims.

Rebased onto `main` at `55ef89b` (65 commits) and re-verified there. Full `node test-all.mjs` **with a nested worktree present: 8088 passed, 0 failed, 14 warnings, exit 0.** `npm run lint` reports 653 files with and without a worktree present.

One note for the reviewer: an earlier full run showed `tests/pipeline-lock.test.mjs:542` failing on a wall-clock `elapsed >= 300` assertion. It passes standalone (21/21) and passed on both full runs since — a load-sensitive flake, unrelated to this change and not addressed here.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recursive source discovery now skips nested Git checkouts, linked worktrees, and submodules.
  * The repository root continues to be scanned correctly, including when its Git marker is a file.

* **Tests**
  * Added coverage for nested checkout detection and scanning behavior.
  * Updated validation checks to avoid treating nested repository contents as part of the current project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->