### PR TITLE
fix(doctor): --json leaked git's "not a git repository" onto stderr (#3721)

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -166,11 +166,29 @@ function checkTrackedBakFiles(root) {
   let raw;
   try {
     raw = execFileSync('git', ['ls-files', '-z', '--', '*.bak*'], {
-      cwd: root, encoding: 'utf-8', timeout: 5000,
+      cwd: root,
+      encoding: 'utf-8',
+      timeout: 5000,
+      // stderr PIPED, not inherited. execFileSync's default hands the child our
+      // own stderr, so outside a checkout git printed
+      //   fatal: not a git repository (or any of the parent directories): .git
+      // before this catch ever ran — ahead of the JSON on `doctor --json`, which
+      // AGENTS.md has every agent run on the first message of every session. The
+      // catch below already handles that case; git's own message added nothing
+      // but the appearance of something being broken.
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
-  } catch {
-    // Not a git checkout (or git unavailable) — nothing to check.
-    return { pass: true, label: 'Tracked .bak files: skipped (not a git checkout)' };
+  } catch (err) {
+    // Piping means the reason is ours to read rather than the terminal's. Not
+    // being a checkout is the expected case and stays a clean skip; anything
+    // else — git missing, a permissions problem, a timeout — is reported, since
+    // silently skipping those would claim a check ran that did not.
+    const stderr = String(err?.stderr ?? '');
+    if (/not a git repository/i.test(stderr) || err?.code === 'ENOENT') {
+      return { pass: true, label: 'Tracked .bak files: skipped (not a git checkout)' };
+    }
+    const detail = stderr.trim().split('\n')[0] || err?.message || 'unknown error';
+    return { warn: true, label: `Tracked .bak files: check could not run (${detail})` };
   }
   const paths = raw.split('\0').filter(Boolean);
   if (paths.length === 0) {

--- a/tests/doctor-clean-stderr.test.mjs
+++ b/tests/doctor-clean-stderr.test.mjs
@@ -1,0 +1,82 @@
+// tests/doctor-clean-stderr.test.mjs — `doctor --json` must not leak a
+// subprocess's diagnostics onto stderr.
+//
+// AGENTS.md has every agent run `node doctor.mjs --json` on the FIRST MESSAGE of
+// every session, which makes this the hottest path in the repo. checkTrackedBakFiles
+// shells out to `git ls-files`, and execFileSync's default hands the child our own
+// stderr — so outside a git checkout git printed
+//
+//     fatal: not a git repository (or any of the parent directories): .git
+//
+// before the catch that handles exactly that case ever ran. The JSON on stdout
+// stayed valid, so nothing broke; it just told every agent, every session, that
+// something was fatally wrong when nothing was.
+//
+// Measured in bytes rather than by matching the message, because the point is
+// that NOTHING reaches stderr on a clean run — a future subprocess leaking a
+// different string should redden this too.
+//
+// Run:  node --test tests/doctor-clean-stderr.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function doctor(cwd, target) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--json', '--target', target], {
+    cwd, encoding: 'utf-8', timeout: 60_000,
+    env: { ...process.env, CAREER_OPS_ROOT: target, CAREER_OPS_DATA_DIR: '' },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return r;
+}
+
+test('--json writes nothing to stderr outside a git checkout', () => {
+  // A temp dir is not a checkout and has no checkout above it — the arrangement
+  // that produced the leak, and the one a user with a data root outside the
+  // repo is in every time.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-doctor-stderr-'));
+  try {
+    const r = doctor(dir, dir);
+    assert.equal(
+      r.stderr,
+      '',
+      `doctor --json leaked ${r.stderr.length} bytes to stderr: ${JSON.stringify(r.stderr.slice(0, 200))}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('and still produces the JSON it is asked for', () => {
+  // Guard: the fix must not buy a clean stderr by suppressing the check or the
+  // output. stdout has to remain a complete, parseable envelope.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-doctor-stderr-'));
+  try {
+    const r = doctor(dir, dir);
+    const j = JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+    assert.equal(typeof j.onboardingNeeded, 'boolean');
+    assert.ok(Array.isArray(j.missing), 'the envelope lost its `missing` array');
+    assert.ok(Array.isArray(j.warnings), 'the envelope lost its `warnings` array');
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('inside a checkout the .bak check still runs', () => {
+  // The other guard. Piping git's stderr must not turn a working check into a
+  // permanent skip — run against the repo itself, where git succeeds.
+  const r = doctor(ROOT, ROOT);
+  assert.equal(r.stderr, '', `stderr not clean inside a checkout: ${JSON.stringify(r.stderr.slice(0, 200))}`);
+  const j = JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+  assert.ok(
+    !(j.warnings || []).some((w) => /check could not run/i.test(String(w))),
+    `the .bak check reported itself broken inside a real checkout: ${JSON.stringify(j.warnings)}`,
+  );
+});


### PR DESCRIPTION
Fixes #3721.

`checkTrackedBakFiles` shells out to `git ls-files`, and `execFileSync`'s default hands the child our own stderr. Outside a checkout git printed before the `catch` that handles exactly that case ever ran:

```
                 stdout            stderr
  before         547 bytes (JSON)   69 bytes -> "fatal: not a git repository ..."
  after          547 bytes (JSON)    0 bytes
```

Nothing broke — the JSON stayed valid and the check still reported a clean skip. It just told every agent, every session, that something was fatally wrong when nothing was. `AGENTS.md` has every agent run `doctor --json` on the **first message of each session**, so this is the hottest path in the repo and it is the first thing an agent sees.

## Piped, not discarded

Muting stderr would have fixed the symptom and hidden a real failure. The `catch` mapped *every* git failure to `skipped (not a git checkout)`, so git missing, a permissions problem or a timeout all reported as "not a checkout" — claiming a check ran that did not.

Now the reason is ours to read: not-a-checkout (and `ENOENT`) stays a clean skip; anything else surfaces as a warning naming what happened.

## Tests

Stderr is measured in **bytes**, not matched against the message — the guarantee is that nothing reaches stderr on a clean run, so a future subprocess leaking a different string reddens this too.

Two guards beside it, both aimed at the ways this fix could cheat:

- the JSON envelope stays complete (a clean stderr bought by suppressing the output would fail),
- inside a real checkout the `.bak` check still runs rather than reporting itself broken (a clean stderr bought by making the check a permanent skip would fail).

Reverting the `stdio` option reddens the first test only. Full suite green at 8370.