### PR TITLE
chore(coderabbit): full review configuration for the org

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -160,13 +160,13 @@ reviews:
 
 chat:
   auto_reply: true
-  allow_non_org_members: true
+  allow_non_org_members: true   # contributors trigger reviews and ask questions on their own PRs; that is the on-ramp
   art: false
 
 knowledge_base:
   opt_out: false
   web_search: { enabled: true }
-  learnings: { scope: auto, approval_delay: 0 }
+  learnings: { scope: auto, approval_delay: 7 }   # a week for a maintainer to reject a learning before it sticks
   issues: { scope: auto }
   pull_requests: { scope: auto }
   code_guidelines:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,26 +1,191 @@
-language: en
+# CodeRabbit configuration for career-ops (career-ops-hq).
+# Reviewed by the maintainers on 2026-09-03 after the move to the org.
+# Docs: https://docs.coderabbit.ai/reference/configuration
+language: en-US
+tone_instructions: "Be specific and brief. Cite file:line. Use colons, not dashes. Warm to first-time contributors. Prefer one precise finding over three vague ones."
+
 reviews:
   profile: assertive
-  request_changes_workflow: false
+  request_changes_workflow: false   # humans decide; the review is a signal
   high_level_summary: true
+  high_level_summary_instructions: "Explain what changes from the user's point of view (what they can do, what breaks). Name which system files are touched: AGENTS.md, modes/, update-system.mjs, DATA_CONTRACT.md, providers/, .github/."
   poem: false
+  collapse_walkthrough: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false          # labels are routing signals here; a maintainer applies them
+  suggested_reviewers: true
+  auto_assign_reviewers: false      # CODEOWNERS already requests the right person
+  abort_on_close: true
+
   auto_review:
     enabled: true
     drafts: false
     base_branches:
       - main
+    ignore_usernames:
+      - renovate[bot]
+      - dependabot[bot]
+      - github-actions[bot]
+    ignore_title_keywords:
+      - "chore(main): release"
+      - "chore: release main"
+
+  path_filters:
+    - "!**/*.lock"
+    - "!package-lock.json"
+    - "!**/*.pdf"
+    - "!**/*.png"
+    - "!docs/hired-wall.svg"
+    - "!SIGNATURES.md"
+    - "!HIRED.md"
+
   path_instructions:
-    - path: "CLAUDE.md"
-      instructions: "This file controls agent behavior (Claude Code). Review changes very carefully for conflicts with existing instructions."
-    - path: "OPENCODE.md"
-      instructions: "This file controls agent behavior (OpenCode). Review changes very carefully for conflicts with existing instructions."
+    - path: "AGENTS.md"
+      instructions: "This is the single canonical instruction file for every AI CLI (Claude Code, Codex, OpenCode, Kimi, Gemini, Copilot). Review changes very carefully for conflicts with existing instructions, for anything that weakens the Data Contract or the source-of-truth boundary, and for user-specific content that belongs in modes/_profile.md or modes/_custom.md instead."
+    - path: "{CLAUDE,CODEX,OPENCODE,KIMI,GEMINI}.md"
+      instructions: "These are thin per-CLI wrappers that must import AGENTS.md (@AGENTS.md) and keep only CLI-specific lines. Flag any content duplicated from AGENTS.md or any instruction that should be canonical: it belongs in AGENTS.md, not here."
+    - path: ".github/copilot-instructions.md"
+      instructions: "Development instructions for Copilot working on the repository (mode B) that must stay compatible with users running career-ops through Copilot CLI (mode A, AGENTS.md governs). Flag anything that would make Copilot refuse product tasks for end users."
     - path: "modes/_shared.md"
-      instructions: "This file controls the scoring system. Any changes affect ALL evaluations. Flag anything that modifies scoring logic."
+      instructions: "This file controls the scoring system. Any change affects ALL evaluations. Flag anything that modifies scoring logic, block letters (A to H) or the report format, which the web UI parses."
+    - path: "modes/**/*.md"
+      instructions: "Product prompts. Localized copies (modes/<lang>/) must keep the canonical structure of modes/*.md: same blocks A to H, same report header labels, same placeholders. Flag structure drift, untranslated placeholders, and any real personal data (names, emails, companies) in examples."
     - path: "DATA_CONTRACT.md"
-      instructions: "This file defines system vs user file boundaries. Changes here are critical — reject if user-layer files are being reclassified."
+      instructions: "Defines the system vs user file boundary. Adding a new system file to a table is normal. Reclassifying a user-layer file as system, or changing the rules, is critical: flag it explicitly."
+    - path: "update-system.mjs"
+      instructions: "The self-updater touches every user install. Flag anything that could write into the user layer (cv.md, config/profile.yml, data/, reports/, output/, modes/_profile.md, modes/_custom.md), any new top-level shipped file missing from SYSTEM_PATHS, and any change to backup or rollback behavior."
     - path: "**/*.mjs"
-      instructions: "Check for command injection, path traversal, and SSRF. Ensure scripts handle missing data/ directories gracefully."
+      instructions: "Check for command injection, path traversal and SSRF. Scripts must handle a missing data/ directory gracefully and must resolve user files through the data-root helpers (CAREER_OPS_ROOT), never from the code root."
+    - path: "providers/**"
+      instructions: "Scanner providers read PUBLIC job listings only. Check against providers/ADDING_A_PROVIDER.md: host allowlist, no redirects to other hosts, SSRF guards, timeouts, parsing pinned with concrete assertions, and a contract test in tests/providers/<name>.test.mjs. Flag any provider that needs credentials, scrapes behind a login, or aggregates listings that are not attributed to an identifiable employer (Source Indexing Policy in CONTRIBUTING.md)."
+    - path: "tests/**"
+      instructions: "New tests belong in their own tests/**/*.test.mjs file (auto-discovered). Flag tests that depend on network, on the developer's real data, or on execution order."
+    - path: "test-all.mjs"
+      instructions: "The harness every check runs through. Flag new numbered sections (they belong in tests/ files) and any change that could make a failure look like a pass."
     - path: "dashboard/**"
-      instructions: "Go TUI code. Check for proper error handling and ensure no hardcoded paths."
+      instructions: "Go TUI code. Check for proper error handling, no hardcoded paths, and that it reads the tracker through the same canonical formats the CLI writes."
+    - path: "web/**"
+      instructions: "First-party web UI. It must remain a view over the canonical files (tracker, pipeline, reports), never a parallel engine. Flag any write to user files that bypasses the CLI scripts, any agent CLI invocation outside the spawn boundary, and any secret or API key committed."
+    - path: ".github/workflows/**"
+      instructions: "Treat as security-sensitive. Flag pull_request_target with a checkout of the fork, secrets exposed to fork code, unpinned third-party actions, and permissions broader than needed."
+    - path: "plugins/_*.mjs"
+      instructions: "Plugin engine and registry chokepoint: a mistake ships unreviewed code to every user. Flag any relaxation of pin, hash or lock verification."
+    - path: "plugins-registry.json"
+      instructions: "Registry entries must be pinned to a commit SHA and reviewed under docs/PLUGIN_REVIEW.md. Flag unpinned refs or entries that fetch from a mutable branch."
+    - path: "README*.md"
+      instructions: "There are 17 localized READMEs. When README.md changes, note which localized copies now drift, but do not request translations in the same PR."
+    - path: "package.json"
+      instructions: "New dependencies need a discussion first. Flag any new dependency, any postinstall change, and any version range widening."
+
+  tools:
+    gitleaks: { enabled: true }
+    trufflehog: { enabled: true }
+    presidio: { enabled: true }        # real names, emails, phones in examples are a hard no here
+    actionlint: { enabled: true }
+    zizmor: { enabled: true }
+    shellcheck: { enabled: true }
+    golangci-lint: { enabled: true }
+    osvScanner: { enabled: true }
+    semgrep: { enabled: true }
+    eslint: { enabled: true }
+    yamllint: { enabled: true }
+    github-checks: { enabled: true, timeout_ms: 900000 }
+    markdownlint: { enabled: false }   # 17 READMEs and long prompts: style noise, not review
+    languagetool: { enabled: false }
+    vale: { enabled: false }
+    ast-grep: { enabled: false }
+
+  finishing_touches:
+    docstrings: { enabled: false }
+    unit_tests: { enabled: true }     # on request only (@coderabbitai generate unit tests)
+    simplify: { enabled: false }
+    autofix: { enabled: false }       # no bot pushes to a contributor's branch
+    fix_ci: { enabled: false }
+    resolve_merge_conflict: { enabled: false }
+
+  pre_merge_checks:
+    docstrings: { mode: off }
+    title:
+      mode: warning
+      requirements: "Conventional Commits prefix (feat, fix, docs, chore, test, refactor, i18n) followed by a scope in parentheses when the change is confined to one area, then a factual summary. Release Please reads the prefix."
+    description:
+      mode: warning
+    issue_assessment:
+      mode: warning
+    custom_checks:
+      - name: "User layer untouched"
+        mode: error
+        instructions: "Fail if the PR adds or modifies any user-layer file defined in DATA_CONTRACT.md: cv.md, config/profile.yml, modes/_profile.md, modes/_custom.md, article-digest.md, portals.yml, anything under data/, documents/, reports/, output/, interview-prep/. Examples under examples/ are fine."
+      - name: "No personal data"
+        mode: error
+        instructions: "Fail if the diff contains real personal data: a person's real name paired with contact details, real emails, phone numbers, or a real CV. Sample data must use obvious placeholders."
+      - name: "Shipped file registered"
+        mode: warning
+        instructions: "Warn if the PR adds a new top-level .mjs, .md, template or config file that users should receive through the updater but SYSTEM_PATHS in update-system.mjs was not updated in the same PR."
+      - name: "Provider contract"
+        mode: warning
+        instructions: "Warn if the PR adds or changes a file under providers/ without a matching tests/providers/<name>.test.mjs, or without host allowlisting and timeouts."
+      - name: "Agent-operated PR disclosure"
+        mode: warning
+        instructions: "If the PR author is a coding agent (branch copilot/* or author app/copilot-swe-agent), warn unless the description contains the sections '## AI assistance' and '## Human review' and the PR carries the label agent-generated."
+
+  labeling_instructions:
+    - label: "🔴 core-architecture"
+      instructions: "Apply when the PR touches AGENTS.md, CLAUDE.md, modes/_shared.md, DATA_CONTRACT.md or update-system.mjs."
+    - label: "⚠️ agent-behavior"
+      instructions: "Apply when the PR changes any file under modes/ or any per-CLI instruction file."
+    - label: "🌐 i18n"
+      instructions: "Apply when the PR touches localized READMEs (README.*.md) or modes/<lang>/."
+    - label: "📊 dashboard"
+      instructions: "Apply when the PR touches dashboard/."
+    - label: "area:web"
+      instructions: "Apply when the PR touches web/."
+    - label: "needs-rebase"
+      instructions: "Apply when the PR has merge conflicts with main."
+
+  suggested_reviewers_instructions:
+    - reviewers:
+        - handle: Scott-Emberson
+          type: user
+      instructions: "Suggest for PRs touching providers/, tests/providers/, tests/ or dashboard/ (area owner)."
+    - reviewers:
+        - handle: FReptar0
+          type: user
+      instructions: "Suggest for PRs touching the tracker scripts, CI under .github/, the updater or the dashboard (reviewer)."
+
 chat:
   auto_reply: true
+  allow_non_org_members: true
+  art: false
+
+knowledge_base:
+  opt_out: false
+  web_search: { enabled: true }
+  learnings: { scope: auto, approval_delay: 0 }
+  issues: { scope: auto }
+  pull_requests: { scope: auto }
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "CONTRIBUTING.md"
+      - "DATA_CONTRACT.md"
+      - "ARCHITECTURE.md"
+      - "providers/ADDING_A_PROVIDER.md"
+      - "docs/PLUGIN_REVIEW.md"
+      - "SECURITY.md"
+  linked_repositories:
+    - repository: career-ops-hq/career-ops-docs
+      instructions: "The documentation site. When a PR here changes a CLI flag, a script name, a mode block or an output format, note that the docs may drift."
+
+issue_enrichment:
+  auto_enrich: { enabled: false }     # people's issues get human replies, not bot plans
+  planning:
+    enabled: true
+    auto_planning: { enabled: false }
+  labeling:
+    auto_apply_labels: false


### PR DESCRIPTION
## What

A complete `.coderabbit.yaml` now that the app is installed on `career-ops-hq`.

- **Path instructions** for what the old file missed: `AGENTS.md` (the canonical instruction file), the per-CLI wrappers, `providers/` against `ADDING_A_PROVIDER.md` and the Source Indexing Policy, `update-system.mjs` and `SYSTEM_PATHS`, `web/`, workflows, the plugin engine and registry, localized modes and READMEs, `package.json`.
- **Scanners on:** secrets (gitleaks, trufflehog), PII (presidio), GitHub Actions (actionlint, zizmor), shell, Go, JS, YAML, dependency vulnerabilities (osv), semgrep. Off: markdownlint, languagetool, vale (style noise on 17 READMEs and long prompts).
- **Pre-merge checks:** user layer untouched (error), no personal data (error), shipped file registered in `SYSTEM_PATHS` (warning), provider contract test present (warning), disclosure sections on agent-operated PRs (warning). Title check asks for a Conventional Commits prefix, which Release Please reads.
- **Everything that decides stays human:** no auto-applied labels, no auto-assigned reviewers, no auto-fix or conflict-resolution pushes to contributors' branches, no automatic plans on issues. Suggestions only.
- Knowledge base reads `CONTRIBUTING.md`, `DATA_CONTRACT.md`, `ARCHITECTURE.md`, the provider guide and the plugin review doc as guidelines; `career-ops-docs` is linked so drift gets a note.
- Skips release PRs and dependency bots.

## Validation

Validated against `https://coderabbit.ai/integrations/schema.v2.json`: 0 errors. This PR is also the live test: CodeRabbit should review it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a complete `.coderabbit.yaml` review policy.
- Expands review guidance for user-layer boundaries, updater registration, provider security, tests, CI, plugins, documentation, and personal-data handling: `.coderabbit.yaml:1`.
- Enables security, PII, workflow, language, dependency, and Semgrep scanners: `.coderabbit.yaml:1`.
- Adds pre-merge checks for `SYSTEM_PATHS`, provider contract tests, disclosure sections, personal data, and Conventional Commit titles: `.coderabbit.yaml:1`.
- Links repository documentation and `career-ops-docs` as knowledge sources: `.coderabbit.yaml:1`.
- Keeps automated labels, reviewer assignment, fixes, conflict-resolution pushes, and issue plans disabled: `.coderabbit.yaml:1`.
- Excludes release pull requests and dependency bots from review: `.coderabbit.yaml:1`.
- Delays contributor-proposed learnings for seven days before application.

## User impact

Contributors receive broader automated review coverage and clearer checks before merge. Reviewers retain control over labels, assignments, fixes, and conflict resolution. The configuration does not change application behavior or exported entities.

## System files

This change touches only `.coderabbit.yaml`. It does not modify `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

## Validation

The configuration passes CodeRabbit schema validation with zero errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->