### PR TITLE
docs(types): document the optional Job.salary field

### DIFF
--- a/providers/_types.js
+++ b/providers/_types.js
@@ -35,19 +35,25 @@
  *                               usable date. scan.mjs ignores it; consumers
  *                               like scan-ats-full.mjs use it for recency
  *                               filtering.
- * @property {{min: number, max: number, currency?: string}} [salary]
+ * @property {{min?: number, max?: number, currency?: string}} [salary]
  *                               Annualized compensation, attached ONLY when the
  *                               source exposes real figures — never inferred
  *                               (`ashby.mjs` is the reference shape; most
- *                               providers omit it). `min` and `max` are both
- *                               present — a one-sided range fills the missing
- *                               bound from the other.
- *                               `currency` is an ISO code when the source gives
- *                               one, and `''` or absent otherwise. Consumed by
- *                               scan.mjs's salary_filter and rendered into
- *                               pipeline.md's compensation column via
- *                               formatCompensation(); an empty/absent value
- *                               always passes the filter.
+ *                               providers omit it). At least one of `min` / `max`
+ *                               is present; most providers normalize both bounds
+ *                               (filling a one-sided range from the other), but
+ *                               some — e.g. `agentic-jobs.mjs` — leave the absent
+ *                               bound off rather than coerce it. scan.mjs's
+ *                               salary_filter reads `min ?? max` and tolerates
+ *                               either bound alone.
+ *                               `currency` is the source's currency string,
+ *                               upper-cased by most providers (`''` or absent
+ *                               when the source gives none); it is not validated
+ *                               as an ISO code, and the filter compares it
+ *                               case-insensitively. Consumed by scan.mjs's
+ *                               salary_filter and rendered into pipeline.md's
+ *                               compensation column via formatCompensation(); an
+ *                               empty/absent value always passes the filter.
  * @property {number} [trustScore] 0-100 trust score from _trust-validator.mjs.
  * @property {string[]} [trustFlags] Flags raised by trust validation (e.g.
  *                                   'invalid_url', 'suspicious_domain').

--- a/providers/_types.js
+++ b/providers/_types.js
@@ -35,6 +35,19 @@
  *                               usable date. scan.mjs ignores it; consumers
  *                               like scan-ats-full.mjs use it for recency
  *                               filtering.
+ * @property {{min: number, max: number, currency?: string}} [salary]
+ *                               Annualized compensation, attached ONLY when the
+ *                               source exposes real figures — never inferred
+ *                               (`ashby.mjs` is the reference shape; most
+ *                               providers omit it). `min` and `max` are both
+ *                               present — a one-sided range fills the missing
+ *                               bound from the other.
+ *                               `currency` is an ISO code when the source gives
+ *                               one, and `''` or absent otherwise. Consumed by
+ *                               scan.mjs's salary_filter and rendered into
+ *                               pipeline.md's compensation column via
+ *                               formatCompensation(); an empty/absent value
+ *                               always passes the filter.
  * @property {number} [trustScore] 0-100 trust score from _trust-validator.mjs.
  * @property {string[]} [trustFlags] Flags raised by trust validation (e.g.
  *                                   'invalid_url', 'suspicious_domain').


### PR DESCRIPTION
`providers/_types.js`'s `Job` typedef gains an optional `[salary]` entry — `{min?: number, max?: number, currency?: string}`.

`job.salary` is already part of the contract in practice: `ashby`, `wttj`, `manfred`, `remotli`, `getro`, `agentic-jobs` and `builtin` attach it, and `scan.mjs` both filters on it (`buildSalaryFilter` / `salary_filter`) and renders it into `data/pipeline.md`'s compensation column (`formatCompensation`). The typedef just never listed it, so `// @ts-check` provider files got no hint for the field and a new provider handling comp data had no sanctioned shape to mirror — `ADDING_A_PROVIDER.md` §1 points authors at `_types.js` as the type catalog.

All three sub-fields are optional. Most providers (`ashby`, `getro`) normalize both bounds, filling a one-sided range from the other; `agentic-jobs` deliberately omits the absent bound rather than coerce it (`normalizeAgenticSalary` returns `{min}` or `{max}` alone), and `scan.mjs`'s `salary_filter` reads `salary.min ?? salary.max`, so a one-sided object is valid input. Declaring both bounds required would make that a `// @ts-check` error via `Provider.fetch`'s `Promise<Job[]>` return type.

`currency` is the source's currency string, upper-cased by most providers (`ashby`, `agentic-jobs`) or passed through with only a `.trim()` (`getro`); `scan.mjs` compares it case-insensitively and never validates it as an ISO code. Absent or `''` when the source gives none.

JSDoc only. `_types.js` is documentation-only (per its own header) — nothing executes it, no runtime or behaviour change.

Tested: `node test-all.mjs` green (8092 passed, 0 failed); `npm run lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Documents the optional `Job.salary` field in `providers/_types.js`:13.

The field accepts optional `min` and `max` numeric bounds and an optional `currency` string. Missing bounds use the other bound. Currency is compared case-insensitively and is not validated.

This change helps providers and consumers use documented salary filtering and compensation rendering. It changes JSDoc only. It does not change runtime behavior.

## User impact

Users can now rely on the documented salary shape and currency behavior. No existing behavior breaks.

## Files changed

`providers/_types.js`: updated the `Job` typedef.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.

## Validation

`node test-all.mjs` and `npm run lint` pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->