### PR TITLE
fix(gitignore): the tracker itself is unignored in the legacy root layout (#3717)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,26 @@ reports/*-RESERVED.md
 # original sitting untracked in the repo root. Trailing `*` covers both.
 *.bak*
 
+# The tracker and its follow-ups file in the LEGACY ROOT LAYOUT. resolveTrackerPath()
+# documents its own fallback chain — CAREER_OPS_TRACKER > <root>/data/applications.md
+# > <root>/applications.md — and that third entry is a supported install shape, not a
+# mistake. data/ is covered by the blanket rule at the top of this file; the root
+# spelling was not covered by anything.
+#
+# The content is the user's whole job search: company, role, score, status, notes.
+# cv.md, portals.yml, article-digest.md and voice-dna.md are all ignored at the root
+# already, and #3469 ignores the derived .db index on the argument that it "holds the
+# same PII as the tracker" — while the tracker itself sat beside it, unignored.
+#
+# Unanchored, like the .db rule below and for the same reason: getCareerOpsRoot()
+# resolves a relative CAREER_OPS_ROOT (or .career-ops-data marker) against the
+# codebase directory, so a data root configured as `career-data` puts these inside
+# the checkout, where an anchored rule would not reach them. The upgrade fixtures
+# that share these names stay tracked via the `!test-fixtures/**` rule further down,
+# which is a later pattern and therefore wins.
+applications.md
+follow-ups.md
+
 # The tracker's derived SQLite index (tracker.mjs, #918). It sits beside the
 # tracker markdown, so on the standard layout it lands in data/ and is already
 # covered by the rules above — but resolveTrackerPath() falls back to

--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -202,6 +202,53 @@ for (const path of timestampedBackupProbes) {
 // directory that can hold the index can hold all three names. Enumerating them
 // by hand is how the -shm sidecar ended up covered in the repo root and missed
 // one directory down.
+// The tracker and its follow-ups file in the LEGACY ROOT LAYOUT — the third
+// entry in resolveTrackerPath()'s own documented fallback chain
+// (CAREER_OPS_TRACKER > <root>/data/applications.md > <root>/applications.md),
+// and a supported install shape rather than a mistake.
+//
+// data/ is covered by the blanket rule at the top of .gitignore; the root
+// spelling was covered by nothing, so the file holding the user's entire job
+// search — company, role, score, status, notes — sat untracked and unignored,
+// one `git add .` from a commit. The derived .db index beside it was ignored
+// first, on the argument that it carries the same PII as the tracker.
+//
+// The career-data/ probes decide the SHAPE, exactly as they do for the index: a
+// relative CAREER_OPS_ROOT resolves against the codebase directory, so an
+// anchored rule would leave a configured data root inside the checkout
+// uncovered.
+const rootLayoutTrackerProbes = [
+  'applications.md',
+  'follow-ups.md',
+  'career-data/applications.md',
+  'career-data/follow-ups.md',
+  'career-data/data/applications.md',
+];
+
+for (const path of rootLayoutTrackerProbes) {
+  const { verdict, stderr } = checkIgnore(path);
+  if (verdict === 'ignored') pass(`${path} is git-ignored`);
+  else if (verdict === 'not-ignored') fail(`${path} is NOT git-ignored — the tracker holds the user's entire job search`);
+  else fail(`${path}: git check-ignore could not answer — ${stderr}`);
+}
+
+// The other direction. These names are also carried by the upgrade fixtures,
+// which are tracked on purpose and stay tracked through the `!test-fixtures/**`
+// rule — a later pattern, so it wins. A future fixture must land the same way,
+// which a rule ordered after that negation would silently break.
+const trackedFixtureProbes = [
+  'test-fixtures/upgrade/state-v1.16/data/applications.md',
+  'test-fixtures/upgrade/state-v1.18/data/follow-ups.md',
+  'test-fixtures/upgrade/state-v1.20/data/applications.md',   // the next one, not yet written
+];
+
+for (const path of trackedFixtureProbes) {
+  const { verdict, stderr } = checkIgnore(path);
+  if (verdict === 'not-ignored') pass(`${path} stays visible to git`);
+  else if (verdict === 'ignored') fail(`${path} became ignored — the upgrade fixtures cannot be committed`);
+  else fail(`${path}: git check-ignore could not answer — ${stderr}`);
+}
+
 const derivedIndexLocations = [
   'applications',                // legacy layout: tracker markdown in the root
   'data/applications',           // standard layout


### PR DESCRIPTION
Fixes #3717.

`resolveTrackerPath()`'s own documented fallback chain ends at `<root>/applications.md`, a supported install shape. `data/` is covered by the blanket rule at the top of `.gitignore`; the root spelling was covered by nothing.

```
  applications.md    NOT IGNORED        data/applications.md   ignored
  follow-ups.md      NOT IGNORED        data/follow-ups.md     ignored
```

The tracker holds the user's whole job search — company, role, score, status, notes. `cv.md`, `portals.yml`, `article-digest.md` and `voice-dna.md` are all ignored at the root already.

The sharp version: **#3469 ignores the derived SQLite index on the argument that it "holds the same PII as the tracker."** It does. The tracker was sitting right beside it, unignored.

## Shape, and the ordering trap

Unanchored, for the same reason as that `.db` rule: `getCareerOpsRoot()` resolves a relative `CAREER_OPS_ROOT` (or `.career-ops-data` marker) against the codebase directory, so a data root configured as `career-data` puts these inside the checkout, where `/applications.md` would not reach them. The `career-data/` probes are what decide that — an anchored rule passes every root probe.

Unlike the `.db` case, these names **are** carried by tracked files: the upgrade fixtures under `test-fixtures/`. They stay tracked through the existing `!test-fixtures/**` rule, which is a later pattern and therefore wins — so the new rule has to sit **above** it. That ordering is invisible in the file, so it is pinned in both directions:

| change | reddens |
|---|---|
| drop the rule | the 5 leak probes |
| move it below `!test-fixtures/**` | the 3 fixture probes |

One of the fixture probes is for `state-v1.20`, which does not exist yet — the next fixture must land the same way as the two that do.

Also verified directly that no currently tracked file became ignored:

```
git ls-files | git check-ignore --stdin   ->   empty
```

Full suite green at 8376.