### PR TITLE
fix(web): separate evaluation and application dates

### DIFF
--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -28,7 +28,15 @@ const TABS = [
 ] as const;
 type Tab = (typeof TABS)[number];
 
-const SORT_KEYS = ["company", "role", "score", "status", "date"] as const;
+const SORT_COLUMNS = [
+  { key: "company", label: "company" },
+  { key: "role", label: "role" },
+  { key: "score", label: "score" },
+  { key: "status", label: "status" },
+  { key: "date", label: "eval date" },
+  { key: "appliedDate", label: "applied date" },
+] as const;
+const SORT_KEYS = SORT_COLUMNS.map((column) => column.key);
 type SortKey = (typeof SORT_KEYS)[number];
 
 export function PipelineView({
@@ -200,17 +208,17 @@ export function PipelineView({
            of being silently cut off. min-w keeps the columns readable rather
            than letting w-full crush them on a phone. */
         <div className="mt-4 overflow-x-auto rounded-2xl border border-border">
-          <table className="w-full min-w-[44rem] text-sm">
+          <table className="w-full min-w-[52rem] text-sm">
             <thead className="bg-surface/60 text-left text-xs uppercase tracking-wide text-faint">
               <tr>
-                {SORT_KEYS.map((k) => (
+                {SORT_COLUMNS.map(({ key, label }) => (
                   <th
-                    key={k}
+                    key={key}
                     className="cursor-pointer select-none whitespace-nowrap px-4 py-2.5 font-medium hover:text-foreground"
-                    onClick={() => setParams({ sort: k, dir: sort.key === k ? sort.dir * -1 : -1 })}
+                    onClick={() => setParams({ sort: key, dir: sort.key === key ? sort.dir * -1 : -1 })}
                   >
                     <span className="inline-flex items-center gap-1">
-                      {k}
+                      {label}
                       <ChevronsUpDown className="size-3" />
                     </span>
                   </th>
@@ -241,6 +249,7 @@ export function PipelineView({
                     </span>
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-faint tabular-nums">{r.date}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-faint tabular-nums">{r.appliedDate || "—"}</td>
                   </tr>
                 );
               })}

--- a/web/src/lib/application-dates.mjs
+++ b/web/src/lib/application-dates.mjs
@@ -1,0 +1,41 @@
+/**
+ * Read the first transition into Applied for every tracker row.
+ * The status ledger records event dates; the tracker Date column records evaluation dates.
+ *
+ * @param {string | null | undefined} tsv data/status-log.tsv content
+ * @returns {Map<string, string>} tracker number to YYYY-MM-DD application date
+ */
+export function parseApplicationDatesFromStatusLog(tsv) {
+  const applicationDates = new Map();
+  for (const rawLine of String(tsv ?? "").split("\n")) {
+    if (!rawLine || rawLine.startsWith("#")) continue;
+    const [trackerNumber, eventDate, , toStatus] = rawLine.split("\t").map((cell) => cell.trim());
+    if (!/^\d+$/.test(trackerNumber) || !isRealApplicationDate(eventDate)) continue;
+    if (toStatus.toLowerCase() !== "applied" || applicationDates.has(trackerNumber)) continue;
+    applicationDates.set(trackerNumber, eventDate);
+  }
+  return applicationDates;
+}
+
+/**
+ * Resolve an application's submission date without falling back to its evaluation date.
+ * The status ledger wins; notes support installations whose status history predates the ledger.
+ *
+ * @param {{n: string, notes?: string}} application tracker application
+ * @param {Map<string, string>} statusLogDates parsed status-ledger dates
+ * @returns {string} YYYY-MM-DD or an empty string when the submission date is unknown
+ */
+export function resolveApplicationAppliedDate(application, statusLogDates) {
+  const fromStatusLog = statusLogDates.get(application.n);
+  if (fromStatusLog) return fromStatusLog;
+
+  const match = String(application.notes ?? "").match(/\bapplied\s+~?(\d{4}-\d{2}-\d{2})(?![\w-])/i);
+  return match && isRealApplicationDate(match[1]) ? match[1] : "";
+}
+
+/** True when a value is a real YYYY-MM-DD application date. */
+function isRealApplicationDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import * as yaml from "js-yaml";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { parseApplications } from "@/lib/tracker-table.mjs";
+import { parseApplicationDatesFromStatusLog, resolveApplicationAppliedDate } from "@/lib/application-dates.mjs";
 // One definition of the `{n}-RESERVED.md` convention, shared with
 // run-cli-support.mjs — see report-files.mjs for why it lives there.
 import { isReservedReportFile } from "@/lib/report-files.mjs";
@@ -133,7 +134,10 @@ export function readScanDates(): Map<string, string> {
 
 export type Application = {
   n: string;
+  /** Date the role was evaluated and entered into the tracker. */
   date: string;
+  /** Date the application was submitted; empty when no submission event is recorded. */
+  appliedDate: string;
   company: string;
   /** Intermediary channel (#1596): agency/recruiter firm, "—" for direct, "" when the tracker has no Via column. */
   via: string;
@@ -155,7 +159,11 @@ export type Application = {
 export function readApplications(): Application[] {
   const md = read("data/applications.md");
   if (!md) return [];
-  return parseApplications(md, careerOpsRoot());
+  const statusLogDates = parseApplicationDatesFromStatusLog(read("data/status-log.tsv"));
+  return parseApplications(md, careerOpsRoot()).map((application) => ({
+    ...application,
+    appliedDate: resolveApplicationAppliedDate(application, statusLogDates),
+  }));
 }
 
 /** Resolve the report-number cell in data/pdf-index.tsv for a given report id.

--- a/web/tests/lib/application-dates.test.mjs
+++ b/web/tests/lib/application-dates.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseApplicationDatesFromStatusLog,
+  resolveApplicationAppliedDate,
+} from "../../src/lib/application-dates.mjs";
+
+test("application date comes from the first transition into Applied", () => {
+  const dates = parseApplicationDatesFromStatusLog([
+    "# tracker#\tdate\tfrom\tto\tsource\tnote",
+    "40\t2026-09-01\t-\tEvaluated\tmerge\t",
+    "40\t2026-09-02\tEvaluated\tApplied\tset-status\t",
+    "40\t2026-09-03\tApplied\tResponded\tset-status\t",
+  ].join("\n"));
+
+  assert.equal(resolveApplicationAppliedDate({ n: "40", notes: "" }, dates), "2026-09-02");
+});
+
+test("application date falls back to notes, never to evaluation date", () => {
+  const noDates = new Map();
+  assert.equal(
+    resolveApplicationAppliedDate({ n: "1", date: "2026-08-20", notes: "Applied 2026-08-27 manually" }, noDates),
+    "2026-08-27",
+  );
+  assert.equal(
+    resolveApplicationAppliedDate({ n: "2", date: "2026-08-20", notes: "Evaluation complete" }, noDates),
+    "",
+  );
+});
+
+test("invalid ledger and note dates are ignored", () => {
+  const dates = parseApplicationDatesFromStatusLog("7\t2026-02-31\tEvaluated\tApplied\tset-status\t");
+  assert.equal(resolveApplicationAppliedDate({ n: "7", notes: "Applied 2026-13-01" }, dates), "");
+});


### PR DESCRIPTION
## Summary

- relabel the tracker Date column as **Eval date**
- add a separately sortable **Applied date** column to every tracker view
- resolve submission dates from the first transition into `Applied` in `data/status-log.tsv`
- fall back to an explicit `Applied YYYY-MM-DD` note for pre-ledger installations, and show an em dash when the date is unknown

## Why

The web pipeline previously labeled and sorted the tracker’s evaluation date as `date`, including on the Applied tab. This made offers appear to have been submitted on the day they were evaluated.

## Validation

- `npm test` in `web/`: 461 passed, 6 skipped, 0 failed
- `npm run typecheck` in `web/`
- `npm run build` in `web/`
- `node test-all.mjs`: 8096 passed, 0 failed