### PR TITLE
fix: honor .career-ops-data marker in generate-pdf and verify-cv-facts

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -63,13 +63,25 @@ const PDF_PAGE_MARGIN = '0.6in';
 // refused to write, intermittently and only under the full suite. Memoized on
 // the variable's own value: same cost as the const while nothing changes, and
 // self-correcting the moment it does. Same defect class as #3159.
+//
+// Derived from the DATA ROOT, exactly like the import-time constant above. The
+// re-derivation used to pass this script's own directory straight in as the
+// root, which skipped getCareerOpsRoot() and with it CAREER_OPS_ROOT,
+// CAREER_OPS_DATA_DIR and the .career-ops-data marker. From a git worktree
+// whose marker points at the real data directory, `workspaceRoot` resolved
+// that directory while this guard resolved the worktree — so every
+// DATA_ROOT-relative input and batch manifest was refused as an escape, and
+// only an explicit CAREER_OPS_TRACKER (the one variable the key did read)
+// could get a PDF written. The data root is part of the cache key, so a change
+// to any of the three variables or to the marker is picked up on the next call.
 let __rootCache = { key: null, root: null, canonical: null };
 function refreshRootCache() {
-  const key = process.env.CAREER_OPS_TRACKER || '';
+  const dataRoot = getCareerOpsRoot();
+  const key = `${dataRoot}\0${process.env.CAREER_OPS_TRACKER || ''}`;
   if (__rootCache.key !== key) {
     // Always re-derive: falling back to the import-time const when the variable
     // is unset would hand back the very value the poisoned import froze.
-    const root = resolveWorkspaceRoot(resolveTrackerPath(__dirname));
+    const root = resolveWorkspaceRoot(resolveTrackerPath(dataRoot));
     __rootCache = { key, root, canonical: realpathSync(root) };
   }
   return __rootCache;

--- a/tests/data-root-marker-worktree.test.mjs
+++ b/tests/data-root-marker-worktree.test.mjs
@@ -1,0 +1,192 @@
+// The user-layer data root is resolved through path-resolver.mjs: the
+// CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR variables, then a `.career-ops-data`
+// marker next to the scripts, then the script directory itself (AGENTS.md,
+// "Path Resolution Override & Precedence"). A git worktree is the layout that
+// exercises the marker for real: the scripts run from a checkout that holds no
+// cv.md, no config/ and no data/, and the marker points at the checkout that
+// does. Two scripts honoured that contract at import time and broke it at use
+// time:
+//
+//   - generate-pdf.mjs derived its containment root from its own directory in
+//     the use-time re-derivation added for #3162, so every DATA_ROOT-relative
+//     input was refused as "escaping the tracker workspace";
+//   - verify-cv-facts.mjs resolved its default sources against process.cwd(),
+//     read an empty cv.md from the worktree, and failed every real number in
+//     the generated CV as "absent from sources".
+//
+// Both are driven here as spawned CLIs from a worktree-shaped sandbox with the
+// three environment overrides stripped, so the marker is the only signal — the
+// exact situation the `pdf` mode runs in from a worktree.
+import { spawnSync } from 'child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, rmSync, linkRepoPackage, ROOT, NODE } from './helpers.mjs';
+
+console.log('\ndata-root-marker-worktree.test.mjs — scripts run from a worktree honour the .career-ops-data marker');
+
+const outputRoot = join(ROOT, 'output');
+mkdirSync(outputRoot, { recursive: true });
+// realpathSync on both: Node resolves import.meta.url from a file's REALPATH
+// while argv keeps the caller's spelling, and generate-pdf's isMain guard
+// compares the two (#3165). The data root is compared canonically by the
+// containment guard, so its expected spelling must be canonical as well.
+const worktree = realpathSync(mkdtempSync(join(outputRoot, 'marker-worktree-')));
+const dataRoot = realpathSync(mkdtempSync(join(tmpdir(), 'career-ops-marker-data-')));
+
+const ENV_OVERRIDES = ['CAREER_OPS_TRACKER', 'CAREER_OPS_ROOT', 'CAREER_OPS_DATA_DIR', 'CAREER_OPS_PDF_INDEX'];
+const cleanEnv = { ...process.env };
+for (const name of ENV_OVERRIDES) delete cleanEnv[name];
+
+function runScript(script, args) {
+  const result = spawnSync(NODE, [join(worktree, script), ...args], {
+    cwd: worktree,
+    env: cleanEnv,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  return { ...result, output: `${result.stdout || ''}${result.stderr || ''}` };
+}
+
+try {
+  // ── The worktree: scripts + marker, and nothing user-layer ─────────────
+  for (const file of [
+    'generate-pdf.mjs', 'verify-cv-facts.mjs', 'theme-style.mjs', 'tracker-utils.mjs',
+    'tracker-parse.mjs', 'tracker-aliases.json', 'pipeline-lock.mjs', 'path-resolver.mjs',
+  ]) {
+    copyFileSync(join(ROOT, file), join(worktree, file));
+  }
+  mkdirSync(join(worktree, 'lib'), { recursive: true });
+  copyFileSync(join(ROOT, 'lib', 'is-main-module.mjs'), join(worktree, 'lib', 'is-main-module.mjs'));
+  linkRepoPackage(worktree, 'js-yaml');
+  writeFileSync(join(worktree, '.career-ops-data'), `${dataRoot}\n`, 'utf-8');
+
+  // Chromium stand-in: a one-page PDF whose page tree generate-pdf can count.
+  const playwrightStub = join(worktree, 'node_modules', 'playwright');
+  mkdirSync(playwrightStub, { recursive: true });
+  writeFileSync(join(playwrightStub, 'package.json'), JSON.stringify({
+    name: 'playwright', type: 'module', exports: './index.js',
+  }), 'utf-8');
+  writeFileSync(join(playwrightStub, 'index.js'), `
+const ONE_PAGE = Buffer.from(\`%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+%%EOF\`, 'latin1');
+const page = { async goto() {}, async evaluate() {}, async pdf() { return ONE_PAGE; }, async close() {} };
+export const chromium = {
+  async launch() {
+    return {
+      async newContext() { return { async newPage() { return page; }, async close() {} }; },
+      async newPage() { return page; },
+      async close() {},
+    };
+  },
+};
+`, 'utf-8');
+
+  // ── The data root: everything the contract says lives there ────────────
+  mkdirSync(join(dataRoot, 'data'), { recursive: true });
+  mkdirSync(join(dataRoot, 'config'), { recursive: true });
+  mkdirSync(join(dataRoot, 'output'), { recursive: true });
+  writeFileSync(join(dataRoot, 'data', 'applications.md'),
+    '# Applications Tracker\n\n| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n|---|---|---|---|---|---|---|---|---|\n', 'utf-8');
+  writeFileSync(join(dataRoot, 'data', 'pdf-index.tsv'), '', 'utf-8');
+  writeFileSync(join(dataRoot, 'cv.md'), [
+    '# Jane Doe',
+    '',
+    '## Summary',
+    'Senior engineer with 6 years of experience.',
+    '',
+    '## Experience',
+    'Cut p95 latency 20% for 40 services.',
+    '',
+  ].join('\n'), 'utf-8');
+  writeFileSync(join(dataRoot, 'config', 'cv-facts.json'), JSON.stringify({
+    allow_metrics: [], allow_facts: [], forbidden_phrases: [], warn_phrases: [],
+  }), 'utf-8');
+  const html = join(dataRoot, 'output', 'cv-probe.html');
+  writeFileSync(html, [
+    '<html><body>',
+    '<h2>Summary</h2><p>Senior engineer with 6 years of experience.</p>',
+    '<h2>Experience</h2><p>Cut p95 latency 20% for 40 services.</p>',
+    '</body></html>',
+  ].join('\n'), 'utf-8');
+
+  // ── generate-pdf.mjs ───────────────────────────────────────────────────
+  const pdf = join(dataRoot, 'output', 'cv-probe.pdf');
+  const render = runScript('generate-pdf.mjs', [html, pdf, '--format=letter']);
+  if (render.status === 0 && existsSync(pdf) && !render.output.includes('outside the tracker workspace')) {
+    pass('generate-pdf.mjs renders a DATA_ROOT input to a DATA_ROOT output from a marker-bearing worktree');
+  } else {
+    fail(`generate-pdf.mjs refused DATA_ROOT paths from a marker-bearing worktree (exit ${render.status}):\n${render.output.trim()}`);
+  }
+
+  // The inverse pins WHICH root the guard is anchored to. A file inside the
+  // worktree is outside the data root, so it must be refused; the defective
+  // guard, anchored to the script directory, accepted it.
+  const stray = join(worktree, 'stray.html');
+  copyFileSync(html, stray);
+  const strayPdf = join(dataRoot, 'output', 'stray.pdf');
+  const escape = runScript('generate-pdf.mjs', [stray, strayPdf, '--format=letter']);
+  if (escape.status !== 0 && escape.output.includes('outside the tracker workspace') && !existsSync(strayPdf)) {
+    pass('generate-pdf.mjs anchors its containment guard to the data root, not the script directory');
+  } else {
+    fail(`generate-pdf.mjs accepted an input inside the worktree (exit ${escape.status}):\n${escape.output.trim()}`);
+  }
+
+  // ── verify-cv-facts.mjs ────────────────────────────────────────────────
+  const gate = runScript('verify-cv-facts.mjs', [html, '--json']);
+  let verdict = null;
+  try { verdict = JSON.parse(gate.stdout.trim().split('\n').pop()); } catch {}
+  if (verdict && verdict.verdict !== 'block' && verdict.invented.length === 0 && verdict.unsupportedFacts.length === 0) {
+    pass('verify-cv-facts.mjs reads cv.md from the data root when no --source is given');
+  } else {
+    fail(`verify-cv-facts.mjs failed a CV built from DATA_ROOT/cv.md (exit ${gate.status}):\n${gate.output.trim()}`);
+  }
+
+  // A number NOT in cv.md must still block, proving the pass above came from
+  // reading the real source rather than from an empty one that checks nothing.
+  const invented = join(dataRoot, 'output', 'cv-invented.html');
+  writeFileSync(invented, '<html><body><p>Cut p95 latency 95% for 400 services.</p></body></html>', 'utf-8');
+  const blocked = runScript('verify-cv-facts.mjs', [invented, '--json']);
+  let blockedVerdict = null;
+  try { blockedVerdict = JSON.parse(blocked.stdout.trim().split('\n').pop()); } catch {}
+  if (blocked.status !== 0 && blockedVerdict?.verdict === 'block' && blockedVerdict.invented.includes('95%')) {
+    pass('verify-cv-facts.mjs still blocks a number absent from the data-root cv.md');
+  } else {
+    fail(`verify-cv-facts.mjs did not block an invented number (exit ${blocked.status}):\n${blocked.output.trim()}`);
+  }
+
+  // ── In-process: the use-time root follows CAREER_OPS_ROOT too ──────────
+  // refreshRootCache() used to key only on CAREER_OPS_TRACKER; a data-root
+  // override set after import was invisible to the containment guard.
+  const saved = Object.fromEntries(ENV_OVERRIDES.map((name) => [name, process.env[name]]));
+  try {
+    for (const name of ENV_OVERRIDES) delete process.env[name];
+    const mod = await import('../generate-pdf.mjs');
+    process.env.CAREER_OPS_ROOT = dataRoot;
+    const overridden = mod.workspaceRelativeManifestPath(join(dataRoot, 'output', 'x.html'));
+    delete process.env.CAREER_OPS_ROOT;
+    const restored = mod.workspaceRelativeManifestPath(join(ROOT, 'output', 'y.html'));
+    if (overridden === 'output/x.html' && restored === 'output/y.html') {
+      pass('generate-pdf.mjs re-derives its workspace root when CAREER_OPS_ROOT changes after import');
+    } else {
+      fail(`workspace root did not follow CAREER_OPS_ROOT: overridden="${overridden}" restored="${restored}"`);
+    }
+  } finally {
+    for (const [name, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+} finally {
+  rmSync(worktree, { recursive: true, force: true });
+  rmSync(dataRoot, { recursive: true, force: true });
+}

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -13,13 +13,31 @@
  */
 
 import { existsSync, readFileSync } from 'fs';
-import { isAbsolute, join, dirname, basename } from 'path';
-import { fileURLToPath } from 'url';
+import { isAbsolute, join, basename } from 'path';
 import { isMainModule } from './lib/is-main-module.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const ROOT = dirname(fileURLToPath(import.meta.url));
-const DEFAULT_SOURCES = ['cv.md', 'article-digest.md'];
-const DEFAULT_CONFIG = join(ROOT, 'config', 'cv-facts.json');
+const DEFAULT_SOURCE_NAMES = ['cv.md', 'article-digest.md'];
+const DEFAULT_CONFIG_NAME = join('config', 'cv-facts.json');
+
+/**
+ * Default sources and config live in the career-ops DATA ROOT (CAREER_OPS_ROOT
+ * / CAREER_OPS_DATA_DIR / the .career-ops-data marker / this directory), not in
+ * the shell's cwd and not next to this script. cv.md, article-digest.md and
+ * config/cv-facts.json are user-layer files: from a git worktree that carries a
+ * marker they exist only in the data root, so a cwd-relative default read an
+ * empty source and failed every real number in a generated CV as "absent from
+ * sources". Resolved per call rather than at import so an override set later
+ * in the same process is honoured (the frozen-const class of #3162). Explicit
+ * --source/--config paths keep their cwd-relative meaning.
+ */
+function defaultSourcePaths() {
+  const root = getCareerOpsRoot();
+  return DEFAULT_SOURCE_NAMES.map(name => join(root, name));
+}
+function defaultConfigPath() {
+  return join(getCareerOpsRoot(), DEFAULT_CONFIG_NAME);
+}
 const TOOL_PROSE_WORDS = new Set([
   'a', 'an', 'and', 'at', 'built', 'by', 'containerized', 'deployment',
   'deployments', 'for', 'from', 'in', 'of', 'on', 'production', 'project',
@@ -492,8 +510,8 @@ function sourceContainsFact(sourceText, value) {
  * @throws when the config is invalid
  */
 export function verifyFacts(targetText, {
-  sourcePaths = DEFAULT_SOURCES,
-  configPath = DEFAULT_CONFIG,
+  sourcePaths = defaultSourcePaths(),
+  configPath = defaultConfigPath(),
   cwd = process.cwd(),
 } = {}) {
   const sourceText = sourcePaths.map(path => readIfExists(resolveInputPath(path, cwd))).join('\n');
@@ -544,7 +562,7 @@ export function assertFacts(targetText, options = {}) {
 function parseCliArgs(args) {
   const sourcePaths = [];
   let targetArg = '';
-  let configPath = DEFAULT_CONFIG;
+  let configPath = defaultConfigPath();
   let json = false;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -574,8 +592,8 @@ function usage() {
 
 Checks generated candidate-facing text for unsupported metrics and explicitly asserted
 non-metric facts (employers, titles, and tools) absent from source files.
-Default sources: cv.md, article-digest.md
-Default config:  config/cv-facts.json (optional)`;
+Default sources: cv.md, article-digest.md (in the career-ops data root)
+Default config:  config/cv-facts.json (optional, in the career-ops data root)`;
 }
 
 /** Exercise the metric extraction regressions that the shared gate depends on. */
@@ -850,7 +868,7 @@ export function runCli(args = process.argv.slice(2)) {
   }
   try {
     const result = verifyFacts(readFileSync(targetPath, 'utf-8'), {
-      sourcePaths: parsed.sourcePaths.length ? parsed.sourcePaths : DEFAULT_SOURCES,
+      sourcePaths: parsed.sourcePaths.length ? parsed.sourcePaths : defaultSourcePaths(),
       configPath: parsed.configPath,
     });
     if (parsed.json) {


### PR DESCRIPTION
## What does this PR do?

Makes `generate-pdf.mjs` and `verify-cv-facts.mjs` honor the documented data-root resolution (`CAREER_OPS_ROOT` / `CAREER_OPS_DATA_DIR` env vars, then the `.career-ops-data` marker) at use time, so the `pdf` mode works from a git worktree whose marker points at the real data directory. Adds a regression test that drives both scripts from a worktree-shaped sandbox.

**`generate-pdf.mjs`** — the use-time root re-derivation added for #3162 (`refreshRootCache()`) passed the script's own `__dirname` in as the root, bypassing `getCareerOpsRoot()`. The import-time `workspaceRoot` constant resolved DATA_ROOT correctly, but the containment guard (`assertInsideWorkspace`) resolved the worktree, so every DATA_ROOT-relative input and batch manifest was refused with `Refusing to write the PDF outside the tracker workspace … workspaceRoot=<worktree>`. Only an explicit `CAREER_OPS_TRACKER` export (the one variable the memo key read) worked around it. The refresh now resolves the data root and keys its memo on it, preserving the #3162 re-derivation while honoring all three overrides and the marker.

**`verify-cv-facts.mjs`** — default sources (`cv.md`, `article-digest.md`) and the default `config/cv-facts.json` were resolved against `process.cwd()`. From a worktree, `cv.md` doesn't exist there (it's user-layer), so the gate read an empty source and blocked every real number in a generated CV as "absent from sources". Defaults now resolve against the data root, per call rather than frozen at import. Explicit `--source` / `--config` paths keep their cwd-relative meaning.

No change to the precedence documented in AGENTS.md — these two scripts weren't following it.

## Related issue

Same defect class as #3162 (use-time root derivation) — no dedicated issue; bug fix sent straight in per the template.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Test evidence

`tests/data-root-marker-worktree.test.mjs` builds a sandbox holding only the scripts and a `.career-ops-data` marker, puts `cv.md` / `config/` / `data/` / `output/` in a separate temp data root, strips the env overrides, and spawns both CLIs from the sandbox:

- DATA_ROOT input → DATA_ROOT output renders (was refused)
- an input inside the worktree is refused (pins the guard to the data root, not the script dir)
- fact gate passes a CV built from the data-root `cv.md` with no `--source` (was blocked)
- an invented number still blocks (proves the real source was read)
- in-process, the workspace root follows a `CAREER_OPS_ROOT` change after import

Against the unpatched scripts the suite fails 4 of 5; patched, 5 of 5. Full `node test-all.mjs`: 7303 passed, 0 failed (12 env-only warnings: no user data, no Go compiler).

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

Diagnosed while running the `pdf` mode from a worktree; fix and test written with Claude Code assistance, reviewed and verified by me.
