### PR TITLE
fix(tests): pass --confirm to apply in the local-paths regression leg

### DIFF
--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -420,7 +420,7 @@ function localPathsLeg() {
 
     let exitCode = 0, output = '';
     try {
-      output = execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
+      output = execFileSync(process.execPath, ['update-system.mjs', 'apply', '--confirm'], {
         cwd: install, encoding: 'utf-8', timeout: 300000,
         env: hermeticEnv(cfg),
       });


### PR DESCRIPTION
## What

`upgrade-tests.mjs --local-paths` now runs `apply --confirm`, like the `--pr-gate` leg already does.

## Why

Since #2866 the updater refuses to install without `--confirm`. The local-paths leg still called plain `apply`, so it stopped at the confirmation message before reading `config/local-paths.txt`, and the two assertions that expect the declaration to be named went red. That is what every PR opened today sees in the Upgrade regression gate; `main` reproduces it locally.

## Validation

`node upgrade-tests.mjs --local-paths` on this branch: the four assertions pass (output in the first comment).
