### PR TITLE
feat(wttj): server-side Algolia filters so a scan can be exhaustive

### DIFF
--- a/providers/wttj.mjs
+++ b/providers/wttj.mjs
@@ -8,16 +8,33 @@
 // hardcoded. The key is referer-locked, so every Algolia request sends a
 // welcometothejungle.com Referer header.
 //
-// The board is global and enormous, so a `wttj:` config block with explicit
-// search queries is REQUIRED — without one the provider throws rather than
-// silently scanning an arbitrary slice:
+// The board is global and enormous, so a `wttj:` config block that narrows it is
+// REQUIRED — without one the provider throws rather than silently scanning an
+// arbitrary slice. Narrow it with `filters`, with `queries`, or with both:
 //
 //   - name: Welcome to the Jungle
 //     provider: wttj
 //     wttj:
+//       # Algolia filter expression, applied server-side (recommended).
+//       filters: 'offices.country_code:FR AND contract_type:full_time'
 //       queries: ["finops", "data platform engineer", "snowflake"]
-//       max_hits: 100        # optional, per query, capped at 200
+//       max_hits: 100        # optional, per query; capped at 200, or 1000 with filters
 //     enabled: true
+//
+// Prefer `filters` over broad keyword queries. A keyword alone cannot narrow a
+// global board: it is Algolia's relevance ranking that decides which `max_hits`
+// results come back, so anything past the cap is invisible no matter how well it
+// matches the scanner's own title/location filters (those run afterwards, on what
+// already came back). Filtering server-side shrinks the result set instead of
+// re-ranking it, which is what makes a scan exhaustive rather than a sample.
+//
+// Useful faceted attributes on this index: offices.country_code, offices.state,
+// offices.city, contract_type, remote, experience_level_minimum,
+// salary_yearly_minimum, organization.name, and WTTJ's own job taxonomy
+// new_profession.sub_category_reference (e.g. "product-management-wNjYw").
+//
+// When `filters` is set, `queries` becomes optional — the empty query means
+// "everything that passes the filter", which is usually what you want.
 //
 // Each hit maps to the normalized Job shape; salary_yearly_minimum (when
 // present) is attached as `salary: {min, max, currency}` so scan.mjs's
@@ -28,6 +45,14 @@ const SITE_ORIGIN = 'https://www.welcometothejungle.com';
 const INDEX = 'wttj_jobs_production_en';
 const DEFAULT_MAX_HITS = 100;
 const MAX_HITS_CAP = 200;
+// An unfiltered keyword query matches a large slice of a global board — "product
+// manager" alone returns ~14k hits — so Algolia's own relevance ranking, not the
+// scanner's filters, decides which 200 are seen. A server-side `filters`
+// expression cuts the result set to something a single request can actually
+// exhaust (e.g. product-management + France + full_time is ~450), so the cap is
+// raised to Algolia's per-request ceiling for this index when one is configured.
+const FILTERED_MAX_HITS_CAP = 1000;
+const FILTERS_MAX_LEN = 1000;
 
 /** Pin a URL to an expected https host. */
 function assertHost(url, host, label) {
@@ -134,20 +159,29 @@ export function normalizeWttjHit(h) {
   return job;
 }
 
-/** Resolve config: required queries list + optional per-query hit cap. */
+/** Resolve config: queries and/or an Algolia filter expression, + per-query hit cap. */
 function resolveConfig(entry) {
   const cfg = entry?.wttj && typeof entry.wttj === 'object' ? entry.wttj : {};
   const queries = Array.isArray(cfg.queries)
     ? cfg.queries.filter((q) => typeof q === 'string' && q.trim()).map((q) => q.trim())
     : [];
-  if (queries.length === 0) {
+  const filters = typeof cfg.filters === 'string' && cfg.filters.trim() ? cfg.filters.trim() : '';
+  if (filters.length > FILTERS_MAX_LEN) {
+    throw new Error(`wttj: \`filters\` is too long (${filters.length} > ${FILTERS_MAX_LEN} chars)`);
+  }
+  if (queries.length === 0 && !filters) {
     throw new Error(
-      'wttj: the WTTJ board is global — configure explicit searches via `wttj: { queries: ["…"] }`',
+      'wttj: the WTTJ board is global — narrow it with `wttj: { filters: "…" }` and/or `wttj: { queries: ["…"] }`',
     );
   }
+  // A filter expression already narrows the board server-side, so the empty query
+  // ("match everything that passes the filter") is the useful default. Without a
+  // filter there is nothing to narrow the board, so a query list stays mandatory.
+  const effectiveQueries = queries.length > 0 ? queries : [''];
+  const cap = filters ? FILTERED_MAX_HITS_CAP : MAX_HITS_CAP;
   const maxHits =
-    Number.isInteger(cfg.max_hits) && cfg.max_hits > 0 ? Math.min(cfg.max_hits, MAX_HITS_CAP) : DEFAULT_MAX_HITS;
-  return { queries, maxHits };
+    Number.isInteger(cfg.max_hits) && cfg.max_hits > 0 ? Math.min(cfg.max_hits, cap) : DEFAULT_MAX_HITS;
+  return { queries: effectiveQueries, filters, maxHits };
 }
 
 /** @type {Provider} */
@@ -159,7 +193,7 @@ export default {
   },
 
   async fetch(entry, ctx) {
-    const { queries, maxHits } = resolveConfig(entry);
+    const { queries, filters, maxHits } = resolveConfig(entry);
 
     // 1. Fresh Algolia credentials from the site's public env endpoint.
     const envText = await ctx.fetchText(assertHost(ENV_URL, 'www.welcometothejungle.com', 'env'), {
@@ -182,6 +216,10 @@ export default {
         attributesToRetrieve:
           'name,slug,organization,offices,remote,published_at_timestamp,salary_yearly_minimum,salary_maximum,salary_period,salary_currency',
       });
+      // Algolia parses `filters` as a filter expression against the index's
+      // faceted attributes; it never reaches a URL or host, so the assertHost
+      // guard above still covers every request target.
+      if (filters) params.set('filters', filters);
       const json = /** @type {any} */ (
         await ctx.fetchJson(url, {
           method: 'POST',

--- a/tests/providers/wttj.test.mjs
+++ b/tests/providers/wttj.test.mjs
@@ -179,7 +179,13 @@ try {
         fetchText: async (url, opts) => { textCalls.push({ url, opts }); return env; },
         fetchJson: async (url, opts) => {
           const params = new URLSearchParams(JSON.parse(opts.body).params);
-          const call = { url, opts, query: params.get('query'), hitsPerPage: params.get('hitsPerPage') };
+          const call = {
+            url,
+            opts,
+            query: params.get('query'),
+            hitsPerPage: params.get('hitsPerPage'),
+            filters: params.get('filters'),
+          };
           jsonCalls.push(call);
           return hitsFor(call);
         },
@@ -250,9 +256,93 @@ try {
   } catch (err) { noQueriesErr = err.message; }
   // Assert the message, not just that something threw — an unrelated crash must not pass.
   if (noQueriesErr.includes('wttj: the WTTJ board is global')) {
-    pass('wttj.fetch() throws without an explicit wttj.queries config (never scans the whole board)');
+    pass('wttj.fetch() throws with neither wttj.queries nor wttj.filters (never scans the whole board)');
   } else {
     fail(`wttj.fetch() missing-queries error = ${JSON.stringify(noQueriesErr) || 'did not throw'}`);
+  }
+
+  // --- Server-side filters (#wttj-filters) -------------------------------
+  // A keyword query cannot narrow a global board: Algolia's relevance ranking
+  // picks which max_hits results come back, and the scanner's own title/location
+  // filters only run on what already arrived. `filters` shrinks the result set
+  // server-side instead, which is what makes a scan exhaustive.
+  const FILTER = 'offices.country_code:FR AND contract_type:full_time';
+
+  const filtered = mkCtx(ENV_OK, () => ({ hits: [mkHit('job-f', 'Product Manager')] }));
+  const filteredJobs = await wttj.fetch(
+    { name: 'WTTJ', provider: 'wttj', wttj: { filters: FILTER } },
+    filtered.ctx,
+  );
+  if (filtered.jsonCalls.length === 1 && filtered.jsonCalls[0].filters === FILTER && filteredJobs.length === 1) {
+    pass('wttj.fetch() passes wttj.filters through to Algolia');
+  } else {
+    fail(`wttj.fetch() filters = ${JSON.stringify(filtered.jsonCalls.map((c) => c.filters))}`);
+  }
+
+  // filters alone → the empty query means "everything that passes the filter".
+  if (filtered.jsonCalls[0].query === '') {
+    pass('wttj.fetch() uses the empty query when only filters are configured');
+  } else {
+    fail(`wttj.fetch() filters-only query = ${JSON.stringify(filtered.jsonCalls[0].query)}`);
+  }
+
+  // filters + queries → the filter applies to every query, not just the first.
+  const both = mkCtx(ENV_OK, () => ({ hits: [] }));
+  await wttj.fetch(
+    { name: 'WTTJ', provider: 'wttj', wttj: { filters: FILTER, queries: ['a', 'b'] } },
+    both.ctx,
+  );
+  if (both.jsonCalls.length === 2 && both.jsonCalls.every((c) => c.filters === FILTER)
+      && both.jsonCalls.map((c) => c.query).join(',') === 'a,b') {
+    pass('wttj.fetch() applies wttj.filters to every configured query');
+  } else {
+    fail(`wttj.fetch() filters+queries = ${JSON.stringify(both.jsonCalls.map((c) => [c.query, c.filters]))}`);
+  }
+
+  // No filters → the 200 cap stands (an unfiltered query can match the whole board).
+  const unfilteredCap = mkCtx(ENV_OK, () => ({ hits: [] }));
+  await wttj.fetch({ name: 'WTTJ', provider: 'wttj', wttj: { queries: ['x'], max_hits: 5000 } }, unfilteredCap.ctx);
+  if (unfilteredCap.jsonCalls[0].hitsPerPage === '200') {
+    pass('wttj.fetch() still caps max_hits at 200 when no filters are configured');
+  } else {
+    fail(`wttj.fetch() unfiltered max_hits=5000 → hitsPerPage=${unfilteredCap.jsonCalls[0].hitsPerPage}`);
+  }
+
+  // With filters → the cap rises to Algolia's per-request ceiling for this index.
+  const filteredCap = mkCtx(ENV_OK, () => ({ hits: [] }));
+  await wttj.fetch(
+    { name: 'WTTJ', provider: 'wttj', wttj: { filters: FILTER, max_hits: 5000 } },
+    filteredCap.ctx,
+  );
+  if (filteredCap.jsonCalls[0].hitsPerPage === '1000') {
+    pass('wttj.fetch() raises the max_hits cap to 1000 when filters narrow the board');
+  } else {
+    fail(`wttj.fetch() filtered max_hits=5000 → hitsPerPage=${filteredCap.jsonCalls[0].hitsPerPage}`);
+  }
+
+  // A blank/whitespace filters value must not silently unlock the higher cap.
+  const blankFilter = mkCtx(ENV_OK, () => ({ hits: [] }));
+  await wttj.fetch(
+    { name: 'WTTJ', provider: 'wttj', wttj: { filters: '   ', queries: ['x'], max_hits: 5000 } },
+    blankFilter.ctx,
+  );
+  if (blankFilter.jsonCalls[0].hitsPerPage === '200' && blankFilter.jsonCalls[0].filters === null) {
+    pass('wttj.fetch() treats a blank wttj.filters as absent (cap stays 200, no filters param sent)');
+  } else {
+    fail(`wttj.fetch() blank filters → hitsPerPage=${blankFilter.jsonCalls[0].hitsPerPage}, filters=${JSON.stringify(blankFilter.jsonCalls[0].filters)}`);
+  }
+
+  let longFilterErr = '';
+  try {
+    await wttj.fetch(
+      { name: 'WTTJ', provider: 'wttj', wttj: { filters: 'a'.repeat(1001) } },
+      mkCtx(ENV_OK, () => ({ hits: [] })).ctx,
+    );
+  } catch (err) { longFilterErr = err.message; }
+  if (longFilterErr.includes('wttj: `filters` is too long')) {
+    pass('wttj.fetch() rejects an over-long filters expression');
+  } else {
+    fail(`wttj.fetch() long-filters error = ${JSON.stringify(longFilterErr) || 'did not throw'}`);
   }
 
   let badShapeErr = '';


### PR DESCRIPTION
## The problem

A keyword query cannot narrow the Welcome to the Jungle board. It is Algolia's relevance ranking — not the scanner's config — that decides which `max_hits` results come back, and `title_filter` / `location_filter` only run *afterwards*, on what already arrived. Anything past the cap is invisible no matter how well it matches the user's own filters.

The provider caps at `MAX_HITS_CAP = 200` per query, and the documented example config uses broad keywords. Measured against the live index on 2026-09-03:

| Query / filter | Hits | Seen |
|---|---|---|
| `"product manager"`, unfiltered | 13 981 | 200 (**1.4 %**) |
| `"senior product manager"` | 4 295 | 200 |
| `"lead product manager"` | 4 093 | 200 |
| `"head of product"` | 895 | 200 |
| `"director of product"` | 1 230 | 200 |
| `"group product manager"` | 692 | 200 |
| `"chef de produit digital"` | 263 | 200 |

Those seven queries return **1 226 distinct jobs in total** — a sample of a board that holds far more matching roles.

This is not theoretical. A real posting (Paris, product management, `full_time`, published *inside* the scan window) sat past rank 200 on `"product manager"` and was never captured across six scan runs, despite passing every configured `title_filter` and `location_filter` rule.

## The fix

Add a `wttj.filters` passthrough for Algolia's filter expression, applied to every configured query. A filter shrinks the result set **server-side** instead of re-ranking it, which is what makes a scan exhaustive rather than a sample:

| Filter | Hits | Requests to exhaust |
|---|---|---|
| `offices.country_code:FR` | 5 091 | 26 |
| `+ contract_type:full_time` | 4 384 | 22 |
| `+ new_profession.sub_category_reference:"product-management-wNjYw"` | **450** | **1** |

Because a filter bounds the result set, the per-query cap rises from 200 to Algolia's per-request ceiling for this index (1000) **when and only when** a filter is configured. Unfiltered queries keep the 200 cap, since they can still match the whole board.

```yaml
  - name: Welcome to the Jungle
    provider: wttj
    wttj:
      filters: 'new_profession.sub_category_reference:"product-management-wNjYw" AND offices.country_code:FR AND contract_type:full_time'
      max_hits: 1000
    enabled: true
```

`queries` becomes optional when `filters` is set — the empty query means "everything that passes the filter", which is the useful default for a taxonomy filter. With neither, the provider still throws rather than scanning the board, so the existing guard is preserved.

Useful faceted attributes on this index, documented in the provider header: `offices.country_code`, `offices.state`, `offices.city`, `contract_type`, `remote`, `experience_level_minimum`, `salary_yearly_minimum`, `organization.name`, and WTTJ's own job taxonomy `new_profession.sub_category_reference`.

## Measured effect

On one real config, replacing the seven truncated keyword queries with a single taxonomy-filtered request: **450 jobs found, 120 new** (previously unseen) in one request. A full scan run went from 32 new offers to 167.

## Safety

- The filter string is parsed by Algolia as a filter expression and **never reaches a URL or host**, so the existing `assertHost` guard still covers every request target.
- Length is bounded (`FILTERS_MAX_LEN = 1000`) so a config typo cannot build an unbounded request body.
- A blank/whitespace `filters` value is treated as absent: the cap stays 200 and no `filters` param is sent.

## Tests

Seven cases added to `tests/providers/wttj.test.mjs`, all following the existing discovered-test layout:

- passes `wttj.filters` through to Algolia
- uses the empty query when only filters are configured
- applies the filter to **every** configured query, not just the first
- still caps `max_hits` at 200 when no filters are configured
- raises the cap to 1000 when filters narrow the board
- treats a blank `filters` as absent (cap stays 200, no param sent)
- rejects an over-long filters expression

Full suite: `7719 passed, 4 failed` with this change vs `7712 passed, 4 failed` on `main` at the same commit — same four pre-existing failures (an invalid Gemini API key in the environment, a locale-dependent number format assertion, and unregistered root-level `*.test.mjs` files in the `SYSTEM_PATHS` coverage guard). No new failures; +7 passing.

## Backward compatibility

Fully additive. A config without `filters` behaves exactly as before: same 200 cap, same mandatory `queries`, same request shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBjnSErr9wEDmcdqYbeyHW