### PR TITLE
fix(icims): read every jobLocation entry when picking the location

### DIFF
--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -179,27 +179,32 @@ export default {
 const COUNTRY_NAMES = { US: 'United States', CA: 'Canada' };
 
 // From flattened JSON-LD nodes, build "Locality, Region, Country" out of the
-// first JobPosting's first jobLocation address. Partial addresses are kept:
-// the country alone is already enough for location_filter to decide.
+// first jobLocation entry (across all JobPosting nodes) that yields any usable
+// parts. Some tenants emit an all-UNAVAILABLE entry ahead of the real address,
+// so reading only the first entry would return no location even though a
+// later one has one. Partial addresses are kept: the country alone is already
+// enough for location_filter to decide.
 function pickLocation(nodes) {
   for (const node of nodes) {
     if (!node || typeof node !== 'object' || !node.jobLocation) continue;
-    const place = Array.isArray(node.jobLocation) ? node.jobLocation[0] : node.jobLocation;
-    const addr = place?.address;
-    if (!addr || typeof addr !== 'object') continue;
-    const clean = v => {
-      const s = String(v ?? '').trim();
-      // iCIMS writes the literal string UNAVAILABLE into fields it has no value
-      // for, so an unchecked join yields "UNAVAILABLE, MD, United States".
-      return !s || /^unavailable$/i.test(s) ? '' : s;
-    };
-    const country = clean(addr.addressCountry);
-    const parts = [
-      clean(addr.addressLocality),
-      clean(addr.addressRegion),
-      COUNTRY_NAMES[country.toUpperCase()] || country,
-    ].filter(Boolean);
-    if (parts.length) return parts.join(', ');
+    const places = Array.isArray(node.jobLocation) ? node.jobLocation : [node.jobLocation];
+    for (const place of places) {
+      const addr = place?.address;
+      if (!addr || typeof addr !== 'object') continue;
+      const clean = v => {
+        const s = String(v ?? '').trim();
+        // iCIMS writes the literal string UNAVAILABLE into fields it has no value
+        // for, so an unchecked join yields "UNAVAILABLE, MD, United States".
+        return !s || /^unavailable$/i.test(s) ? '' : s;
+      };
+      const country = clean(addr.addressCountry);
+      const parts = [
+        clean(addr.addressLocality),
+        clean(addr.addressRegion),
+        COUNTRY_NAMES[country.toUpperCase()] || country,
+      ].filter(Boolean);
+      if (parts.length) return parts.join(', ');
+    }
   }
   return null;
 }

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -244,6 +244,24 @@ const mkCtx = (pages) => ({
   if (job.location === 'MD, United States') pass('enrichDate drops UNAVAILABLE address parts');
   else fail(`location: ${job.location}`);
 }
+// Regression for #3727: the first jobLocation entry is entirely UNAVAILABLE
+// and the real address lives in a later entry. Reading only jobLocation[0]
+// returned no location at all even though a usable one was in the array.
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","jobLocation":[{"address":{"addressCountry":"UNAVAILABLE"}},{"address":{"addressLocality":"Toronto","addressRegion":"ON","addressCountry":"CA"}}]}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: '' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.location === 'Toronto, ON, Canada') pass('enrichDate walks past an all-UNAVAILABLE jobLocation entry to a later one');
+  else fail(`location: ${job.location}`);
+}
+// Single-entry jobLocation behavior is unchanged.
+{
+  const detail = `<script type="application/ld+json">{"@type":"JobPosting","jobLocation":[{"address":{"addressLocality":"Denver","addressRegion":"CO","addressCountry":"US"}}]}</script>`;
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: '' };
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.location === 'Denver, CO, United States') pass('enrichDate still handles a single jobLocation entry');
+  else fail(`location: ${job.location}`);
+}
 // A location the list page did supply is authoritative: enrichment never
 // overwrites it.
 {


### PR DESCRIPTION
## What does this PR do?

pickLocation() only looked at node.jobLocation[0]. When that entry is all UNAVAILABLE and a later one has a real address, the posting ends up with no location and location_filter can't apply. Now it walks every entry and takes the first one that yields any address parts. Same UNAVAILABLE cleanup and country mapping as before. Fixes #3727.

## Related issue

Fixes #3727

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`providers/icims.mjs:pickLocation()` now checks every `jobLocation` entry. It skips entries with only `UNAVAILABLE` or empty fields and returns the first usable address.

Country and region mapping remain available for `location_filter`.

`tests/providers/icims.test.mjs` adds regression coverage for multiple locations and preserves single-location behavior.

Touched system files: `providers/` and `tests/providers/`. No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->