### PR TITLE
Fix merge-tracker help and external data hooks

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -11,7 +11,7 @@
  * If duplicate with higher score → update in-place, update report link
  * Validates status against states.yml (rejects non-canonical, logs warning)
  *
- * Run: node career-ops/merge-tracker.mjs [--dry-run] [--verify]
+ * Run: node merge-tracker.mjs [--dry-run] [--verify]
  */
 
 import { readFileSync, readdirSync, mkdirSync, renameSync, existsSync } from 'fs';
@@ -32,22 +32,39 @@ import { resolveTrackerPath, resolveWorkspaceRoot, resolvePdfIndexPath, trackerL
 // can adopt the same key later without the definitions drifting.
 import { normalizeUrl } from './url-key.mjs';
 
-const CAREER_OPS = getCareerOpsRoot();
+const MERGE_TRACKER_HELP_REQUESTED = process.argv.includes('--help') || process.argv.includes('-h');
+if (MERGE_TRACKER_HELP_REQUESTED) {
+  console.log(`Usage: node merge-tracker.mjs [options]
+
+Options:
+  --dry-run        Preview the merge without writing files
+  --verify         Run pipeline verification after a successful merge
+  --migrate        Rewrite legacy report links relative to the tracker
+  --migrate-via    Add the Via column to a legacy tracker
+  --backfill-urls  Add the URL column and populate it from report metadata
+  -h, --help       Show this help and exit`);
+  process.exit(0);
+}
+
+// Executable hooks live beside this script even when user data is redirected
+// through CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR / .career-ops-data.
+const CAREER_OPS_CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
 // Support both layouts: data/applications.md (boilerplate) and applications.md
 // (original). CAREER_OPS_TRACKER overrides the path (used by tests and
 // non-standard layouts). Resolution lives in tracker-utils.mjs so every tracker
 // writer agrees on the same canonical path (and therefore the same lock).
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 const TRACKER_DIR = dirname(APPS_FILE);
 // CAREER_OPS_ADDITIONS overrides the additions dir (used by tests, mirrors CAREER_OPS_TRACKER).
 const ADDITIONS_DIR = process.env.CAREER_OPS_ADDITIONS
   ? process.env.CAREER_OPS_ADDITIONS
-  : join(CAREER_OPS, 'batch/tracker-additions');
+  : join(DATA_ROOT, 'batch/tracker-additions');
 const MERGED_DIR = join(ADDITIONS_DIR, 'merged');
 // CAREER_OPS_BATCH_STATE overrides the batch-state.tsv path (used by tests).
 const BATCH_STATE_FILE = process.env.CAREER_OPS_BATCH_STATE
   ? process.env.CAREER_OPS_BATCH_STATE
-  : join(CAREER_OPS, 'batch/batch-state.tsv');
+  : join(DATA_ROOT, 'batch/batch-state.tsv');
 
 // Cross-check against batch-state.tsv (found 2026-07-30): a worker can write
 // a well-formed tracker TSV even when its own JSON result said "failed" --
@@ -106,7 +123,7 @@ const PDF_INDEX_FILE = resolvePdfIndexPath(APPS_FILE);
 const normalizeReportLink = (reportField) => normalizeLink(reportField, TRACKER_DIR, REPORTS_ROOT);
 
 // Ensure required directories exist (fresh setup)
-mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
+mkdirSync(join(DATA_ROOT, 'data'), { recursive: true });
 mkdirSync(ADDITIONS_DIR, { recursive: true });
 
 /**
@@ -822,7 +839,7 @@ if (MIGRATE) {
     console.log(`🔎 Migration (dry-run): ${changed} row(s) would be rewritten in ${basename(APPS_FILE)}`);
   } else {
     writeFileAtomic(APPS_FILE, migrated.join('\n'));
-    console.log(`✅ Migration: rewrote ${changed} report link(s) in ${basename(APPS_FILE)} relative to ${TRACKER_DIR === CAREER_OPS ? 'repo root' : 'data/'}`);
+    console.log(`✅ Migration: rewrote ${changed} report link(s) in ${basename(APPS_FILE)} relative to ${TRACKER_DIR === DATA_ROOT ? 'repo root' : 'data/'}`);
   }
   process.exit(0);
 }
@@ -1569,7 +1586,7 @@ trackerLock.release();
 // Sync PDF flags (idempotent; uses its own lock/transaction)
 if (!DRY_RUN) {
   try {
-    execFileSync('node', [join(CAREER_OPS, 'sync-pdf-flags.mjs')], { stdio: 'inherit' });
+    execFileSync(process.execPath, [join(CAREER_OPS_CODE_ROOT, 'sync-pdf-flags.mjs')], { stdio: 'inherit' });
   } catch (e) {
     console.warn(`⚠️  Failed to sync PDF flags: ${e.message}`);
   }
@@ -1579,7 +1596,7 @@ if (!DRY_RUN) {
 if (VERIFY && !DRY_RUN) {
   console.log('\n--- Running verification ---');
   try {
-    execFileSync('node', [join(CAREER_OPS, 'verify-pipeline.mjs')], { stdio: 'inherit' });
+    execFileSync(process.execPath, [join(CAREER_OPS_CODE_ROOT, 'verify-pipeline.mjs')], { stdio: 'inherit' });
   } catch (e) {
     process.exit(1);
   }

--- a/sync-pdf-flags.mjs
+++ b/sync-pdf-flags.mjs
@@ -14,13 +14,13 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { rebuildRow, resolveTrackerPath, resolvePdfIndexPath, openTrackerTransaction } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const DATA_ROOT = getCareerOpsRoot();
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 // Derived from the TRACKER, not from this script's location, so a redirected
 // CAREER_OPS_TRACKER moves the whole workspace together (#2471).
 const PDF_MANIFEST = resolvePdfIndexPath(APPS_FILE);

--- a/tests/merge-tracker-cli-roots.test.mjs
+++ b/tests/merge-tracker-cli-roots.test.mjs
@@ -1,0 +1,88 @@
+// merge-tracker CLI regression coverage for help safety and split code/data roots.
+//
+// The CLI is intentionally exercised as a child process because importing it
+// runs the merge. Every data path points at a disposable external DATA_ROOT;
+// no test reads or writes the repository's user-layer fixtures.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const CODE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const TRACKER_HEADER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+].join('\n');
+
+/** Run merge-tracker against a disposable external data root. */
+function runMergeTrackerCli(dataRoot, ...args) {
+  const env = { ...process.env, CAREER_OPS_ROOT: dataRoot };
+  delete env.CAREER_OPS_DATA_DIR;
+  delete env.CAREER_OPS_TRACKER;
+  delete env.CAREER_OPS_ADDITIONS;
+  delete env.CAREER_OPS_BATCH_STATE;
+  const result = spawnSync(process.execPath, [join(CODE_ROOT, 'merge-tracker.mjs'), ...args], {
+    cwd: CODE_ROOT,
+    env,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  assert.equal(result.error, undefined, `merge-tracker failed to spawn: ${result.error?.message}`);
+  assert.equal(result.signal, null, `merge-tracker was killed by ${result.signal}`);
+  return { ...result, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+test('merge-tracker --help exits before mutating tracker or additions', () => {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-merge-help-'));
+  try {
+    const tracker = join(dataRoot, 'data', 'applications.md');
+    const additionsDir = join(dataRoot, 'batch', 'tracker-additions');
+    const addition = join(additionsDir, '002-globex.tsv');
+    mkdirSync(dirname(tracker), { recursive: true });
+    mkdirSync(additionsDir, { recursive: true });
+    const trackerBefore = `${TRACKER_HEADER}\n| 1 | 2026-01-01 | Acme | PM | 4.0/5 | Evaluated | ❌ | [1](../reports/001-acme.md) | seeded |\n`;
+    const additionBefore = '2\t2026-01-02\tGlobex\tPM\tEvaluated\t4.1/5\t❌\t[2](reports/002-globex.md)\tqueued\n';
+    writeFileSync(tracker, trackerBefore);
+    writeFileSync(addition, additionBefore);
+
+    const result = runMergeTrackerCli(dataRoot, '--help');
+
+    assert.equal(result.status, 0, result.output);
+    assert.match(result.output, /Usage: node merge-tracker\.mjs/);
+    assert.equal(readFileSync(tracker, 'utf-8'), trackerBefore, '--help rewrote the tracker');
+    assert.equal(readFileSync(addition, 'utf-8'), additionBefore, '--help rewrote or archived the pending TSV');
+    assert.equal(existsSync(join(additionsDir, 'merged')), false, '--help created the merged archive directory');
+  } finally {
+    rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('merge-tracker resolves executable post-hook from code root and PDF data from external DATA_ROOT', () => {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-merge-external-root-'));
+  try {
+    const tracker = join(dataRoot, 'data', 'applications.md');
+    mkdirSync(dirname(tracker), { recursive: true });
+    writeFileSync(
+      tracker,
+      `${TRACKER_HEADER}\n| 7 | 2026-01-04 | Acme | Engineer | 4.2/5 | Evaluated | ❌ | [12](../reports/012-acme.md) | seeded |\n`,
+    );
+    writeFileSync(
+      join(dataRoot, 'data', 'pdf-index.tsv'),
+      '# report\tpdf\thtml\tformat\tdate\n012\toutput/cv-acme.pdf\toutput/cv-acme.html\tletter\t2026-01-04\n',
+    );
+
+    const result = runMergeTrackerCli(dataRoot);
+    const trackerAfter = readFileSync(tracker, 'utf-8');
+
+    assert.equal(result.status, 0, result.output);
+    assert.doesNotMatch(result.output, /Failed to sync PDF flags/);
+    assert.match(trackerAfter, /\| ✅ \| \[12\]\(\.\.\/reports\/012-acme\.md\) \|/);
+  } finally {
+    rmSync(dataRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- make `merge-tracker.mjs --help` and `-h` print usage and exit before any tracker, queue, archive, or lock mutation
- separate the career-ops code root from the external data root when resolving post-merge executables
- make `sync-pdf-flags.mjs` resolve tracker data through the standard DATA_ROOT contract
- add CLI regression coverage for non-mutating help and post-hook execution with an external DATA_ROOT

## Root cause

`merge-tracker.mjs` used the result of `getCareerOpsRoot()` for both user data and executable scripts. With `.career-ops-data` or an environment override, that made the post-hook path point into the external data directory. The PDF sync script also resolved its tracker from its own install directory rather than through `getCareerOpsRoot()`.

The help flags were never handled, so they fell through to the normal merge path.

## Tests

- `node --test tests/merge-tracker-cli-roots.test.mjs`
- `node test-all.mjs --only merge-tracker-cli-roots`
- `npm run lint` (655 files)
- `node test-all.mjs` (8096 passed, 0 failed; 13 existing diagnostic warnings)