### PR TITLE
feat(scan): one machine-findable marker line above every scan summary (#3560)

### DIFF
--- a/lib/scan-summary-marker.mjs
+++ b/lib/scan-summary-marker.mjs
@@ -1,0 +1,61 @@
+/**
+ * scan-summary-marker.mjs — the machine-findable boundary where a scan's
+ * summary begins (#3560).
+ *
+ * Every scanner ends a run with a human-readable summary, but until now the
+ * only way to find where that summary starts was to hardcode the scanner's
+ * banner text. Those banners are presentation strings: rewording one is a
+ * cosmetic change here and a silent breakage in whatever slices the log —
+ * the slice quietly returns the wrong region, or nothing, and the caller
+ * cannot tell that from "the scan found nothing".
+ *
+ * They are also not safe to match loosely. `scan-ats-full.mjs` prints
+ * `Reverse ATS scan — ...` at the START of a run and `Reverse ATS Scan — ...`
+ * for the summary: a case-insensitive match on the obvious string swallows
+ * the whole log, which for a full sweep is thousands of progress lines.
+ *
+ * So the banners stay exactly as they are, and one marker line goes above
+ * them. The marker is the interface; the banner is decoration.
+ *
+ * MATCHING CONTRACT: consumers match the whole trimmed line against
+ * SCAN_SUMMARY_MARKER — equality, not a prefix. Nothing is appended to it
+ * (no scanner id, no counts), and adding anything later would be a breaking
+ * change to be made knowingly, not a formatting tweak.
+ *
+ * Stream: the marker follows its scanner's summary. `scan-ats-full.mjs`
+ * routes every human line to stderr under `--json` so that stdout carries
+ * exactly one JSON object; passing that scanner's `log` as `emit` keeps the
+ * marker on stderr with the summary it belongs to, and stdout uncontaminated.
+ */
+
+/**
+ * The line printed immediately above a scan summary. Deliberately not a word
+ * any scanner would print for another reason.
+ */
+export const SCAN_SUMMARY_MARKER = '::career-ops:scan-summary::';
+
+/**
+ * The marker plus the banner block that follows it.
+ *
+ * @param {string} title - Human banner title, e.g. 'Portal Scan'.
+ * @param {string} date - Run date, already formatted (YYYY-MM-DD).
+ * @returns {string[]} Lines to print in order. The leading '' preserves the
+ *   blank line the scanners printed before their banner.
+ */
+export function scanSummaryHeaderLines(title, date) {
+  const rule = '━'.repeat(45);
+  return ['', SCAN_SUMMARY_MARKER, rule, `${title} — ${date}`, rule];
+}
+
+/**
+ * Print the marker and banner block.
+ *
+ * @param {string} title - Human banner title, e.g. 'Portal Scan'.
+ * @param {string} date - Run date, already formatted (YYYY-MM-DD).
+ * @param {(line: string) => void} [emit] - Where to write; defaults to
+ *   console.log. Pass the scanner's own logger when it redirects output
+ *   (see the stream note above).
+ */
+export function printScanSummaryHeader(title, date, emit = console.log) {
+  for (const line of scanSummaryHeaderLines(title, date)) emit(line);
+}

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -50,6 +50,7 @@ import workday from './providers/workday.mjs';
 import icims from './providers/icims.mjs';
 import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays, PORTALS_PATH, PIPELINE_PATH } from './scan.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { printScanSummaryHeader } from './lib/scan-summary-marker.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
@@ -1066,9 +1067,7 @@ async function main() {
   if (offers.length && opts.liveness) offers = await filterLive(offers);
   offers.sort((a, b) => (b.postedAt || 0) - (a.postedAt || 0));
 
-  log(`\n${'━'.repeat(45)}`);
-  log(`Reverse ATS Scan — ${date}`);
-  log(`${'━'.repeat(45)}`);
+  printScanSummaryHeader('Reverse ATS Scan', date, log);
   log(`Companies scanned:  ${totalCompaniesScanned}${capHit ? ` of ${totalCompaniesAvailable} (capped)` : ''}`);
   log(`Unreachable boards: ${totalErrors}`);
   if (cappedBoards) log(`Page-capped boards: ${cappedBoards} (partial coverage — later postings not scanned)`);

--- a/scan-hn.mjs
+++ b/scan-hn.mjs
@@ -22,6 +22,7 @@ import { localToday } from './lib/local-today.mjs';
 // Import the deterministic provider
 import hnProvider from './providers/hackernews.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
+import { printScanSummaryHeader } from './lib/scan-summary-marker.mjs';
 
 // ── Configuration ────────────────────────────────────────────────────
 // Imported from scan.mjs so it honors CAREER_OPS_PORTALS and the data root (#3510).
@@ -115,8 +116,15 @@ async function main() {
   if (newOffers.length > 0) {
     await appendToPipeline(newOffers);
     await appendToScanHistory(newOffers, localToday(), 'added');
-    console.log(`\n🎉 Success: ${newOffers.length} offers added.`);
   }
+
+  // Printed on every run, including the zero-match one. This scanner used to
+  // end in silence when nothing matched, which reads identically to a run that
+  // died at the fetch — the summary is what tells those apart (#3560).
+  printScanSummaryHeader('HN Scan', localToday());
+  console.log(`Postings fetched:   ${rawJobs.length}`);
+  console.log(`New offers:         ${newOffers.length}`);
+  if (newOffers.length > 0) console.log(`\n🎉 Success: ${newOffers.length} offers added.`);
 }
 
 if (isMainModule(import.meta.url)) {

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -24,6 +24,7 @@ import * as yaml from 'js-yaml';
 import { appendToPipeline, appendToScanHistory, loadSeenUrls, PORTALS_PATH, SCAN_HISTORY_PATH } from './scan.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { printScanSummaryHeader } from './lib/scan-summary-marker.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 // ── Config ───────────────────────────────────────────────────────────
@@ -344,9 +345,7 @@ async function main() {
   }
 
   // Summary
-  console.log(`\n${'━'.repeat(45)}`);
-  console.log(`Interamt Scan — ${date}`);
-  console.log(`${'━'.repeat(45)}`);
+  printScanSummaryHeader('Interamt Scan', date);
   console.log(`Keywords searched:  ${keywords.length}`);
   console.log(`Total found:        ${totalFound}`);
   console.log(`Filtered by title:  ${titleSkipped.length}`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -72,6 +72,7 @@ import { compileKeyword, compilePositiveKeyword, compileContentKeyword, buildTit
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { withPortalHealthLock } from './portal-health-lock.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { printScanSummaryHeader } from './lib/scan-summary-marker.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 import { promoteKnownFragmentIdentity } from './url-key.mjs';
 
@@ -3008,9 +3009,7 @@ async function main() {
   }
 
   // 7. Print summary
-  console.log(`\n${'━'.repeat(45)}`);
-  console.log(`Portal Scan — ${date}`);
-  console.log(`${'━'.repeat(45)}`);
+  printScanSummaryHeader('Portal Scan', date);
   const summaryCompanies = targets.filter(t => !t._isBoard).length;
   const summaryBoards = targets.filter(t => t._isBoard).length;
   console.log(`Companies scanned:     ${summaryCompanies}`);

--- a/tests/scan-summary-marker.test.mjs
+++ b/tests/scan-summary-marker.test.mjs
@@ -1,0 +1,69 @@
+// tests/scan-summary-marker.test.mjs — the marker is an interface, the banner
+// is decoration (#3560).
+//
+// The point of the marker is that a consumer can find where a summary starts
+// without knowing any scanner's banner text. Two things have to hold for that
+// to be true, and both are asserted here:
+//
+//   1. The marker line is exactly SCAN_SUMMARY_MARKER, alone on its line, so
+//      whole-line equality works. A consumer matching a prefix would keep
+//      working if someone appended a scanner id; one matching the whole line
+//      would not, and the whole-line form is the documented contract.
+//   2. The banner underneath is byte-identical to what the scanners printed
+//      before the marker existed. That is the promise the issue was answered
+//      with ("existing banners left as they are underneath"), and it is a
+//      golden string here rather than a claim in a PR description.
+//
+// Run:  node --test tests/scan-summary-marker.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SCAN_SUMMARY_MARKER, scanSummaryHeaderLines, printScanSummaryHeader } from '../lib/scan-summary-marker.mjs';
+
+const RULE = '━'.repeat(45);
+
+test('the marker is a whole line of its own, immediately above the banner', () => {
+  const lines = scanSummaryHeaderLines('Portal Scan', '2026-09-03');
+  assert.deepEqual(lines, ['', SCAN_SUMMARY_MARKER, RULE, 'Portal Scan — 2026-09-03', RULE]);
+  assert.equal(lines[1].trim(), SCAN_SUMMARY_MARKER);
+  // Nothing is appended to the token — that is what makes whole-line equality
+  // a usable contract for consumers.
+  assert.equal(lines[1], SCAN_SUMMARY_MARKER);
+});
+
+test('printed output keeps the pre-marker banner byte-for-byte', () => {
+  const out = [];
+  printScanSummaryHeader('Reverse ATS Scan', '2026-09-03', (l) => out.push(l));
+  const printed = out.map((l) => `${l}\n`).join('');
+  // What the scanner printed before this change, with one line inserted:
+  //   console.log(`\n${'━'.repeat(45)}`)
+  //   console.log(`Reverse ATS Scan — ${date}`)
+  //   console.log(`${'━'.repeat(45)}`)
+  const before = `\n${RULE}\n` + `Reverse ATS Scan — 2026-09-03\n` + `${RULE}\n`;
+  assert.equal(printed, `\n${SCAN_SUMMARY_MARKER}\n${before.slice(1)}`);
+  assert.equal(printed.split('\n')[1], SCAN_SUMMARY_MARKER);
+});
+
+test('emit defaults to console.log and receives one call per line', () => {
+  const calls = [];
+  const original = console.log;
+  console.log = (...a) => calls.push(a);
+  try {
+    printScanSummaryHeader('Interamt Scan', '2026-09-03');
+  } finally {
+    console.log = original;
+  }
+  assert.equal(calls.length, 5);
+  assert.deepEqual(calls.map((c) => c[0]), scanSummaryHeaderLines('Interamt Scan', '2026-09-03'));
+  // One argument per call: console.log(a, b) would join with a space and put
+  // something after the marker on its line.
+  assert.ok(calls.every((c) => c.length === 1));
+});
+
+test('the title is the only thing that varies between scanners', () => {
+  for (const title of ['Portal Scan', 'Reverse ATS Scan', 'Interamt Scan', 'HN Scan']) {
+    const lines = scanSummaryHeaderLines(title, '2026-09-03');
+    assert.equal(lines[1], SCAN_SUMMARY_MARKER);
+    assert.equal(lines[3], `${title} — 2026-09-03`);
+  }
+});

--- a/tests/scan-summary-marker.test.mjs
+++ b/tests/scan-summary-marker.test.mjs
@@ -22,6 +22,15 @@ import { SCAN_SUMMARY_MARKER, scanSummaryHeaderLines, printScanSummaryHeader } f
 
 const RULE = '━'.repeat(45);
 
+// The token itself is the interface, so it is pinned as a literal here and not
+// only compared against the imported constant: renaming or re-spelling
+// SCAN_SUMMARY_MARKER would otherwise leave every assertion green while every
+// consumer downstream breaks.
+test('the marker token is exactly this string', () => {
+  assert.equal(SCAN_SUMMARY_MARKER, '::career-ops:scan-summary::');
+  assert.equal(scanSummaryHeaderLines('Portal Scan', '2026-09-03')[1], '::career-ops:scan-summary::');
+});
+
 test('the marker is a whole line of its own, immediately above the banner', () => {
   const lines = scanSummaryHeaderLines('Portal Scan', '2026-09-03');
   assert.deepEqual(lines, ['', SCAN_SUMMARY_MARKER, RULE, 'Portal Scan — 2026-09-03', RULE]);

--- a/tests/scan-summary-marker.test.mjs
+++ b/tests/scan-summary-marker.test.mjs
@@ -67,3 +67,31 @@ test('the title is the only thing that varies between scanners', () => {
     assert.equal(lines[3], `${title} — 2026-09-03`);
   }
 });
+
+// The module can be perfect and the marker still absent from a run: what makes
+// the boundary usable is that every scanner actually emits it. Assert the
+// wiring per scanner, so a refactor that drops one call fails here instead of
+// silently returning a consumer to banner-matching.
+//
+// Deliberately narrow: this looks for the helper call and the banner title it
+// is given, not for the rule characters. A test that grepped for
+// `'━'.repeat(45)` would also match stats.mjs and weekly-digest.mjs, which
+// build the same rule for unrelated tables, and would fail the day either of
+// those is touched.
+test('every scanner imports the module and prints the header', async () => {
+  const { readFileSync } = await import('node:fs');
+  const scanners = [
+    ['scan.mjs', 'Portal Scan'],
+    ['scan-ats-full.mjs', 'Reverse ATS Scan'],
+    ['scan-interamt.mjs', 'Interamt Scan'],
+    ['scan-hn.mjs', 'HN Scan'],
+  ];
+  for (const [file, title] of scanners) {
+    const src = readFileSync(new URL(`../${file}`, import.meta.url), 'utf-8');
+    assert.match(src, /from '\.\/lib\/scan-summary-marker\.mjs'/, `${file} imports the module`);
+    assert.ok(
+      src.includes(`printScanSummaryHeader('${title}'`),
+      `${file} prints the summary header with the banner title "${title}"`,
+    );
+  }
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -232,6 +232,7 @@ const SYSTEM_PATHS = [
   'lib/cli-flags.mjs',
   'lib/gemini-node-floor.mjs',
   'lib/local-today.mjs',
+  'lib/scan-summary-marker.mjs',
   'lib/is-main-module.mjs',
   'lib/mjs-files.mjs',
   'lib/outcome-dir.mjs',


### PR DESCRIPTION
Closes #3560, in the scope you named there: one shared marker line emitted by every scanner right before its summary, with the existing banners left as they are underneath.

### What changed

- **New `lib/scan-summary-marker.mjs`** — `SCAN_SUMMARY_MARKER` (`::career-ops:scan-summary::`) plus `scanSummaryHeaderLines()` / `printScanSummaryHeader()`.
- **`scan.mjs`, `scan-ats-full.mjs`, `scan-interamt.mjs`** print the marker above their existing banner. Banner text, rule width, and the blank line above it are unchanged.
- **`scan-hn.mjs`** gets the banner block it never had, printed unconditionally — see below.
- `lib/scan-summary-marker.mjs` registered in `SYSTEM_PATHS`.

### The matching contract

Consumers match the **whole trimmed line** against the constant — equality, not a prefix. Nothing is appended to the token (no scanner id, no counts), so adding one later would be a knowingly breaking change rather than a formatting tweak. That is stated in the module header and asserted in the test.

### `--json` stdout is untouched

`scan-ats-full.mjs` routes human output to stderr under `--json` (`log`, `:691`) so stdout carries exactly one JSON object. The marker goes through that same `log`, so under `--json` it lands on stderr with the summary it belongs to. The JSON emit path (`:1152`) is unchanged.

### The one behaviour change, flagged deliberately: `scan-hn.mjs`

Today `scan-hn.mjs` prints nothing at all when nothing matched — the run just ends after `⚠️ No AI key...`. A consumer cannot tell that from a run that died at the fetch, and a marker printed only on the happy path would carry the same ambiguity, so the block is unconditional and reports `New offers: 0`. This is the one place where the PR changes what an existing scanner prints rather than only adding a line. Item 5 of the issue named the hn block, but it is the part of this PR most worth a second look, so I am not burying it.

The `🎉 Success:` line is unchanged and still prints only when something was added.

### Left alone deliberately

`scan-ats-full.mjs:1128` writes `# Reverse ATS Scan — ${date}` into the `--md-out` digest. That is the third copy of the literal the issue called out, but it is a markdown heading in a file, not a boundary in a log stream, so it gets no marker.

### Tests

`tests/scan-summary-marker.test.mjs` (auto-discovered, no registration). It asserts the marker is alone on its line, and that the printed block is byte-identical to what the scanners emitted before the marker existed — a golden string rather than a claim in this description.

Full suite locally on Windows/Node 22: **8084 passed, 0 failed, 18 warnings**; a clean checkout of `main` at 398edb1 gives 8081 passed and the same 18 warnings, so nothing new is warned about.

### Not in this PR

Items 1-4 of the issue (reusing `nowStr` for the run row, `scan-runs.tsv` rows for the other three scanners, extending the `--json` convention, a run id) are untouched here — happy to send any of them separately, in whatever order suits you.
