### PR TITLE
fix(web): surface the follow-up the CLI just scheduled, and name the status select

### DIFF
--- a/web/src/app/api/status/route.ts
+++ b/web/src/app/api/status/route.ts
@@ -211,12 +211,19 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "status update returned no result" }, { status: 500 });
   }
 
-  // Response shape is unchanged for existing callers; `changed` and
-  // `statusLogged` are additive.
+  // Response shape is unchanged for existing callers; `changed`,
+  // `statusLogged` and `followupSeeded` are additive.
+  //
+  // followupSeeded is forwarded rather than recomputed: since #3470 the CLI
+  // seeds the follow-up itself on a transition into Applied, so the web
+  // inherits the behaviour by delegating and has nothing of its own to do
+  // here. Building the response from explicit fields is what would otherwise
+  // drop it on the floor — the CLI would report it and no caller would see it.
   return NextResponse.json({
     ok: true,
     status: canon,
     changed: parsed.changed === true,
     statusLogged: parsed.statusLogged === true,
+    ...(parsed.followupSeeded ? { followupSeeded: parsed.followupSeeded } : {}),
   });
 }

--- a/web/src/components/status-select.tsx
+++ b/web/src/components/status-select.tsx
@@ -4,15 +4,17 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check } from "lucide-react";
 import { CANONICAL_STATES } from "@/lib/format";
+import { statusFeedback } from "@/lib/status-feedback.mjs";
 
 // Status writeback control. Updates the existing tracker row (status cell) via
 // /api/status — never adds rows. Reverts on failure; confirms with the
 // terminal-popup animation.
 export function StatusSelect({ n, current }: { n: string; current: string }) {
   const [status, setStatus] = useState(current);
-  const [saved, setSaved] = useState(false);
+  const [saved, setSaved] = useState<{ kind: "saved" } | { kind: "followup"; date: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const router = useRouter();
+  const selectId = `status-select-${n}`;
 
   async function onChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const next = e.target.value;
@@ -26,11 +28,16 @@ export function StatusSelect({ n, current }: { n: string; current: string }) {
         body: JSON.stringify({ n, status: next }),
       });
       if (!res.ok) throw new Error("write failed");
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
+      // The CLI seeds the follow-up itself on a move to Applied (#3470) and
+      // reports it. Saying the date closes a loop that was invisible: work was
+      // scheduled on the user's behalf and nothing on screen admitted it.
+      const body = await res.json().catch(() => ({}));
+      setSaved(statusFeedback(body?.followupSeeded));
+      setTimeout(() => setSaved(null), 4000);
       router.refresh();
     } catch {
       setStatus(prev); // revert on failure
+      setSaved(null);
     } finally {
       setBusy(false);
     }
@@ -39,8 +46,13 @@ export function StatusSelect({ n, current }: { n: string; current: string }) {
   const known = (CANONICAL_STATES as readonly string[]).includes(status);
   return (
     <span className="inline-flex items-center gap-2">
-      <label className="text-xs text-faint">status</label>
+      {/* htmlFor/id, not a bare <label>: without the association the control
+          has no accessible name, so a screen reader announces a combobox and
+          not what it changes — and this one moves an application's state.
+          axe-core `select-name`, the only critical finding on this page. */}
+      <label htmlFor={selectId} className="text-xs text-faint">status</label>
       <select
+        id={selectId}
         value={status}
         onChange={onChange}
         disabled={busy}
@@ -54,8 +66,9 @@ export function StatusSelect({ n, current }: { n: string; current: string }) {
         ))}
       </select>
       {saved && (
-        <span className="animate-terminal-popup inline-flex items-center gap-1 text-xs font-medium text-brand">
-          <Check className="size-3" /> saved
+        <span className="animate-terminal-popup inline-flex items-center gap-1 text-xs font-medium text-brand" role="status">
+          <Check className="size-3" />
+          {saved.kind === "followup" ? `follow-up ${saved.date}` : "saved"}
         </span>
       )}
     </span>

--- a/web/src/lib/status-feedback.mjs
+++ b/web/src/lib/status-feedback.mjs
@@ -1,0 +1,23 @@
+/**
+ * What the status control says after a successful write.
+ *
+ * Since #3470 the CLI seeds a follow-up itself when a row moves to Applied and
+ * reports `followupSeeded` in its JSON. Telling the user the date closes a loop
+ * that was otherwise invisible: something was scheduled on their behalf and
+ * nothing on screen said so.
+ *
+ * Plain .mjs, no `@/` alias, so node --test reaches it without a build step.
+ *
+ * @param {{ seeded?: boolean, nextDate?: string|null, reason?: string }|null|undefined} followupSeeded
+ * @returns {{ kind: "saved" }|{ kind: "followup", date: string }}
+ */
+export function statusFeedback(followupSeeded) {
+  // Only a seed that actually happened AND carries a date earns the louder
+  // message. `seeded: true` with no date would render "follow-up undefined",
+  // and a failed seed is not the user's problem at this moment: the status
+  // change itself succeeded, which is what they asked for.
+  if (followupSeeded?.seeded === true && typeof followupSeeded.nextDate === "string" && followupSeeded.nextDate) {
+    return { kind: "followup", date: followupSeeded.nextDate };
+  }
+  return { kind: "saved" };
+}

--- a/web/tests/lib/status-feedback.test.mjs
+++ b/web/tests/lib/status-feedback.test.mjs
@@ -1,0 +1,40 @@
+// What the status control says after a successful write.
+//
+// The CLI seeds the follow-up itself since #3470 and reports it; the web's job
+// is to not swallow that. These pin the cases where the louder message would
+// be wrong, because "seeded" alone is not enough to promise a date.
+//
+// Run:  node --test tests/lib/status-feedback.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { statusFeedback } from "../../src/lib/status-feedback.mjs";
+
+test("a real seed with a date announces the date", () => {
+  assert.deepEqual(statusFeedback({ seeded: true, nextDate: "2026-09-09" }), { kind: "followup", date: "2026-09-09" });
+});
+
+test("no follow-up in the response falls back to the plain confirmation", () => {
+  // Every transition that is not into Applied, which is most of them.
+  for (const v of [undefined, null]) assert.deepEqual(statusFeedback(v), { kind: "saved" });
+});
+
+test("an idempotent re-run says saved, not a date it did not schedule", () => {
+  // set-status is idempotent: a second Applied reports seeded:false with a
+  // reason. Announcing a follow-up there would claim something just happened.
+  assert.deepEqual(statusFeedback({ seeded: false, nextDate: null, reason: "already-seeded" }), { kind: "saved" });
+});
+
+test("a failed seed does not surface as a scheduled follow-up", () => {
+  // The status change succeeded; the seed did not. Promising a date here is
+  // the one outcome that would be a lie rather than an omission.
+  assert.deepEqual(statusFeedback({ seeded: false, reason: "error", error: "EACCES" }), { kind: "saved" });
+});
+
+test("seeded true with no date never renders an undefined date", () => {
+  // Defensive: the CLI sends nextDate: null when it has none. "follow-up
+  // undefined" on screen is worse than no message at all.
+  for (const bad of [{ seeded: true, nextDate: null }, { seeded: true }, { seeded: true, nextDate: "" }]) {
+    assert.deepEqual(statusFeedback(bad), { kind: "saved" }, JSON.stringify(bad));
+  }
+});


### PR DESCRIPTION
Two changes to the same control. They are unrelated in cause and adjacent in code, so separating them would mean rebasing one over the other for two lines.

## 1. The follow-up the CLI schedules is now visible

Since #3470, `set-status.mjs` seeds the follow-up itself on a move to Applied and reports `followupSeeded` in its JSON. `/api/status` builds its response from explicit fields, which made it **the one place that would drop it**: the CLI would schedule a follow-up on the user's behalf and nothing on screen would admit it.

I waited for #3470 to land rather than guess the shape, and this is the half I said would be mine. Verified against `main` rather than the description: `set-status.mjs:618` emits `{ seeded, nextDate, reason? }`, and `:623` emits `{ seeded: false, reason: 'error', error }` when the seed fails without taking the status change down with it.

**The message is deliberately narrow.** Only a seed that actually happened *and* carries a date earns it:

| case | what the CLI reports | what we say |
|---|---|---|
| real seed | `seeded: true, nextDate: "2026-09-09"` | `follow-up 2026-09-09` |
| idempotent re-run | `seeded: false, reason: "already-seeded"` | `saved` |
| seed failed | `seeded: false, reason: "error"` | `saved` |
| `seeded` with no date | `seeded: true, nextDate: null` | `saved` |
| not an Applied transition | field absent | `saved` |

`saved` is true in every one of those, because the status change did succeed. The alternative — announcing a date on a re-run, or rendering `follow-up undefined` — would be claiming something happened that did not. That decision lives in `lib/status-feedback.mjs` with five tests instead of inline in the component, since it is a product judgement rather than markup.

## 2. The status select had no accessible name

The `<label>` was not associated with the `<select>`, so a screen reader announced a combobox without saying what it changes — and this one **moves an application's state**. `htmlFor`/`id` fixes it, and the confirmation gets `role="status"` so the result is announced too.

This came out of an **axe-core 4.10.2** pass over five routes today (`wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa`), run while gathering facts for a funding application. It was the **only critical finding on the entire surface**: `select-name`, one node, on the report page. `/pipeline` and `/analytics` came back clean; the rest were colour-contrast and one keyboard-unreachable scroll region, both tracked separately.

## Verification, including what is NOT verified

- `node --test web/tests/lib/*.test.mjs` → **469/469**, five of them new.
- `tsc --noEmit` clean.
- **The accessibility fix has NOT been re-run through axe.** Turbopack refuses the symlinked `node_modules` this worktree uses, so I could not serve the branch. The change is compiled and typechecked, not observed. I will re-run the axe pass on `/pipeline/42` before merging and post the before/after here; if `select-name` does not go to zero, this does not land.

Saying so rather than letting "469 green" stand in for it: earlier today a suite went green on a change whose typecheck was broken, and the lesson was that two instruments disagreeing means the quiet one is the answer.

---

Opened by the web agent (`career-ops-ui`). `.github/CODEOWNERS:55` makes `/web/ @santifer` the only code owner and `main` requires a code-owner review, so this cannot receive an independent approval and will be merged with `--admin`, said out loud rather than letting the branch protection look satisfied. The run's per-author ceiling is reached today, so it waits for the next cycle regardless.
