### PR TITLE
fix(web): bind the dashboard to loopback by default

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -22,6 +22,9 @@ npm run dev
 Open http://localhost:3000. The app reads the career-ops checkout it lives in
 (the parent directory) — your existing CV, pipeline and reports appear as-is.
 
+The server binds IPv4 loopback, so reach it as `localhost` or `127.0.0.1`;
+`http://[::1]:3000` has nothing listening on it.
+
 ## What works today
 
 - **Pipeline** — your tracker as a sortable, filterable table; status changes
@@ -37,6 +40,10 @@ Open http://localhost:3000. The app reads the career-ops checkout it lives in
 
 - **Local-first:** the local web app runs entirely on your machine — no cloud,
   no account needed. Your CV and data stay in your own files.
+- **Loopback by default:** `npm run dev` and `npm start` bind `127.0.0.1`, so
+  nothing else on your network can reach the dashboard. It has no login — the
+  bind is the access control. Opt out deliberately with
+  `CAREER_OPS_WEB_ALLOWED_HOSTS` ([below](#exposing-it-beyond-this-machine)).
 - **Never auto-submits:** the apply flow drafts and prefills; submitting is
   always a human action.
 - **CV generation never asks the agent to write:** the `pdf` worker tailors your
@@ -74,11 +81,57 @@ from a `chrome-extension://` origin, which Fetch Metadata always reports as
 `cross-site`, so the guard refuses it unless the id is named here. The host
 layer still applies to an allowlisted origin.
 
+Pass one-off flags through npm's `--`: `npm run dev -- -p 4000`.
+
+### Exposing it beyond this machine
+
+`CAREER_OPS_WEB_ALLOWED_HOSTS` is the switch. Unset (or blank) the server binds
+`127.0.0.1`; name a host it cannot already reach on loopback and the server binds
+`0.0.0.0`, with the API guard answering for loopback and the hosts you named:
+
+```bash
+CAREER_OPS_WEB_ALLOWED_HOSTS="192.168.1.50" npm run dev
+```
+
+Naming only loopback (`localhost`, `127.0.0.1`, `::1`) is not an opt-in and
+changes nothing — the guard already answers for those, so widening the socket
+would expose every interface while granting no host that wasn't already allowed.
+
+Set through `CAREER_OPS_WEB_ALLOWED_HOSTS`, neither layer can widen without the
+other — the bind and the allow-list are derived from that one value. They are not
+equivalent, and two things move them apart: the guard also answers for loopback,
+which no bind address changes, and a `-H` of your own moves the bind while the
+allow-list stays as it was (see below).
+
+Understand what you are turning on. The host allow-list covers `/api/*` only
+(`src/proxy.ts`'s matcher), so once the socket is open **every page the
+dashboard renders — your CV, pipeline and reports — is readable by anyone who
+can reach that port**, and there is no login. Two further caveats: a client that
+can reach the port can also supply its own `Host` header, so on a widened bind
+the allow-list filters honest clients rather than hostile ones; and `0.0.0.0` is
+IPv4-only, so an opted-in IPv6 address will pass the filter with nothing
+listening for it.
+
+You can also override the bind directly — `npm run dev -- -H 0.0.0.0` — since
+Next keeps the last value of a repeated option. **Prefer the env var.** An `-H`
+on its own opens the socket while the allow-list stays empty, which is the one
+combination with no honest reading: the guard then refuses LAN clients that
+identify themselves truthfully and admits any that spell `Host: localhost`. The
+launcher says so on startup rather than doing it quietly.
+
+Use it on a network you trust, and prefer an SSH tunnel
+(`ssh -L 3000:127.0.0.1:3000 you@box`) where you can — that needs no env var at
+all and keeps the bind on loopback.
+
 ### Tests
 
 Suites live in `web/tests/`, mirroring the path of what they test under
 `web/src/` — so `src/lib/clean-chips.mjs` is tested by
 `tests/lib/clean-chips.test.mjs`. Name the file `{module}.test.mjs`.
+
+Root-level scripts are the one exception: `server.mjs` is tested by
+`tests/lib/server-launcher.test.mjs`, because `test-all.mjs`'s parity check gates
+only `web/tests/lib/` and a suite outside it would never run in the required check.
 
 `npm test` discovers them with a glob (`tests/**/*.test.mjs`), so a new suite
 needs **no registration** — just add the file. **Requires Node ≥ 22**: earlier

--- a/web/README.md
+++ b/web/README.md
@@ -85,13 +85,31 @@ Pass one-off flags through npm's `--`: `npm run dev -- -p 4000`.
 
 ### Exposing it beyond this machine
 
-`CAREER_OPS_WEB_ALLOWED_HOSTS` is the switch. Unset (or blank) the server binds
-`127.0.0.1`; name a host it cannot already reach on loopback and the server binds
-`0.0.0.0`, with the API guard answering for loopback and the hosts you named:
+`CAREER_OPS_WEB_ALLOWED_HOSTS` is the list of hosts allowed to reach the
+dashboard. Unset (or blank) the server binds `127.0.0.1`; name a host it cannot
+already reach on loopback and the socket opens, with the guard answering for
+loopback and the hosts you named:
 
 ```bash
 CAREER_OPS_WEB_ALLOWED_HOSTS="192.168.1.50" npm run dev
 ```
+
+It is not an on/off switch, and it is not read as one: `off`, `false`, `no` and
+`0` are all valid hostnames, so treating them as words would have opened the
+socket to the whole network for someone typing the word for "closed". They are
+refused, as is anything else that cannot be read as a hostname or an IP address.
+To stay on loopback, unset the variable.
+
+**How the bind is chosen.** Name a single IP address and the socket binds exactly
+that address — `192.168.1.50` and nothing else. Binding `0.0.0.0` for it would
+also publish the dashboard on every other interface the machine has, a VPN tunnel
+or a phone hotspot included, none of which you asked for. One socket carries one
+address, so `http://localhost:3000` stops answering; open it at the address you
+named. If you want loopback too, name a loopback host alongside
+(`"192.168.1.50, localhost"`) — that binds `0.0.0.0` and accepts the wider
+exposure deliberately. Anything else — a hostname, which needs a resolver the
+launcher does not have, or two addresses, which cannot share a socket — binds
+`0.0.0.0`. The startup line says which of these happened.
 
 Naming only loopback (`localhost`, `127.0.0.1`, `::1`) is not an opt-in and
 changes nothing — the guard already answers for those, so widening the socket
@@ -117,9 +135,17 @@ re-resolve its own domain to `127.0.0.1` and read the dashboard from your own
 browser as same-origin, which a loopback bind does nothing to stop. The `Host`
 header on that request carries the attacker's domain, which is what refuses it.
 
-You can also override the bind directly — `npm run dev -- -H 0.0.0.0` — since
-Next keeps the last value of a repeated option. **Prefer the env var.** An `-H`
-on its own opens the socket while the allow-list stays empty, which is the one
+**In a container** the bind has to be `0.0.0.0` — loopback inside a network
+namespace is not reachable from the host — so name a non-loopback host to open
+it. A forwarded port (`-p 3000:3000`) still arrives with `Host: localhost`, which
+the guard admits, so the port publication is the whole of the access control
+there: publish it on `127.0.0.1:3000:3000`, not `0.0.0.0`.
+
+You can also override the bind directly — `npm run dev -- -H 0.0.0.0`. When you
+pass `-H` or `--hostname`, the launcher injects nothing and Next resolves the
+flag itself, so the startup line says the bind is Next's to choose rather than
+claiming an address it would have to guess. **Prefer the env var.** An `-H` on
+its own opens the socket while the allow-list stays empty, which is the one
 combination with no honest reading: the guard then refuses LAN clients that
 identify themselves truthfully and admits any that spell `Host: localhost`. The
 launcher says so on startup rather than doing it quietly.

--- a/web/README.md
+++ b/web/README.md
@@ -100,8 +100,20 @@ socket to the whole network for someone typing the word for "closed". They are
 refused, as is anything else that cannot be read as a hostname or an IP address.
 To stay on loopback, unset the variable.
 
+`0.0.0.0` and `::` are refused too. They name every interface, which is a bind
+target rather than a host anyone is addressed by: accepting one would open the
+socket while the guard went on matching `Host` literally, so honest clients on
+your network would get `403` and only a client spelling `Host: 0.0.0.0` would be
+let in. To open it up, name the hosts that should reach it.
+
 **How the bind is chosen.** Name a single IP address and the socket binds exactly
-that address — `192.168.1.50` and nothing else. Binding `0.0.0.0` for it would
+that address — `192.168.1.50` and nothing else. It has to be an address *this*
+machine holds: naming the address of the laptop that should reach the dev box
+makes the server fail to start with `EADDRNOTAVAIL`, since you can only listen on
+your own interfaces. Name that laptop's *hostname* instead, or use a hostname for
+the box, and the bind falls back to every interface. Link-local addresses
+(`fe80::…`) are refused: they are ambiguous across interfaces and cannot be bound
+without a zone index. Binding `0.0.0.0` for a single address would
 also publish the dashboard on every other interface the machine has, a VPN tunnel
 or a phone hotspot included, none of which you asked for. One socket carries one
 address, so `http://localhost:3000` stops answering; open it at the address you
@@ -136,8 +148,11 @@ browser as same-origin, which a loopback bind does nothing to stop. The `Host`
 header on that request carries the attacker's domain, which is what refuses it.
 
 **In a container** the bind has to be `0.0.0.0` — loopback inside a network
-namespace is not reachable from the host — so name a non-loopback host to open
-it. A forwarded port (`-p 3000:3000`) still arrives with `Host: localhost`, which
+namespace is not reachable from the host. Since `0.0.0.0` itself is refused as an
+allowed host, get there by naming a *hostname* (the container's own name is the
+obvious one): a hostname needs a resolver the launcher does not have, so the bind
+falls back to every interface, which is what a namespace needs. A forwarded port
+(`-p 3000:3000`) still arrives with `Host: localhost`, which
 the guard admits, so the port publication is the whole of the access control
 there: publish it on `127.0.0.1:3000:3000`, not `0.0.0.0`.
 

--- a/web/README.md
+++ b/web/README.md
@@ -71,8 +71,8 @@ npm run build        # production build
 Set `CAREER_OPS_ROOT=/path/to/checkout` in `web/.env.local` to point the app at
 a different career-ops directory (useful for testing against sample data).
 
-`/api` is gated by the same-origin + loopback guard in `src/lib/origin-guard.mjs`.
-Two opt-ins widen it, both unset by default and both in `web/.env.local`:
+Every route but build assets is gated by the same-origin + loopback guard in
+`src/lib/origin-guard.mjs`. Two opt-ins widen it, both unset by default and both in `web/.env.local`:
 `CAREER_OPS_WEB_ALLOWED_HOSTS` names extra non-loopback hosts the dashboard may
 answer on, and `CAREER_OPS_ALLOWED_ORIGINS` names origins allowed to call the
 API from outside the app — a comma- or space-separated list, no trailing slash.
@@ -103,14 +103,19 @@ equivalent, and two things move them apart: the guard also answers for loopback,
 which no bind address changes, and a `-H` of your own moves the bind while the
 allow-list stays as it was (see below).
 
-Understand what you are turning on. The host allow-list covers `/api/*` only
-(`src/proxy.ts`'s matcher), so once the socket is open **every page the
-dashboard renders — your CV, pipeline and reports — is readable by anyone who
-can reach that port**, and there is no login. Two further caveats: a client that
-can reach the port can also supply its own `Host` header, so on a widened bind
-the allow-list filters honest clients rather than hostile ones; and `0.0.0.0` is
-IPv4-only, so an opted-in IPv6 address will pass the filter with nothing
-listening for it.
+Understand what you are turning on. Once the socket is open, **everything the
+dashboard serves — your CV, pipeline and reports — is reachable by anyone who can
+both reach that port and satisfy the host filter**, and there is no login. Two
+further caveats: a client that can reach the port can also supply its own `Host`
+header, so on a widened bind the allow-list filters honest clients rather than
+hostile ones; and a `0.0.0.0` bind is IPv4-only, so an opted-in IPv6 address will
+pass the filter with nothing listening for it.
+
+The guard covers page routes as well as `/api/*` (`src/proxy.ts`'s matcher spans
+everything but build assets). That is not about the bind: a page you visit can
+re-resolve its own domain to `127.0.0.1` and read the dashboard from your own
+browser as same-origin, which a loopback bind does nothing to stop. The `Host`
+header on that request carries the attacker's domain, which is what refuses it.
 
 You can also override the bind directly — `npm run dev -- -H 0.0.0.0` — since
 Next keeps the last value of a repeated option. **Prefer the env var.** An `-H`

--- a/web/package.json
+++ b/web/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Official web experience for career-ops — local-first.",
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.mjs dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node server.mjs start",
     "typecheck": "tsc --noEmit",
     "test": "node --test \"tests/**/*.test.mjs\""
   },

--- a/web/server.mjs
+++ b/web/server.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// server.mjs — starts the dashboard on the interface bind-host.mjs chooses.
+//
+// A thin shell on purpose: every decision lives in src/lib/bind-host.mjs, which
+// is pure and unit-tested, so this file only resolves next, reports what is
+// about to be exposed, and forwards the child's exit status. See that module and
+// origin-guard.mjs's header for why the bind is the access control.
+//
+// Imports nothing outside web/: this tree is excluded from the core's packaging
+// and coverage contracts (validate-system-paths-coverage.mjs EXCLUDE_PREFIXES),
+// so lib/cli-flags.mjs and lib/is-main-module.mjs are out of reach by design.
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import os from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { planNextRun } from "./src/lib/bind-host.mjs";
+
+const requireHere = createRequire(import.meta.url);
+const [command, ...extra] = process.argv.slice(2);
+
+const plan = planNextRun({
+  command,
+  extra,
+  envValue: process.env.CAREER_OPS_WEB_ALLOWED_HOSTS,
+});
+if (!plan.ok) {
+  console.error(plan.error);
+  process.exit(1);
+}
+
+// Reported before next is resolved: a user whose install is broken should still
+// learn their run would have been network-reachable, and the required CI job has
+// no web/node_modules, so anything below the resolve is untestable there.
+if (plan.widened) {
+  const why = plan.overridden
+    ? `-H ${plan.effectiveBindHost} overrides the resolved bind`
+    : `allowed hosts: ${plan.allowedHosts.join(", ")}`;
+  console.error(
+    `career-ops web: binding ${plan.effectiveBindHost} — reachable from your network (${why}).`,
+  );
+  if (plan.overridden && plan.grantsNoNewHost) {
+    // The one combination with no honest reading: an open port whose Host filter
+    // names nobody it could not already serve on loopback. It refuses LAN clients
+    // that identify themselves truthfully and admits any that spell
+    // `Host: localhost`. A list of only loopback spellings counts as naming
+    // nobody, which is why this asks what the list grants rather than its length.
+    console.error(
+      "career-ops web: CAREER_OPS_WEB_ALLOWED_HOSTS names no host beyond loopback, so " +
+        "the request guard will refuse honest clients on this interface and admit " +
+        "spoofed loopback ones. Name the hosts that should reach it in that variable.",
+    );
+  }
+} else {
+  console.error(`career-ops web: binding ${plan.effectiveBindHost} — loopback only.`);
+}
+
+// next's declared entry, not the private dist path: node_modules/.bin/next is a
+// .cmd on Windows that spawn() cannot exec without a shell, and a shell would
+// reparse every forwarded argument.
+let nextEntry;
+try {
+  const manifest = requireHere.resolve("next/package.json");
+  nextEntry = join(dirname(manifest), requireHere(manifest).bin.next);
+} catch (err) {
+  console.error(
+    err.code === "MODULE_NOT_FOUND"
+      ? "Cannot find next — run `npm ci` in web/ and retry."
+      : `Cannot resolve next (${err.code ?? "error"}): ${err.message}`,
+  );
+  process.exit(1);
+}
+
+// cwd is pinned to this file's directory rather than inherited: career-ops.ts
+// resolves the checkout as `resolve(process.cwd(), "..")`, so a run started from
+// the repo root would otherwise read the repo's PARENT as the career-ops root.
+//
+// spawnSync because the child runs until Ctrl-C and this process has nothing to
+// do meanwhile. The terminal delivers SIGINT to the whole foreground group, so
+// next shuts itself down; re-signalling it from here would only double up.
+const result = spawnSync(process.execPath, [nextEntry, ...plan.argv], {
+  cwd: dirname(fileURLToPath(import.meta.url)),
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(`Could not start next: ${result.error.message}`);
+  process.exit(1);
+}
+// A signalled child reports status null. Exiting 128+signal keeps a SIGTERM
+// distinguishable from a startup failure.
+process.exit(result.signal ? 128 + (os.constants.signals[result.signal] ?? 0) : result.status ?? 1);

--- a/web/server.mjs
+++ b/web/server.mjs
@@ -33,27 +33,40 @@ if (!plan.ok) {
 // Reported before next is resolved: a user whose install is broken should still
 // learn their run would have been network-reachable, and the required CI job has
 // no web/node_modules, so anything below the resolve is untestable there.
-if (plan.widened) {
-  const why = plan.overridden
-    ? `-H ${plan.effectiveBindHost} overrides the resolved bind`
-    : `allowed hosts: ${plan.allowedHosts.join(", ")}`;
+if (plan.hostFlagSupplied) {
+  // No bind was injected, so next resolves the flag itself and this process does
+  // not know the answer. Saying "may be" is the whole point: the alternative is
+  // reimplementing commander here and asserting a bind that could be wrong, which
+  // is how this launcher once announced loopback while every interface was open.
   console.error(
-    `career-ops web: binding ${plan.effectiveBindHost} — reachable from your network (${why}).`,
+    "career-ops web: -H/--hostname supplied, so next chooses the bind — this run may be " +
+      "reachable from your network.",
   );
-  if (plan.overridden && plan.grantsNoNewHost) {
+  if (plan.grantsNoNewHost) {
     // The one combination with no honest reading: an open port whose Host filter
     // names nobody it could not already serve on loopback. It refuses LAN clients
     // that identify themselves truthfully and admits any that spell
     // `Host: localhost`. A list of only loopback spellings counts as naming
     // nobody, which is why this asks what the list grants rather than its length.
     console.error(
-      "career-ops web: CAREER_OPS_WEB_ALLOWED_HOSTS names no host beyond loopback, so " +
-        "the request guard will refuse honest clients on this interface and admit " +
-        "spoofed loopback ones. Name the hosts that should reach it in that variable.",
+      "career-ops web: CAREER_OPS_WEB_ALLOWED_HOSTS names no host beyond loopback, so if that " +
+        "flag opens the socket the request guard will refuse honest clients on this interface " +
+        "and admit spoofed loopback ones. Name the hosts that should reach it in that variable.",
+    );
+  }
+} else if (plan.widened) {
+  console.error(
+    `career-ops web: binding ${plan.bindHost} — reachable from your network ` +
+      `(allowed hosts: ${plan.allowedHosts.join(", ")}).`,
+  );
+  if (plan.loopbackUnreachable) {
+    console.error(
+      `career-ops web: one socket carries one address, so http://localhost:PORT will not answer — ` +
+        `open it at ${plan.bindHost}. Name a loopback host alongside it to bind every interface instead.`,
     );
   }
 } else {
-  console.error(`career-ops web: binding ${plan.effectiveBindHost} — loopback only.`);
+  console.error(`career-ops web: binding ${plan.bindHost} — loopback only.`);
 }
 
 // next's declared entry, not the private dist path: node_modules/.bin/next is a

--- a/web/src/lib/bind-host.mjs
+++ b/web/src/lib/bind-host.mjs
@@ -17,10 +17,17 @@
 // nothing listening for it. planNextRun reports the first; the README documents
 // both.
 //
-// Pure: no node imports, no process state. server.mjs passes the environment in
-// and acts on what comes back, so the whole decision is testable on values
-// rather than inferred from the launcher's source text.
+// Pure in the sense that matters: no process state, no I/O. server.mjs passes
+// the environment in and acts on what comes back, so the whole decision is
+// testable on values rather than inferred from the launcher's source text.
+//
+// It does import node:net for isIP. Only server.mjs and the tests import this
+// module — proxy.ts imports origin-guard.mjs, which stays free of node imports
+// for the edge runtime — so the dependency costs nothing here, and hand-rolling
+// an address parser instead proved to be exactly the wrong trade: the version
+// that counted colons admitted `2001:db8:1` as a bind target.
 
+import { isIP } from "node:net";
 import { parseAllowedHosts, isLoopbackHost } from "./origin-guard.mjs";
 
 export const LOOPBACK_BIND = "127.0.0.1";
@@ -46,40 +53,23 @@ const URL_SCHEMES = Object.freeze(new Set(["http", "https"]));
 const HOSTNAME_LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
 /**
- * A dotted-quad IPv4 literal, rejecting the leading-zero form.
+ * An IPv4 or IPv6 literal, already unbracketed by parseAllowedHosts.
  *
- * `010.0.0.1` is read as octal by some resolvers and as decimal by others, which
- * makes it a poor thing to hand a bind call or compare an allow-list against.
+ * Node's own parser rather than a hand-rolled one. The first version here
+ * counted colons and hex digits, which accepted incomplete addresses like
+ * `2001:db8:1` — enough to be treated as a bindable literal and handed to
+ * `next -H`, where listen() then refused to start the server. Being lenient here
+ * cannot fail safe, because whatever this admits becomes a bind target.
  *
- * @param {string} host
- * @returns {boolean}
- */
-function isIPv4Literal(host) {
-  const octets = host.split(".");
-  return (
-    octets.length === 4 &&
-    octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255 && String(Number(o)) === o)
-  );
-}
-
-/**
- * An IPv6 literal, already unbracketed by parseAllowedHosts.
- *
- * Deliberately shallow — hex groups and at most one `::` run. A malformed
- * address that slips through fails loudly at listen() with the address in the
- * message; the point here is to separate addresses from words, not to
- * reimplement inet_pton.
+ * isIP also rejects the leading-zero form `010.0.0.1`, which some resolvers read
+ * as octal and others as decimal — a poor thing to bind or to compare an
+ * allow-list against.
  *
  * @param {string} host
  * @returns {boolean}
  */
-function isIPv6Literal(host) {
-  if (!host.includes(":") || !/^[0-9a-f:]+$/.test(host)) return false;
-  return host.split("::").length <= 2 && host.split(":").filter(Boolean).length <= 8;
-}
-
 function isIPLiteral(host) {
-  return isIPv4Literal(host) || isIPv6Literal(host);
+  return isIP(host) !== 0;
 }
 
 /**

--- a/web/src/lib/bind-host.mjs
+++ b/web/src/lib/bind-host.mjs
@@ -1,19 +1,21 @@
 // bind-host.mjs — what interface the dashboard listens on, and the argv that says so.
 //
-// The socket is the dashboard's access control. `next dev` / `next start` with
-// no -H reach server.listen(port, undefined), which binds every interface, and
-// the request guard cannot compensate: Host is chosen by the client, so a LAN
-// caller spelling `Host: localhost` satisfies it. See origin-guard.mjs's header
-// for the full threat model — this module owns only the bind half of it.
+// The socket is the dashboard's outermost access control. `next dev` /
+// `next start` with no -H reach server.listen(port, undefined), which binds every
+// interface, and the request guard cannot compensate: Host is chosen by the
+// client, so a LAN caller spelling `Host: localhost` satisfies it. See
+// origin-guard.mjs's header for the full threat model — this module owns only the
+// bind half of it, and the bind is not the whole of it.
 //
 // Kept out of origin-guard.mjs, which is per-request decision logic pinned to
 // the edge runtime. Both read CAREER_OPS_WEB_ALLOWED_HOSTS through the same
 // parseAllowedHosts, so neither can widen on that variable without the other.
 //
 // That is the limit of the guarantee, and the two layers do diverge elsewhere:
-// a caller's -H moves the bind with the allow-list untouched, and 0.0.0.0 is
-// IPv4-only, so an opted-in IPv6 host passes the filter with nothing listening
-// for it. planNextRun reports the first; the README documents both.
+// a caller's own -H moves the bind with the allow-list untouched, and a fallback
+// bind of 0.0.0.0 is IPv4-only, so an opted-in IPv6 host passes the filter with
+// nothing listening for it. planNextRun reports the first; the README documents
+// both.
 //
 // Pure: no node imports, no process state. server.mjs passes the environment in
 // and acts on what comes back, so the whole decision is testable on values
@@ -27,34 +29,158 @@ export const ALL_INTERFACES_BIND = "0.0.0.0";
 /** The `next` subcommands this launcher fronts. */
 export const NEXT_COMMANDS = Object.freeze(["dev", "start"]);
 
-/** Spellings of next's hostname option, in both `-H x` and `--hostname=x` forms. */
-const HOST_FLAGS = Object.freeze(["-H", "--hostname"]);
+// Values a user reaches for after reading the variable's name as a switch.
+// Every one of them is a syntactically valid hostname, so only an explicit list
+// catches them — and each would otherwise be a non-loopback host, i.e. an opt-in
+// to full network exposure typed by someone trying to turn exposure OFF.
+const SWITCH_LIKE = Object.freeze(
+  new Set(["on", "off", "true", "false", "yes", "no", "0", "1", "none", "all", "enable", "enabled", "disable", "disabled"]),
+);
+
+// A URL written where a host belongs. Host-header normalization cuts at the
+// first colon, so `http://192.168.1.50` arrives here as the bare name `http` —
+// a valid hostname, and a non-loopback one, so it too would have opened the
+// socket while looking like it named an address.
+const URL_SCHEMES = Object.freeze(new Set(["http", "https"]));
+
+const HOSTNAME_LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * A dotted-quad IPv4 literal, rejecting the leading-zero form.
+ *
+ * `010.0.0.1` is read as octal by some resolvers and as decimal by others, which
+ * makes it a poor thing to hand a bind call or compare an allow-list against.
+ *
+ * @param {string} host
+ * @returns {boolean}
+ */
+function isIPv4Literal(host) {
+  const octets = host.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255 && String(Number(o)) === o)
+  );
+}
+
+/**
+ * An IPv6 literal, already unbracketed by parseAllowedHosts.
+ *
+ * Deliberately shallow — hex groups and at most one `::` run. A malformed
+ * address that slips through fails loudly at listen() with the address in the
+ * message; the point here is to separate addresses from words, not to
+ * reimplement inet_pton.
+ *
+ * @param {string} host
+ * @returns {boolean}
+ */
+function isIPv6Literal(host) {
+  if (!host.includes(":") || !/^[0-9a-f:]+$/.test(host)) return false;
+  return host.split("::").length <= 2 && host.split(":").filter(Boolean).length <= 8;
+}
+
+function isIPLiteral(host) {
+  return isIPv4Literal(host) || isIPv6Literal(host);
+}
+
+/**
+ * Is this a host someone could plausibly have meant?
+ *
+ * @param {string} host  a single entry, already lowercased and port-stripped
+ * @returns {boolean}
+ */
+function isPlausibleHost(host) {
+  if (isIPLiteral(host)) return true;
+  if (host.length > 253) return false;
+  const labels = host.replace(/\.$/, "").split("."); // a trailing root dot is a valid FQDN
+  if (!labels.every((label) => label.length <= 63 && HOSTNAME_LABEL.test(label))) return false;
+  // Having already failed isIPLiteral, an all-numeric final label means a
+  // malformed address — `10.0.0.999` — rather than a name anything could
+  // resolve (RFC 1123 §2.1 forbids a wholly numeric top-level label).
+  return !/^\d+$/.test(labels[labels.length - 1]);
+}
+
+/**
+ * The opted-in hosts, or a refusal naming what could not be read as a host.
+ *
+ * Fails fast rather than widening on nonsense: every value this rejects would
+ * otherwise have counted as a non-loopback host and opened the socket to the
+ * whole network, which is the opposite of what someone typing `off` intends.
+ *
+ * @param {string|undefined} envValue  CAREER_OPS_WEB_ALLOWED_HOSTS
+ * @returns {{ok: true, hosts: string[]} | {ok: false, error: string}}
+ */
+export function validateAllowedHosts(envValue) {
+  const hosts = [...parseAllowedHosts(envValue)];
+  for (const host of hosts) {
+    if (SWITCH_LIKE.has(host)) {
+      return {
+        ok: false,
+        error:
+          `CAREER_OPS_WEB_ALLOWED_HOSTS="${host}" is not a switch — it is the list of hosts allowed to\n` +
+          "reach the dashboard, and any name in it opens the socket beyond this machine.\n" +
+          "Unset the variable to stay on loopback, or name the hosts that should reach it.",
+      };
+    }
+    if (URL_SCHEMES.has(host)) {
+      return {
+        ok: false,
+        error:
+          "CAREER_OPS_WEB_ALLOWED_HOSTS takes hosts, not URLs — a scheme is cut off at the colon,\n" +
+          "leaving the name of the scheme itself as the allowed host.\n" +
+          'Write the host alone, e.g. CAREER_OPS_WEB_ALLOWED_HOSTS="192.168.1.50".',
+      };
+    }
+    if (!isPlausibleHost(host)) {
+      return {
+        ok: false,
+        error:
+          `CAREER_OPS_WEB_ALLOWED_HOSTS contains "${host}", which is not a hostname or IP address.\n` +
+          "Separate entries with commas or spaces, e.g. CAREER_OPS_WEB_ALLOWED_HOSTS=\"192.168.1.50, nas.local\".",
+      };
+    }
+  }
+  return { ok: true, hosts };
+}
 
 /**
  * Which interface to listen on, given the opt-in.
  *
- * Widens only for a host that loopback cannot already serve. Naming a loopback
- * host (`localhost`, `127.0.0.1`, `::1`) is not an opt-in to anything: the Host
- * filter admits loopback unconditionally, so widening for it would open every
- * interface while granting no host that was not already allowed — full LAN
- * exposure from a value a user could reasonably read as a no-op, or even as a
- * tightening.
+ * Three outcomes, narrowest first:
+ *
+ *   - Loopback, when nothing is named that loopback cannot already serve. Naming
+ *     a loopback host (`localhost`, `127.0.0.1`, `::1`) is not an opt-in to
+ *     anything: the Host filter admits loopback unconditionally, so widening for
+ *     it would open every interface while granting no host that was not already
+ *     allowed — full network exposure from a value a user could reasonably read
+ *     as a no-op, or even as a tightening.
+ *   - That address alone, when exactly one host is named and it is an IP
+ *     literal. Binding 0.0.0.0 for it would also publish the dashboard on every
+ *     other interface the machine happens to have — a VPN tunnel, a phone
+ *     hotspot — none of which was asked for. The cost is that loopback stops
+ *     answering, since one socket carries one address; naming a loopback host
+ *     alongside it is how a caller asks for both and accepts 0.0.0.0.
+ *   - 0.0.0.0, otherwise: a hostname needs a resolver this module deliberately
+ *     does not have, and two addresses cannot share one socket.
+ *
+ * Assumes validateAllowedHosts has already accepted the value.
  *
  * @param {string|undefined} envValue  CAREER_OPS_WEB_ALLOWED_HOSTS
- * @returns {"0.0.0.0"|"127.0.0.1"}
+ * @returns {string}
  */
 export function resolveBindHost(envValue) {
-  for (const host of parseAllowedHosts(envValue)) {
-    if (!isLoopbackHost(host)) return ALL_INTERFACES_BIND;
-  }
-  return LOOPBACK_BIND;
+  const named = [...parseAllowedHosts(envValue)];
+  const reachable = named.filter((host) => !isLoopbackHost(host));
+  if (reachable.length === 0) return LOOPBACK_BIND;
+  const loopbackAlsoNamed = reachable.length !== named.length;
+  if (!loopbackAlsoNamed && reachable.length === 1 && isIPLiteral(reachable[0])) return reachable[0];
+  return ALL_INTERFACES_BIND;
 }
 
 /**
  * Is this bind reachable from outside the machine?
  *
- * Asked of the host itself rather than compared against LOOPBACK_BIND, so a
- * future third value (`::1`, a specific interface) cannot silently invert the
+ * Asked of the host itself rather than compared against LOOPBACK_BIND, so the
+ * specific-address and all-interfaces binds above cannot silently invert the
  * warning that depends on it.
  *
  * @param {string} bindHost
@@ -65,60 +191,46 @@ export function isWidenedBind(bindHost) {
 }
 
 /**
- * The last hostname a caller supplied in forwarded argv, if any.
+ * Did the caller supply next's hostname flag themselves?
  *
- * next parses with commander, where a repeated option keeps the LAST value — so
- * this, not the resolved bind, is what the server will actually listen on.
+ * Presence only — not the value. next parses with commander, and reproducing its
+ * resolution here (attached `-H0.0.0.0`, `--hostname=`, last-of-repeated) is a
+ * standing bet against a dependency, one this launcher has already lost once:
+ * a missed spelling made it announce loopback while every interface was open.
+ * Knowing only that the flag is there is enough to hand the decision back to
+ * next and say so, and it cannot drift as next's parser changes.
+ *
+ * Erring towards a false positive is safe — the launcher forwards argv untouched
+ * and warns — so the short form is matched on its prefix, which has no false
+ * negative. No other `next dev` / `next start` option begins with `-H`.
  *
  * @param {string[]} extra
- * @returns {string|null}
+ * @returns {boolean}
  */
-function overriddenHost(extra) {
-  let found = null;
-  for (let i = 0; i < extra.length; i++) {
-    const token = String(extra[i]);
-
-    // Commander's attached short form, `-H0.0.0.0`. Missing it is not a silent
-    // no-op: next honours the flag and binds every interface while the startup
-    // notice, computed from the resolved bind, announces loopback. `--hostname`
-    // starts with `--`, so it cannot be caught here by accident.
-    if (token.startsWith("-H") && token.length > 2) {
-      found = token.slice(2);
-      continue;
-    }
-
-    const [name, attached] = token.split(/=(.*)/s);
-    if (!HOST_FLAGS.includes(name)) continue;
-    // A separated value is only a value if it is not the next flag: `-H -p 4000`
-    // would otherwise be reported as "binding -p".
-    const separated = extra[i + 1] !== undefined && !String(extra[i + 1]).startsWith("-")
-      ? extra[i + 1]
-      : undefined;
-    const value = attached !== undefined ? attached : separated;
-    if (value !== undefined) found = value;
-  }
-  return found;
+export function hasHostFlag(extra) {
+  return extra.some((token) => {
+    const flag = String(token);
+    return flag.startsWith("-H") || flag === "--hostname" || flag.startsWith("--hostname=");
+  });
 }
 
 /**
  * The argv for a `next` run, plus what it will actually expose.
  *
- * `-H` is forwarded rather than refused: it is a flag someone typed
- * deliberately, and Next accepts it. But because commander keeps the last value,
- * a caller-supplied `-H` overrides the resolved bind — and if it widens while
- * CAREER_OPS_WEB_ALLOWED_HOSTS is empty, the result is an open port whose filter
- * names nobody: honest LAN clients get 403, a client spoofing `Host: localhost`
- * gets through. That combination cannot be prevented without refusing the flag,
- * so it is reported instead. `widened` is therefore computed from the EFFECTIVE
- * host, never from the env value, so the warning can never go quiet while the
- * socket is open.
+ * The bind is injected only when the caller supplied no hostname flag of their
+ * own. `-H` is theirs to pass — they typed it deliberately and next accepts it —
+ * so rather than appending a second one and relying on how commander resolves the
+ * duplicate, the launcher stands aside and reports that next now owns the
+ * decision. The run may well be network-reachable; nothing here can say it is
+ * loopback, so nothing here does.
  *
  * @param {object} input
  * @param {string|undefined} input.command   argv[2] — a NEXT_COMMANDS entry
  * @param {string[]} [input.extra]           remaining argv, forwarded verbatim
  * @param {string|undefined} input.envValue  CAREER_OPS_WEB_ALLOWED_HOSTS
- * @returns {{ok: true, argv: string[], bindHost: string, effectiveBindHost: string,
- *            widened: boolean, overridden: boolean, allowedHosts: string[]}
+ * @returns {{ok: true, argv: string[], bindHost: string, hostFlagSupplied: boolean,
+ *            widened: boolean, allowedHosts: string[], grantsNoNewHost: boolean,
+ *            loopbackUnreachable: boolean}
  *          | {ok: false, error: string}}
  */
 export function planNextRun({ command, extra = [], envValue }) {
@@ -131,31 +243,35 @@ export function planNextRun({ command, extra = [], envValue }) {
     };
   }
 
-  const bindHost = resolveBindHost(envValue);
-  const override = overriddenHost(extra);
-  // An empty value is not "no override": Node binds every interface for
-  // listen(port, "") exactly as it does for undefined, so `-H ""` widens the
-  // socket. Naming it here keeps the notice readable and, more importantly,
-  // keeps it truthful — reporting the empty string as the bind would be
-  // accurate and useless, and treating it as absent would hide a real exposure.
-  const effectiveBindHost =
-    override === null ? bindHost : override.trim() === "" ? ALL_INTERFACES_BIND : override;
+  const validation = validateAllowedHosts(envValue);
+  if (!validation.ok) return validation;
 
-  const allowedHosts = [...parseAllowedHosts(envValue)];
+  const { hosts: allowedHosts } = validation;
+  const bindHost = resolveBindHost(envValue);
+  const hostFlagSupplied = hasHostFlag(extra);
+  const widened = isWidenedBind(bindHost);
+
   return {
     ok: true,
-    argv: [command, "-H", bindHost, ...extra],
+    argv: hostFlagSupplied ? [command, ...extra] : [command, "-H", bindHost, ...extra],
     bindHost,
-    effectiveBindHost,
-    widened: isWidenedBind(effectiveBindHost),
-    overridden: override !== null,
+    hostFlagSupplied,
+    // Describes the resolved bind, which is what next listens on unless the
+    // caller supplied their own flag — hence read together with hostFlagSupplied,
+    // never on its own.
+    widened,
     allowedHosts,
     // Whether the filter names anyone loopback could not already serve. An open
     // socket in this state has no honest reading: it refuses LAN clients that
     // identify themselves truthfully and admits any that spell `Host: localhost`.
-    // Asked of the hosts rather than of the list's length, because
-    // CAREER_OPS_WEB_ALLOWED_HOSTS=localhost is a non-empty list that grants
-    // exactly nothing — the case that used to slip through silently.
+    // Only reachable via a caller's own -H — the env var cannot widen the bind
+    // without naming such a host — and asked of the hosts rather than of the
+    // list's length, because CAREER_OPS_WEB_ALLOWED_HOSTS=localhost is a
+    // non-empty list that grants exactly nothing.
     grantsNoNewHost: !allowedHosts.some((host) => !isLoopbackHost(host)),
+    // A single named address carries the whole socket, so http://localhost:PORT
+    // stops answering. Worth saying out loud: the symptom otherwise looks like a
+    // server that failed to start.
+    loopbackUnreachable: !hostFlagSupplied && widened && bindHost !== ALL_INTERFACES_BIND,
   };
 }

--- a/web/src/lib/bind-host.mjs
+++ b/web/src/lib/bind-host.mjs
@@ -107,6 +107,29 @@ function isUnscopedLinkLocalV6(host) {
 }
 
 /**
+ * An IP literal that cannot identify one TCP listener interface.
+ *
+ * IPv4 multicast is 224.0.0.0/4, IPv6 multicast is ff00::/8, and
+ * 255.255.255.255 is the IPv4 limited-broadcast address. A subnet-directed
+ * broadcast such as 192.168.1.255 cannot be classified from the address alone:
+ * it depends on the machine's interface prefix, which this pure planner does
+ * not inspect.
+ *
+ * Assumes the normalized, lower-case spelling returned by parseAllowedHosts.
+ *
+ * @param {string} host
+ * @returns {boolean}
+ */
+function isNonUnicastAddress(host) {
+  const version = isIP(host);
+  if (version === 4) {
+    const firstOctet = Number(host.slice(0, host.indexOf(".")));
+    return (firstOctet >= 224 && firstOctet <= 239) || host === "255.255.255.255";
+  }
+  return version === 6 && host.startsWith("ff");
+}
+
+/**
  * Is this a host someone could plausibly have meant?
  *
  * @param {string} host  a single entry, already lowercased and port-stripped
@@ -163,6 +186,15 @@ export function validateAllowedHosts(envValue) {
           `CAREER_OPS_WEB_ALLOWED_HOSTS contains the link-local address "${host}", which is ambiguous\n` +
           "across interfaces and cannot be bound without a zone index. Use a routable address or a\n" +
           "hostname instead.",
+      };
+    }
+    if (isNonUnicastAddress(host)) {
+      return {
+        ok: false,
+        error:
+          `CAREER_OPS_WEB_ALLOWED_HOSTS contains "${host}", which is not a unicast address and\n` +
+          "cannot identify one interface for a TCP listener. Use a unicast address or a hostname\n" +
+          "instead.",
       };
     }
     if (URL_SCHEMES.has(host)) {

--- a/web/src/lib/bind-host.mjs
+++ b/web/src/lib/bind-host.mjs
@@ -1,0 +1,161 @@
+// bind-host.mjs — what interface the dashboard listens on, and the argv that says so.
+//
+// The socket is the dashboard's access control. `next dev` / `next start` with
+// no -H reach server.listen(port, undefined), which binds every interface, and
+// the request guard cannot compensate: Host is chosen by the client, so a LAN
+// caller spelling `Host: localhost` satisfies it. See origin-guard.mjs's header
+// for the full threat model — this module owns only the bind half of it.
+//
+// Kept out of origin-guard.mjs, which is per-request decision logic pinned to
+// the edge runtime. Both read CAREER_OPS_WEB_ALLOWED_HOSTS through the same
+// parseAllowedHosts, so neither can widen on that variable without the other.
+//
+// That is the limit of the guarantee, and the two layers do diverge elsewhere:
+// a caller's -H moves the bind with the allow-list untouched, and 0.0.0.0 is
+// IPv4-only, so an opted-in IPv6 host passes the filter with nothing listening
+// for it. planNextRun reports the first; the README documents both.
+//
+// Pure: no node imports, no process state. server.mjs passes the environment in
+// and acts on what comes back, so the whole decision is testable on values
+// rather than inferred from the launcher's source text.
+
+import { parseAllowedHosts, isLoopbackHost } from "./origin-guard.mjs";
+
+export const LOOPBACK_BIND = "127.0.0.1";
+export const ALL_INTERFACES_BIND = "0.0.0.0";
+
+/** The `next` subcommands this launcher fronts. */
+export const NEXT_COMMANDS = Object.freeze(["dev", "start"]);
+
+/** Spellings of next's hostname option, in both `-H x` and `--hostname=x` forms. */
+const HOST_FLAGS = Object.freeze(["-H", "--hostname"]);
+
+/**
+ * Which interface to listen on, given the opt-in.
+ *
+ * Widens only for a host that loopback cannot already serve. Naming a loopback
+ * host (`localhost`, `127.0.0.1`, `::1`) is not an opt-in to anything: the Host
+ * filter admits loopback unconditionally, so widening for it would open every
+ * interface while granting no host that was not already allowed — full LAN
+ * exposure from a value a user could reasonably read as a no-op, or even as a
+ * tightening.
+ *
+ * @param {string|undefined} envValue  CAREER_OPS_WEB_ALLOWED_HOSTS
+ * @returns {"0.0.0.0"|"127.0.0.1"}
+ */
+export function resolveBindHost(envValue) {
+  for (const host of parseAllowedHosts(envValue)) {
+    if (!isLoopbackHost(host)) return ALL_INTERFACES_BIND;
+  }
+  return LOOPBACK_BIND;
+}
+
+/**
+ * Is this bind reachable from outside the machine?
+ *
+ * Asked of the host itself rather than compared against LOOPBACK_BIND, so a
+ * future third value (`::1`, a specific interface) cannot silently invert the
+ * warning that depends on it.
+ *
+ * @param {string} bindHost
+ * @returns {boolean}
+ */
+export function isWidenedBind(bindHost) {
+  return !isLoopbackHost(bindHost);
+}
+
+/**
+ * The last hostname a caller supplied in forwarded argv, if any.
+ *
+ * next parses with commander, where a repeated option keeps the LAST value — so
+ * this, not the resolved bind, is what the server will actually listen on.
+ *
+ * @param {string[]} extra
+ * @returns {string|null}
+ */
+function overriddenHost(extra) {
+  let found = null;
+  for (let i = 0; i < extra.length; i++) {
+    const token = String(extra[i]);
+
+    // Commander's attached short form, `-H0.0.0.0`. Missing it is not a silent
+    // no-op: next honours the flag and binds every interface while the startup
+    // notice, computed from the resolved bind, announces loopback. `--hostname`
+    // starts with `--`, so it cannot be caught here by accident.
+    if (token.startsWith("-H") && token.length > 2) {
+      found = token.slice(2);
+      continue;
+    }
+
+    const [name, attached] = token.split(/=(.*)/s);
+    if (!HOST_FLAGS.includes(name)) continue;
+    // A separated value is only a value if it is not the next flag: `-H -p 4000`
+    // would otherwise be reported as "binding -p".
+    const separated = extra[i + 1] !== undefined && !String(extra[i + 1]).startsWith("-")
+      ? extra[i + 1]
+      : undefined;
+    const value = attached !== undefined ? attached : separated;
+    if (value !== undefined) found = value;
+  }
+  return found;
+}
+
+/**
+ * The argv for a `next` run, plus what it will actually expose.
+ *
+ * `-H` is forwarded rather than refused: it is a flag someone typed
+ * deliberately, and Next accepts it. But because commander keeps the last value,
+ * a caller-supplied `-H` overrides the resolved bind — and if it widens while
+ * CAREER_OPS_WEB_ALLOWED_HOSTS is empty, the result is an open port whose filter
+ * names nobody: honest LAN clients get 403, a client spoofing `Host: localhost`
+ * gets through. That combination cannot be prevented without refusing the flag,
+ * so it is reported instead. `widened` is therefore computed from the EFFECTIVE
+ * host, never from the env value, so the warning can never go quiet while the
+ * socket is open.
+ *
+ * @param {object} input
+ * @param {string|undefined} input.command   argv[2] — a NEXT_COMMANDS entry
+ * @param {string[]} [input.extra]           remaining argv, forwarded verbatim
+ * @param {string|undefined} input.envValue  CAREER_OPS_WEB_ALLOWED_HOSTS
+ * @returns {{ok: true, argv: string[], bindHost: string, effectiveBindHost: string,
+ *            widened: boolean, overridden: boolean, allowedHosts: string[]}
+ *          | {ok: false, error: string}}
+ */
+export function planNextRun({ command, extra = [], envValue }) {
+  if (!NEXT_COMMANDS.includes(command)) {
+    return {
+      ok: false,
+      error:
+        `Usage: node server.mjs <${NEXT_COMMANDS.join("|")}> [next options]\n` +
+        "Run it through npm: `npm run dev` / `npm start` (extra flags after --).",
+    };
+  }
+
+  const bindHost = resolveBindHost(envValue);
+  const override = overriddenHost(extra);
+  // An empty value is not "no override": Node binds every interface for
+  // listen(port, "") exactly as it does for undefined, so `-H ""` widens the
+  // socket. Naming it here keeps the notice readable and, more importantly,
+  // keeps it truthful — reporting the empty string as the bind would be
+  // accurate and useless, and treating it as absent would hide a real exposure.
+  const effectiveBindHost =
+    override === null ? bindHost : override.trim() === "" ? ALL_INTERFACES_BIND : override;
+
+  const allowedHosts = [...parseAllowedHosts(envValue)];
+  return {
+    ok: true,
+    argv: [command, "-H", bindHost, ...extra],
+    bindHost,
+    effectiveBindHost,
+    widened: isWidenedBind(effectiveBindHost),
+    overridden: override !== null,
+    allowedHosts,
+    // Whether the filter names anyone loopback could not already serve. An open
+    // socket in this state has no honest reading: it refuses LAN clients that
+    // identify themselves truthfully and admits any that spell `Host: localhost`.
+    // Asked of the hosts rather than of the list's length, because
+    // CAREER_OPS_WEB_ALLOWED_HOSTS=localhost is a non-empty list that grants
+    // exactly nothing — the case that used to slip through silently.
+    grantsNoNewHost: !allowedHosts.some((host) => !isLoopbackHost(host)),
+  };
+}

--- a/web/src/lib/bind-host.mjs
+++ b/web/src/lib/bind-host.mjs
@@ -83,6 +83,40 @@ function isIPLiteral(host) {
 }
 
 /**
+ * Is this address "every interface" rather than one of them?
+ *
+ * Covers `0.0.0.0` and every spelling of the IPv6 wildcard (`::`, `0::0`,
+ * `0:0:0:0:0:0:0:0`). Both are bind targets, never identities a client can be
+ * addressed by, so they mean something different in a bind than in a host list.
+ *
+ * Exported because it guards two unrelated decisions — refusing a wildcard in
+ * the allow-list, and refusing to claim loopback is lost on a wildcard bind —
+ * and validation makes the second unreachable through planNextRun. Tested
+ * directly so that guard stays falsifiable rather than becoming decoration.
+ *
+ * @param {string} host
+ * @returns {boolean}
+ */
+export function isWildcardAddress(host) {
+  return host === ALL_INTERFACES_BIND || (host.includes(":") && /^[0:]+$/.test(host));
+}
+
+/**
+ * An IPv6 link-local address (fe80::/10) with no zone index.
+ *
+ * A link-local address is ambiguous across interfaces, so binding one requires
+ * a zone (`fe80::1%en0`) — without it listen() fails. The scoped spelling is
+ * refused earlier as a hostname, since `%` is not a host character, so this
+ * only has to catch the bare form.
+ *
+ * @param {string} host
+ * @returns {boolean}
+ */
+function isUnscopedLinkLocalV6(host) {
+  return /^fe[89ab][0-9a-f]:/.test(host);
+}
+
+/**
  * Is this a host someone could plausibly have meant?
  *
  * @param {string} host  a single entry, already lowercased and port-stripped
@@ -119,6 +153,26 @@ export function validateAllowedHosts(envValue) {
           `CAREER_OPS_WEB_ALLOWED_HOSTS="${host}" is not a switch — it is the list of hosts allowed to\n` +
           "reach the dashboard, and any name in it opens the socket beyond this machine.\n" +
           "Unset the variable to stay on loopback, or name the hosts that should reach it.",
+      };
+    }
+    if (isWildcardAddress(host)) {
+      return {
+        ok: false,
+        error:
+          `CAREER_OPS_WEB_ALLOWED_HOSTS="${host}" names every interface, which is a bind target and\n` +
+          "not a host any client is addressed by. Accepting it opens the socket while the request\n" +
+          "guard still matches Host literally, so honest clients on your network get 403 and only a\n" +
+          `client that spells "Host: ${host}" is let in.\n` +
+          'Name the hosts that should reach it, e.g. CAREER_OPS_WEB_ALLOWED_HOSTS="192.168.1.50".',
+      };
+    }
+    if (isUnscopedLinkLocalV6(host)) {
+      return {
+        ok: false,
+        error:
+          `CAREER_OPS_WEB_ALLOWED_HOSTS contains the link-local address "${host}", which is ambiguous\n` +
+          "across interfaces and cannot be bound without a zone index. Use a routable address or a\n" +
+          "hostname instead.",
       };
     }
     if (URL_SCHEMES.has(host)) {
@@ -272,6 +326,11 @@ export function planNextRun({ command, extra = [], envValue }) {
     // A single named address carries the whole socket, so http://localhost:PORT
     // stops answering. Worth saying out loud: the symptom otherwise looks like a
     // server that failed to start.
-    loopbackUnreachable: !hostFlagSupplied && widened && bindHost !== ALL_INTERFACES_BIND,
+    // Asked of the address rather than compared against the 0.0.0.0 literal: the
+    // IPv6 wildcard is also every interface, loopback included, so comparing to
+    // one spelling would have the launcher announce that localhost stops
+    // answering while it answers fine — a false claim about its own bind, which
+    // is the failure this module exists to prevent.
+    loopbackUnreachable: !hostFlagSupplied && widened && !isWildcardAddress(bindHost),
   };
 }

--- a/web/src/lib/origin-guard.mjs
+++ b/web/src/lib/origin-guard.mjs
@@ -9,6 +9,14 @@
 //   F2 — LAN: a server bound to every interface answers anyone on the same
 //        network directly — no browser, no user, no page visit involved.
 //
+// F1 covers more than the API. A page that re-resolves its own domain to
+// 127.0.0.1 (DNS rebinding) reaches the dashboard from the user's own browser as
+// same-origin, so the page routes — which render the CV, pipeline and reports —
+// are as sensitive as /api and are gated too; see src/proxy.ts's matcher. A
+// loopback bind does not close that, because the browser making the request is
+// already on the machine. What closes it is the Host filter below: the rebound
+// request still carries the attacker's domain in Host.
+//
 // This module is the pure decision logic behind `src/proxy.ts` (Next 16's
 // name for what used to be middleware.ts). It is kept free of node/next
 // imports so it runs on the edge runtime and is unit testable in isolation.
@@ -26,10 +34,13 @@
 //     is NOT derived from that variable.
 //
 // Nothing here closes F2, and nothing here can: Host is chosen by the client,
-// so a LAN request spelling `Host: localhost` satisfies the filter above. Only
-// the interface the server listens on decides who can open the connection at
-// all — see bind-host.mjs, which reads the same env value through the same
-// parseAllowedHosts so the two cannot disagree about what is exposed.
+// so a direct LAN request spelling `Host: localhost` satisfies the filter above.
+// Only the interface the server listens on decides who can open the connection
+// at all — see bind-host.mjs, which reads the same env value through the same
+// parseAllowedHosts so the two cannot disagree about what is exposed. The
+// division is by attacker, not by route: the bind answers callers who connect
+// directly, this module answers callers who arrive through a browser the user
+// already trusts.
 
 /** Lowercase a Host/authority, drop the port, unwrap a bracketed IPv6 literal. */
 export function normalizeHost(hostHeader) {

--- a/web/src/lib/origin-guard.mjs
+++ b/web/src/lib/origin-guard.mjs
@@ -6,12 +6,12 @@
 //
 //   F1 — drive-by: any web page the user visits can POST to
 //        http://localhost:3000/api/... in the background (classic CSRF).
-//   F2 — LAN: if the dev server is bound to 0.0.0.0, anyone on the same
-//        network can hit those routes directly.
+//   F2 — LAN: a server bound to every interface answers anyone on the same
+//        network directly — no browser, no user, no page visit involved.
 //
-// This module is the pure decision logic behind `proxy.ts`. It is kept free of
-// node/next imports so it runs on the edge runtime and is unit testable in
-// isolation. Two independent layers, both must pass:
+// This module is the pure decision logic behind `src/proxy.ts` (Next 16's
+// name for what used to be middleware.ts). It is kept free of node/next
+// imports so it runs on the edge runtime and is unit testable in isolation.
 //
 //   Origin layer (F1): trust Sec-Fetch-Site when the browser sends it, fall
 //     back to comparing Origin against Host for older/non-browser clients.
@@ -21,8 +21,15 @@
 //     sound a signal as same-origin is. That is what a local companion client
 //     needs — a browser extension speaks from a chrome-extension:// origin,
 //     which is always "cross-site" to Fetch Metadata and so blocked outright.
-//   Host layer (F2): only answer on a loopback Host by default; extra hosts
-//     require an explicit opt-in (CAREER_OPS_WEB_ALLOWED_HOSTS).
+//   Host filter: answer only for loopback OR a host that was opted in via
+//     CAREER_OPS_WEB_ALLOWED_HOSTS. Note the loopback half is unconditional and
+//     is NOT derived from that variable.
+//
+// Nothing here closes F2, and nothing here can: Host is chosen by the client,
+// so a LAN request spelling `Host: localhost` satisfies the filter above. Only
+// the interface the server listens on decides who can open the connection at
+// all — see bind-host.mjs, which reads the same env value through the same
+// parseAllowedHosts so the two cannot disagree about what is exposed.
 
 /** Lowercase a Host/authority, drop the port, unwrap a bracketed IPv6 literal. */
 export function normalizeHost(hostHeader) {
@@ -114,7 +121,8 @@ function block(reason) {
  * @returns {{ok: true} | {ok: false, status: number, reason: string}}
  */
 export function checkRequest({ secFetchSite, origin, host, allowedHosts, allowedOrigins }) {
-  // Host layer (F2): must be loopback, or an explicitly opted-in host.
+  // Host filter (see header — NOT the LAN control): loopback, or an opted-in
+  // host. A direct client picks its own Host, so this cannot be what closes F2.
   const normalizedHost = normalizeHost(host);
   if (!normalizedHost) return block("missing Host header");
   const hostAllowed = isLoopbackHost(normalizedHost) || (allowedHosts && allowedHosts.has(normalizedHost));

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -6,10 +6,11 @@ import {
   parseAllowedOrigins,
 } from "@/lib/origin-guard.mjs";
 
-// Single choke point over the API surface. Every /api request is gated on the
-// same-origin + loopback guard before it can reach a route handler (which may
-// spawn a child process or write the user's files). See origin-guard.mjs for
-// the two-layer rationale (F1 drive-by CSRF, F2 LAN reachability).
+// Single choke point over everything the dashboard serves. Every request is
+// gated on the same-origin + loopback guard before it can reach a route handler
+// (which may spawn a child process or write the user's files) or a page (which
+// renders the user's CV, pipeline and reports). See origin-guard.mjs for the
+// two-layer rationale (F1 drive-by CSRF, F2 LAN reachability).
 //
 // Opt in to extra hosts (e.g. a trusted LAN box) with a comma/space separated
 // CAREER_OPS_WEB_ALLOWED_HOSTS; unset means loopback only.
@@ -33,4 +34,12 @@ export function proxy(req: NextRequest) {
   return NextResponse.next();
 }
 
-export const config = { matcher: "/api/:path*" };
+// Everything except build assets. Scoping this to /api left every page route
+// ungated, which loopback does not cover: a page that re-resolves its own domain
+// to 127.0.0.1 (DNS rebinding) fetches /pipeline same-origin from the user's own
+// browser, and force-dynamic pages read the tracker off disk on each request.
+// The Host header carries the attacker's domain there, so the guard refuses it —
+// but only if it runs. Build assets stay out: they are the same for every user,
+// carry nothing of theirs, and a caller who cannot read a page has no use for
+// the chunk that renders it.
+export const config = { matcher: "/((?!_next/static|_next/image|favicon.ico).*)" };

--- a/web/tests/lib/bind-host.test.mjs
+++ b/web/tests/lib/bind-host.test.mjs
@@ -1,13 +1,16 @@
 // The bind decision, tested on values.
 //
 // This is the module the launcher exists to apply, so these are the cases that
-// decide whether the dashboard is reachable from the network. Two of them are
+// decide whether the dashboard is reachable from the network. Several are
 // regressions that shipped once and were caught in review:
 //
 //   - a loopback-only opt-in used to widen the socket to every interface while
 //     granting no host the Host filter did not already admit;
-//   - `widened` used to be read off the env value, so a caller-supplied -H could
-//     open the socket with the startup warning staying silent.
+//   - the widened warning used to be read off the env value, so a caller-supplied
+//     -H could open the socket with the startup notice staying silent;
+//   - any string the loopback predicate rejected counted as an opt-in, so
+//     CAREER_OPS_WEB_ALLOWED_HOSTS=off bound every interface;
+//   - naming one LAN address bound every interface rather than that address.
 //
 // Run:  node --test tests/lib/bind-host.test.mjs
 
@@ -18,15 +21,77 @@ import {
   LOOPBACK_BIND,
   ALL_INTERFACES_BIND,
   NEXT_COMMANDS,
+  validateAllowedHosts,
   resolveBindHost,
   isWidenedBind,
+  hasHostFlag,
   planNextRun,
 } from "../../src/lib/bind-host.mjs";
+
+// --- validateAllowedHosts -------------------------------------------------
+
+test("a value that reads as a switch is refused, not treated as a host", () => {
+  // Given the words someone types to turn exposure OFF. Each is a syntactically
+  // valid hostname, so the loopback predicate rejects it and it used to count as
+  // an opt-in — binding every interface for a user asking for the opposite.
+  for (const envValue of ["off", "false", "no", "0", "none", "disabled"]) {
+    // When the value is validated
+    const result = validateAllowedHosts(envValue);
+    // Then the run is refused with the reason, rather than silently widening
+    assert.equal(result.ok, false, `${JSON.stringify(envValue)} must be refused`);
+    assert.match(result.error, /not a switch/, "the message must explain what the variable is");
+  }
+});
+
+test("a token that is not a hostname or an address is refused", () => {
+  // Given values no resolver could take
+  // `10.0.0.999` and `010.0.0.1` are the near-misses: neither is a valid address,
+  // and both would otherwise have passed as all-numeric "hostnames" and opened
+  // the socket. A leading-zero quad is read as octal by some resolvers and
+  // decimal by others, which is no basis for a bind or an allow-list comparison.
+  for (const envValue of ["what?!", "-nas", "host_name", "10.0.0.999", "010.0.0.1"]) {
+    // When the value is validated
+    const result = validateAllowedHosts(envValue);
+    // Then it fails fast and names the offending token
+    assert.equal(result.ok, false, `${JSON.stringify(envValue)} must be refused`);
+  }
+});
+
+test("a URL written where a host belongs is refused", () => {
+  // Given a URL. Host-header normalization cuts at the first colon, so this
+  // arrives as the bare name `http` — valid, non-loopback, and would have opened
+  // the socket while appearing to name an address.
+  const result = validateAllowedHosts("http://192.168.1.50");
+  // When the value is validated
+  // Then it is refused with the reason, not resolved to the scheme name
+  assert.equal(result.ok, false);
+  assert.match(result.error, /not URLs/);
+});
+
+test("real hosts and addresses are accepted", () => {
+  // Given the spellings the README tells users to write
+  for (const envValue of ["192.168.1.50", "nas.local", "dev-box", "fe80::1", "nas.local.", "a.b, 10.0.0.4"]) {
+    // When the value is validated
+    // Then it is accepted, so a legitimate opt-in is never blocked by the guard
+    assert.equal(validateAllowedHosts(envValue).ok, true, `${JSON.stringify(envValue)} must be accepted`);
+  }
+});
+
+test("an absent or blank value is accepted and names nobody", () => {
+  // Given no opt-in, in each spelling a shell or a stray comma produces
+  for (const envValue of [undefined, "", " ", ",", " , , ", ":3000", "[]"]) {
+    // When the value is validated
+    const result = validateAllowedHosts(envValue);
+    // Then it passes with an empty list — blankness is not a typo
+    assert.equal(result.ok, true, `${JSON.stringify(envValue)} must not be an error`);
+    assert.deepEqual(result.hosts, []);
+  }
+});
 
 // --- resolveBindHost ------------------------------------------------------
 
 test("an absent or blank opt-in keeps the socket on loopback", () => {
-  // Given no opt-in, in each of the spellings a shell or a stray comma produces
+  // Given no opt-in
   for (const envValue of [undefined, "", " ", ",", " , , ", ":3000", "[]"]) {
     // When the bind is resolved
     const bind = resolveBindHost(envValue);
@@ -47,17 +112,33 @@ test("naming only loopback hosts is not an opt-in to anything", () => {
   }
 });
 
-test("naming a host loopback cannot serve widens the bind", () => {
-  // Given a host that is only reachable off-loopback
+test("naming one address binds that address, not every interface", () => {
+  // Given a single IP literal — the documented way to reach one LAN box
   // When the bind is resolved
-  // Then the socket opens so that host can actually connect
+  // Then only that interface is published: 0.0.0.0 would also expose a VPN
+  // tunnel or a phone hotspot that was never opted in to.
+  assert.equal(resolveBindHost("192.168.1.50"), "192.168.1.50");
+  assert.equal(resolveBindHost("192.168.1.50:3000"), "192.168.1.50", "a port is not part of the address");
+  assert.equal(resolveBindHost("fe80::1"), "fe80::1", "an IPv6 literal binds too — 0.0.0.0 could not serve it");
+});
+
+test("naming a loopback host alongside an address opts back into every interface", () => {
+  // Given a caller who wants the LAN box AND their own browser to reach it
+  // When the bind is resolved
+  // Then it widens, because one socket cannot carry two addresses — this is the
+  // documented escape hatch from the single-address bind above
+  assert.equal(resolveBindHost("192.168.1.50, localhost"), ALL_INTERFACES_BIND);
+  assert.equal(resolveBindHost("127.0.0.1 10.0.0.4"), ALL_INTERFACES_BIND);
+});
+
+test("anything the launcher cannot bind to one address falls back to every interface", () => {
+  // Given a hostname, which needs a resolver this module deliberately lacks, or
+  // two addresses, which cannot share a socket
+  // When the bind is resolved
+  // Then it widens rather than guessing
   assert.equal(resolveBindHost("nas.local"), ALL_INTERFACES_BIND);
-  assert.equal(resolveBindHost("192.168.1.50:3000"), ALL_INTERFACES_BIND);
-  assert.equal(
-    resolveBindHost("localhost, 10.0.0.4"),
-    ALL_INTERFACES_BIND,
-    "one non-loopback host among loopback ones is still a real opt-in",
-  );
+  assert.equal(resolveBindHost("10.0.0.4, 10.0.0.5"), ALL_INTERFACES_BIND);
+  assert.equal(resolveBindHost("nas.local, 10.0.0.4"), ALL_INTERFACES_BIND);
 });
 
 test("the bind widens exactly when the opt-in names a non-loopback host", () => {
@@ -71,7 +152,7 @@ test("the bind widens exactly when the opt-in names a non-loopback host", () => 
   ]) {
     const grantsSomethingNew = [...parseAllowedHosts(envValue)].some((h) => !isLoopbackHost(h));
     assert.equal(
-      resolveBindHost(envValue) === ALL_INTERFACES_BIND,
+      isWidenedBind(resolveBindHost(envValue)),
       grantsSomethingNew,
       `${JSON.stringify(envValue)}: the bind must widen iff the filter gains a non-loopback host`,
     );
@@ -81,14 +162,41 @@ test("the bind widens exactly when the opt-in names a non-loopback host", () => 
 // --- isWidenedBind --------------------------------------------------------
 
 test("a bind is widened only when it is not a loopback address", () => {
-  // Given the addresses this module can produce, plus ones a future change might
+  // Given every address this module can now produce
   // When each is classified
-  // Then the answer follows the address itself, not a comparison to one literal
+  // Then the answer follows the address itself, not a comparison to one literal —
+  // which matters more now that a specific LAN address is one of the outcomes
   assert.equal(isWidenedBind(ALL_INTERFACES_BIND), true);
   assert.equal(isWidenedBind(LOOPBACK_BIND), false);
   assert.equal(isWidenedBind("::1"), false, "IPv6 loopback must not read as widened");
   assert.equal(isWidenedBind("127.0.0.2"), false, "the whole 127/8 range is loopback");
   assert.equal(isWidenedBind("192.168.1.50"), true);
+});
+
+// --- hasHostFlag ----------------------------------------------------------
+
+test("every spelling of next's hostname flag is detected", () => {
+  // Given the forms commander accepts, including the attached short form that
+  // was once missed — which made the launcher announce loopback while next
+  // opened every interface
+  for (const extra of [
+    ["-H", "0.0.0.0"], ["-H0.0.0.0"], ["--hostname", "0.0.0.0"], ["--hostname=0.0.0.0"],
+    ["-H"], ["--hostname"], ["-H", ""], ["--hostname="],
+    ["-p", "4000", "-H0.0.0.0"], ["-H", "0.0.0.0", "-H", "127.0.0.1"],
+  ]) {
+    // When argv is scanned
+    // Then the flag is seen regardless of how the value is attached, or absent
+    assert.equal(hasHostFlag(extra), true, `${extra.join(" ")} supplies a hostname flag`);
+  }
+});
+
+test("argv without a hostname flag is left alone", () => {
+  // Given flags the launcher has no opinion about
+  for (const extra of [[], ["-p", "4000"], ["--turbopack"], ["--experimental-https"]]) {
+    // When argv is scanned
+    // Then nothing is mistaken for the hostname flag, so the bind is still injected
+    assert.equal(hasHostFlag(extra), false, `${extra.join(" ")} supplies no hostname flag`);
+  }
 });
 
 // --- planNextRun ----------------------------------------------------------
@@ -104,6 +212,15 @@ test("an unknown or missing command is refused with usage", () => {
   }
 });
 
+test("an unreadable opt-in refuses the run rather than starting a widened server", () => {
+  // Given a value that cannot be a host list
+  const plan = planNextRun({ command: "dev", envValue: "off" });
+  // When a run is planned
+  // Then there is no argv to spawn — failing fast beats binding every interface
+  assert.equal(plan.ok, false);
+  assert.match(plan.error, /CAREER_OPS_WEB_ALLOWED_HOSTS/);
+});
+
 test("each supported command builds argv with the bind ahead of forwarded flags", () => {
   // Given a supported command and a caller's own flag
   for (const command of NEXT_COMMANDS) {
@@ -113,73 +230,78 @@ test("each supported command builds argv with the bind ahead of forwarded flags"
     assert.equal(plan.ok, true);
     assert.deepEqual(plan.argv, [command, "-H", LOOPBACK_BIND, "-p", "4000"]);
     assert.equal(plan.widened, false);
-    assert.equal(plan.overridden, false);
+    assert.equal(plan.hostFlagSupplied, false);
   }
 });
 
 test("an opt-in that widens is reported along with the hosts that caused it", () => {
-  // Given a real opt-in
+  // Given a real opt-in that cannot resolve to a single address
   const plan = planNextRun({ command: "start", envValue: "nas.local, 10.0.0.4" });
   // When the run is planned
   // Then the caller has everything needed to explain the exposure
   assert.equal(plan.ok, true);
   assert.deepEqual(plan.argv, ["start", "-H", ALL_INTERFACES_BIND]);
   assert.equal(plan.widened, true);
-  assert.equal(plan.overridden, false);
+  assert.equal(plan.hostFlagSupplied, false);
+  assert.equal(plan.loopbackUnreachable, false, "0.0.0.0 still answers on loopback");
   assert.deepEqual(plan.allowedHosts.sort(), ["10.0.0.4", "nas.local"]);
 });
 
-test("a caller's -H is forwarded and reported as the effective bind", () => {
-  // Given a deliberate override and no opt-in — the combination that used to
-  // widen the socket in silence, because `widened` was read off the env value
-  for (const extra of [["-H", "0.0.0.0"], ["--hostname", "0.0.0.0"], ["--hostname=0.0.0.0"]]) {
+test("a single-address bind is flagged as costing loopback", () => {
+  // Given the opt-in that now binds one address instead of every interface
+  const plan = planNextRun({ command: "dev", envValue: "192.168.1.50" });
+  // When the run is planned
+  // Then the caller is told localhost will stop answering — the symptom
+  // otherwise looks like a server that failed to start
+  assert.deepEqual(plan.argv, ["dev", "-H", "192.168.1.50"]);
+  assert.equal(plan.widened, true);
+  assert.equal(plan.loopbackUnreachable, true);
+});
+
+test("a caller's own hostname flag hands the bind decision to next", () => {
+  // Given a deliberate override, in each spelling commander accepts. Injecting a
+  // second -H alongside it made this launcher's warning depend on how commander
+  // resolves a duplicate — a bet against a dependency it has already lost once.
+  for (const extra of [
+    ["-H", "0.0.0.0"], ["--hostname", "0.0.0.0"], ["--hostname=0.0.0.0"], ["-H0.0.0.0"],
+    ["-H", ""], ["--hostname="], ["-H"], ["-H", "0.0.0.0", "-H", "127.0.0.1"],
+  ]) {
     // When the run is planned
     const plan = planNextRun({ command: "dev", extra, envValue: undefined });
-    // Then the plan reports what next will actually listen on, not what was resolved
+    // Then argv carries the caller's flag and nothing else, so there is no
+    // duplicate for commander to resolve and no bind for the launcher to assert
     assert.equal(plan.ok, true, `${extra.join(" ")} must still produce a runnable plan`);
-    assert.equal(plan.bindHost, LOOPBACK_BIND, "the resolved bind is unchanged");
-    assert.equal(plan.effectiveBindHost, "0.0.0.0", `${extra.join(" ")} decides the real bind`);
-    assert.equal(plan.widened, true, `${extra.join(" ")} must be reported as widening`);
-    assert.equal(plan.overridden, true);
+    assert.deepEqual(plan.argv, ["dev", ...extra], `${extra.join(" ")} must be forwarded untouched`);
+    assert.equal(plan.hostFlagSupplied, true, `${extra.join(" ")} must be reported as caller-owned`);
     assert.deepEqual(plan.allowedHosts, [], "the filter still names nobody");
   }
 });
 
-test("the attached short form -H0.0.0.0 is recognised as an override", () => {
-  // Given commander's attached spelling, which next honours. Missing it did not
-  // fail safe: the launcher announced the resolved bind while next opened every
-  // interface — a false statement about exposure rather than a silent one.
-  for (const extra of [["-H0.0.0.0"], ["-p", "3000", "-H0.0.0.0"]]) {
-    // When the run is planned with no opt-in
-    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
-    // Then the plan reports the interface next will really listen on
-    assert.equal(plan.effectiveBindHost, "0.0.0.0", `${extra.join(" ")} sets the real bind`);
-    assert.equal(plan.widened, true, `${extra.join(" ")} must be reported as widening`);
-    assert.equal(plan.overridden, true);
-  }
-});
-
-test("a -H whose next token is another flag supplies no host", () => {
-  // Given a malformed invocation next will reject itself
-  const plan = planNextRun({ command: "dev", extra: ["-H", "-p", "4000"], envValue: undefined });
+test("a caller's flag does not silence the resolved bind, it replaces the claim", () => {
+  // Given an override alongside an opt-in that would have widened
+  const plan = planNextRun({ command: "dev", extra: ["-H", "127.0.0.1"], envValue: "nas.local" });
   // When the run is planned
-  // Then `-p` is not mistaken for the hostname, which would announce "binding -p"
-  assert.equal(plan.effectiveBindHost, LOOPBACK_BIND);
-  assert.equal(plan.widened, false);
+  // Then the launcher injects nothing and reports that next owns the bind. The
+  // resolved value is still there for context, but hostFlagSupplied is what any
+  // claim about exposure must be read against.
+  assert.deepEqual(plan.argv, ["dev", "-H", "127.0.0.1"]);
+  assert.equal(plan.hostFlagSupplied, true);
+  assert.equal(plan.bindHost, ALL_INTERFACES_BIND, "the resolved bind is unchanged and unused");
+  assert.equal(plan.loopbackUnreachable, false, "no claim is made about a bind next chooses");
 });
 
 test("an allow-list of only loopback hosts grants nothing new", () => {
-  // Given an opt-in that names hosts the guard already admits, plus an override
-  // that opens the socket — the state that used to print no second notice
+  // Given an opt-in naming hosts the guard already admits, plus a caller's flag
+  // that may open the socket — the state that used to print no second notice
   const plan = planNextRun({
     command: "dev",
     extra: ["-H", "0.0.0.0"],
     envValue: "localhost, 127.0.0.1, ::1",
   });
   // When the run is planned
-  // Then it is flagged: the port is open and the filter names nobody who could
-  // not already reach it on loopback
-  assert.equal(plan.widened, true);
+  // Then it is flagged: if that flag opens the port, the filter names nobody who
+  // could not already reach it on loopback
+  assert.equal(plan.hostFlagSupplied, true);
   assert.equal(plan.grantsNoNewHost, true, "a loopback-only list grants nothing");
 });
 
@@ -189,59 +311,4 @@ test("an allow-list naming a reachable host does grant something", () => {
   // When the run is planned
   // Then the filter is meaningful and the second notice must not fire
   assert.equal(plan.grantsNoNewHost, false);
-});
-
-test("an empty -H value widens the bind, because Node treats it as unset", () => {
-  // Given an override with no value — `-H ""` or `--hostname=`
-  for (const extra of [["-H", ""], ["--hostname="]]) {
-    // When the run is planned
-    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
-    // Then it is reported as widening: listen(port, "") binds every interface
-    // exactly as listen(port, undefined) does, so treating it as "no override"
-    // would silence a warning for a socket that really is open.
-    assert.equal(plan.widened, true, `${extra.join(" ")} opens every interface`);
-    assert.equal(
-      plan.effectiveBindHost,
-      ALL_INTERFACES_BIND,
-      "the notice must name the interface, not echo an empty string",
-    );
-  }
-});
-
-test("a bare -H at the end of argv is not read as an override", () => {
-  // Given a flag with nothing following it — next will reject this itself
-  for (const extra of [["-H"], ["--hostname"], ["-p", "4000", "-H"]]) {
-    // When the run is planned
-    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
-    // Then there is no value to override with, so the resolved bind stands
-    assert.equal(plan.effectiveBindHost, LOOPBACK_BIND, `${extra.join(" ")} supplies no host`);
-    assert.equal(plan.widened, false);
-  }
-});
-
-test("the last -H wins, as next itself resolves a repeated option", () => {
-  // Given a caller who passes the flag twice
-  const plan = planNextRun({
-    command: "dev",
-    extra: ["-H", "0.0.0.0", "-H", "127.0.0.1"],
-    envValue: undefined,
-  });
-  // When the effective bind is computed
-  // Then it matches what commander will hand next, so the warning cannot disagree
-  assert.equal(plan.effectiveBindHost, "127.0.0.1");
-  assert.equal(plan.widened, false, "a narrowing override must not warn");
-});
-
-test("an override that narrows an opted-in bind is not reported as widening", () => {
-  // Given an opt-in that widens, and a caller pulling the bind back to loopback
-  const plan = planNextRun({
-    command: "dev",
-    extra: ["-H", "127.0.0.1"],
-    envValue: "nas.local",
-  });
-  // When the run is planned
-  // Then the resolved bind still widens, but nothing is actually exposed
-  assert.equal(plan.bindHost, ALL_INTERFACES_BIND);
-  assert.equal(plan.effectiveBindHost, "127.0.0.1");
-  assert.equal(plan.widened, false, "the warning must follow the socket, not the env var");
 });

--- a/web/tests/lib/bind-host.test.mjs
+++ b/web/tests/lib/bind-host.test.mjs
@@ -101,6 +101,21 @@ test("an unscoped link-local address is refused", () => {
   assert.equal(validateAllowedHosts("fe80::1%en0").ok, false);
 });
 
+test("multicast and limited-broadcast addresses are refused before planning a bind", () => {
+  // Given address classes that are valid IP syntax but cannot identify one TCP
+  // listener interface. Accepting one would make next fail during listen()
+  // instead of returning the launcher's structured configuration error.
+  for (const envValue of ["224.0.0.1", "239.255.255.250", "255.255.255.255", "ff02::1", "ff0e::dead:beef"]) {
+    // When the value is validated directly and through the public planner
+    const validation = validateAllowedHosts(envValue);
+    const plan = planNextRun({ command: "dev", envValue });
+    // Then neither path produces a bind target
+    assert.equal(validation.ok, false, `${envValue} must be refused`);
+    assert.match(validation.error, /not a unicast address/);
+    assert.deepEqual(plan, validation, `${envValue} must fail before argv is built`);
+  }
+});
+
 test("every spelling of every-interface is recognised as a wildcard", () => {
   // Given the wildcards, and the specific addresses they must not be confused
   // with. `loopbackUnreachable` is derived from this rather than from equality

--- a/web/tests/lib/bind-host.test.mjs
+++ b/web/tests/lib/bind-host.test.mjs
@@ -1,0 +1,247 @@
+// The bind decision, tested on values.
+//
+// This is the module the launcher exists to apply, so these are the cases that
+// decide whether the dashboard is reachable from the network. Two of them are
+// regressions that shipped once and were caught in review:
+//
+//   - a loopback-only opt-in used to widen the socket to every interface while
+//     granting no host the Host filter did not already admit;
+//   - `widened` used to be read off the env value, so a caller-supplied -H could
+//     open the socket with the startup warning staying silent.
+//
+// Run:  node --test tests/lib/bind-host.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseAllowedHosts, isLoopbackHost } from "../../src/lib/origin-guard.mjs";
+import {
+  LOOPBACK_BIND,
+  ALL_INTERFACES_BIND,
+  NEXT_COMMANDS,
+  resolveBindHost,
+  isWidenedBind,
+  planNextRun,
+} from "../../src/lib/bind-host.mjs";
+
+// --- resolveBindHost ------------------------------------------------------
+
+test("an absent or blank opt-in keeps the socket on loopback", () => {
+  // Given no opt-in, in each of the spellings a shell or a stray comma produces
+  for (const envValue of [undefined, "", " ", ",", " , , ", ":3000", "[]"]) {
+    // When the bind is resolved
+    const bind = resolveBindHost(envValue);
+    // Then nothing outside the machine can open a connection
+    assert.equal(bind, LOOPBACK_BIND, `${JSON.stringify(envValue)} must not widen the bind`);
+  }
+});
+
+test("naming only loopback hosts is not an opt-in to anything", () => {
+  // Given a value a user could read as a no-op, or even as a tightening
+  for (const envValue of ["localhost", "127.0.0.1", "::1", "localhost, 127.0.0.1"]) {
+    // When the bind is resolved
+    const bind = resolveBindHost(envValue);
+    // Then the socket stays closed: the Host filter admits loopback whatever
+    // this value says, so widening for it would expose every interface and
+    // grant no host that was not already allowed.
+    assert.equal(bind, LOOPBACK_BIND, `${JSON.stringify(envValue)} grants nothing, so must not widen`);
+  }
+});
+
+test("naming a host loopback cannot serve widens the bind", () => {
+  // Given a host that is only reachable off-loopback
+  // When the bind is resolved
+  // Then the socket opens so that host can actually connect
+  assert.equal(resolveBindHost("nas.local"), ALL_INTERFACES_BIND);
+  assert.equal(resolveBindHost("192.168.1.50:3000"), ALL_INTERFACES_BIND);
+  assert.equal(
+    resolveBindHost("localhost, 10.0.0.4"),
+    ALL_INTERFACES_BIND,
+    "one non-loopback host among loopback ones is still a real opt-in",
+  );
+});
+
+test("the bind widens exactly when the opt-in names a non-loopback host", () => {
+  // Given one shared list spanning every input class above
+  // When each is put through the bind decision and the filter's own parse
+  // Then the two agree — a reimplementation that drifted on any input fails here
+  for (const envValue of [
+    undefined, "", " ", ",", ":3000", "[]",
+    "localhost", "127.0.0.1", "::1", "localhost, ::1",
+    "nas.local", "10.0.0.4", "localhost, 10.0.0.4", "a.local b.local",
+  ]) {
+    const grantsSomethingNew = [...parseAllowedHosts(envValue)].some((h) => !isLoopbackHost(h));
+    assert.equal(
+      resolveBindHost(envValue) === ALL_INTERFACES_BIND,
+      grantsSomethingNew,
+      `${JSON.stringify(envValue)}: the bind must widen iff the filter gains a non-loopback host`,
+    );
+  }
+});
+
+// --- isWidenedBind --------------------------------------------------------
+
+test("a bind is widened only when it is not a loopback address", () => {
+  // Given the addresses this module can produce, plus ones a future change might
+  // When each is classified
+  // Then the answer follows the address itself, not a comparison to one literal
+  assert.equal(isWidenedBind(ALL_INTERFACES_BIND), true);
+  assert.equal(isWidenedBind(LOOPBACK_BIND), false);
+  assert.equal(isWidenedBind("::1"), false, "IPv6 loopback must not read as widened");
+  assert.equal(isWidenedBind("127.0.0.2"), false, "the whole 127/8 range is loopback");
+  assert.equal(isWidenedBind("192.168.1.50"), true);
+});
+
+// --- planNextRun ----------------------------------------------------------
+
+test("an unknown or missing command is refused with usage", () => {
+  // Given argv that names no next subcommand
+  for (const command of [undefined, "", "serve", "--help"]) {
+    // When a run is planned
+    const plan = planNextRun({ command, envValue: undefined });
+    // Then nothing is spawned and the caller is told how to invoke it
+    assert.equal(plan.ok, false, `${JSON.stringify(command)} must not produce a runnable plan`);
+    assert.ok(plan.error.includes("Usage: node server.mjs"), "the refusal must name the usage");
+  }
+});
+
+test("each supported command builds argv with the bind ahead of forwarded flags", () => {
+  // Given a supported command and a caller's own flag
+  for (const command of NEXT_COMMANDS) {
+    // When a run is planned with no opt-in
+    const plan = planNextRun({ command, extra: ["-p", "4000"], envValue: undefined });
+    // Then next is told the bind first, and the caller's flags survive verbatim
+    assert.equal(plan.ok, true);
+    assert.deepEqual(plan.argv, [command, "-H", LOOPBACK_BIND, "-p", "4000"]);
+    assert.equal(plan.widened, false);
+    assert.equal(plan.overridden, false);
+  }
+});
+
+test("an opt-in that widens is reported along with the hosts that caused it", () => {
+  // Given a real opt-in
+  const plan = planNextRun({ command: "start", envValue: "nas.local, 10.0.0.4" });
+  // When the run is planned
+  // Then the caller has everything needed to explain the exposure
+  assert.equal(plan.ok, true);
+  assert.deepEqual(plan.argv, ["start", "-H", ALL_INTERFACES_BIND]);
+  assert.equal(plan.widened, true);
+  assert.equal(plan.overridden, false);
+  assert.deepEqual(plan.allowedHosts.sort(), ["10.0.0.4", "nas.local"]);
+});
+
+test("a caller's -H is forwarded and reported as the effective bind", () => {
+  // Given a deliberate override and no opt-in — the combination that used to
+  // widen the socket in silence, because `widened` was read off the env value
+  for (const extra of [["-H", "0.0.0.0"], ["--hostname", "0.0.0.0"], ["--hostname=0.0.0.0"]]) {
+    // When the run is planned
+    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
+    // Then the plan reports what next will actually listen on, not what was resolved
+    assert.equal(plan.ok, true, `${extra.join(" ")} must still produce a runnable plan`);
+    assert.equal(plan.bindHost, LOOPBACK_BIND, "the resolved bind is unchanged");
+    assert.equal(plan.effectiveBindHost, "0.0.0.0", `${extra.join(" ")} decides the real bind`);
+    assert.equal(plan.widened, true, `${extra.join(" ")} must be reported as widening`);
+    assert.equal(plan.overridden, true);
+    assert.deepEqual(plan.allowedHosts, [], "the filter still names nobody");
+  }
+});
+
+test("the attached short form -H0.0.0.0 is recognised as an override", () => {
+  // Given commander's attached spelling, which next honours. Missing it did not
+  // fail safe: the launcher announced the resolved bind while next opened every
+  // interface — a false statement about exposure rather than a silent one.
+  for (const extra of [["-H0.0.0.0"], ["-p", "3000", "-H0.0.0.0"]]) {
+    // When the run is planned with no opt-in
+    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
+    // Then the plan reports the interface next will really listen on
+    assert.equal(plan.effectiveBindHost, "0.0.0.0", `${extra.join(" ")} sets the real bind`);
+    assert.equal(plan.widened, true, `${extra.join(" ")} must be reported as widening`);
+    assert.equal(plan.overridden, true);
+  }
+});
+
+test("a -H whose next token is another flag supplies no host", () => {
+  // Given a malformed invocation next will reject itself
+  const plan = planNextRun({ command: "dev", extra: ["-H", "-p", "4000"], envValue: undefined });
+  // When the run is planned
+  // Then `-p` is not mistaken for the hostname, which would announce "binding -p"
+  assert.equal(plan.effectiveBindHost, LOOPBACK_BIND);
+  assert.equal(plan.widened, false);
+});
+
+test("an allow-list of only loopback hosts grants nothing new", () => {
+  // Given an opt-in that names hosts the guard already admits, plus an override
+  // that opens the socket — the state that used to print no second notice
+  const plan = planNextRun({
+    command: "dev",
+    extra: ["-H", "0.0.0.0"],
+    envValue: "localhost, 127.0.0.1, ::1",
+  });
+  // When the run is planned
+  // Then it is flagged: the port is open and the filter names nobody who could
+  // not already reach it on loopback
+  assert.equal(plan.widened, true);
+  assert.equal(plan.grantsNoNewHost, true, "a loopback-only list grants nothing");
+});
+
+test("an allow-list naming a reachable host does grant something", () => {
+  // Given an opt-in that names a host loopback cannot serve
+  const plan = planNextRun({ command: "dev", envValue: "nas.local" });
+  // When the run is planned
+  // Then the filter is meaningful and the second notice must not fire
+  assert.equal(plan.grantsNoNewHost, false);
+});
+
+test("an empty -H value widens the bind, because Node treats it as unset", () => {
+  // Given an override with no value — `-H ""` or `--hostname=`
+  for (const extra of [["-H", ""], ["--hostname="]]) {
+    // When the run is planned
+    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
+    // Then it is reported as widening: listen(port, "") binds every interface
+    // exactly as listen(port, undefined) does, so treating it as "no override"
+    // would silence a warning for a socket that really is open.
+    assert.equal(plan.widened, true, `${extra.join(" ")} opens every interface`);
+    assert.equal(
+      plan.effectiveBindHost,
+      ALL_INTERFACES_BIND,
+      "the notice must name the interface, not echo an empty string",
+    );
+  }
+});
+
+test("a bare -H at the end of argv is not read as an override", () => {
+  // Given a flag with nothing following it — next will reject this itself
+  for (const extra of [["-H"], ["--hostname"], ["-p", "4000", "-H"]]) {
+    // When the run is planned
+    const plan = planNextRun({ command: "dev", extra, envValue: undefined });
+    // Then there is no value to override with, so the resolved bind stands
+    assert.equal(plan.effectiveBindHost, LOOPBACK_BIND, `${extra.join(" ")} supplies no host`);
+    assert.equal(plan.widened, false);
+  }
+});
+
+test("the last -H wins, as next itself resolves a repeated option", () => {
+  // Given a caller who passes the flag twice
+  const plan = planNextRun({
+    command: "dev",
+    extra: ["-H", "0.0.0.0", "-H", "127.0.0.1"],
+    envValue: undefined,
+  });
+  // When the effective bind is computed
+  // Then it matches what commander will hand next, so the warning cannot disagree
+  assert.equal(plan.effectiveBindHost, "127.0.0.1");
+  assert.equal(plan.widened, false, "a narrowing override must not warn");
+});
+
+test("an override that narrows an opted-in bind is not reported as widening", () => {
+  // Given an opt-in that widens, and a caller pulling the bind back to loopback
+  const plan = planNextRun({
+    command: "dev",
+    extra: ["-H", "127.0.0.1"],
+    envValue: "nas.local",
+  });
+  // When the run is planned
+  // Then the resolved bind still widens, but nothing is actually exposed
+  assert.equal(plan.bindHost, ALL_INTERFACES_BIND);
+  assert.equal(plan.effectiveBindHost, "127.0.0.1");
+  assert.equal(plan.widened, false, "the warning must follow the socket, not the env var");
+});

--- a/web/tests/lib/bind-host.test.mjs
+++ b/web/tests/lib/bind-host.test.mjs
@@ -24,6 +24,7 @@ import {
   validateAllowedHosts,
   resolveBindHost,
   isWidenedBind,
+  isWildcardAddress,
   hasHostFlag,
   planNextRun,
 } from "../../src/lib/bind-host.mjs";
@@ -57,6 +58,59 @@ test("a token that is not a hostname or an address is refused", () => {
   }
 });
 
+test("an every-interface address is refused as an allowed host", () => {
+  // Given the wildcards, in each spelling. Accepting one was the worst state the
+  // module can reach: the socket opens on every interface while the guard still
+  // matches Host literally, so an honest LAN client gets 403 and only a client
+  // spelling `Host: 0.0.0.0` is admitted — and grantsNoNewHost, which flags that
+  // shape elsewhere, reads false because the list does name a non-loopback host.
+  for (const envValue of ["0.0.0.0", "::", "0::0", "0:0:0:0:0:0:0:0"]) {
+    // When the value is validated
+    const result = validateAllowedHosts(envValue);
+    // Then it is refused: a bind target is not a host identity
+    assert.equal(result.ok, false, `${JSON.stringify(envValue)} must be refused`);
+    assert.match(result.error, /every interface/);
+  }
+});
+
+test("an unscoped link-local address is refused", () => {
+  // Given a link-local address, which is ambiguous across interfaces and cannot
+  // be bound without a zone index — listen() would fail on it
+  for (const envValue of ["fe80::1", "febf::dead:beef"]) {
+    // When the value is validated
+    // Then it is refused rather than accepted as a bindable address
+    assert.equal(validateAllowedHosts(envValue).ok, false, `${envValue} must be refused`);
+  }
+  // And the scoped spelling is refused too, as `%` is not a host character
+  assert.equal(validateAllowedHosts("fe80::1%en0").ok, false);
+});
+
+test("every spelling of every-interface is recognised as a wildcard", () => {
+  // Given the wildcards, and the specific addresses they must not be confused
+  // with. `loopbackUnreachable` is derived from this rather than from equality
+  // with the 0.0.0.0 literal: `::` is the IPv6 wildcard and serves loopback just
+  // as 0.0.0.0 does, so a literal comparison would have the launcher announce
+  // that localhost stops answering while it answers fine.
+  for (const host of [ALL_INTERFACES_BIND, "::", "0::0", "0:0:0:0:0:0:0:0"]) {
+    // When each is classified
+    assert.equal(isWildcardAddress(host), true, `${host} is every interface`);
+  }
+  // Then a real address is not swept up with them
+  for (const host of ["192.168.1.50", "2001:db8::5", LOOPBACK_BIND, "::1", "10.0.0.4"]) {
+    assert.equal(isWildcardAddress(host), false, `${host} is one interface`);
+  }
+});
+
+test("a wildcard bind is never reported as costing loopback", () => {
+  // Given the wildcard bind an opt-in can still produce, via a hostname
+  const plan = planNextRun({ command: "dev", envValue: "nas.local, 10.0.0.4" });
+  // When the run is planned
+  // Then it widens but does not claim localhost stops answering
+  assert.equal(plan.bindHost, ALL_INTERFACES_BIND);
+  assert.equal(plan.widened, true);
+  assert.equal(plan.loopbackUnreachable, false, "a wildcard bind still answers on loopback");
+});
+
 test("a URL written where a host belongs is refused", () => {
   // Given a URL. Host-header normalization cuts at the first colon, so this
   // arrives as the bare name `http` — valid, non-loopback, and would have opened
@@ -70,7 +124,7 @@ test("a URL written where a host belongs is refused", () => {
 
 test("real hosts and addresses are accepted", () => {
   // Given the spellings the README tells users to write
-  for (const envValue of ["192.168.1.50", "nas.local", "dev-box", "fe80::1", "nas.local.", "a.b, 10.0.0.4"]) {
+  for (const envValue of ["192.168.1.50", "nas.local", "dev-box", "2001:db8::5", "nas.local.", "a.b, 10.0.0.4"]) {
     // When the value is validated
     // Then it is accepted, so a legitimate opt-in is never blocked by the guard
     assert.equal(validateAllowedHosts(envValue).ok, true, `${JSON.stringify(envValue)} must be accepted`);
@@ -119,7 +173,7 @@ test("naming one address binds that address, not every interface", () => {
   // tunnel or a phone hotspot that was never opted in to.
   assert.equal(resolveBindHost("192.168.1.50"), "192.168.1.50");
   assert.equal(resolveBindHost("192.168.1.50:3000"), "192.168.1.50", "a port is not part of the address");
-  assert.equal(resolveBindHost("fe80::1"), "fe80::1", "an IPv6 literal binds too — 0.0.0.0 could not serve it");
+  assert.equal(resolveBindHost("2001:db8::5"), "2001:db8::5", "an IPv6 literal binds too — 0.0.0.0 could not serve it");
 });
 
 test("naming a loopback host alongside an address opts back into every interface", () => {

--- a/web/tests/lib/bind-host.test.mjs
+++ b/web/tests/lib/bind-host.test.mjs
@@ -50,7 +50,7 @@ test("a token that is not a hostname or an address is refused", () => {
   // and both would otherwise have passed as all-numeric "hostnames" and opened
   // the socket. A leading-zero quad is read as octal by some resolvers and
   // decimal by others, which is no basis for a bind or an allow-list comparison.
-  for (const envValue of ["what?!", "-nas", "host_name", "10.0.0.999", "010.0.0.1"]) {
+  for (const envValue of ["what?!", "-nas", "host_name", "10.0.0.999", "010.0.0.1", "192.168.1"]) {
     // When the value is validated
     const result = validateAllowedHosts(envValue);
     // Then it fails fast and names the offending token
@@ -71,6 +71,22 @@ test("an every-interface address is refused as an allowed host", () => {
     assert.equal(result.ok, false, `${JSON.stringify(envValue)} must be refused`);
     assert.match(result.error, /every interface/);
   }
+});
+
+test("an incomplete IPv6 address is refused, not treated as a bind target", () => {
+  // Given addresses that look right to a colon-counting check but are not valid.
+  // Leniency here cannot fail safe: whatever validation admits as a literal
+  // becomes the address handed to `next -H`, and listen() then refuses to start
+  // the server at all. The first parser here accepted every one of these.
+  for (const envValue of ["2001:db8:1", "1:2:3", "2001:db8::5::1", "12345::1", "2001:db8:zz::1"]) {
+    // When the value is validated
+    // Then it is refused before it can reach the bind
+    assert.equal(validateAllowedHosts(envValue).ok, false, `${envValue} is not a valid address`);
+  }
+  // And a well-formed address of each family is still accepted, so the check
+  // discriminates rather than simply rejecting anything with colons
+  assert.equal(validateAllowedHosts("2001:db8::5").ok, true);
+  assert.equal(validateAllowedHosts("192.168.1.50").ok, true);
 });
 
 test("an unscoped link-local address is refused", () => {

--- a/web/tests/lib/origin-guard.test.mjs
+++ b/web/tests/lib/origin-guard.test.mjs
@@ -1,5 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   normalizeHost,
   isLoopbackHost,
@@ -8,6 +11,8 @@ import {
   normalizeOrigin,
   checkRequest,
 } from "../../src/lib/origin-guard.mjs";
+
+const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 // --- normalizeHost --------------------------------------------------------
 
@@ -57,6 +62,35 @@ test("parseAllowedHosts returns an empty set for blank/undefined", () => {
 
 // The bind decision that reads this module's parseAllowedHosts lives in
 // bind-host.mjs and is covered by tests/lib/bind-host.test.mjs.
+
+// --- where the guard runs -------------------------------------------------
+
+// A decision this module cannot make about itself: proxy.ts's matcher chooses
+// which requests reach checkRequest at all, and a guard that never runs is
+// indistinguishable from one that always allows. The matcher is a plain regex
+// path, so it is extracted and exercised rather than pattern-matched as text.
+test("the guard runs on page routes, not only on /api", () => {
+  // Given the matcher proxy.ts exports
+  const source = readFileSync(join(WEB_ROOT, "src", "proxy.ts"), "utf8");
+  const matcher = /matcher:\s*"([^"]+)"/.exec(source)?.[1];
+  assert.ok(matcher, "proxy.ts should export a single string matcher");
+  const matches = (path) => new RegExp(`^${matcher}$`).test(path);
+
+  // When the paths that carry the user's data are tested against it
+  // Then they are gated. Scoping this to /api left every page ungated, which a
+  // loopback bind does not cover: a DNS-rebinding page reads /pipeline from the
+  // user's own browser as same-origin, and force-dynamic pages read the tracker
+  // off disk on each request.
+  assert.equal(matches("/"), true, "the dashboard root renders user data");
+  assert.equal(matches("/pipeline"), true, "page routes must be gated");
+  assert.equal(matches("/cv"), true);
+  assert.equal(matches("/api/run"), true, "the API must stay gated");
+
+  // And build assets stay out: they carry no user data, and a 403 on them would
+  // break the very error page that explains the 403.
+  assert.equal(matches("/_next/static/chunks/main.js"), false);
+  assert.equal(matches("/favicon.ico"), false);
+});
 
 // --- checkRequest: the app's own same-origin traffic passes ---------------
 

--- a/web/tests/lib/origin-guard.test.mjs
+++ b/web/tests/lib/origin-guard.test.mjs
@@ -55,6 +55,9 @@ test("parseAllowedHosts returns an empty set for blank/undefined", () => {
   assert.equal(parseAllowedHosts(undefined).size, 0);
 });
 
+// The bind decision that reads this module's parseAllowedHosts lives in
+// bind-host.mjs and is covered by tests/lib/bind-host.test.mjs.
+
 // --- checkRequest: the app's own same-origin traffic passes ---------------
 
 test("allows a same-origin fetch from the local app", () => {
@@ -78,6 +81,11 @@ test("allows a direct address-bar navigation (Sec-Fetch-Site: none)", () => {
 });
 
 test("allows a non-browser client with no Origin and no Sec-Fetch-Site (curl)", () => {
+  // Nothing here distinguishes this caller from one on the LAN spelling a
+  // loopback Host: the header is client-chosen and there is no trustworthy peer
+  // address at this layer. That is why the socket, not this filter, is what
+  // closes LAN reachability — see bind-host.mjs. Hardening this branch later
+  // would be more conservative, not a contradiction.
   const d = checkRequest({
     secFetchSite: null,
     origin: null,
@@ -141,7 +149,7 @@ test("blocks an opaque 'null' Origin", () => {
   assert.equal(d.ok, false);
 });
 
-// --- checkRequest: F2 LAN reachability is blocked unless opted in ---------
+// --- checkRequest: the Host filter, which is NOT the LAN control ----------
 
 test("blocks a request reaching the server on a LAN host, even same-origin", () => {
   const d = checkRequest({

--- a/web/tests/lib/server-launcher.test.mjs
+++ b/web/tests/lib/server-launcher.test.mjs
@@ -208,11 +208,18 @@ test("the child's exit code is forwarded", () => {
   assert.equal(run.status, 3);
 });
 
-test("a signalled child is distinguishable from a startup failure", () => {
+test("a terminated child returns a non-zero platform-native status", () => {
   // Given a next killed by a signal rather than exiting
   // When the launcher wraps it
   const run = launch({ args: ["dev"], body: "process.kill(process.pid, 'SIGTERM');\n" });
-  // Then the exit code is 128+signal, not the 1 that means "could not start"
+  // Windows has no POSIX signal delivery: Node emulates SIGTERM as forced
+  // termination, so only a non-zero native status is portable there. Unix
+  // reports a real signal, which the launcher converts to 128+signal.
+  if (process.platform === "win32") {
+    assert.equal(run.signal, null, "the launcher exits normally after Windows terminates its child");
+    assert.notEqual(run.status, 0, "a terminated child must not look successful");
+    return;
+  }
   assert.equal(run.status, 128 + os.constants.signals.SIGTERM);
   assert.notEqual(run.status, 1, "a killed server must not look like a failed launch");
 });

--- a/web/tests/lib/server-launcher.test.mjs
+++ b/web/tests/lib/server-launcher.test.mjs
@@ -109,7 +109,7 @@ test("an opt-in naming only loopback does not widen the bind", () => {
 });
 
 test("an opt-in naming a real host widens the bind and says so", () => {
-  // Given a host that loopback cannot serve
+  // Given a hostname, which the launcher cannot resolve to one address
   // When the launcher starts next
   const run = launch({ args: ["start"], env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "nas.local" } });
   // Then next binds every interface and the user is told, with the reason
@@ -119,19 +119,57 @@ test("an opt-in naming a real host widens the bind and says so", () => {
   assert.ok(run.stderr.includes("nas.local"), "the notice should name what widened it");
 });
 
+test("an opt-in naming one address binds that address alone", () => {
+  // Given a single LAN address. Binding 0.0.0.0 here would also publish the
+  // dashboard on a VPN tunnel or a phone hotspot nobody opted in to.
+  const run = launch({ args: ["dev"], env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "192.168.1.50" } });
+  // When the launcher starts next
+  // Then only that interface is published, and the cost is stated: one socket
+  // carries one address, so localhost stops answering
+  assert.deepEqual(run.argv, ["dev", "-H", "192.168.1.50"]);
+  assert.ok(run.stderr.includes("binding 192.168.1.50"), `stderr was: ${run.stderr}`);
+  assert.ok(!run.stderr.includes("binding 0.0.0.0"), "every interface must not be published");
+  assert.ok(run.stderr.includes("http://localhost:PORT will not answer"), "the cost must be stated");
+});
+
+test("naming a loopback host alongside an address opts back into every interface", () => {
+  // Given the documented escape hatch for keeping localhost working
+  const run = launch({
+    args: ["dev"],
+    env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "192.168.1.50, localhost" },
+  });
+  // When the launcher starts next
+  // Then the wider bind is taken deliberately, and not reported as costing loopback
+  assert.deepEqual(run.argv, ["dev", "-H", "0.0.0.0"]);
+  assert.ok(!run.stderr.includes("will not answer"), "0.0.0.0 still answers on loopback");
+});
+
+test("a value that reads as a switch refuses the run instead of widening", () => {
+  // Given someone turning exposure off the way the variable's name suggests.
+  // Every such word is a valid hostname, so this used to bind every interface.
+  const run = launch({ args: ["dev"], env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "off" } });
+  // When the launcher runs
+  // Then next never starts, and the message explains what the variable is
+  assert.equal(run.status, 1);
+  assert.equal(run.argv, null, "next must not run on an unreadable opt-in");
+  assert.ok(run.stderr.includes("is not a switch"), `stderr was: ${run.stderr}`);
+});
+
 // --- a caller's own -H ----------------------------------------------------
 
-test("a caller's -H is forwarded and announced, even with no opt-in", () => {
-  // Given the override that used to widen the socket in silence
-  // When the launcher starts next
+test("a caller's -H is forwarded alone, with no injected bind to resolve against", () => {
+  // Given the override that used to widen the socket in silence. The launcher
+  // used to append it after its own -H and rely on commander keeping the last
+  // value — a bet against a dependency, asserted only against this stub.
   const run = launch({ args: ["dev", "-H", "0.0.0.0"] });
-  // Then next still receives it last, so it wins as commander resolves it
-  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1", "-H", "0.0.0.0"]);
-  // And the exposure is reported rather than left silent, naming the address
-  // that will actually be bound rather than the one that was resolved
-  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
-  assert.ok(run.stderr.includes("reachable from your network"), "an overriding -H must warn");
-  assert.ok(run.stderr.includes("overrides the resolved bind"), "the notice should name the cause");
+  // When the launcher starts next
+  // Then argv carries exactly what the caller wrote: no duplicate flag exists,
+  // so no assumption about how commander resolves one is load-bearing
+  assert.deepEqual(run.argv, ["dev", "-H", "0.0.0.0"]);
+  // And the run is reported as possibly exposed rather than claimed as loopback
+  assert.ok(run.stderr.includes("next chooses the bind"), `stderr was: ${run.stderr}`);
+  assert.ok(run.stderr.includes("may be reachable from your network"), "an -H must warn");
+  assert.ok(!run.stderr.includes("loopback only"), "it must not claim loopback");
   // And the combination with no honest reading is called out specifically
   assert.ok(
     run.stderr.includes("names no host beyond loopback"),
@@ -139,19 +177,22 @@ test("a caller's -H is forwarded and announced, even with no opt-in", () => {
   );
 });
 
-test("the attached short form -H0.0.0.0 is announced, not reported as loopback", () => {
+test("the attached short form -H0.0.0.0 is not reported as loopback", () => {
   // Given commander's attached spelling, which next honours. This exact argv
   // once printed "binding 127.0.0.1 — loopback only" while opening every
-  // interface, and a LAN client spoofing Host: localhost was served.
-  const run = launch({ args: ["dev", "-H0.0.0.0"] });
-  // When the launcher starts next
-  // Then the flag reaches next, and the notice tells the truth about it
-  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1", "-H0.0.0.0"]);
-  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
-  assert.ok(!run.stderr.includes("loopback only"), "it must not claim loopback");
+  // interface, and a LAN client spoofing Host: localhost was served. Presence
+  // detection, unlike value parsing, cannot miss a spelling of the value.
+  for (const args of [["dev", "-H0.0.0.0"], ["dev", "-p", "4000", "-H0.0.0.0"], ["dev", "--hostname=0.0.0.0"]]) {
+    // When the launcher starts next
+    const run = launch({ args });
+    // Then the flag reaches next untouched, and no loopback claim is made
+    assert.deepEqual(run.argv, args, `${args.join(" ")} must be forwarded untouched`);
+    assert.ok(!run.stderr.includes("loopback only"), `${args.join(" ")} must not claim loopback`);
+    assert.ok(run.stderr.includes("next chooses the bind"), `stderr was: ${run.stderr}`);
+  }
 });
 
-test("a loopback-only allow-list with an override is flagged, not silently widened", () => {
+test("a loopback-only allow-list with an override is flagged, not silently passed", () => {
   // Given a non-empty allow-list that names nobody the guard could not already
   // serve — the state a length check mistook for a meaningful opt-in
   const run = launch({
@@ -159,23 +200,24 @@ test("a loopback-only allow-list with an override is flagged, not silently widen
     env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "localhost" },
   });
   // When the launcher starts next
-  // Then the port is open and the user is told the filter protects nobody
-  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
+  // Then the user is told the filter would protect nobody on an open port
   assert.ok(
     run.stderr.includes("names no host beyond loopback"),
-    "a loopback-only list must not silence the notice",
+    `a loopback-only list must not silence the notice; stderr was: ${run.stderr}`,
   );
 });
 
-test("an -H that narrows an opted-in bind is not announced as exposure", () => {
-  // Given an opt-in, overridden back down to loopback
-  // When the launcher starts next
+test("an -H alongside an opt-in still hands the bind to next", () => {
+  // Given an opt-in that would have widened, plus a caller pulling it back down
   const run = launch({
     args: ["dev", "-H", "127.0.0.1"],
     env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "nas.local" },
   });
-  // Then the notice follows the socket, not the variable
-  assert.ok(!run.stderr.includes("reachable from your network"), "nothing is exposed here");
+  // When the launcher starts next
+  // Then the resolved 0.0.0.0 is neither injected nor announced: the caller's
+  // flag is the only bind in argv, and the launcher does not claim to know it
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1"]);
+  assert.ok(!run.stderr.includes("binding 0.0.0.0"), "the unused resolved bind must not be announced");
 });
 
 // --- forwarding and failure modes -----------------------------------------

--- a/web/tests/lib/server-launcher.test.mjs
+++ b/web/tests/lib/server-launcher.test.mjs
@@ -1,0 +1,265 @@
+// The launcher must not be startable in a way that quietly binds every interface.
+//
+// An earlier version of this suite asserted that tokens appeared in server.mjs's
+// source text. Review showed that catches nothing: hardcoding `"-H", "0.0.0.0"`
+// left it green, and so did dropping -H from argv entirely while keeping the
+// literal alive in an unused constant. Substring checks cannot see what the
+// launcher does.
+//
+// So it is run for real, against a stub `next` in a temp directory that prints
+// the argv it was handed. No installed Next, no socket, no network — the whole
+// bind decision is observable from the child's stdout, and the startup notice
+// from its stderr.
+//
+// Lives in tests/lib/ rather than mirroring server.mjs's position at the web
+// root because test-all.mjs's web-suite parity check fails any web suite outside
+// tests/lib.
+//
+// Run:  node --test tests/lib/server-launcher.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os, { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * A throwaway web/ whose `next` runs `body` instead of serving.
+ *
+ * @param {object} [options]
+ * @param {string} [options.body]     the stub next's source; defaults to printing its argv
+ * @param {boolean} [options.install] false to omit node_modules/next entirely
+ */
+function stubbedWebRoot({ body, install = true } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "career-ops-launcher-"));
+  cpSync(join(WEB_ROOT, "server.mjs"), join(root, "server.mjs"));
+  cpSync(join(WEB_ROOT, "src", "lib"), join(root, "src", "lib"), { recursive: true });
+  if (!install) return root;
+
+  const nextDir = join(root, "node_modules", "next");
+  mkdirSync(join(nextDir, "dist", "bin"), { recursive: true });
+  // No `exports` map, so the launcher's resolve of package.json + bin.next works
+  // the same way it does against the real package.
+  writeFileSync(
+    join(nextDir, "package.json"),
+    JSON.stringify({ name: "next", version: "0.0.0-stub", bin: { next: "./dist/bin/next.js" } }),
+  );
+  writeFileSync(
+    join(nextDir, "dist", "bin", "next.js"),
+    body ?? "console.log(JSON.stringify(process.argv.slice(2)));\n",
+  );
+  return root;
+}
+
+/** Run the launcher in a stub tree and report what `next` actually received. */
+function launch({ args = ["dev"], env = {}, ...stub } = {}) {
+  const root = stubbedWebRoot(stub);
+  try {
+    const result = spawnSync(process.execPath, [join(root, "server.mjs"), ...args], {
+      encoding: "utf8",
+      timeout: 30_000,
+      // Explicit env: the developer running the suite may have the variable set.
+      env: { PATH: process.env.PATH, ...env },
+    });
+    assert.equal(result.error, undefined, `launcher failed to run: ${result.error?.message}`);
+    return {
+      status: result.status,
+      signal: result.signal,
+      stderr: result.stderr,
+      argv: result.stdout.trim() ? JSON.parse(result.stdout.trim()) : null,
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// --- the bind next is actually told to use --------------------------------
+
+test("with no opt-in, next is told to bind loopback", () => {
+  // Given a default developer run
+  // When the launcher starts next
+  const run = launch({ args: ["dev"] });
+  // Then nothing outside the machine can open a connection, and the notice names
+  // the address — asserting only the phrase let a notice that announced the
+  // resolved bind while next opened every interface pass unnoticed.
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1"]);
+  assert.ok(run.stderr.includes("binding 127.0.0.1"), `stderr was: ${run.stderr}`);
+  assert.ok(run.stderr.includes("loopback only"), "a loopback bind should be stated plainly");
+});
+
+test("a blank opt-in is not an opt-in", () => {
+  // Given a variable that is set but names nothing
+  // When the launcher starts next
+  const run = launch({ args: ["dev"], env: { CAREER_OPS_WEB_ALLOWED_HOSTS: " , " } });
+  // Then the bind is unchanged
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1"]);
+});
+
+test("an opt-in naming only loopback does not widen the bind", () => {
+  // Given the value that used to open every interface while granting nothing
+  // When the launcher starts next
+  const run = launch({ args: ["dev"], env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "localhost" } });
+  // Then the socket stays on loopback
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1"], "a loopback-only opt-in must not widen");
+  assert.ok(!run.stderr.includes("reachable from your network"), "and must not claim exposure");
+});
+
+test("an opt-in naming a real host widens the bind and says so", () => {
+  // Given a host that loopback cannot serve
+  // When the launcher starts next
+  const run = launch({ args: ["start"], env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "nas.local" } });
+  // Then next binds every interface and the user is told, with the reason
+  assert.deepEqual(run.argv, ["start", "-H", "0.0.0.0"]);
+  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
+  assert.ok(run.stderr.includes("reachable from your network"), "widening must be announced");
+  assert.ok(run.stderr.includes("nas.local"), "the notice should name what widened it");
+});
+
+// --- a caller's own -H ----------------------------------------------------
+
+test("a caller's -H is forwarded and announced, even with no opt-in", () => {
+  // Given the override that used to widen the socket in silence
+  // When the launcher starts next
+  const run = launch({ args: ["dev", "-H", "0.0.0.0"] });
+  // Then next still receives it last, so it wins as commander resolves it
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1", "-H", "0.0.0.0"]);
+  // And the exposure is reported rather than left silent, naming the address
+  // that will actually be bound rather than the one that was resolved
+  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
+  assert.ok(run.stderr.includes("reachable from your network"), "an overriding -H must warn");
+  assert.ok(run.stderr.includes("overrides the resolved bind"), "the notice should name the cause");
+  // And the combination with no honest reading is called out specifically
+  assert.ok(
+    run.stderr.includes("names no host beyond loopback"),
+    "an open socket whose filter names nobody must be flagged",
+  );
+});
+
+test("the attached short form -H0.0.0.0 is announced, not reported as loopback", () => {
+  // Given commander's attached spelling, which next honours. This exact argv
+  // once printed "binding 127.0.0.1 — loopback only" while opening every
+  // interface, and a LAN client spoofing Host: localhost was served.
+  const run = launch({ args: ["dev", "-H0.0.0.0"] });
+  // When the launcher starts next
+  // Then the flag reaches next, and the notice tells the truth about it
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1", "-H0.0.0.0"]);
+  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
+  assert.ok(!run.stderr.includes("loopback only"), "it must not claim loopback");
+});
+
+test("a loopback-only allow-list with an override is flagged, not silently widened", () => {
+  // Given a non-empty allow-list that names nobody the guard could not already
+  // serve — the state a length check mistook for a meaningful opt-in
+  const run = launch({
+    args: ["dev", "-H", "0.0.0.0"],
+    env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "localhost" },
+  });
+  // When the launcher starts next
+  // Then the port is open and the user is told the filter protects nobody
+  assert.ok(run.stderr.includes("binding 0.0.0.0"), `stderr was: ${run.stderr}`);
+  assert.ok(
+    run.stderr.includes("names no host beyond loopback"),
+    "a loopback-only list must not silence the notice",
+  );
+});
+
+test("an -H that narrows an opted-in bind is not announced as exposure", () => {
+  // Given an opt-in, overridden back down to loopback
+  // When the launcher starts next
+  const run = launch({
+    args: ["dev", "-H", "127.0.0.1"],
+    env: { CAREER_OPS_WEB_ALLOWED_HOSTS: "nas.local" },
+  });
+  // Then the notice follows the socket, not the variable
+  assert.ok(!run.stderr.includes("reachable from your network"), "nothing is exposed here");
+});
+
+// --- forwarding and failure modes -----------------------------------------
+
+test("unrelated flags are forwarded untouched", () => {
+  // Given a caller passing next's own options through npm's `--`
+  // When the launcher starts next
+  const run = launch({ args: ["dev", "-p", "4000", "--turbopack"] });
+  // Then they arrive in order, after the bind
+  assert.deepEqual(run.argv, ["dev", "-H", "127.0.0.1", "-p", "4000", "--turbopack"]);
+});
+
+test("a missing next install is reported as a missing install", () => {
+  // Given a checkout where npm ci has not been run
+  // When the launcher tries to start
+  const run = launch({ args: ["dev"], install: false });
+  // Then the message names the fix, rather than reporting a generic resolve error
+  assert.equal(run.status, 1);
+  assert.ok(run.stderr.includes("run `npm ci` in web/"), `stderr was: ${run.stderr}`);
+  // And the bind was still announced first, so a broken install does not hide
+  // the fact that this run would have been network-reachable
+  assert.ok(run.stderr.includes("loopback only"), "the bind is reported before next is resolved");
+});
+
+test("the child's exit code is forwarded", () => {
+  // Given a next that fails with a distinctive status
+  // When the launcher wraps it
+  const run = launch({ args: ["dev"], body: "process.exit(3);\n" });
+  // Then the caller sees next's status, not a flattened 1
+  assert.equal(run.status, 3);
+});
+
+test("a signalled child is distinguishable from a startup failure", () => {
+  // Given a next killed by a signal rather than exiting
+  // When the launcher wraps it
+  const run = launch({ args: ["dev"], body: "process.kill(process.pid, 'SIGTERM');\n" });
+  // Then the exit code is 128+signal, not the 1 that means "could not start"
+  assert.equal(run.status, 128 + os.constants.signals.SIGTERM);
+  assert.notEqual(run.status, 1, "a killed server must not look like a failed launch");
+});
+
+test("an unknown command prints usage and exits 1 without starting next", () => {
+  // Given argv naming no next subcommand
+  // When the launcher runs
+  const run = launch({ args: ["--probe-not-a-command"] });
+  // Then nothing is spawned and the caller is told how to invoke it
+  assert.equal(run.status, 1);
+  assert.equal(run.argv, null, "next must not run for an unknown command");
+  assert.ok(run.stderr.includes("Usage: node server.mjs"), "usage should be printed");
+});
+
+// --- the scripts that reach it --------------------------------------------
+
+const pkg = JSON.parse(readFileSync(join(WEB_ROOT, "package.json"), "utf8"));
+const scripts = pkg.scripts ?? {};
+
+/** A script handing `next dev`/`next start` its own argv, bypassing the launcher. */
+const CALLS_NEXT_DIRECTLY = /(^|&&|\|\||\s)next\s+(dev|start)\b/;
+
+test("the dev and start scripts route through the launcher", () => {
+  // Given the two scripts a developer actually runs
+  // When each is read
+  // Then both reach next only via server.mjs — `startsWith`, so that adding a
+  // flag to the script is not mistaken for bypassing it
+  assert.ok(scripts.dev?.startsWith("node server.mjs dev"), `dev script was: ${scripts.dev}`);
+  assert.ok(scripts.start?.startsWith("node server.mjs start"), `start script was: ${scripts.start}`);
+});
+
+test("no script starts next on its own", () => {
+  // Given every script in the package, not just the two above
+  // When each is scanned for a direct next invocation
+  const offenders = Object.entries(scripts)
+    .filter(([, command]) => CALLS_NEXT_DIRECTLY.test(command))
+    .map(([name]) => name);
+  // Then none bypasses the bind decision — this catches a re-added `"dev": "next dev"`
+  // and equally a new `"dev:lan": "next dev -H 0.0.0.0"` nobody thought to review
+  assert.deepEqual(offenders, []);
+});
+
+test("the bypass check actually fires", () => {
+  // Given the shapes it exists to catch, and one it must not
+  // When each is tested
+  // Then the guard discriminates — an unfalsifiable guard is a hypothesis
+  assert.equal(CALLS_NEXT_DIRECTLY.test("next dev"), true);
+  assert.equal(CALLS_NEXT_DIRECTLY.test("rm -rf .next && next start -H 0.0.0.0"), true);
+  assert.equal(CALLS_NEXT_DIRECTLY.test("node server.mjs dev"), false);
+});


### PR DESCRIPTION
## What does this PR do?

`next dev` / `next start` with no `-H` reach `server.listen(port, undefined)`, which binds every network interface. The dashboard is a local-first tool with no login, so the interface it listens on is what decides who can reach it — it should default to this machine only.

The bind is derived from `CAREER_OPS_WEB_ALLOWED_HOSTS`, the variable `origin-guard.mjs` already reads, so the socket and the request guard are driven by one value instead of two independent settings.

Review (thanks @nikitacometa) established that the bind alone does not close the exposure — a DNS-rebinding page reaches the ungated page routes from the user's own browser regardless of what the socket is bound to. That is fixed here too; see *The guard now runs on page routes* below.

## Related issue

None — bug fix, sent straight in per the template's note.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` — green in CI on all three OS legs. `web` suite: 546/546, `tsc --noEmit` clean.
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (system layer only)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

### Design notes

**One variable, both layers.** Unset (or blank) binds `127.0.0.1`. Naming a host that loopback cannot already serve opens the socket, with the guard still answering for loopback and the hosts named. Naming *only* loopback (`localhost`, `127.0.0.1`, `::1`) is deliberately **not** an opt-in — widening for it would open every interface while granting nothing the guard did not already admit.

**The bind is as narrow as the opt-in allows.** A single named IP literal binds *that address*, not `0.0.0.0`: opting in one LAN box should not also publish the dashboard on a VPN tunnel or a phone hotspot. One socket carries one address, so loopback stops answering — the startup line says so, since the symptom otherwise looks like a server that failed to start, and naming a loopback host alongside is the documented way back to `0.0.0.0`. A hostname (which needs a resolver the launcher deliberately does not have) or two addresses (which cannot share a socket) still fall back to `0.0.0.0`.

**The variable is validated, not just parsed.** Every token the loopback predicate rejected used to count as an opt-in, so `CAREER_OPS_WEB_ALLOWED_HOSTS=off` bound every interface for someone trying to turn exposure *off* — and `off`, `false`, `no` and `0` are all syntactically valid hostnames, so only an explicit check catches them. Values are now validated as hostnames or IP literals, with the run aborted rather than widened. Refused by name:

| value | why |
|---|---|
| `off`, `false`, `no`, `0`, `none`, … | switch-like words — valid hostnames, so silence was not an option |
| `http://192.168.1.50` | host normalisation cuts at the first colon, so a URL used to arrive as the bare host `http` — valid, non-loopback, and an opt-in to everything |
| `0.0.0.0`, `::`, `0::0`, `0:0:0:0:0:0:0:0` | wildcards are bind targets, not host identities. Accepting one opened the socket while the guard went on matching `Host` literally — honest clients got `403`, and only a client spelling `Host: 0.0.0.0` was let in |
| `fe80::…` | link-local: ambiguous across interfaces, unbindable without a zone index |
| `224.0.0.1`, `ff02::1`, `255.255.255.255` | multicast and limited-broadcast — TCP is point-to-point, so these can never be listened on |
| `2001:db8:1`, `192.168.1`, `010.0.0.1` | incomplete or leading-zero literals |

The last row is why the hand-rolled parsers went: `isIPv6Literal` counted hex groups and `::` runs, so `2001:db8:1` passed, became a single-address bind, and reached `next -H`, where `listen()` refused to start the server. Leniency in that predicate cannot fail safe, because whatever it admits becomes the bind target. `node:net`'s `isIP` is the parser to use, and it covers the leading-zero IPv4 case for free. The module keeps its no-I/O, no-process-state property — it now imports `node:net` for one pure predicate, and only `server.mjs` and the tests import it (`proxy.ts` imports `origin-guard.mjs`, which stays free of node imports for the edge runtime).

**The guard now runs on page routes.** The matcher was `/api/:path*`, so no page route was filtered on any bind. A page that re-resolves its own domain to `127.0.0.1` fetches `/pipeline` same-origin from the user's own browser, and `force-dynamic` pages read the tracker off disk per request — a loopback bind does not close that, because the browser making the request is already on the machine. What does close it is the Host filter: a browser sets `Host` from the URL and will not let script forge it, so the rebound request carries the attacker's domain and is refused — but only if the guard runs. Verified against a live server: that request goes 200 → 403, while normal navigation and same-origin fetches are unaffected. Build assets stay excluded; they are identical for every user, and a caller who cannot read a page has no use for the chunk that renders it.

**`-H` is still yours, and the launcher stops guessing what it means.** The bind is injected only when no hostname flag was supplied. When one was, `next` owns the decision and the notice says exactly that, rather than naming an address the launcher would have to derive by reimplementing commander's resolution — a bet this launcher already lost once, when a missed spelling of the attached short form (`-H0.0.0.0`) had it announce "loopback only" while every interface was open. The cost is deliberate conservatism: an `-H` that *narrows* to loopback is also reported as next's to choose. A warning that is never false beats one that is precise until the parser drifts.

**Why a launcher.** npm scripts cannot branch on an env var portably given the Windows CI leg and no `cross-env`, so `web/server.mjs` resolves the bind and spawns `next` through this Node rather than `node_modules/.bin/next`, which is a `.cmd` shim on Windows that `spawn()` cannot exec without a shell. It follows `build-dashboard.mjs`'s shape and prints the interface it is about to listen on *before* resolving next, so a broken install still reports what the run would have exposed.

**Policy is pure and tested on values.** `server.mjs` only prints and spawns. `web/tests/lib/server-launcher.test.mjs` runs the real launcher against a stub `next` in a temp dir that echoes its argv, so the tests assert the argv `next` actually receives rather than the launcher's source text. The matcher is extracted from `proxy.ts` and exercised in the guard's own suite, since a guard that never runs is indistinguishable from one that always allows.

### Rebased onto main after #3597

#3597 (@andrgavrilenko) landed in `origin-guard.mjs` while this was open, which put the branch in conflict. Rebased; two files needed resolution, and two consequences are worth calling out rather than leaving to be discovered.

**The `checkRequest` hunk was adjacent, the header hunk was not.** #3597's header says *"Host layer (F2): only answer on a loopback Host by default"* — retracting exactly that is what this PR is for, since `Host` is client-chosen and a LAN request spelling `Host: localhost` satisfies it. Resolved by taking either side wholesale, that claim comes back. The merged header keeps the F2 correction and folds the allowlist paragraph into F1; `allowedOrigins` is passed through unchanged.

**The origin allowlist now reaches past `/api/*`.** #3597 shipped gating the API; this matcher spans every route but build assets, so an opted-in `chrome-extension://` origin now reaches page routes too. Measured against a running server:

| | allowlisted origin | `evil.test` |
|---|---|---|
| `/pipeline`, `/cv` | 200 | 403 |
| `/api/*` | passes guard | 403 |

Build assets stay outside the matcher — they load with no `Origin`; the 403 a cross-origin request gets for them in dev is Next's own `allowedDevOrigins` block, not this guard (plain `Unauthorized`, where this guard returns JSON). Both invariants #3597 pinned still hold: the host layer runs first and independently, and `null` is still refused. The widening looks right — an extension that can read the API can already read what the pages render — but it is a scope change that PR did not ask for.

One README line needed fixing on top: #3597's paragraph opened *"`/api` is gated by the same-origin + loopback guard"*, accurate when written and made false by this matcher. It now reads "Every route but build assets is gated…", squashed into the matcher commit so no commit contradicts itself.

### Deliberately out of scope

- `CAREER_OPS_WEB_ALLOWED_HOSTS` recognises the loopback spellings `isLoopbackHost` already knows; unusual ones (`127.1`, `localhost.`, `::ffff:127.0.0.1`) still widen. No worse than before this PR, and narrowing that predicate would change the request guard's behaviour, which this diff should not do. The IPv4-mapped form (`::ffff:224.0.0.1`) slips past the non-unicast check for the same reason — fixing it in `bind-host.mjs` alone would make the two predicates disagree about what an address is, which is the failure this PR exists to prevent.
- A subnet-directed broadcast (`192.168.1.255`) is not classified: whether it is one depends on the interface prefix the machine holds, which this pure planner does not inspect.
- `origin-guard.mjs`'s predicates are untouched — only its threat-model header changed, to record that the bind and the guard answer different attackers: the socket answers callers who connect directly, the guard answers callers arriving through a browser the user already trusts.
- There is still no login, and on an opened socket `Host` remains client-chosen — so the allow-list filters honest clients rather than hostile ones. The bind stays the real access control. Documented in `web/README.md` rather than papered over.
