### PR TITLE
docs(governance): add scanner providers to Scott-Emberson's code-owner area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,3 +63,9 @@
 # check runs through, so it keeps the wider review.
 /tests/     @Scott-Emberson
 /dashboard/ @Scott-Emberson
+# Scanner providers and their contract suites are one reviewable unit: the
+# module and its test land together, and the review that matters on a fetch
+# surface (host allowlisting, redirects, SSRF, parsing pinned with concrete
+# assertions) is the one he has been doing on every provider PR (2-sep).
+/providers/       @Scott-Emberson
+/tests/providers/ @Scott-Emberson

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ This file lists who maintains career-ops and how contributors grow into review a
 |------|-----|-------|
 | Lead maintainer | [@santifer](https://github.com/santifer) | All areas; final say on architecture, scoring, and the data contract |
 | Reviewer | [@FReptar0](https://github.com/FReptar0) | Dashboard, tracker, CI, updater — triage, labels, first-pass reviews; his approvals unblock merges |
-| Area owner | [@Scott-Emberson](https://github.com/Scott-Emberson) | Test-suite infrastructure (`tests/`) and the Go dashboard (`dashboard/`) — code owner on both, so PRs touching them route to him for review |
+| Area owner | [@Scott-Emberson](https://github.com/Scott-Emberson) | Test-suite infrastructure (`tests/`), the Go dashboard (`dashboard/`) and the scanner providers with their contract suites (`providers/`, `tests/providers/`) — code owner on all of them, so a PR touching any of these cannot merge without his review. If a PR in his area has waited 7 days without that review, a maintainer reviews it in his place so the gate never becomes a queue. |
 
 Reviewers and additional maintainers are added as the contributor ladder below produces them. This list growing slowly is by design — see "Trust & access" below.
 


### PR DESCRIPTION
## What does this PR do?

Adds `/providers/` and `/tests/providers/` to @Scott-Emberson's code-owner area, next to `/tests/` and `/dashboard/`. The provider module and its contract suite are one reviewable unit, and the review that matters on a fetch surface (host allowlisting, redirect handling, SSRF, parsing pinned with concrete assertions) is the one he has been carrying on every provider PR.

MAINTAINERS.md says what the area means in practice: a PR touching it cannot merge without his review, and a PR that has waited 7 days without that review is reviewed by a maintainer in his place, so the gate never becomes a queue.

Follows #3687 (reviewer approvals decide inside their area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9mnb6ho4JQLJMm4HVSTcR
