### PR TITLE
fix(update): resolve preserved files before staging so :(exclude) never reaches git add

### DIFF
--- a/tests/updater-add-paths.test.mjs
+++ b/tests/updater-add-paths.test.mjs
@@ -25,7 +25,7 @@
 import { writeFileSync, mkdirSync, rmSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { pass, fail, makeUpdaterRepo } from './helpers.mjs';
-import { gitIn, addPaths, isTracked, expandToShippedFiles } from '../update-system.mjs';
+import { gitIn, addPaths, isTracked, expandToShippedFiles, stagingFileList } from '../update-system.mjs';
 
 // Shared with updater-is-tracked.test.mjs so the git-isolation pins live in one
 // body: dropping one has to redden both suites, not leave this one quietly
@@ -862,6 +862,70 @@ console.log('\n🧪 Testing updater staging behavior (ignored + never-tracked pa
     pass('an unreadable ref propagates instead of silently expanding to nothing');
   } else {
     fail(`a bad ref was absorbed and returned ${JSON.stringify(out)} — staging would go quietly incomplete`);
+  }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 14. a preserved :(exclude) spec never reaches addPaths as a literal ──
+//    apply() stages `[...updated, ...preserveSpecs]`, where preserveSpecs are
+//    `:(exclude)<path>` entries for files THIS install modified and the update
+//    leaves alone (#2337). addPaths force-adds under --literal-pathspecs, so a
+//    `:(exclude)Dockerfile` handed straight to it is a literal, unmatched
+//    pathspec that aborts the whole update commit half-done — the break a
+//    Docker/sandbox Dockerfile local edit hit in the field. stagingFileList
+//    resolves preservation into a plain file list before it gets there, and
+//    subtracts a preserved file that a positive directory entry would otherwise
+//    pull back in — the subtraction the exclude spec never did during staging.
+{
+  const { dir, g, ctx } = makeRepo();
+  mkdirSync(join(dir, 'providers'));
+  writeFileSync(join(dir, 'AGENTS.md'), 'v1');
+  writeFileSync(join(dir, 'Dockerfile'), 'shipped upstream');
+  writeFileSync(join(dir, 'providers/core.mjs'), 'v1');
+  writeFileSync(join(dir, 'providers/acme.mjs'), 'v1');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+
+  // The update rewrites all four, but this install locally edited Dockerfile
+  // (standalone) and providers/acme.mjs (under an updated directory), so both
+  // are preserved: kept on disk with the user's content and out of the commit.
+  writeFileSync(join(dir, 'AGENTS.md'), 'v2');
+  writeFileSync(join(dir, 'Dockerfile'), "the user's local sandbox edit");
+  writeFileSync(join(dir, 'providers/core.mjs'), 'v2');
+  writeFileSync(join(dir, 'providers/acme.mjs'), "the user's local edit");
+
+  const pathsToStage = ['AGENTS.md', 'providers/', ':(exclude)Dockerfile', ':(exclude)providers/acme.mjs'];
+  const preserved = ['Dockerfile', 'providers/acme.mjs'];
+  const files = stagingFileList(pathsToStage, preserved, 'HEAD', ctx);
+
+  if (!files.some(f => f.startsWith(':(exclude)'))) {
+    pass('stagingFileList emits no :(exclude) spec');
+  } else {
+    fail(`an exclusion spec survived into the staging list: ${files.join(', ')}`);
+  }
+  if (!files.includes('Dockerfile') && !files.includes('providers/acme.mjs')) {
+    pass('a standalone AND an under-directory preserved file are both subtracted');
+  } else {
+    fail(`a preserved file reached the staging list: ${files.join(', ')}`);
+  }
+  if (files.includes('AGENTS.md') && files.includes('providers/core.mjs')) {
+    pass("the update's own files remain in the staging list");
+  } else {
+    fail(`stagingFileList dropped a real update file: ${files.join(', ')}`);
+  }
+
+  let threw = null;
+  try {
+    addPaths(files, ctx);
+  } catch (err) {
+    threw = err;
+  }
+  const staged = stagedPaths(g);
+  if (!threw && staged.has('AGENTS.md') && staged.has('providers/core.mjs')
+      && !staged.has('Dockerfile') && !staged.has('providers/acme.mjs')) {
+    pass('the derived list stages cleanly and leaves preserved files uncommitted');
+  } else {
+    fail(`staging the derived list failed: ${threw?.message.split('\n')[0] ?? [...staged].join(', ')}`);
   }
   rmSync(dir, { recursive: true, force: true });
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1566,6 +1566,40 @@ function rejectDirectories(paths, root) {
 const EXCLUDE_PATHSPEC_PREFIX = ':(exclude)';
 
 /**
+ * The concrete FILE list to stage and scope-commit for an update.
+ *
+ * `pathsToStage` is a git PATHSPEC list: positive manifest entries (files, and
+ * directory entries ending in '/') plus `:(exclude)<path>` specs for files this
+ * install preserved (#2337). Two consumers need a plain file list, not that
+ * pathspec list:
+ *
+ *   - addPaths force-adds under `--literal-pathspecs`, where a `:(exclude)`
+ *     spec is read as a LITERAL, nonexistent filename. git aborts with "pathspec
+ *     did not match any files" and the whole update commit dies half-done — the
+ *     exact break a preserved local edit (a Docker/sandbox `Dockerfile`) hit in
+ *     the field. The exclude specs simply must not reach it.
+ *   - the scoped commit is clearest, and mode-safe, naming exactly what staged.
+ *
+ * So expand only the positive specs against the target tree, then SUBTRACT the
+ * preserved files. Subtraction is what the exclude spec was meant to do and,
+ * during staging, never did: a preserved file living under a positive DIRECTORY
+ * entry (`providers/` over a preserved `providers/acme.mjs`) is pulled in by the
+ * expansion and has to be removed here, not merely appended as a spec the
+ * expansion ignores.
+ *
+ * @param {string[]} pathsToStage - positive specs + `:(exclude)<path>` specs.
+ * @param {string[]|Set<string>} [preserved] - exact preserved file paths.
+ * @param {string} [ref] - tree the directory entries resolve against.
+ * @param {{git?: Function}} [ctx] - test seam; defaults to the ROOT-bound runner.
+ * @returns {string[]} concrete file paths, preserved files removed, no exclusions.
+ */
+export function stagingFileList(pathsToStage, preserved = [], ref = 'FETCH_HEAD', ctx = {}) {
+  const preservedSet = preserved instanceof Set ? preserved : new Set(preserved);
+  const positives = pathsToStage.filter((spec) => !spec.startsWith(EXCLUDE_PATHSPEC_PREFIX));
+  return expandToShippedFiles(positives, ref, ctx).filter((path) => !preservedSet.has(path));
+}
+
+/**
  * Staged paths that are NOT covered by `owned`.
  *
  * Used to decide whether committing the whole index is equivalent to a
@@ -2413,13 +2447,16 @@ async function apply() {
     // recovery command. Declared outside the try because the catch reads it.
     let usedIndexCommit = false;
 
-    // The staging and scoped-commit paths must use the same file-only list.
+    // The staging and scoped-commit paths must use the same concrete file list.
     // Passing a manifest directory to `git commit -- <dir>` reads matching
     // tracked files from the working tree, including files the target tree no
-    // longer ships. That can sweep a user's unstaged edit into the updater
-    // commit even though staging never touched it (#3504). Exclusion
-    // pathspecs remain in the expanded list so preserved files stay out.
-    const expandedPathsToStage = expandToShippedFiles(pathsToStage);
+    // longer ships, which can sweep a user's unstaged edit into the updater
+    // commit even though staging never touched it (#3504). stagingFileList
+    // expands the positive specs and subtracts the preserved files, so no
+    // `:(exclude)` spec reaches addPaths (where --literal-pathspecs would read
+    // it as a literal filename and abort the commit) and no preserved file is
+    // staged. preservedSet is the same Set built at the top of apply().
+    const expandedPathsToStage = stagingFileList(pathsToStage, preservedSet);
 
     try {
       prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);


### PR DESCRIPTION
Fixes #3740.

## What breaks

Run the self-updater with a locally-edited system file (I hit it with a customized `Dockerfile`) and the update commits halfway, then aborts: "files may be staged but not committed."

The updater protects your local edits by marking them with a `:(exclude)<path>` pathspec. That spec gets passed to `git add --literal-pathspecs`, which switches off pathspec magic and reads `:(exclude)Dockerfile` as a literal filename that doesn't exist:

```
fatal: pathspec ':(exclude)Dockerfile' did not match any files
```

One bad pathspec kills the whole commit.

## The fix

Work out which files to keep before staging: expand the real paths, subtract the preserved ones, pass git a plain list. New `stagingFileList()`, so no `:(exclude)` ever reaches `git add`. Also fixes a quieter version where a preserved file inside an updated directory got swept back in.

## Tests

Regression test in `updater-add-paths.test.mjs` covering a standalone preserved file and one under an updated directory. All `updater-*` suites pass.