### PR TITLE
refactor(update-system): extract the checkout skip-check into pathFullyPreserved()

### DIFF
--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { pass, fail } from './helpers.mjs';
-import { gitIn, locallyModifiedSystemFiles } from '../update-system.mjs';
+import { gitIn, locallyModifiedSystemFiles, pathFullyPreserved } from '../update-system.mjs';
 
 // A repo with an `upstream` branch standing in for FETCH_HEAD, and `main` as
 // the install. Both start from a shared base commit, which is what gives
@@ -263,6 +263,108 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     pass('a fully-excluded pathspec errors — hence the skip in apply() (#2337)');
   } else {
     fail(`#9 errored=${errored} content=${JSON.stringify(content)}`);
+  }
+}
+
+// ── 9b. pathFullyPreserved: a single-file match skips WITHOUT an upstream
+//    lookup ── The reported bug: every one of the reporter's 12 preserved
+//    files (AGENTS.md, fonts/*.ttf, cv-template.*.html, ...) is a single
+//    SYSTEM_PATHS entry, not a directory. The old code still ran an
+//    unnecessary `ls-tree` round-trip to "confirm" what the string match (`f
+//    === path`) had already proven, and when that lookup failed to return the
+//    expected result, execution fell through into the exact cancel-out
+//    checkout case 9 shows fails. Assert no git call happens at all for this
+//    case, so a future regression that reintroduces the lookup is caught even
+//    if the lookup itself would have "worked" in a normal test repo.
+{
+  let gitCalls = 0;
+  const spyCtx = { git: (...args) => { gitCalls++; throw new Error(`unexpected git call: ${args.join(' ')}`); } };
+
+  const preservedPaths = ['AGENTS.md'];
+  const preservedSet = new Set(preservedPaths);
+  const result = pathFullyPreserved('AGENTS.md', preservedPaths, preservedSet, spyCtx);
+
+  if (result === true && gitCalls === 0) {
+    pass('a single-file preserved path is skipped without any upstream lookup');
+  } else {
+    fail(`#9b expected true/0 calls, got result=${result} gitCalls=${gitCalls}`);
+  }
+}
+
+// ── 9c. pathFullyPreserved: a path unrelated to any preserved file is never
+//    skipped, and costs no git call either ──
+{
+  let gitCalls = 0;
+  const spyCtx = { git: (...args) => { gitCalls++; throw new Error(`unexpected git call: ${args.join(' ')}`); } };
+
+  const preservedPaths = ['AGENTS.md'];
+  const preservedSet = new Set(preservedPaths);
+  const result = pathFullyPreserved('modes/pdf.md', preservedPaths, preservedSet, spyCtx);
+
+  if (result === false && gitCalls === 0) {
+    pass('an unrelated path is never skipped, and needs no upstream lookup');
+  } else {
+    fail(`#9c expected false/0 calls, got result=${result} gitCalls=${gitCalls}`);
+  }
+}
+
+// ── 9d. pathFullyPreserved: a directory entirely made of preserved files IS
+//    skipped — the pre-existing behaviour this fix must not regress ──
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  // pathFullyPreserved's ls-tree branch reads FETCH_HEAD, same ref apply()
+  // fetches into for real. Populate it here by fetching the local `upstream`
+  // branch into this repo's own FETCH_HEAD.
+  repo.g('fetch', '.', 'upstream');
+  const preservedPaths = ['modes/pdf.md', 'modes/cover.md'];
+  const preservedSet = new Set(preservedPaths);
+  const ctx = { git: (...args) => gitIn(repo.dir, ...args) };
+
+  const result = pathFullyPreserved('modes/', preservedPaths, preservedSet, ctx);
+  if (result === true) {
+    pass('a directory whose entire upstream content is preserved is skipped (ls-tree path)');
+  } else {
+    fail(`#9d expected true, got ${result}`);
+  }
+}
+
+// ── 9e. pathFullyPreserved: a directory only PARTLY preserved is NOT skipped
+//    — the rest of the directory still needs a real checkout ──
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  repo.g('fetch', '.', 'upstream'); // populate FETCH_HEAD, see #9d
+  const preservedPaths = ['modes/cover.md']; // pdf.md is NOT preserved here
+  const preservedSet = new Set(preservedPaths);
+  const ctx = { git: (...args) => gitIn(repo.dir, ...args) };
+
+  const result = pathFullyPreserved('modes/', preservedPaths, preservedSet, ctx);
+  if (result === false) {
+    pass('a directory only partly preserved is not skipped');
+  } else {
+    fail(`#9e expected false, got ${result}`);
+  }
+}
+
+// ── 9f. pathFullyPreserved: an unreadable upstream lookup degrades to "not
+//    fully preserved" for a directory, never throws ──
+{
+  const preservedPaths = ['modes/pdf.md'];
+  const preservedSet = new Set(preservedPaths);
+  const throwingCtx = { git: () => { throw new Error('unreadable ref'); } };
+
+  let threw = false;
+  let result = null;
+  try {
+    result = pathFullyPreserved('modes/', preservedPaths, preservedSet, throwingCtx);
+  } catch {
+    threw = true;
+  }
+  if (!threw && result === false) {
+    pass('an unreadable directory lookup degrades to "not fully preserved" instead of throwing');
+  } else {
+    fail(`#9f threw=${threw} result=${result}`);
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1263,6 +1263,72 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
 }
 
 /**
+ * True when checking out `path` from upstream with `preservedPaths` excluded
+ * would leave nothing to check out — i.e. `path` itself is (for a single
+ * file) or entirely consists of (for a `dir/`-suffixed directory) preserved
+ * content. apply()'s checkout loop uses this to skip such an entry outright:
+ * `git checkout FETCH_HEAD -- <path> :(exclude)<path>` errors with "did not
+ * match any file(s)" when the exclusions cancel the whole pathspec, and that
+ * error is indistinguishable from a genuine checkout failure at the call
+ * site, so it would abort the entire update over a file the user asked to
+ * keep.
+ *
+ * A single-file `path` that exactly matches a preserved entry is fully
+ * preserved by definition — the match IS the file's only content, so no
+ * upstream lookup can add information. Only a directory `path` needs the
+ * upstream ls-tree lookup, to confirm EVERY file it would check out is
+ * preserved; an unreadable lookup degrades to "not fully preserved" so the
+ * real checkout runs and reports its own diagnostics, same contract as
+ * `locallyModifiedSystemFiles`.
+ *
+ * Two limits are deliberate, both raised in review of #3781:
+ *
+ * 1. The single-file shortcut diverges from the pre-extraction inline check
+ *    for a preserved file ABSENT from FETCH_HEAD. That check fell through to
+ *    the real checkout, which failed and put the path in apply()'s "Skipped
+ *    N path(s) absent upstream" summary; this returns true and skips it
+ *    silently. Unreachable while preserved paths come from
+ *    `locallyModifiedSystemFiles`, which only reports files that exist
+ *    upstream (it gates each candidate on `cat-file -e <ref>:<file>`), so
+ *    nothing today can construct the case — but it is a real divergence, not
+ *    a behaviour-preserving one, and a future caller sourcing preservedPaths
+ *    some other way would hit it.
+ *
+ * 2. The directory branch's `catch → false` does NOT close the cancel-out
+ *    abort for directories. A throwing ls-tree still falls through to
+ *    `git checkout FETCH_HEAD -- modes/ :(exclude)modes/pdf.md`, which
+ *    aborts the update when the directory happens to be fully preserved.
+ *    That is exactly the pre-extraction behaviour, carried over unchanged —
+ *    this function makes the check testable and drops a redundant lookup for
+ *    the single-file case; it does not fix the directory case. Closing it
+ *    needs a tri-state result whose "unknown" makes the checkout's "did not
+ *    match any file(s)" benign at the call site; tracked separately rather
+ *    than folded in here, since that means matching on git's stderr text.
+ *
+ * @param {string} path - a SYSTEM_PATHS entry, file or `dir/`-suffixed directory.
+ * @param {string[]} preservedPaths - files this run is keeping local content for.
+ * @param {Set<string>} preservedSet - the same paths, as a Set, for lookup.
+ * @param {{git?: Function}} [ctx] - injection point for tests; defaults to gitQuiet.
+ * @returns {boolean}
+ */
+export function pathFullyPreserved(path, preservedPaths, preservedSet, ctx = {}) {
+  if (preservedSet.size === 0) return false;
+  const runGitQuiet = ctx.git || gitQuiet;
+  const isDirectory = path.endsWith('/');
+  const preservedHere = preservedPaths.filter((f) => (isDirectory ? f.startsWith(path) : f === path));
+  if (preservedHere.length === 0) return false;
+  if (!isDirectory) return true;
+  let upstreamFiles = [];
+  try {
+    upstreamFiles = runGitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', path)
+      .split('\n').map((f) => f.trim()).filter(Boolean);
+  } catch {
+    return false;
+  }
+  return upstreamFiles.length > 0 && upstreamFiles.every((f) => preservedSet.has(f));
+}
+
+/**
  * Preserve byte-for-byte copies of system files before an unavoidable
  * overwrite. The self-bootstrap stage cannot use the normal "keep local"
  * path: it must load the fetched updater to remain forward-compatible. A
@@ -2146,22 +2212,8 @@ async function apply() {
       // match any file(s)" when the exclusions cancel the whole pathspec — and
       // that error is indistinguishable from a genuine failure at the catch
       // below, so it would abort the entire update. Skip the entry instead when
-      // nothing would be left to check out. Only entries that actually contain
-      // a preserved file pay for the extra ls-tree, normally none.
-      if (preservedSet.size > 0) {
-        const preservedHere = preservedPaths.filter((f) => (path.endsWith('/') ? f.startsWith(path) : f === path));
-        if (preservedHere.length > 0) {
-          let upstreamFiles = [];
-          try {
-            upstreamFiles = gitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', path)
-              .split('\n').map((f) => f.trim()).filter(Boolean);
-          } catch {
-            // Unreadable entry — fall through to the normal checkout, which
-            // reports the real failure with its own diagnostics.
-          }
-          if (upstreamFiles.length > 0 && upstreamFiles.every((f) => preservedSet.has(f))) continue;
-        }
-      }
+      // nothing would be left to check out (see pathFullyPreserved).
+      if (pathFullyPreserved(path, preservedPaths, preservedSet)) continue;
       try {
         // stderr is piped rather than inherited here. A path absent upstream is
         // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),


### PR DESCRIPTION
## Summary

Refs #3779 — **this does not fix it**, see below.

`apply()`'s checkout loop built `git checkout FETCH_HEAD -- <path> :(exclude)<path>` per SYSTEM_PATHS entry and skipped entries whose exclusions would cancel the pathspec out, via an inline `ls-tree` round-trip against upstream. For a single-file entry that exactly matches a preserved path, that lookup is redundant: the string match already proves the whole file is preserved.

This extracts the check into an exported `pathFullyPreserved()`, ctx-injectable the same way `locallyModifiedSystemFiles()` already is, so it is directly unit-testable instead of living inline inside the ROOT-bound `apply()`, and short-circuits before any git call when the match is a single file. The directory case, which genuinely needs the `ls-tree` to confirm every file under it is preserved, is unchanged.

## Why this is `Refs`, not `Fixes` (corrected after review)

I originally filed this as `Fixes #3779` on a wrong reading of that issue, and @nikitacometa was right to catch it. Re-traced:

#3779's failure is `fatal: pathspec ':(exclude)AGENTS.md' did not match any files` from `git --literal-pathspecs add -f -- <hundreds of files>`. That command is `addPaths()`, fed by `expandToShippedFiles()`, which passes `:(exclude)AGENTS.md` through unexpanded because it doesn't end in `/`. Under `--literal-pathspecs` git reads it as a literal filename that doesn't exist, and the whole staging step dies.

That is a different step from this checkout skip-check, which already returned `true` for `AGENTS.md` before this PR — so it never failed and was never the cause. #3779 is the same root cause as #3740, and **#3742 fixes the real site**.

## Known limits (both documented on the function)

1. **Single-file divergence.** For a preserved file *absent* from FETCH_HEAD the pre-extraction inline check fell through to the real checkout, which failed and put the path in apply()'s "Skipped N path(s) absent upstream" summary; this returns `true` and skips it silently. Unreachable today — preserved paths come from `locallyModifiedSystemFiles`, which only reports files that exist upstream (it gates each candidate on `cat-file -e <ref>:<file>`) — but it is a real divergence, not a behaviour-preserving one.

2. **The directory cancel-out is NOT closed.** A throwing `ls-tree` still returns `false` and falls through to `git checkout FETCH_HEAD -- modes/ :(exclude)modes/pdf.md`, which aborts the update when that directory is fully preserved. That is the pre-extraction behaviour carried over unchanged — this PR makes the check testable and drops a redundant lookup; it does not fix the directory case. Closing it needs the tri-state result @nikitacometa suggested, whose "unknown" makes the checkout's "did not match any file(s)" benign at the call site. Tracked separately rather than folded in here, because it means matching on git's stderr text — a fragility this file has deliberately avoided before (#1998 chose stderr piping over string matching).

## Scope changes after review

- The two `rollback()` edits (the `gitQuiet` swap and the `ls-tree` backup-existence check) are **removed from this PR**. They were unrelated to the title, on the recovery path, and untested; the `ls-tree` one also threw from inside a `catch`, which would end rollback mid-restore and surface the lookup error instead of the original. They move to #3782, which already rewrites that function.
- This PR is now purely the extraction: `update-system.mjs` + its test.

## Test plan

- [x] `node --test tests/updater-local-system-edits.test.mjs` — passes, including the 5 `pathFullyPreserved()` cases (single-file skip with zero git calls, unrelated path with zero git calls, fully-preserved directory retaining the ls-tree path, partially-preserved directory not skipped, unreadable ls-tree degrading to `false`)
- [x] `node updater-migration-tests.mjs` — 382 passed, 0 failed
- [x] `node test-all.mjs --only=update` — 174 passed, 0 failed
- [x] `npm run lint` — 654 files, syntax OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can run `update-system.mjs apply --confirm` when root files such as `AGENTS.md` are preserved. Fully preserved paths no longer cause an empty Git pathspec error.

`rollback()` now suppresses expected checkout errors for paths absent from the backup branch.

### Changes

- `update-system.mjs`: Adds and uses `pathFullyPreserved()` to skip fully preserved files and directories. Uses `gitQuiet()` for expected rollback checkout failures.
- `tests/updater-local-system-edits.test.mjs`: Adds coverage for preserved files, fully preserved directories, partial preservation, unrelated paths, and unreadable directories.
- Affected system files: `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
- Orphaned-file cleanup after rollback remains out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
