### PR TITLE
fix(web): read set-status.mjs's pretty --json document, not one line of it

### DIFF
--- a/web/src/lib/status-cli.mjs
+++ b/web/src/lib/status-cli.mjs
@@ -13,9 +13,23 @@ const GENERIC_FAILURE = "status update failed";
  * not parse. The route then reports 500 for a write the CLI already committed,
  * losing `changed` and `statusLogged` with it.
  *
- * So the document is read from the end: the last line that parses as a plain
- * object is the result. A diagnostic that happens to be valid JSON cannot shadow
- * it, because the result is printed last.
+ * So the document is read from the end: the LAST line that *opens* a parsable
+ * object, together with every line after it, is the result. A diagnostic that
+ * happens to be valid JSON cannot shadow it, because the result is printed last.
+ *
+ * The document is a slice rather than a single line because the CLIs pretty-print
+ * it. set-status.mjs ends in JSON.stringify(result, null, 2) - as does most of
+ * this repo - so the object spans many lines and its first line is the bare `{`,
+ * which parses as nothing on its own. Matching one line at a time therefore
+ * failed on every successful --json run: the tracker was written, the ledger row
+ * appended, and /api/status still answered 500 "status update returned no result"
+ * because the only shape it could read was a compact object set-status.mjs never
+ * prints. Every test fed it one, which is why the suite stayed green.
+ *
+ * A pretty document's inner braces (an object inside an array) open a candidate
+ * slice of their own, and those slices carry trailing `]`/`}` lines that do not
+ * parse - so scanning on past them to the outermost `{` is the behaviour here,
+ * not a lucky escape.
  *
  * @param {string} stdout
  * @returns {Record<string, unknown> | null}
@@ -23,15 +37,14 @@ const GENERIC_FAILURE = "status update failed";
 export function parseCliJson(stdout) {
   const lines = String(stdout ?? "").split("\n");
   for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i].trim();
-    if (!line.startsWith("{")) continue;
+    if (!lines[i].trimStart().startsWith("{")) continue;
     try {
-      const parsed = JSON.parse(line);
+      const parsed = JSON.parse(lines.slice(i).join("\n"));
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return /** @type {Record<string, unknown>} */ (parsed);
       }
     } catch {
-      // Not the document line. Keep scanning earlier lines.
+      // Not where the document starts. Keep scanning earlier lines.
     }
   }
   return null;

--- a/web/tests/lib/status-cli.test.mjs
+++ b/web/tests/lib/status-cli.test.mjs
@@ -84,3 +84,54 @@ test("a non-string error field is not passed through as one", () => {
   assert.equal(clientErrorMessage({ error: { nested: true } }), "status update failed");
   assert.equal(clientErrorMessage({}), "status update failed");
 });
+
+// ── the shape set-status.mjs actually prints ─────────────────────────────────
+// Every test above feeds a COMPACT object, and the CLI prints none. Its --json
+// path ends in `JSON.stringify(result, null, 2)`, so the document is pretty and
+// its first line is a bare `{`. Reading one line at a time therefore matched
+// nothing on the success path: /api/status answered 500 "status update returned
+// no result" for a tracker row it had just written, and the suite stayed green
+// because no case here had ever been pretty. So these build their document the
+// same way the CLI does rather than hand-writing one.
+
+// set-status.mjs's own `result` object, verbatim in shape, for a real transition.
+const SET_STATUS_RESULT = {
+  changed: true,
+  num: 42,
+  company: "Acme Corp",
+  role: "QA Engineer",
+  oldStatus: "Evaluated",
+  newStatus: "SKIP",
+  statusLogged: true,
+  tracker: "data/applications.md",
+};
+
+test("a pretty-printed document is read, because that is the only shape the CLI prints", () => {
+  const stdout = `${JSON.stringify(SET_STATUS_RESULT, null, 2)}
+`;
+  assert.deepEqual(parseCliJson(stdout), SET_STATUS_RESULT);
+});
+
+test("a diagnostic ahead of a pretty document still does not shadow it", () => {
+  const stdout = `warning: ledger append skipped for row {12} (no notes column)
+${JSON.stringify(SET_STATUS_RESULT, null, 2)}
+`;
+  assert.deepEqual(parseCliJson(stdout), SET_STATUS_RESULT);
+});
+
+test("an object nested in an array does not end the scan before the real document", () => {
+  // A pretty array element opens its own line with `{`, so it is a candidate
+  // slice scanned before the outermost one. It has to fail to parse - trailing
+  // `]`/`}` lines follow it - rather than be returned as the document.
+  const withArray = { changed: false, rows: [{ num: 11 }, { num: 12 }], tracker: "data/applications.md" };
+  const stdout = `${JSON.stringify(withArray, null, 2)}
+`;
+  assert.deepEqual(parseCliJson(stdout), withArray);
+});
+
+test("a pretty document wins over an earlier compact one, same as line-at-a-time did", () => {
+  const stdout = `{"note":"pre-flight"}
+${JSON.stringify(SET_STATUS_RESULT, null, 2)}
+`;
+  assert.deepEqual(parseCliJson(stdout), SET_STATUS_RESULT);
+});


### PR DESCRIPTION
This was opened by mistake while I was using my AI coding tool.

It was not meant to be submitted to this repository, so please disregard it. Sorry for the noise and the extra work.