### PR TITLE
fix(upgrade-tests): pass --confirm in the local-paths leg

### DIFF
--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -420,7 +420,7 @@ function localPathsLeg() {
 
     let exitCode = 0, output = '';
     try {
-      output = execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
+      output = execFileSync(process.execPath, ['update-system.mjs', 'apply', '--confirm'], {
         cwd: install, encoding: 'utf-8', timeout: 300000,
         env: hermeticEnv(cfg),
       });


### PR DESCRIPTION
`localPathsLeg()` runs the cloned install's updater as `apply`, while the pr-gate leg one function up runs it as `apply --confirm`. That difference was harmless until the confirmation requirement shipped: `update-system.mjs` first refuses an unconfirmed install at `career-ops-v1.32.0` (the string is absent at v1.31.0 and v1.30.0).

The leg clones the install at the newest release tag that is an ancestor of HEAD, so from the moment v1.32.0 was published the cloned updater stops at the confirm gate before it ever reads `config/local-paths.txt`. The two assertions that still pass do so for the wrong reason — `apply` exits non-zero, and the fork file survives because nothing was applied — and the two that read the output fail.

**This is currently red on every PR, regardless of content.** v1.32.0 was published at 2026-09-03T07:17:37Z; gate runs at 05:00Z–06:09Z that day were green and every run after 07:43Z is red. #3513 and #3530 are useful controls — neither touches `update-system.mjs` and both fail this step the same way.

Verified on a clean checkout of `main` at e58eb65, with no other change in the tree:

```
before:  FAIL apply names the declaration file as the reason
         FAIL apply names the offending entry (run-nightly.ps1)
         RED: 2 failure(s)

after:   PASS apply names the declaration file as the reason
         PASS apply names the offending entry (run-nightly.ps1)
         GREEN
```

The `--local-paths` leg needs release tags to run at all (`fetch-depth: 0` in CI); on a shallow clone it exits with "No release tag is an ancestor of HEAD" before reaching any assertion.

Flagged in #3747 and sending it separately rather than folding it into that PR, since it blocks every open PR and has nothing to do with that change.
