### PR TITLE
fix(analysis): funnel-velocity, calibrate and weekly-digest ignore the configured data root (#3714)

### DIFF
--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -38,10 +38,16 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { parseTrackerRow, resolveColumns, isSeparatorRow, isHeaderRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { canonicalOutcome } from './lib/outcome-types.mjs';
 import { outcomeDirsFor } from './lib/outcome-dir.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+// The USER's data root, not this file's directory. It was __dirname under the
+// name CAREER_OPS, so resolveTrackerPath() looked inside the checkout and a user
+// with CAREER_OPS_ROOT (or a .career-ops-data marker) got "No tracker found ...
+// nothing to calibrate yet" — which reads as "you have no outcome data",
+// exactly the thing this advisory is meant to answer.
+const DATA_ROOT = getCareerOpsRoot();
 
 // --- Outcome semantics ---------------------------------------------------
 //
@@ -440,7 +446,7 @@ if (isMainModule(import.meta.url)) {
     console.error('--min-band-n must be a positive integer');
     process.exit(2);
   }
-  const appsFile = resolveTrackerPath(CAREER_OPS);
+  const appsFile = resolveTrackerPath(DATA_ROOT);
   if (!existsSync(appsFile)) {
     console.error(`No tracker found at ${appsFile} — nothing to calibrate yet.`);
     process.exit(1);

--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -43,13 +43,25 @@ import * as yaml from 'js-yaml';
 import { computeFunnel, computeFunnelWithHistory, parseStatusLogStages, trackerStatusByNum, computeTrackerStats } from './stats.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, loadCanonicalStates, resolveCanonicalState } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { parseAppliedDate, normalizeStatus } from './followup-cadence.mjs';
 import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 import { localToday } from './lib/local-today.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
+// Two roots, because this file reads both layers and they are not the same
+// directory. CODE_ROOT is where the shipped templates live; DATA_ROOT is where
+// the USER's tracker and overrides live, and getCareerOpsRoot() is what honours
+// CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR / the .career-ops-data marker.
+//
+// One name for both is how this went wrong: the constant was called CAREER_OPS
+// and held __dirname, so it read correctly for templates and silently pointed
+// the tracker lookup at the checkout. A user with a data root configured got
+// "No tracker found ... nothing to calibrate yet" — indistinguishable from
+// having no data.
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
+const STATES_FILE = join(CODE_ROOT, 'templates/states.yml');
 
 const KNOWN_FLAGS = ['--summary', '--self-test', '--benchmarks', '--help', '-h'];
 const VALUE_FLAGS = ['--benchmarks'];
@@ -236,7 +248,7 @@ export function computeVelocity(timelines, todayStr) {
 // --- Benchmarks ---
 export function loadBenchmarks(explicitPath) {
   const path = explicitPath
-    || (existsSync(join(CAREER_OPS, 'config/benchmarks.yml')) ? join(CAREER_OPS, 'config/benchmarks.yml') : join(CAREER_OPS, 'templates/benchmarks.yml'));
+    || (existsSync(join(DATA_ROOT, 'config/benchmarks.yml')) ? join(DATA_ROOT, 'config/benchmarks.yml') : join(CODE_ROOT, 'templates/benchmarks.yml'));
   let doc;
   try {
     doc = yaml.load(readFileSync(path, 'utf-8'));
@@ -590,7 +602,7 @@ function selfTest() {
   check(v3.appliedToResponded.censored === 2, 'velocity: censored drops to 2 after row 4 completes');
 
   // -- benchmarks + classification --
-  const bm = loadBenchmarks(join(CAREER_OPS, 'templates/benchmarks.yml')).benchmarks;
+  const bm = loadBenchmarks(join(CODE_ROOT, 'templates/benchmarks.yml')).benchmarks;
   check(bm.response_rate && Array.isArray(bm.response_rate.range_pct), 'benchmarks: shipped file loads');
   check(bm.days_first_response.range_days[1] === 14, 'benchmarks: first-response window upper bound');
   check(!('time_to_fill' in bm), 'benchmarks: employer-side time_to_fill must not exist');
@@ -809,7 +821,7 @@ function main() {
     process.exit(1);
   }
   const states = loadCanonicalStates(STATES_FILE);
-  const trackerPath = resolveTrackerPath(CAREER_OPS);
+  const trackerPath = resolveTrackerPath(DATA_ROOT);
   const logPath = join(dirname(trackerPath), 'status-log.tsv');
   const trackerContent = existsSync(trackerPath) ? readFileSync(trackerPath, 'utf-8') : '';
   const logContent = existsSync(logPath) ? readFileSync(logPath, 'utf-8') : '';

--- a/tests/analysis-scripts-data-root.test.mjs
+++ b/tests/analysis-scripts-data-root.test.mjs
@@ -1,0 +1,143 @@
+// tests/analysis-scripts-data-root.test.mjs — the analysis scripts read the
+// USER's data root, not the directory they happen to live in (#3510's family).
+//
+// #3511 fixed this for the scanners and added a structural guard against a new
+// bare cwd-relative literal. These three had a different spelling of the same
+// bug and that guard does not see it: the constant was named CAREER_OPS and
+// assigned `dirname(fileURLToPath(import.meta.url))`, so it reads as the
+// project root and is in fact the CODE root. Both documented overrides —
+// CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR and the .career-ops-data marker — were
+// ignored, and getCareerOpsRoot() is the only thing that honours them.
+//
+// The failures were quiet in the way that matters:
+//
+//   funnel-velocity   "No tracker found at <CHECKOUT>/applications.md"
+//   calibrate         "... nothing to calibrate yet"   <- reads as "you have no data"
+//   weekly-digest     "no session files fall inside this range"  <- blames the DATES
+//
+// Each runs in a child with the data root and the cwd pointed at DIFFERENT
+// directories. A path following the cwd or the checkout finds nothing; one
+// following the data root finds the fixture. If those were the same directory
+// this suite could not tell them apart, which is exactly how the drift survived.
+//
+// Run:  node --test tests/analysis-scripts-data-root.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function fixture() {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-analysisroot-'));
+  const decoyCwd = mkdtempSync(join(tmpdir(), 'career-ops-analysiscwd-'));
+  mkdirSync(join(dataRoot, 'data'), { recursive: true });
+  mkdirSync(join(dataRoot, 'interview-prep', 'sessions'), { recursive: true });
+  writeFileSync(join(dataRoot, 'data', 'applications.md'), [
+    '# Applications Tracker',
+    '',
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|---|---|---|---|---|---|---|---|',
+    '| 1 | 2026-01-05 | Acme | Backend Engineer | 4.2/5 | Applied | ✅ | [1](r1.md) | n |',
+    '| 2 | 2026-02-05 | Globex | ML Engineer | 4.4/5 | Interview | ✅ | [2](r2.md) | n |',
+    '',
+  ].join('\n'));
+  writeFileSync(join(dataRoot, 'interview-prep', 'sessions', 'acme-backend-r1.md'), [
+    '---', 'company: Acme', 'role: Backend Engineer', 'round: 1',
+    'date: 2026-08-26', 'competencies: [system-design]', '---', 'Round 1 notes.', '',
+  ].join('\n'));
+  return { dataRoot, decoyCwd };
+}
+
+function run(script, args, { dataRoot, decoyCwd }) {
+  const r = spawnSync(process.execPath, [join(ROOT, script), ...args], {
+    cwd: decoyCwd,
+    encoding: 'utf-8',
+    timeout: 60_000,
+    env: { ...process.env, CAREER_OPS_ROOT: dataRoot, CAREER_OPS_DATA_DIR: '' },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+const cleanup = (f) => {
+  for (const d of [f.dataRoot, f.decoyCwd]) rmSync(d, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+};
+
+test('funnel-velocity reads the configured data root', () => {
+  const f = fixture();
+  try {
+    const r = run('funnel-velocity.mjs', ['--summary'], f);
+    assert.doesNotMatch(r.all, /No tracker found/i, `it looked in the checkout, not the data root:\n${r.all.slice(0, 400)}`);
+    assert.match(r.all, /Funnel Calibration/i, `no report was produced:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('calibrate reads the configured data root', () => {
+  const f = fixture();
+  try {
+    const r = run('calibrate.mjs', ['--summary'], f);
+    assert.doesNotMatch(
+      r.all,
+      /No tracker found/i,
+      'calibrate reported no tracker — for the advisory that answers "do my scores predict outcomes", '
+      + `that reads as "you have no data":\n${r.all.slice(0, 400)}`,
+    );
+  } finally { cleanup(f); }
+});
+
+test('weekly-digest reads the configured data root', () => {
+  const f = fixture();
+  try {
+    const r = run('weekly-digest.mjs', ['--summary', '--from', '2026-08-24', '--to', '2026-08-30'], f);
+    assert.match(
+      r.all,
+      /Sessions:\s+1 in range/,
+      'the digest found no sessions. Note the message it prints instead blames the date range for a '
+      + `directory it never opened:\n${r.all.slice(0, 400)}`,
+    );
+  } finally { cleanup(f); }
+});
+
+test('and none of them writes into the cwd it was launched from', () => {
+  // A path that follows the cwd would create its data/ there. Nothing here is a
+  // writer, so the decoy must come back untouched.
+  const f = fixture();
+  try {
+    run('funnel-velocity.mjs', ['--summary'], f);
+    run('calibrate.mjs', ['--summary'], f);
+    run('weekly-digest.mjs', ['--summary'], f);
+    assert.deepEqual(readdirSync(f.decoyCwd), [], 'a script wrote into the directory it was launched from');
+  } finally { cleanup(f); }
+});
+
+test('system files still resolve from the CODE root, not the data root', () => {
+  // The other half of the split. funnel-velocity reads templates/states.yml and
+  // templates/benchmarks.yml, which ship with the code and are NOT in the user's
+  // data root — pointing everything at DATA_ROOT would have broken those.
+  const f = fixture();
+  try {
+    const r = run('funnel-velocity.mjs', ['--summary'], f);
+    assert.doesNotMatch(r.all, /states\.yml|benchmarks\.yml/i, `a system template was reported missing:\n${r.all.slice(0, 400)}`);
+    assert.equal(r.status, 0, `exited ${r.status}: ${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('no analysis script derives a data path from its own directory', () => {
+  // The structural half, in the spirit of #3511's check 6. That one greps for a
+  // bare relative string literal; this spelling assigns __dirname to a constant
+  // and joins user-layer paths onto it, which reads as correct and is not.
+  const offenders = [];
+  const USER_LAYER = /join\(\s*(CAREER_OPS|CODE_ROOT)\s*,\s*'(data|interview-prep|reports|output|jds|documents)[/']/;
+  for (const file of ['funnel-velocity.mjs', 'calibrate.mjs', 'weekly-digest.mjs', 'stats.mjs', 'company-history.mjs']) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    for (const line of src.split('\n')) {
+      if (USER_LAYER.test(line)) offenders.push(`${file}: ${line.trim().slice(0, 80)}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `user-layer path(s) joined onto the code root:\n${offenders.join('\n')}`);
+});

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -47,10 +47,15 @@ import * as yaml from 'js-yaml';
 import { validateFlags } from './lib/cli-flags.mjs';
 import { localToday } from './lib/local-today.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const DEFAULT_SESSIONS_DIR = join(CAREER_OPS, 'interview-prep', 'sessions');
-const DEFAULT_QUESTION_BANK_PATH = join(CAREER_OPS, 'interview-prep', 'question-bank.md');
+// The USER's data root. interview-prep/ is USER_PATHS in update-system.mjs, so
+// resolving it from this file's directory meant that with a data root configured
+// the digest looked in the checkout, found nothing, and said "no session files
+// fall inside this range" — blaming the dates for a directory it never opened.
+const DATA_ROOT = getCareerOpsRoot();
+const DEFAULT_SESSIONS_DIR = join(DATA_ROOT, 'interview-prep', 'sessions');
+const DEFAULT_QUESTION_BANK_PATH = join(DATA_ROOT, 'interview-prep', 'question-bank.md');
 
 const ROUND_ENUM = ['screen', 'hiring-manager', 'technical', 'system-design', 'behavioral', 'onsite', 'final'];
 


### PR DESCRIPTION
Fixes #3714.

#3511 fixed this class for the scanners. These three have a different spelling of the same bug, and the structural guard it added does not see it — not a bare relative literal, but a constant named as though it were the project root, holding the **code** root, with user-layer paths joined onto it.

```js
const CAREER_OPS = dirname(fileURLToPath(import.meta.url));   // the CODE root
...
resolveTrackerPath(CAREER_OPS)                                 // user data
join(CAREER_OPS, 'interview-prep', 'sessions')                 // user data
```

`getCareerOpsRoot()` is the only thing that honours `CAREER_OPS_ROOT`, `CAREER_OPS_DATA_DIR` and the `.career-ops-data` marker, and none of the three called it.

## What the user saw

```
funnel-velocity   "No tracker found at <CHECKOUT>/applications.md — nothing to calibrate yet."
calibrate          same
weekly-digest     "No interviews recorded in this range (no session files fall inside this range)."
                   --dir <same directory>  ->  "Sessions: 1 in range across 1 companies"
```

None of them errors, which is the problem. `calibrate` exists to answer *"are my scores predicting my real outcomes"*, and `nothing to calibrate yet` is a legitimate answer for a new user — given to someone with a full tracker it is a wrong answer that looks like a right one. `weekly-digest` is sharper still: the parenthetical asserts that sessions exist and none match the dates, sending the user to check their range for a directory that was never opened.

## funnel-velocity needed two roots, not a substitution

It genuinely reads both layers, so a blanket move to `DATA_ROOT` would have broken the shipped templates:

| Path | Root | Why |
|---|---|---|
| `templates/states.yml` | CODE | ships with the code, absent from a user's data root |
| `templates/benchmarks.yml` | CODE | the shipped default |
| `config/benchmarks.yml` | DATA | the file's own header calls it a user override, and every other reader of `config/` resolves it that way |
| the tracker | DATA | |

One name for both is what let this survive — the wrong lookups sat beside correct ones and read identically. `data/outcomes/` in `calibrate` follows automatically, since `resolveWorkspaceRoot()` derives it from the tracker path.

## Tests

Six checks, each in a child with the data root and the cwd pointed at **different** directories — same reasoning as #3511's suite: if those were one directory the test could not tell the two resolutions apart, which is how the drift survived.

Two guards beyond the three fixes:

- **The other half of the split** — `templates/states.yml` and `templates/benchmarks.yml` must keep resolving from the code root, so a blanket `DATA_ROOT` move reddens it.
- **A structural check for this spelling**, in the spirit of #3511's check 6: no user-layer path may be joined onto a code-root constant. It covers five analysis scripts, not just the three being fixed, so the next one fails closed.

Reverting any one file's root reddens exactly its own check (5 pass / 1 fail, three times). Full suite green at 8370.

One thing found while building this and left alone: `browser-extract.mjs:91` and `followup-cadence.mjs:32` still resolve `config/profile.yml` from their own directory, the same way. Out of scope here — happy to file it separately.