### PR TITLE
docs(agents): drop a script reference that never existed, and guard the rest (#3719)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ Headless worker command per CLI:
 |--------|----------|
 | `archive-posting.mjs` | `{YYYY-MM-DD}_{company}_{role}.pdf` |
 | `archive-posting.mjs --report=N` | `{NNN}-{YYYY-MM-DD}_{company}_{role}.pdf` |
-| `plugins/apify/index.mjs`, `scan-apify.mjs` | `{company}-{role}-{sha1(url)[0:10]}.md` |
+| `plugins/apify/index.mjs` | `{company}-{role}-{sha1(url)[0:10]}.md` |
 | `scan` mode (manual save) | `{company}-{role-slug}.md` |
 
 **Prefer `--report=N` when archiving for a tracked row.** A capture named only from the date and the scraped company and role can be found again only by rebuilding that exact string, so it stops resolving the day after it is written — precisely when the posting has gone dead and the capture is the only remaining record. `jd-capture.mjs` looks captures up by report number instead, matching padded and unpadded prefixes (`064-`, `64-`, `01-`), and `outcome.mjs` uses it before falling back to re-archiving a live URL.

--- a/tests/agent-docs-script-refs.test.mjs
+++ b/tests/agent-docs-script-refs.test.mjs
@@ -1,0 +1,55 @@
+// tests/agent-docs-script-refs.test.mjs — every `*.mjs` a top-level agent
+// document names has to exist.
+//
+// AGENTS.md is loaded into every agent session, so a path in it is not prose:
+// it is an instruction an agent will act on. A name that resolves to nothing
+// costs a tool call every time one goes looking, and the agent has no way to
+// tell "this was renamed" from "I am in the wrong directory".
+//
+// The one this was written for is `scan-apify.mjs`, listed in the jds/ capture
+// table beside plugins/apify/index.mjs. It never existed — no commit in the
+// history ever added or removed it — so it was wrong from the day it was
+// written rather than stale, which is the kind of error only a check like this
+// finds.
+//
+// Scoped to .mjs on purpose. These documents also name templates, data files
+// and paths that are created at runtime or belong to the user layer, none of
+// which need to exist in a fresh checkout. A script does.
+//
+// Run:  node --test tests/agent-docs-script-refs.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// The documents a CLI loads automatically. DATA_CONTRACT.md is included because
+// the agent instructions point at it as the authority on file ownership.
+const AGENT_DOCS = [
+  'AGENTS.md', 'CLAUDE.md', 'CODEX.md', 'OPENCODE.md',
+  'GEMINI.md', 'KIMI.md', 'DATA_CONTRACT.md',
+];
+
+// Backticked only. Prose can discuss a script that a user might write, and a
+// code fence can hold an example invocation; a backticked path is a reference.
+const MJS_REF = /`([A-Za-z0-9_./-]+\.mjs)`/g;
+
+for (const doc of AGENT_DOCS) {
+  test(`${doc} names no script that does not exist`, () => {
+    const path = join(ROOT, doc);
+    if (!existsSync(path)) return;   // not every CLI's file ships in every fork
+    const src = readFileSync(path, 'utf-8');
+    const missing = [...new Set([...src.matchAll(MJS_REF)].map((m) => m[1]))]
+      .filter((ref) => !existsSync(join(ROOT, ref)))
+      .sort();
+    assert.deepEqual(
+      missing,
+      [],
+      `${doc} names ${missing.length} script(s) that do not exist: ${missing.join(', ')}. `
+      + 'An agent reading this will spend a tool call looking for each one.',
+    );
+  });
+}


### PR DESCRIPTION
Fixes #3719.

`AGENTS.md:423` listed `scan-apify.mjs` beside `plugins/apify/index.mjs` in the jds/ capture table. No commit in the history ever added or removed it — it was wrong when written, not left behind by a rename. The plugin does write that filename shape (`index.mjs:127-135`), so the row is correct once the second name is gone.

Small on its own. The reason it is worth a check rather than a one-line edit: `AGENTS.md` is loaded into every agent session, which makes a path in it an instruction an agent will act on, not prose. A name that resolves to nothing costs a tool call every time one goes looking, and the agent cannot tell *"this was renamed"* from *"I am in the wrong directory"*.

## The guard

Covers the seven documents a CLI loads automatically (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `OPENCODE.md`, `GEMINI.md`, `KIMI.md`, `DATA_CONTRACT.md`), and is scoped to `.mjs` **deliberately** — these files also name templates, data files and user-layer paths that legitimately do not exist in a fresh checkout. A script does.

Backticked references only, so prose and example invocations are left alone. Files absent from a given fork are skipped rather than failed.

Exactly one ghost across all seven today, so it starts green. Restoring the reference reddens it. Full suite green at 8370.