### PR TITLE
fix(tracker): map "fecha" to the date column (#3705)

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12274,11 +12274,15 @@ try {
     // to LEGACY_COLMAP (#2274). On a plain 9-column table the fallback happens
     // to line up and hides the bug; with a Location column inserted, the Score
     // cell is read from Location instead — an ES tracker scored "Remote".
+    // `date` is not in REQUIRED_HEADER_FIELDS, so a missing `fecha` alias does
+    // not fail the header — it resolves with no date column and every row comes
+    // back with an empty date (#3705). Assert the Fecha column is actually
+    // resolved, not silently absent.
     const trackerParse = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
     const esHeader = '| # | Fecha | Empresa | Puesto | Location | Score | Status | PDF | Report | Notes |';
     const esMap = trackerParse.detectColumns([esHeader]);
-    if (esMap && esMap.score === 6 && esMap.company === 3 && esMap.role === 4 && esMap.location === 5) {
-      pass('a fully localized header maps through the alias table (#2274)');
+    if (esMap && esMap.date === 2 && esMap.score === 6 && esMap.company === 3 && esMap.role === 4 && esMap.location === 5) {
+      pass('a fully localized header maps through the alias table (#2274, #3705)');
     } else {
       fail(`localized header did not map: ${JSON.stringify(esMap)}`);
     }

--- a/tracker-aliases.json
+++ b/tracker-aliases.json
@@ -2,6 +2,7 @@
   "#": "num",
   "num": "num",
   "date": "date",
+  "fecha": "date",
   "company": "company",
   "empresa": "company",
   "via": "via",


### PR DESCRIPTION
Fixes #3705.

## Problem

`tracker-parse.mjs` resolves tracker table columns by header name through `tracker-aliases.json`. The Spanish label **`Fecha`** is missing from that table, even though `empresa` → company and `puesto` → role are present — so the Spanish header is only half-supported.

Because `date` is not in `REQUIRED_HEADER_FIELDS`, a localized header like `| # | Fecha | Empresa | Puesto | … |` still *resolves* — it just resolves **with no date column**. Every row then comes back with an empty date, and consumers keyed off it (follow-up cadence, funnel velocity, anything sorting or ageing rows) see a dateless row rather than a parse failure. This is not a fallback to the legacy fixed layout, which would at least read position 2 by accident.

## Fix

- Add `"fecha": "date"` to `tracker-aliases.json` — one line, in the single file aliases are meant to live in (`tracker-parse.mjs` says to add them there, not in code). The web reader loads the same file, so it picks this up too (`tracker-columns-tests.mjs` Test 8 already guards that the two tables stay byte-identical). `fecha` is already an established localized date alias elsewhere in the codebase (`web/src/lib/format.ts`).
- Strengthen the existing "fully localized header maps through the alias table" test (#2274). It checked `company` / `role` / `location` / `score` positions but **not** `date` — which is exactly why this gap survived. It now asserts the `Fecha` column resolves.

Scope kept to `fecha` per the maintainer's split on #3517. The separate matter of `modes/es/oferta.md` shipping `Rol` / `Estado` (labels that fail to resolve *at all*) belongs to #3704.

## Testing

- `node tracker-columns-tests.mjs` — 46/46 pass
- `node test-all.mjs` — the targeted assertion `a fully localized header maps through the alias table (#2274, #3705)` passes; full suite 8090 pass (one unrelated `update-system.mjs check` network-timeout flake under full-suite load, passes in isolation)
- Confirmed the repro: without the alias, `detectColumns` returns a map with no `date` key; with it, `date` resolves to column 2