### PR TITLE
fix(update-system): rollback reads the failed update's own target manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 * **tracker:** sort the applications table by # ascending on write ([#3515](https://github.com/career-ops-hq/career-ops/issues/3515)) ([372cd04](https://github.com/career-ops-hq/career-ops/commit/372cd043b35e8d07cd522fec955a65252c0906db))
 * **triage:** fall back to Playwright when WebFetch finds nothing ([#3571](https://github.com/career-ops-hq/career-ops/issues/3571)) ([10b93a5](https://github.com/career-ops-hq/career-ops/commit/10b93a5f6e4444332243fefaef65b8b153835fc1))
 * **update-system:** apply() cannot commit when a path it stages is ignored or never tracked ([ae6909f](https://github.com/career-ops-hq/career-ops/commit/ae6909f718c9316a0d1424379e1688f438a07706))
+* **update-system:** retain rollback target refs only while their paired backup branch exists, and validate that pair before branch creation
+* **update-system:** migrate redundant local declarations already covered by `USER_PATHS`; replace broad mixed paths such as `config/` or `modes/` with precise fork-owned entries
 * **update:** point the updater at the repository's new home ([9063495](https://github.com/career-ops-hq/career-ops/commit/9063495036e253668e42d6bbbd4234e750b25782))
 * **updater:** back up self-bootstrap edits before checkout ([#3474](https://github.com/career-ops-hq/career-ops/issues/3474)) ([203c90b](https://github.com/career-ops-hq/career-ops/commit/203c90b79e632209e3a55068499f8ca5cbea489e))
 * **updater:** scope commits to shipped files ([#3688](https://github.com/career-ops-hq/career-ops/issues/3688)) ([455bf37](https://github.com/career-ops-hq/career-ops/commit/455bf375a84508a955acd58819392fa9f7a07bd0))

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -563,7 +563,7 @@ Possible JSON responses:
 
 ## update
 
-Applies the upstream update. Creates a timestamped backup branch (`backup-pre-update-<version>-<YYYYMMDDTHHMMSSZ>`), fetches from the canonical repo, checks out only system-layer files, runs `npm install`, and commits. The timestamp is derived from UTC ISO time with separators and milliseconds removed (for example, `backup-pre-update-1.8.1-20260608T071302Z`). User-layer files (`cv.md`, `config/profile.yml`, `data/`, etc.) are never touched.
+Applies the upstream update. Creates a timestamped backup branch (`backup-pre-update-<version>-<YYYYMMDDTHHMMSSZ>`), fetches from the canonical repo, checks out only system-layer files, runs `npm install`, and commits. The timestamp is derived from UTC ISO time with separators and milliseconds removed (for example, `backup-pre-update-1.8.1-20260608T071302Z`). User-layer files (`cv.md`, `config/profile.yml`, `data/`, etc.) are never touched. Each current-format backup has an internal paired target ref at `refs/backup-pre-update-target/<backup-branch>` so rollback can identify files introduced by that update. Target refs are retained while their backup branch exists; a later update prunes only paired refs whose backup branch was deleted.
 
 ```bash
 npm run update

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -601,24 +601,26 @@ export async function captureConsoleErrors(fn) {
 }
 
 /**
- * Build a throwaway git repository for the two updater suites that drive git
- * through the `gitIn` seam (`updater-add-paths`, `updater-is-tracked`). Only
- * the first asserts on ignore RESOLUTION; the second writes its own .gitignore
- * and then asks about index membership, which is a different question.
+ * Build a throwaway git repository for the updater suites that drive git
+ * through the `gitIn` seam (`updater-add-paths`, `updater-is-tracked`, and
+ * `updater-rollback-target-manifest`). The first asserts on ignore RESOLUTION;
+ * the second writes its own .gitignore and asks about index membership; the
+ * third builds real backup/target commits and invokes the rollback CLI.
  *
  * The pins below are the reason this is shared rather than copied, but they are
- * not all load-bearing for both callers, and this docstring should not imply
+ * not all load-bearing for every caller, and this docstring should not imply
  * otherwise. Mutation-tested by dropping each pin under a GIT_CONFIG_GLOBAL it
  * exists to neutralise:
  *
  *   - `commit.gpgsign=false` and `core.hooksPath` → an empty dir. Either one
  *     inherited from the environment breaks every commit the fixtures make.
- *     Dropping either reddens BOTH suites.
+ *     Dropping either reddens all three suites.
  *   - `core.excludesFile` → an empty file. A global ignore rule silently alters
  *     what is measured (the failure mode reported in #2269). Dropping it reddens
  *     updater-add-paths only: updater-is-tracked writes its own .gitignore and
- *     then reads index membership, which a global rule does not move. Kept for
- *     both as a defensive pin, proven by one.
+ *     then reads index membership, while updater-rollback-target-manifest stages
+ *     snapshots with `git add -A`. Kept for all three as a defensive pin,
+ *     proven by one.
  *
  * Point `core.excludesFile` at an empty file rather than /dev/null: git on
  * Windows maps that to `nul` and dies with "fatal: cannot use nul as an

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -619,8 +619,8 @@ export async function captureConsoleErrors(fn) {
  *     what is measured (the failure mode reported in #2269). Dropping it reddens
  *     updater-add-paths only: updater-is-tracked writes its own .gitignore and
  *     then reads index membership, while updater-rollback-target-manifest stages
- *     snapshots with `git add -A`. Kept for all three as a defensive pin,
- *     proven by one.
+ *     snapshots with `git add -A`, so a global rule could drop a fixture file;
+ *     it stayed green in the mutation run only because no such rule was set.
  *
  * Point `core.excludesFile` at an empty file rather than /dev/null: git on
  * Windows maps that to `nul` and dies with "fatal: cannot use nul as an

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -656,6 +656,7 @@ export function makeUpdaterRepo(gitIn, { prefix = 'co-updater-', includeRoot = f
   const dir = mkdtempSync(join(tmpdir(), prefix));
   const g = (...args) => gitIn(dir, ...args);
   g('init', '-q', '-b', 'main', '.');
+  g('config', 'core.autocrlf', 'false');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
   const emptyExcludes = join(dir, '.git', 'co-empty-excludes');

--- a/tests/updater-local-paths.test.mjs
+++ b/tests/updater-local-paths.test.mjs
@@ -139,7 +139,50 @@ console.log('\n🧪 Local user-paths declaration file (#2421)\n');
   }
 }
 
-// ── 8. Absolute paths and parent-directory escapes are refused ──
+// ── 8. An ancestor of a SYSTEM_PATHS entry is refused too ──
+//    A local declaration is consumed as a protected path later in apply().
+//    Declaring `modes/` used to pass this validation because the manifest
+//    lists its children, then made the later manifest guard reject every
+//    shipped child instead of reporting the bad declaration here.
+{
+  const collisions = [
+    ['modes/', 'a system-directory ancestor'],
+    ['modes', 'the same ancestor without its directory marker'],
+    ['merge-tracker.mjs/child', 'a child below a system file'],
+    ['te\u017Fts/', 'a Unicode case-folded alias of a system directory'],
+  ];
+  const survivors = [];
+  for (const [path, shape] of collisions) {
+    let threw = null;
+    try {
+      localUserPaths(root(`${path}\n`));
+    } catch (err) {
+      threw = err;
+    }
+    if (!threw || !threw.message.includes(path)) survivors.push(`${shape} → ${path}`);
+  }
+  if (survivors.length === 0) {
+    pass('system-path ancestors and descendants are refused at declaration time');
+  } else {
+    fail(`#8 accepted system overlaps: ${survivors.join('; ')}`);
+  }
+
+  const neighbours = ['modes-local/', 'merge-tracker.mjs.local'];
+  let problem = null;
+  try {
+    const got = localUserPaths(root(`${neighbours.join('\n')}\n`));
+    if (!eq(got, neighbours)) problem = `returned ${JSON.stringify(got)}`;
+  } catch (err) {
+    problem = err.message;
+  }
+  if (!problem) {
+    pass('prefix-sharing but non-overlapping local declarations remain valid');
+  } else {
+    fail(`#8 rejected valid system-path neighbours: ${problem}`);
+  }
+}
+
+// ── 9. Absolute paths and parent-directory escapes are refused ──
 //    The declaration is a repo-relative statement about this checkout. A path
 //    that leaves it can only widen the "never touch" set over files the
 //    updater does not own.
@@ -328,13 +371,11 @@ console.log('\n🧪 Local user-paths declaration file (#2421)\n');
 
 // ── 19. Non-canonical spellings of a system path are refused ──
 //
-// The collision check compares strings exactly (`path === sys`), and
-// userLayerViolations() later compares against git's changed-path format, which
-// is always canonical. A declaration written as `./merge-tracker.mjs` therefore
-// matches NEITHER: the collision check waves it through, and the safety check
-// never recognises it as the file it names. The declaration silently protects
-// nothing and the updater overwrites the file — the exact data loss #2421
-// exists to prevent, reachable from a plausible typo.
+// userLayerViolations() compares against git's changed-path format, which is
+// always canonical. A declaration written as `./merge-tracker.mjs` is never
+// recognised as the file it names when the safety check runs. The declaration
+// silently protects nothing and the updater overwrites the file — the exact
+// data loss #2421 exists to prevent, reachable from a plausible typo.
 //
 // Canonical syntax is REQUIRED rather than normalised, because normalising
 // would quietly accept several spellings for one path and leave this file

--- a/tests/updater-local-paths.test.mjs
+++ b/tests/updater-local-paths.test.mjs
@@ -182,7 +182,48 @@ console.log('\n🧪 Local user-paths declaration file (#2421)\n');
   }
 }
 
-// ── 9. Absolute paths and parent-directory escapes are refused ──
+// ── 9. Redundant built-in declarations migrate away without widening scope ──
+//    Older local-paths files sometimes repeated a USER_PATHS directory before it
+//    gained a tracked scaffold. That declaration is already fully protected, so
+//    rejecting it would make both apply and rollback fail after an upgrade.
+{
+  const redundant = ['documents/', 'interview-prep/', 'writing-samples/', 'data/private/'];
+  const retained = 'fork-runner.mjs';
+  let problem = null;
+  try {
+    const got = localUserPaths(root(`${redundant.join('\n')}\n${retained}\n`));
+    if (!eq(got, [retained])) problem = `returned ${JSON.stringify(got)}`;
+    const widened = effectiveUserPaths(root(`${redundant.join('\n')}\n${retained}\n`));
+    if (!eq(widened, [...USER_PATHS, retained])) problem = `union was ${JSON.stringify(widened)}`;
+  } catch (err) {
+    problem = err.message;
+  }
+  if (!problem) {
+    pass('redundant built-in user-path declarations are ignored during migration');
+  } else {
+    fail(`#9 redundant built-in declarations did not migrate: ${problem}`);
+  }
+
+  const mixedAncestors = ['config/', 'modes/'];
+  const accepted = [];
+  for (const path of mixedAncestors) {
+    try {
+      localUserPaths(root(`${path}\n`));
+      accepted.push(path);
+    } catch (err) {
+      if (!err.message.includes('USER_PATHS') || !err.message.includes('narrow')) {
+        accepted.push(`${path} (missing actionable guidance: ${err.message})`);
+      }
+    }
+  }
+  if (accepted.length === 0) {
+    pass('mixed system/user ancestors remain refused with removal-or-narrowing guidance');
+  } else {
+    fail(`#9 unsafe broad declarations were accepted or unclear: ${accepted.join('; ')}`);
+  }
+}
+
+// ── 10. Absolute paths and parent-directory escapes are refused ──
 //    The declaration is a repo-relative statement about this checkout. A path
 //    that leaves it can only widen the "never touch" set over files the
 //    updater does not own.
@@ -202,7 +243,7 @@ console.log('\n🧪 Local user-paths declaration file (#2421)\n');
   }
 }
 
-// ── 9. The declaration file never declares itself away ──
+// ── 11. The declaration file never declares itself away ──
 //    It is gitignored, so it is not a tracked file and needs no coverage; a
 //    self-reference is a sign of a confused config, not a valid statement.
 {

--- a/tests/updater-rollback-target-manifest.test.mjs
+++ b/tests/updater-rollback-target-manifest.test.mjs
@@ -1,0 +1,565 @@
+/*
+ * updater-rollback-target-manifest.test.mjs — rollback target pairing and
+ * manifest-boundary coverage (#3782).
+ *
+ * The pure checks pin the canonical path policy and the concrete-file helper.
+ * The final five cases execute the real rollback CLI in throwaway repositories:
+ * paired and missing target refs, ordinary and dangling symlinked parents, and
+ * a target-only file replaced by a directory.
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  lstatSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  MANIFEST_USER_PATH_OVERLAPS,
+  gitIn,
+  isSafeManifestPath,
+  manifestTreeFiles,
+  targetRefForBackup,
+} from '../update-system.mjs';
+import { fail, makeUpdaterRepo, pass, rmSync } from './helpers.mjs';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const updaterSource = readFileSync(join(ROOT, 'update-system.mjs'), 'utf8');
+const protectedUserPaths = [
+  'cv.md',
+  'data/',
+  'documents/',
+  'interview-prep/',
+  'writing-samples/',
+];
+const expectedOverlaps = [
+  'writing-samples/README.md',
+  'interview-prep/sessions/.gitkeep',
+  'interview-prep/sessions/README.md',
+  'documents/.gitkeep',
+  'documents/README.md',
+];
+
+console.log('\n🧪 Testing updater rollback target manifests (#3782)...');
+
+function check(condition, ok, bad) {
+  if (condition) pass(ok);
+  else fail(bad);
+}
+
+function rejectedBy(fn) {
+  try {
+    return !fn();
+  } catch {
+    return true;
+  }
+}
+
+// ── 1. The overlap escape hatch is exact, small, and reviewable ──
+{
+  const actual = [...MANIFEST_USER_PATH_OVERLAPS];
+  check(
+    actual.length === expectedOverlaps.length
+      && expectedOverlaps.every((path) => actual.includes(path)),
+    'the exact user/system overlap constant contains only the five documented scaffolds',
+    `overlap constant drifted: ${JSON.stringify(actual)}`,
+  );
+
+  const allowed = expectedOverlaps.every((path) =>
+    isSafeManifestPath(path, protectedUserPaths));
+  check(
+    allowed,
+    'all five byte-exact overlap paths are allowed inside protected user directories',
+    'one or more documented overlap paths were rejected',
+  );
+
+  const nearOverlaps = [
+    'Writing-samples/README.md',
+    'writing-samples/readme.md',
+    'writing-samples/README.md/',
+    'writing-samples/README.md.bak',
+    'interview-prep/sessions/README.md/child',
+    'documents/readme.md',
+  ];
+  check(
+    nearOverlaps.every((path) => !isSafeManifestPath(path, protectedUserPaths)),
+    'case, suffix, slash, and descendant aliases do not inherit the overlap exception',
+    `near-overlap escaped: ${nearOverlaps.filter((path) => isSafeManifestPath(path, protectedUserPaths)).join(', ')}`,
+  );
+}
+
+// ── 2. User paths are protected in all three directions ──
+{
+  const cases = [
+    ['cv.md', ['cv.md'], 'exact file'],
+    ['data/', ['data/'], 'exact directory'],
+    ['data/applications.md', ['data/'], 'descendant'],
+    ['data/', ['data/applications.md'], 'ancestor directory'],
+    ['interview-prep/', ['interview-prep/sessions/private.md'], 'ancestor of nested file'],
+    ['CV.md', ['cv.md'], 'case alias'],
+    ['DATA/applications.md', ['data/'], 'case-folded descendant'],
+  ];
+  const escaped = cases.filter(([path, users]) => isSafeManifestPath(path, users));
+  check(
+    escaped.length === 0,
+    'exact user paths, descendants, ancestors, and case aliases are rejected',
+    `user path cases escaped: ${escaped.map((entry) => entry[2]).join(', ')}`,
+  );
+
+  const nfc = `caf${String.fromCodePoint(0xe9)}.md`;
+  const nfd = `caf${String.fromCodePoint(0x65, 0x301)}.md`;
+  check(
+    nfc !== nfd
+      && !isSafeManifestPath(nfd, [nfc])
+      && !isSafeManifestPath(nfc, [nfd]),
+    'NFC/NFD aliases are rejected in both comparison directions',
+    'Unicode-normalization aliases did not resolve to the protected path',
+  );
+}
+
+// ── 3. Non-canonical and pathspec-active spellings never reach git ──
+{
+  const malformed = [
+    '', null, 42,
+    '/etc/passwd', 'C:/Windows/System32/config', 'C:\\Windows\\System32',
+    '\\\\server\\share\\file', '\\rooted',
+    './modes/pdf.md', 'modes\\pdf.md', 'modes//pdf.md', 'modes/pdf.md//',
+    'modes/./pdf.md', 'modes/../cv.md',
+    'modes/control\u0000name.md', 'modes/line\nbreak.md',
+    ':(glob)modes/*.md', 'modes/a:b.md', 'modes/*.md', 'modes/?.md', 'modes/[ab].md',
+    '.git', '.GIT/hooks/pre-commit', 'modes/.gIt/config',
+  ];
+  const accepted = malformed.filter((path) => isSafeManifestPath(path, []));
+  check(
+    accepted.length === 0,
+    'empty/non-string, absolute, alias, control, pathspec-magic, and .git paths are rejected',
+    `unsafe spellings accepted: ${accepted.map((path) => JSON.stringify(path)).join(', ')}`,
+  );
+
+  check(
+    isSafeManifestPath('modes/pdf.md', protectedUserPaths)
+      && isSafeManifestPath('providers/', protectedUserPaths),
+    'canonical system file and directory entries remain valid',
+    'ordinary canonical system paths were rejected',
+  );
+}
+
+// ── 4. A backup branch has one strict, durable target-ref identity ──
+{
+  const backup = 'backup-pre-update-1.2.3-20260907T120000Z';
+  const expected = `refs/backup-pre-update-target/${backup}`;
+  check(
+    targetRefForBackup(backup) === expected,
+    'a strict backup branch maps to its durable paired target ref',
+    `paired ref mismatch: ${String(targetRefForBackup(backup))}`,
+  );
+
+  const invalid = [
+    'backup-pre-update-1.2-20260907T120000Z',
+    'backup-pre-update-1.2.3-20260907T120000Z/child',
+    'refs/heads/backup-pre-update-1.2.3-20260907T120000Z',
+    '../backup-pre-update-1.2.3-20260907T120000Z',
+  ];
+  check(
+    invalid.every((branch) => rejectedBy(() => targetRefForBackup(branch))),
+    'malformed backup names cannot manufacture a paired ref',
+    'the paired-ref helper accepted a malformed backup branch',
+  );
+}
+
+// ── 5. Tree expansion yields concrete, safe files only ──
+{
+  const { dir, g, ctx } = makeUpdaterRepo(gitIn, {
+    prefix: 'co-rollback-manifest-files-',
+    includeRoot: true,
+  });
+  try {
+    mkdirSync(join(dir, 'system', 'nested'), { recursive: true });
+    mkdirSync(join(dir, 'data'), { recursive: true });
+    mkdirSync(join(dir, 'writing-samples'), { recursive: true });
+    writeFileSync(join(dir, 'system', 'root.txt'), 'root\n');
+    writeFileSync(join(dir, 'system', 'nested', 'keep.txt'), 'keep\n');
+    writeFileSync(join(dir, 'system', 'nested', 'second.txt'), 'second\n');
+    writeFileSync(join(dir, 'data', 'private.txt'), 'private\n');
+    writeFileSync(join(dir, 'writing-samples', 'README.md'), 'scaffold\n');
+    g('add', '-A');
+    g('commit', '-qm', 'tree');
+
+    const files = manifestTreeFiles(
+      [
+        'system/root.txt',
+        'system/nested/',
+        'system/nested/keep.txt', // duplicate coverage must de-duplicate
+        'absent-direct.txt',      // unlike expandToShippedFiles, must not pass through
+        'data/',                  // protected before expansion
+        'writing-samples/README.md',
+      ],
+      'HEAD',
+      protectedUserPaths,
+      ctx,
+    );
+    const expected = new Set([
+      'system/root.txt',
+      'system/nested/keep.txt',
+      'system/nested/second.txt',
+      'writing-samples/README.md',
+    ]);
+    check(
+      files.length === expected.size && files.every((path) => expected.has(path)),
+      'manifest tree expansion returns de-duplicated concrete safe files and exact overlaps',
+      `concrete manifest files were wrong: ${JSON.stringify(files)}`,
+    );
+    check(
+      !files.includes('absent-direct.txt')
+        && !files.includes('data/private.txt'),
+      'absent and protected files never pass through concrete expansion',
+      `unsafe/nonexistent concrete entry survived: ${JSON.stringify(files)}`,
+    );
+
+    // Windows cannot materialize control characters in a filename. Inject a
+    // raw NUL-delimited tree response so this policy check remains portable
+    // while still proving manifestTreeFiles filters every concrete tree name.
+    const synthetic = manifestTreeFiles(
+      ['system/nested/'],
+      'HEAD',
+      protectedUserPaths,
+      {
+        git: () => 'system/nested/keep.txt\0system/nested/line\nbreak.txt\0',
+      },
+    );
+    check(
+      synthetic.length === 1 && synthetic[0] === 'system/nested/keep.txt',
+      'control-character tree filenames are rejected without filesystem-dependent fixtures',
+      `control-character concrete entry survived: ${JSON.stringify(synthetic)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function sourceWithManifest(paths) {
+  const declaration = /((?:export\s+)?const SYSTEM_PATHS\s*=\s*)\[[\s\S]*?\n\];/;
+  if (!declaration.test(updaterSource)) {
+    throw new Error('fixture could not locate the SYSTEM_PATHS declaration');
+  }
+  const body = `[\n${paths.map((path) => `  ${JSON.stringify(path)},`).join('\n')}\n];`;
+  return updaterSource.replace(declaration, `$1${body}`);
+}
+
+function put(dir, path, bytes) {
+  const destination = join(dir, ...path.split('/'));
+  mkdirSync(dirname(destination), { recursive: true });
+  writeFileSync(destination, bytes);
+}
+
+function runRollback(dir) {
+  return spawnSync(process.execPath, ['update-system.mjs', 'rollback'], {
+    cwd: dir,
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      CAREER_OPS_GIT_TIMEOUT_MS: '10000',
+    },
+  });
+}
+
+function seedRollbackRepo(prefix, { paired, fetchTarget }) {
+  const fixture = makeUpdaterRepo(gitIn, { prefix });
+  const { dir, g } = fixture;
+  const backup = paired
+    ? 'backup-pre-update-1.2.3-20260907T120000Z'
+    : 'backup-pre-update-1.2.3-20260907T130000Z';
+  const commonManifest = [
+    'update-system.mjs',
+    'system/root.txt',
+    'system/nested/',
+    'writing-samples/README.md',
+  ];
+  const targetManifest = [...commonManifest, 'target-only.mjs'];
+
+  try {
+    put(dir, 'update-system.mjs', sourceWithManifest(commonManifest));
+    put(dir, 'system/root.txt', 'backup root\n');
+    put(dir, 'system/nested/keep.txt', 'backup nested\n');
+    put(dir, 'writing-samples/README.md', 'backup scaffold\n');
+    put(dir, 'writing-samples/private.md', 'user sibling base\n');
+    put(dir, 'cv.md', 'user cv base\n');
+    g('add', '-A');
+    g('commit', '-qm', 'backup state');
+    const backupCommit = g('rev-parse', 'HEAD');
+    g('branch', backup, backupCommit);
+
+    put(dir, 'update-system.mjs', sourceWithManifest(targetManifest));
+    put(dir, 'system/root.txt', 'target root\n');
+    put(dir, 'system/nested/keep.txt', 'target nested\n');
+    put(dir, 'system/nested/target-only.txt', 'target-only nested\n');
+    put(dir, 'target-only.mjs', 'target-only top-level\n');
+    put(dir, 'writing-samples/README.md', 'target scaffold\n');
+    g('add', '-A');
+    g('commit', '-qm', 'target state');
+    const targetCommit = g('rev-parse', 'HEAD');
+
+    if (paired) g('update-ref', targetRefForBackup(backup), targetCommit);
+
+    // These are user-owned bytes present before rollback. Both are tracked and
+    // modified, so recursive checkout/removal of a protected ancestor destroys
+    // them immediately and observably.
+    put(dir, 'writing-samples/private.md', 'user sibling current\n');
+    put(dir, 'cv.md', 'user cv current\n');
+
+    // FETCH_HEAD is deliberately wrong for the paired case and maximally
+    // tempting in the missing-pair case. Either way rollback's decision must be
+    // a function of the durable pair, never this mutable process-global ref.
+    const distractorCommit = fetchTarget ? targetCommit : backupCommit;
+    g('branch', 'rollback-fetch-distractor', distractorCommit);
+    g('fetch', '.', 'rollback-fetch-distractor');
+
+    return { ...fixture, backup, backupCommit, targetCommit };
+  } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+function outputOf(result) {
+  return `${result.stdout || ''}\n${result.stderr || ''}`;
+}
+
+function readMaybe(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+// ── 6. Real CLI: paired target wins over a distractor FETCH_HEAD ──
+{
+  const fixture = seedRollbackRepo('co-rollback-paired-', {
+    paired: true,
+    fetchTarget: false,
+  });
+  const { dir, g, backupCommit } = fixture;
+  try {
+    check(
+      g('rev-parse', 'FETCH_HEAD') === backupCommit,
+      'paired-ref fixture mutates FETCH_HEAD to a non-target distractor',
+      'paired-ref fixture did not arrange its FETCH_HEAD distractor',
+    );
+
+    const result = runRollback(dir);
+    const userCv = readMaybe(join(dir, 'cv.md'));
+    const userSibling = readMaybe(join(dir, 'writing-samples/private.md'));
+    check(
+      result.status === 0 && !result.error,
+      'real rollback CLI succeeds with a readable paired target ref',
+      `paired rollback failed (status ${result.status}): ${outputOf(result)}`,
+    );
+    check(
+      readMaybe(join(dir, 'system/root.txt')) === 'backup root\n'
+        && readMaybe(join(dir, 'system/nested/keep.txt')) === 'backup nested\n'
+        && readMaybe(join(dir, 'writing-samples/README.md')) === 'backup scaffold\n',
+      'rollback restores backup system files and the exact-overlap scaffold',
+      'rollback did not restore the complete backup system/scaffold state',
+    );
+    check(
+      !existsSync(join(dir, 'target-only.mjs'))
+        && !existsSync(join(dir, 'system/nested/target-only.txt')),
+      'rollback removes target-only top-level and nested concrete files despite distractor FETCH_HEAD',
+      'rollback left a target-only file behind or consulted the FETCH_HEAD distractor',
+    );
+    check(
+      userCv === 'user cv current\n' && userSibling === 'user sibling current\n',
+      'rollback preserves changed user files and protected siblings byte-for-byte',
+      `rollback changed user bytes: cv=${JSON.stringify(userCv)} sibling=${JSON.stringify(userSibling)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 7. Real CLI: no paired ref means warn + conservative leftovers ──
+{
+  const fixture = seedRollbackRepo('co-rollback-unpaired-', {
+    paired: false,
+    fetchTarget: true,
+  });
+  const { dir, g, targetCommit, backup } = fixture;
+  try {
+    let pairExists = true;
+    try {
+      g('show-ref', '--verify', '--quiet', targetRefForBackup(backup));
+    } catch {
+      pairExists = false;
+    }
+    check(
+      !pairExists && g('rev-parse', 'FETCH_HEAD') === targetCommit,
+      'missing-pair fixture points FETCH_HEAD at the tempting target commit',
+      'missing-pair fixture did not isolate the no-fallback condition',
+    );
+
+    const result = runRollback(dir);
+    const output = outputOf(result);
+    check(
+      result.status === 0 && !result.error,
+      'real rollback CLI degrades conservatively when the paired target ref is missing',
+      `unpaired rollback failed (status ${result.status}): ${output}`,
+    );
+    check(
+      /(?:target|paired)[^\n]*(?:missing|unavailable|could not)/i.test(output)
+        && /(?:leftover|left behind|may remain)/i.test(output),
+      'missing-pair rollback visibly warns that target-only leftovers may remain',
+      `missing-pair rollback warning was absent or unclear: ${JSON.stringify(output)}`,
+    );
+    check(
+      existsSync(join(dir, 'target-only.mjs'))
+        && existsSync(join(dir, 'system/nested/target-only.txt')),
+      'missing-pair rollback leaves target-only files, proving it did not fall back to FETCH_HEAD',
+      'missing-pair rollback removed a target-only file via mutable FETCH_HEAD',
+    );
+    check(
+      readMaybe(join(dir, 'system/root.txt')) === 'backup root\n'
+        && readMaybe(join(dir, 'writing-samples/README.md')) === 'backup scaffold\n'
+        && readMaybe(join(dir, 'cv.md')) === 'user cv current\n'
+        && readMaybe(join(dir, 'writing-samples/private.md')) === 'user sibling current\n',
+      'degraded rollback still restores known backup files without touching user bytes',
+      'degraded rollback failed its safe known-backup restore contract',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 8. Real CLI: symlinked parents cannot redirect rollback outside ROOT ──
+{
+  const fixture = seedRollbackRepo('co-rollback-symlink-', {
+    paired: true,
+    fetchTarget: false,
+  });
+  const { dir } = fixture;
+  const external = mkdtempSync(join(tmpdir(), 'co-rollback-external-'));
+  try {
+    rmSync(join(dir, 'system/nested'), { recursive: true, force: true });
+    writeFileSync(join(external, 'keep.txt'), 'external keep\n');
+    writeFileSync(join(external, 'target-only.txt'), 'external target-only\n');
+    let symlinkUnavailable = false;
+    try {
+      symlinkSync(external, join(dir, 'system/nested'), 'dir');
+    } catch (err) {
+      if (err?.code !== 'EPERM') throw err;
+      symlinkUnavailable = true;
+      console.log('  SKIP: symlink-parent rollback guard (symlink creation returned EPERM)');
+    }
+
+    if (!symlinkUnavailable) {
+      const result = runRollback(dir);
+      const output = outputOf(result);
+      check(
+        result.status === 0 && !result.error,
+        'rollback degrades safely when a concrete path has a symlinked parent',
+        `symlink-parent rollback failed (status ${result.status}): ${output}`,
+      );
+      check(
+        readMaybe(join(external, 'keep.txt')) === 'external keep\n'
+          && readMaybe(join(external, 'target-only.txt')) === 'external target-only\n',
+        'rollback never restores or removes through a symlinked parent',
+        'rollback followed a symlinked parent and changed bytes outside the repository',
+      );
+      check(
+        /symlinked parent/i.test(output),
+        'rollback visibly warns when leaving a symlink-rerouted path untouched',
+        `symlink-parent warning was absent: ${JSON.stringify(output)}`,
+      );
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(external, { recursive: true, force: true });
+  }
+}
+
+// ── 9. Real CLI: a dangling symlinked parent is still left untouched ──
+{
+  const fixture = seedRollbackRepo('co-rollback-broken-symlink-', {
+    paired: true,
+    fetchTarget: false,
+  });
+  const { dir } = fixture;
+  const external = mkdtempSync(join(tmpdir(), 'co-rollback-broken-external-'));
+  const nested = join(dir, 'system/nested');
+  try {
+    rmSync(nested, { recursive: true, force: true });
+    let symlinkUnavailable = false;
+    try {
+      symlinkSync(join(external, 'missing-target'), nested, 'dir');
+    } catch (err) {
+      if (err?.code !== 'EPERM') throw err;
+      symlinkUnavailable = true;
+      console.log('  SKIP: broken-symlink rollback guard (symlink creation returned EPERM)');
+    }
+
+    if (!symlinkUnavailable) {
+      const result = runRollback(dir);
+      const output = outputOf(result);
+      check(
+        result.status === 0 && !result.error,
+        'rollback degrades safely when a concrete path has a dangling symlinked parent',
+        `broken-symlink rollback failed (status ${result.status}): ${output}`,
+      );
+      check(
+        lstatSync(nested).isSymbolicLink(),
+        'rollback leaves a dangling symlinked parent in place',
+        'rollback changed the dangling symlinked parent',
+      );
+      check(
+        /symlinked parent/i.test(output),
+        'rollback visibly warns when a dangling symlinked parent is left untouched',
+        `broken-symlink warning was absent: ${JSON.stringify(output)}`,
+      );
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(external, { recursive: true, force: true });
+  }
+}
+
+// ── 10. Real CLI: a target-only file replaced by a directory is preserved ──
+{
+  const fixture = seedRollbackRepo('co-rollback-became-dir-', {
+    paired: true,
+    fetchTarget: false,
+  });
+  const { dir } = fixture;
+  try {
+    rmSync(join(dir, 'target-only.mjs'), { force: true });
+    mkdirSync(join(dir, 'target-only.mjs'));
+    writeFileSync(join(dir, 'target-only.mjs/private.txt'), 'private child\n');
+
+    const result = runRollback(dir);
+    const output = outputOf(result);
+    check(
+      result.status === 0 && !result.error,
+      'rollback degrades safely when a target-only file became a directory',
+      `became-directory rollback failed (status ${result.status}): ${output}`,
+    );
+    check(
+      readMaybe(join(dir, 'target-only.mjs/private.txt')) === 'private child\n',
+      'rollback leaves every child of a replacement directory untouched',
+      'rollback recursively removed a directory that replaced a target-only file',
+    );
+    check(
+      /became a directory|is now a directory/i.test(output),
+      'rollback visibly warns when a target-only file became a directory',
+      `replacement-directory warning was absent: ${JSON.stringify(output)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/tests/updater-rollback-target-manifest.test.mjs
+++ b/tests/updater-rollback-target-manifest.test.mjs
@@ -26,6 +26,7 @@ import {
   gitIn,
   isSafeManifestPath,
   manifestTreeFiles,
+  pruneStaleTargetRefs,
   targetRefForBackup,
 } from '../update-system.mjs';
 import { fail, makeUpdaterRepo, pass, rmSync } from './helpers.mjs';
@@ -174,7 +175,47 @@ function rejectedBy(fn) {
   );
 }
 
-// ── 5. Tree expansion yields concrete, safe files only ──
+// ── 5. Target refs are retained only while their strict backup branch exists ──
+{
+  const { dir, g, ctx } = makeUpdaterRepo(gitIn, { prefix: 'co-target-ref-prune-' });
+  try {
+    writeFileSync(join(dir, 'seed.txt'), 'seed\n');
+    g('add', 'seed.txt');
+    g('commit', '-qm', 'seed');
+    const commit = g('rev-parse', 'HEAD');
+    const live = 'backup-pre-update-1.2.3-20260907T120000Z';
+    const stale = 'backup-pre-update-1.2.3-20260907T130000Z';
+    const liveRef = targetRefForBackup(live);
+    const staleRef = targetRefForBackup(stale);
+    const manualRef = 'refs/backup-pre-update-target/manual-retain';
+    g('branch', live, commit);
+    g('branch', stale, commit);
+    g('update-ref', liveRef, commit);
+    g('update-ref', staleRef, commit);
+    g('update-ref', manualRef, commit);
+    g('branch', '-D', stale);
+
+    const pruned = pruneStaleTargetRefs(ctx);
+    const hasRef = (ref) => {
+      try { g('show-ref', '--verify', '--quiet', ref); return true; }
+      catch { return false; }
+    };
+    check(
+      pruned.length === 1 && pruned[0] === staleRef && !hasRef(staleRef),
+      'stale paired target refs are pruned when their backup branch is gone',
+      `stale paired ref was not pruned: ${JSON.stringify(pruned)}`,
+    );
+    check(
+      hasRef(liveRef) && hasRef(manualRef),
+      'live backup pairs and unrecognised namespace refs are retained',
+      'target-ref pruning removed a live pair or manual namespace ref',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 6. Tree expansion yields concrete, safe files only ──
 {
   const { dir, g, ctx } = makeUpdaterRepo(gitIn, {
     prefix: 'co-rollback-manifest-files-',

--- a/tests/updater-self-bootstrap-backup.test.mjs
+++ b/tests/updater-self-bootstrap-backup.test.mjs
@@ -33,13 +33,16 @@ try {
   }
 
   const source = readFileSync(join(root, 'update-system.mjs'), 'utf8');
-  const detectAt = source.indexOf("locallyModifiedSystemFiles(reexecFiles, 'FETCH_HEAD')");
+  const closureAt = source.indexOf('const reexecFiles = assertSafeManifestPaths(');
+  const coverageAt = source.indexOf('uncoveredReexecFiles.length > 0', closureAt);
+  const detectAt = source.indexOf('locallyModifiedSystemFiles(reexecFiles, targetRef)', coverageAt);
   const backUpAt = source.indexOf('backupSystemFiles(bootstrapAtRisk)', detectAt);
-  const checkoutAt = source.indexOf("git('checkout', 'FETCH_HEAD', '--', ...reexecFiles)", detectAt);
-  if (detectAt !== -1 && backUpAt > detectAt && checkoutAt > backUpAt) {
-    pass('apply detects and backs up bootstrap edits before checkout');
+  const checkoutAt = source.indexOf("git('--literal-pathspecs', 'checkout', targetRef, '--', ...reexecFiles)", detectAt);
+  if (closureAt !== -1 && coverageAt > closureAt && detectAt > coverageAt
+      && backUpAt > detectAt && checkoutAt > backUpAt) {
+    pass('apply validates, detects, and backs up bootstrap edits before literal checkout');
   } else {
-    fail('apply must preserve bootstrap edits before the destructive checkout');
+    fail('apply must validate and preserve bootstrap edits before the destructive checkout');
   }
 
   const recordAt = source.indexOf('generatedBackupPaths.add(result.backup)');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -77,6 +77,8 @@ export function consumeReexecMarker() {
   }
 }
 
+const BACKUP_BRANCH_RE = /^backup-pre-update-\d+\.\d+\.\d+-\d{8}T\d{6}Z$/;
+
 function isLegacyReexec() {
   if (process.env.CAREER_OPS_UPDATE_REEXEC !== '1') {
     return false;
@@ -88,7 +90,7 @@ function isLegacyReexec() {
     return false;
   }
   const backupBranch = process.env.CAREER_OPS_UPDATE_BACKUP_BRANCH || '';
-  if (!/^backup-pre-update-\d+\.\d+\.\d+-\d{8}T\d{6}Z$/.test(backupBranch)) {
+  if (!BACKUP_BRANCH_RE.test(backupBranch)) {
     return false;
   }
   try {
@@ -123,6 +125,17 @@ export const PLAYWRIGHT_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER
 export const DASHBOARD_REBUILD_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_DASHBOARD_REBUILD_TIMEOUT_MS, 60000);
 export const UPDATE_PATH_CHECKOUT_BUDGET_MS = parsePositiveInt(process.env.CAREER_OPS_UPDATE_PATH_CHECKOUT_BUDGET_MS, 5000);
 export const REEXEC_BUFFER_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_REEXEC_BUFFER_TIMEOUT_MS, 60000);
+
+// The only byte-exact files the system deliberately owns inside user-layer
+// directories. Keep this escape hatch small and reviewable: aliases, parents,
+// children, and case/Unicode variants are not overlaps.
+export const MANIFEST_USER_PATH_OVERLAPS = Object.freeze([
+  'writing-samples/README.md',
+  'interview-prep/sessions/.gitkeep',
+  'interview-prep/sessions/README.md',
+  'documents/.gitkeep',
+  'documents/README.md',
+]);
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
@@ -574,14 +587,13 @@ export function localUserPaths(root = ROOT) {
     }
     // Canonical spelling, required BEFORE the collision check below.
     //
-    // That check compares strings exactly (`path === sys`), and
+    // That check compares canonical path segments, while
     // userLayerViolations() later compares against git's changed-path format,
-    // which is always canonical. A non-canonical spelling therefore matches
-    // NEITHER: `./merge-tracker.mjs` sails past the collision check, and is
-    // never recognised as the file it names when the safety check runs. The
-    // declaration silently protects nothing while the updater overwrites the
-    // file — the data loss this feature exists to prevent, reachable from a
-    // plausible typo.
+    // which is always canonical. A non-canonical spelling could otherwise
+    // evade one or both checks: `./merge-tracker.mjs` is never recognised as
+    // the file it names when the safety check runs. The declaration silently
+    // protects nothing while the updater overwrites the file — the data loss
+    // this feature exists to prevent, reachable from a plausible typo.
     //
     // Rejected rather than normalised, deliberately. Normalising would accept
     // several spellings for one path and leave this file disagreeing with what
@@ -598,9 +610,12 @@ export function localUserPaths(root = ROOT) {
     if (segments.includes('.')) {
       reject(path, 'paths must be written plainly, with no "." segment (use "merge-tracker.mjs", not "./merge-tracker.mjs")');
     }
-    const collision = SYSTEM_PATHS.find((sys) =>
-      sys.endsWith('/') ? path.startsWith(sys) : path === sys,
-    );
+    const pathSegments = manifestPathSegments(path);
+    const collision = SYSTEM_PATHS.find((sys) => {
+      const systemSegments = manifestPathSegments(sys);
+      const shared = Math.min(pathSegments.length, systemSegments.length);
+      return pathSegments.slice(0, shared).every((segment, index) => segment === systemSegments[index]);
+    });
     if (collision) {
       reject(
         path,
@@ -621,6 +636,96 @@ export function localUserPaths(root = ROOT) {
  */
 export function effectiveUserPaths(root = ROOT) {
   return [...USER_PATHS, ...localUserPaths(root)];
+}
+
+function manifestPathSegments(path) {
+  const withoutTrailingSlash = path.endsWith('/') ? path.slice(0, -1) : path;
+  return withoutTrailingSlash.split('/').map((segment) =>
+    // Uppercasing after the first lowercase expansion approximates Unicode case
+    // folding where JavaScript has no caseFold(): ß → ss, final sigma → σ,
+    // and the long s → s. Extra aliases reject declarations/manifest paths
+    // conservatively, which is safe on case-sensitive filesystems too.
+    segment.normalize('NFC').toLowerCase().toUpperCase().toLowerCase(),
+  );
+}
+
+function unsafeManifestPathReason(path, userPaths) {
+  if (typeof path !== 'string' || path.length === 0) return 'it is not a non-empty string';
+  if (path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path) || path.startsWith('\\')) {
+    return 'absolute, drive-qualified, and UNC paths are forbidden';
+  }
+  if (path.startsWith('./')) return 'leading "./" aliases are forbidden';
+  if (path.includes('\\')) return 'backslashes are forbidden';
+  if (path.includes('//')) return 'repeated separators and multiple trailing slashes are forbidden';
+  if (/[\u0000-\u001f\u007f-\u009f]/u.test(path)) return 'control characters are forbidden';
+  if (/[:*?\[\]]/u.test(path)) return 'git pathspec magic is forbidden';
+
+  const segments = manifestPathSegments(path);
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return 'empty, ".", and ".." path segments are forbidden';
+  }
+  if (segments.some((segment) => segment === '.git')) return 'the git metadata directory is forbidden';
+
+  // The five system-owned scaffolds are exceptions only in their exact byte
+  // spelling. Testing this before the protected-boundary comparison allows the
+  // documented files while ensuring no alias, parent, or child inherits it.
+  if (MANIFEST_USER_PATH_OVERLAPS.includes(path)) return null;
+
+  for (const userPath of userPaths) {
+    if (typeof userPath !== 'string' || userPath.length === 0) continue;
+    const protectedSegments = manifestPathSegments(userPath);
+    const common = Math.min(segments.length, protectedSegments.length);
+    let prefix = true;
+    for (let i = 0; i < common; i++) {
+      if (segments[i] !== protectedSegments[i]) {
+        prefix = false;
+        break;
+      }
+    }
+    if (prefix) {
+      return `it overlaps protected user path "${userPath}"`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether a manifest entry is canonical and cannot address user data.
+ * Comparisons against protected paths are segment-based, NFC-normalized, and
+ * case-folded so filesystem aliases fail closed on macOS and Windows.
+ */
+export function isSafeManifestPath(path, userPaths = USER_PATHS) {
+  return unsafeManifestPathReason(path, userPaths) === null;
+}
+
+function filterSafeManifestPaths(paths, userPaths, onRejected = () => {}) {
+  const safe = [];
+  const seen = new Set();
+  for (const path of Array.isArray(paths) ? paths : []) {
+    const reason = unsafeManifestPathReason(path, userPaths);
+    if (reason) {
+      onRejected(path, reason);
+      continue;
+    }
+    if (!seen.has(path)) {
+      seen.add(path);
+      safe.push(path);
+    }
+  }
+  return safe;
+}
+
+function assertSafeManifestPaths(paths, userPaths, label) {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error(`${label} is missing or empty; refusing to update`);
+  }
+  const rejected = [];
+  const safe = filterSafeManifestPaths(paths, userPaths, (path, reason) => rejected.push({ path, reason }));
+  if (rejected.length > 0) {
+    const detail = rejected.map(({ path, reason }) => `${JSON.stringify(path)} (${reason})`).join(', ');
+    throw new Error(`${label} contains unsafe manifest path(s): ${detail}`);
+  }
+  return safe;
 }
 
 /**
@@ -679,6 +784,14 @@ function updateBackupBranchName(version, date = new Date()) {
     .replace(/[-:]/g, '')
     .replace(/\.\d{3}Z$/, 'Z');
   return `backup-pre-update-${version}-${stamp}`;
+}
+
+/** Map a strict updater backup branch to its durable attempted-target ref. */
+export function targetRefForBackup(backupBranch) {
+  if (!BACKUP_BRANCH_RE.test(backupBranch)) {
+    throw new Error(`Invalid updater backup branch: ${backupBranch}`);
+  }
+  return `refs/backup-pre-update-target/${backupBranch}`;
 }
 
 function backupTimestamp(branchName) {
@@ -859,9 +972,10 @@ function assertOwnGitToplevel() {
  * out when the next script crashes with ERR_MODULE_NOT_FOUND (#1998).
  *
  * @param {string[]} targetPaths - SYSTEM_PATHS read from the target updater.
- * @returns {string[]} Entries present in FETCH_HEAD but absent locally.
+ * @param {string} targetRef - Durable ref for the attempted target release.
+ * @returns {string[]} Entries present in targetRef but absent locally.
  */
-function missingFromTargetManifest(targetPaths) {
+function missingFromTargetManifest(targetPaths, targetRef) {
   const missing = [];
   for (const path of targetPaths) {
     const spec = path.endsWith('/') ? path.slice(0, -1) : path;
@@ -874,10 +988,10 @@ function missingFromTargetManifest(targetPaths) {
     if (path.endsWith('/')) {
       let treeFiles = [];
       try {
-        treeFiles = gitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', spec)
+        treeFiles = gitQuiet('ls-tree', '-r', '--name-only', targetRef, '--', spec)
           .split('\n').map(s => s.trim()).filter(Boolean);
       } catch {
-        continue; // FETCH_HEAD unreadable for this spec — treat as stale, not missing
+        continue; // target ref unreadable for this spec — treat as stale, not missing
       }
       // Empty tree ⇒ the target ships nothing here (stale manifest entry).
       if (treeFiles.some(f => !existsSync(join(ROOT, f)))) missing.push(path);
@@ -888,7 +1002,7 @@ function missingFromTargetManifest(targetPaths) {
     // Only count it as missing when the target actually ships it — a manifest
     // entry the target no longer carries is a stale entry, not a failed update.
     try {
-      gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`);
+      gitQuiet('cat-file', '-e', `${targetRef}:${spec}`);
       missing.push(path);
     } catch { /* absent upstream too — nothing to materialize */ }
   }
@@ -1151,7 +1265,7 @@ export function systemTreeDiffers(systemPaths, upstreamRef = 'FETCH_HEAD', ctx =
  *      isolated when one of their two fixes survived an update.
  *
  * @param {string[]} paths - manifest entries (files or `dir/` prefixes).
- * @param {string} upstreamRef - ref being checked out, normally FETCH_HEAD.
+ * @param {string} upstreamRef - Ref being checked out; apply passes its durable paired target.
  * @param {{git?: Function}} [ctx] - injectable git runner, for tests.
  * @returns {string[]} repo-relative file paths, sorted.
  */
@@ -1257,7 +1371,7 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  * would leave nothing to check out — i.e. `path` itself is (for a single
  * file) or entirely consists of (for a `dir/`-suffixed directory) preserved
  * content. apply()'s checkout loop uses this to skip such an entry outright:
- * `git checkout FETCH_HEAD -- <path> :(exclude)<path>` errors with "did not
+ * `git checkout <target-ref> -- <path> :(exclude)<path>` errors with "did not
  * match any file(s)" when the exclusions cancel the whole pathspec, and that
  * error is indistinguishable from a genuine checkout failure at the call
  * site, so it would abort the entire update over a file the user asked to
@@ -1274,7 +1388,7 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  * Two limits are deliberate, both raised in review of #3781:
  *
  * 1. The single-file shortcut diverges from the pre-extraction inline check
- *    for a preserved file ABSENT from FETCH_HEAD. That check fell through to
+ *    for a preserved file ABSENT from the target ref. That check fell through to
  *    the real checkout, which failed and put the path in apply()'s "Skipped
  *    N path(s) absent upstream" summary; this returns true and skips it
  *    silently. Unreachable while preserved paths come from
@@ -1286,7 +1400,7 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  *
  * 2. The directory branch's `catch → false` does NOT close the cancel-out
  *    abort for directories. A throwing ls-tree still falls through to
- *    `git checkout FETCH_HEAD -- modes/ :(exclude)modes/pdf.md`, which
+ *    `git checkout <target-ref> -- modes/ :(exclude)modes/pdf.md`, which
  *    aborts the update when the directory happens to be fully preserved.
  *    That is exactly the pre-extraction behaviour, carried over unchanged —
  *    this function makes the check testable and drops a redundant lookup for
@@ -1298,19 +1412,21 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  * @param {string} path - a SYSTEM_PATHS entry, file or `dir/`-suffixed directory.
  * @param {string[]} preservedPaths - files this run is keeping local content for.
  * @param {Set<string>} preservedSet - the same paths, as a Set, for lookup.
- * @param {{git?: Function}} [ctx] - injection point for tests; defaults to gitQuiet.
+ * @param {{git?: Function, ref?: string}} [ctx] - injection point for tests;
+ *   defaults to gitQuiet and FETCH_HEAD.
  * @returns {boolean}
  */
 export function pathFullyPreserved(path, preservedPaths, preservedSet, ctx = {}) {
   if (preservedSet.size === 0) return false;
   const runGitQuiet = ctx.git || gitQuiet;
+  const upstreamRef = ctx.ref || 'FETCH_HEAD';
   const isDirectory = path.endsWith('/');
   const preservedHere = preservedPaths.filter((f) => (isDirectory ? f.startsWith(path) : f === path));
   if (preservedHere.length === 0) return false;
   if (!isDirectory) return true;
   let upstreamFiles = [];
   try {
-    upstreamFiles = runGitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', path)
+    upstreamFiles = runGitQuiet('ls-tree', '-r', '--name-only', upstreamRef, '--', path)
       .split('\n').map((f) => f.trim()).filter(Boolean);
   } catch {
     return false;
@@ -1348,7 +1464,7 @@ export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {
   const root = ctx.root || ROOT;
   if (paths.length === 0) return;
   // Must restore from HEAD, not from the index (#915 bug 1). After
-  // `git checkout FETCH_HEAD -- <path>` the index already holds the new
+  // `git checkout <target-ref> -- <path>` leaves the index holding the new
   // content, so `git checkout -- <path>` (index→worktree) is a no-op.
   // `git checkout HEAD -- <path>` resets both the index and the worktree
   // to the pre-update commit, which is the correct rollback target.
@@ -1464,7 +1580,7 @@ export function isTracked(path, ctx = {}) {
  * downstream — a `-f` on an explicit filename cannot sweep a sibling. It also
  * cannot reach a user file at all, because every name comes out of the TARGET
  * TREE: by construction each one is a file upstream ships. That is the property
- * that matters, and it is why the expansion asks FETCH_HEAD rather than the
+ * that matters, and it is why the expansion asks the target ref rather than the
  * user's index — `ls-files`/`status` read the user's checkout to decide what to
  * force into a commit, which is the same class of mistake in the other
  * direction. A status-based guard cannot even see the problem: `git status`
@@ -1500,6 +1616,34 @@ export function expandToShippedFiles(paths, ref = 'FETCH_HEAD', ctx = {}) {
     // ever reinterpreted as a glob.
     const listed = runGit('--literal-pathspecs', 'ls-tree', '-r', '--name-only', '-z', ref, '--', path);
     for (const file of listed.split('\0')) take(file);
+  }
+  return files;
+}
+
+/**
+ * Expand safe manifest coverage to concrete files that actually exist in a
+ * tree. Unlike expandToShippedFiles(), absent direct entries are dropped: this
+ * helper drives rollback deletion, where passing through a manifest spelling
+ * that was never in the paired target would manufacture authority to remove it.
+ */
+export function manifestTreeFiles(paths, ref, userPaths = USER_PATHS, ctx = {}) {
+  const runGit = ctx.git || git;
+  const onRejected = ctx.onRejected || (() => {});
+  const safePaths = filterSafeManifestPaths(paths, userPaths, onRejected);
+  const seen = new Set();
+  const files = [];
+  for (const path of safePaths) {
+    const listed = runGit('--literal-pathspecs', 'ls-tree', '-r', '--name-only', '-z', ref, '--', path);
+    for (const file of listed.split('\0').filter(Boolean)) {
+      const reason = unsafeManifestPathReason(file, userPaths);
+      if (reason) {
+        onRejected(file, reason);
+        continue;
+      }
+      if (seen.has(file)) continue;
+      seen.add(file);
+      files.push(file);
+    }
   }
   return files;
 }
@@ -1996,7 +2140,7 @@ async function writeGitignoreAtomic(filePath, content) {
  * only ordering that does not require rewriting lines we do not own.
  *
  * @param {string} localText - Current .gitignore content.
- * @param {string} upstreamText - Upstream .gitignore content (FETCH_HEAD).
+ * @param {string} upstreamText - Upstream .gitignore content from the target tree.
  * @returns {{ text: string, added: string[] }} Reconciled content and the
  *   patterns appended. `added` is empty and `text` is byte-identical to
  *   `localText` when nothing was missing, which is what makes repeated runs
@@ -2062,8 +2206,8 @@ async function apply() {
   // Environment variables are a private one-use channel for the self-reexec;
   // they must not authorize the initial invocation (#2866).
   const legacyReexec = isLegacyReexec();
-  const isReexec = consumeReexecMarker() || legacyReexec ||
-    (process.argv.includes('--confirm') && process.env.CAREER_OPS_UPDATE_REEXEC === '1');
+  const authenticatedReexec = consumeReexecMarker();
+  const isReexec = authenticatedReexec || legacyReexec;
   const updateForce = process.argv.includes('--force') ||
     (isReexec && process.env.CAREER_OPS_UPDATE_FORCE === '1');
   const updateConfirmed = process.argv.includes('--confirm') ||
@@ -2100,7 +2244,11 @@ async function apply() {
     // invisible to `git branch` and can be lost if the update aborts.
     // `git stash create` builds a stash object without touching the stash
     // stack, giving a recoverable ref for WIP even if the update fails.
-    const backupBranch = process.env.CAREER_OPS_UPDATE_BACKUP_BRANCH || updateBackupBranchName(local);
+    const inheritedBackupBranch = process.env.CAREER_OPS_UPDATE_BACKUP_BRANCH || '';
+    const backupBranch = isReexec ? inheritedBackupBranch : updateBackupBranchName(local);
+    if (isReexec && !BACKUP_BRANCH_RE.test(backupBranch)) {
+      throw new Error('Authenticated updater re-exec did not carry a valid backup branch');
+    }
     if (!isReexec) {
       try {
         const wip = git('stash', 'create');
@@ -2118,6 +2266,30 @@ async function apply() {
     // 2. Fetch from canonical repo
     console.log('Fetching latest from upstream...');
     git('fetch', CANONICAL_REPO, 'main');
+    // FETCH_HEAD is process-global and any later fetch can mutate it. Pair the
+    // attempted target with this run's backup immediately, then use only that
+    // durable ref for every read and checkout below.
+    const targetRef = targetRefForBackup(backupBranch);
+    git('update-ref', targetRef, 'FETCH_HEAD');
+
+    // The fetched manifest is trusted updater code, but its paths still have to
+    // obey the canonical data-contract boundary. Validate before even the
+    // self-bootstrap checkout, and fail closed when the target updater or its
+    // manifest is missing/corrupt.
+    const manifestUserPaths = effectiveUserPaths();
+    let remoteUpdaterSource;
+    try {
+      remoteUpdaterSource = git('show', `${targetRef}:update-system.mjs`);
+    } catch (err) {
+      throw new Error(`Target updater is unreadable; refusing to update (${err.message})`);
+    }
+    let remoteSystemPaths = extractArrayFromSource(remoteUpdaterSource, 'SYSTEM_PATHS');
+    remoteSystemPaths = assertSafeManifestPaths(remoteSystemPaths, manifestUserPaths, 'Target SYSTEM_PATHS');
+    const updatePaths = assertSafeManifestPaths(
+      mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS),
+      manifestUserPaths,
+      'Merged updater manifest',
+    );
 
     if (!isReexec) {
       const timeout = reexecTimeoutMs();
@@ -2126,8 +2298,20 @@ async function apply() {
         // at load time must exist first. Resolve the fetched update-system.mjs's
         // relative-import closure and check out exactly those files, so a future
         // new top-level import can't reintroduce the self-reexec crash (#1245).
-        const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
-        const bootstrapAtRisk = locallyModifiedSystemFiles(reexecFiles, 'FETCH_HEAD');
+        const reexecFiles = assertSafeManifestPaths(
+          resolveReexecCheckout(targetRef, 'update-system.mjs'),
+          manifestUserPaths,
+          'Target updater import closure',
+        );
+        const uncoveredReexecFiles = reexecFiles.filter(
+          (file) => !updatePaths.some((path) => pathMatchesManifest(file, path)),
+        );
+        if (uncoveredReexecFiles.length > 0) {
+          throw new Error(
+            `Target updater import closure is outside the validated manifest: ${uncoveredReexecFiles.join(', ')}`,
+          );
+        }
+        const bootstrapAtRisk = locallyModifiedSystemFiles(reexecFiles, targetRef);
         if (bootstrapAtRisk.length > 0) {
           console.log('');
           console.log(`${bootstrapAtRisk.length} self-bootstrap file(s) differ from upstream because THIS install changed them:`);
@@ -2141,7 +2325,7 @@ async function apply() {
           console.log('Self-bootstrap must load the upstream versions; the local versions remain in the backups above.');
           console.log('');
         }
-        git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
+        git('--literal-pathspecs', 'checkout', targetRef, '--', ...reexecFiles);
         const marker = createReexecMarker();
         execFileSync(process.execPath, [
           'update-system.mjs',
@@ -2180,18 +2364,9 @@ async function apply() {
     // 3. Checkout system files only
     console.log('Updating system files...');
     const updated = [];
-    let remoteSystemPaths = [];
-    try {
-      const remoteUpdaterSource = git('show', 'FETCH_HEAD:update-system.mjs');
-      remoteSystemPaths = extractArrayFromSource(remoteUpdaterSource, 'SYSTEM_PATHS');
-    } catch {
-      // Older targets may not have update-system.mjs. Fall back to the
-      // local manifest plus bootstrap paths below.
-    }
 
-    // 3a. Keep bootstrap paths as a fallback for very old targets, but the
-    // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
+    // 3a. The validated target manifest is the source of truth for new files;
+    // current and bootstrap entries preserve old→new migration coverage.
 
     // 3b. Local edits to system files (#2337). The checkout is a raw overwrite,
     // so anything this install fixed locally and upstream has not adopted is
@@ -2199,7 +2374,7 @@ async function apply() {
     // so; `--force` overwrites. Either way a .bak of the local content is
     // written first, so the fix is recoverable even from the forced path.
     const preservedPaths = [];
-    const atRisk = locallyModifiedSystemFiles(updatePaths, 'FETCH_HEAD');
+    const atRisk = locallyModifiedSystemFiles(updatePaths, targetRef);
     if (atRisk.length > 0) {
       console.log('');
       console.log(`${atRisk.length} system file(s) differ from upstream because THIS install changed them:`);
@@ -2237,7 +2412,7 @@ async function apply() {
       // that error is indistinguishable from a genuine failure at the catch
       // below, so it would abort the entire update. Skip the entry instead when
       // nothing would be left to check out (see pathFullyPreserved).
-      if (pathFullyPreserved(path, preservedPaths, preservedSet)) continue;
+      if (pathFullyPreserved(path, preservedPaths, preservedSet, { ref: targetRef })) continue;
       try {
         // stderr is piped rather than inherited here. A path absent upstream is
         // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),
@@ -2245,17 +2420,18 @@ async function apply() {
         // `error: pathspec '...' did not match any file(s) known to git`
         // immediately before the success banner — which reads as a failed
         // update and sends people chasing the wrong root cause (#1998).
-        gitQuiet('checkout', 'FETCH_HEAD', '--', path, ...preserveSpecs);
+        gitQuiet('checkout', targetRef, '--', path, ...preserveSpecs);
         updated.push(path);
       } catch (err) {
         // A path genuinely absent upstream is the expected skip. But the catch
         // also caught timeouts, permission errors, and repo corruption and
         // reported them as skips too — letting a partial update reach the
         // success banner (#1998). Confirm the path is actually absent from
-        // FETCH_HEAD before treating the failure as benign; otherwise rethrow.
+        // the paired target before treating the failure as benign; otherwise
+        // rethrow.
         const spec = path.endsWith('/') ? path.slice(0, -1) : path;
         let absentUpstream = false;
-        try { gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`); }
+        try { gitQuiet('cat-file', '-e', `${targetRef}:${spec}`); }
         catch { absentUpstream = true; }
         if (!absentUpstream) throw err;
         skippedPaths.push(path);
@@ -2274,7 +2450,7 @@ async function apply() {
       let remoteFiles = new Set();
       try {
         remoteFiles = new Set(
-          git('ls-tree', '-r', '--name-only', 'FETCH_HEAD')
+          git('ls-tree', '-r', '--name-only', targetRef)
             .split('\n').filter(Boolean).map((p) => p.replace(/\\/g, '/'))
         );
       } catch {
@@ -2287,7 +2463,7 @@ async function apply() {
         // be deleted here as "stale" — the two checks used to run independently,
         // so a preserved file with no upstream counterpart was backed up to
         // .bak by the block above and then unlinked by this one in the same run.
-        const staleCandidates = staleSystemFiles(localFiles, remoteFiles, SYSTEM_PATHS, mergePathLists(USER_PATHS, preservedPaths));
+        const staleCandidates = staleSystemFiles(localFiles, remoteFiles, updatePaths, mergePathLists(manifestUserPaths, preservedPaths));
         for (const f of staleCandidates) {
           if (isReferencedByPreservedFile(f, preservedPaths)) {
             console.log(`Kept stale asset still referenced by a preserved file: ${f}`);
@@ -2317,7 +2493,7 @@ async function apply() {
     // and what it could only prevent inside this repository.
     try {
       const gitignorePath = join(ROOT, '.gitignore');
-      const upstreamGitignore = gitShowRaw('FETCH_HEAD:.gitignore');
+      const upstreamGitignore = gitShowRaw(`${targetRef}:.gitignore`);
       // Uncommitted local edits to .gitignore are the user's, and that is a
       // routine state rather than an exotic one: agent-inbox.mjs's own
       // ensureGitignored() appends a rule without committing it. Such a file
@@ -2360,7 +2536,7 @@ async function apply() {
       // Never abort an update over this, but never swallow it either: a silent
       // skip here is precisely how the original bug stayed invisible.
       console.error(`Could not reconcile .gitignore: ${err.message}`);
-      console.error('Your own rules were left untouched. Compare manually with: git diff FETCH_HEAD -- .gitignore');
+      console.error(`Your own rules were left untouched. Compare manually with: git diff ${targetRef} -- .gitignore`);
     }
 
     // Lazy import: keep update-system.mjs self-loading (see the top-of-file
@@ -2388,7 +2564,7 @@ async function apply() {
       const changed = gitStatusEntries()
         .map((entry) => entry.path)
         .filter((file) => !initialStatusPaths.has(file) && !generatedBackupPaths.has(file));
-      for (const file of userLayerViolations(changed, updatePaths, effectiveUserPaths())) {
+      for (const file of userLayerViolations(changed, updatePaths, manifestUserPaths)) {
         console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
         violatedUserPaths.add(file);
       }
@@ -2498,7 +2674,7 @@ async function apply() {
     // `:(exclude)` spec reaches addPaths (where --literal-pathspecs would read
     // it as a literal filename and abort the commit) and no preserved file is
     // staged. preservedSet is the same Set built at the top of apply().
-    const expandedPathsToStage = stagingFileList(pathsToStage, preservedSet);
+    const expandedPathsToStage = stagingFileList(pathsToStage, preservedSet, targetRef);
 
     try {
       prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);
@@ -2514,7 +2690,7 @@ async function apply() {
       // …but the pathspec form builds the commit from the WORKING TREE for those
       // paths rather than from the index. Where `core.fileMode` is false — the
       // default on Windows — the working tree cannot express the executable bit,
-      // so a mode change that `git checkout FETCH_HEAD -- <path>` just staged is
+      // so a mode change that `git checkout <target-ref> -- <path>` just staged is
       // dropped from the commit and left sitting in the index. The install is
       // dirty the instant a "clean" update finishes, and stays dirty, because
       // every later update re-stages the same mode and drops it again.
@@ -2583,7 +2759,7 @@ async function apply() {
     // Re-running apply fixes it (the first pass did update update-system.mjs
     // itself, so the second pass uses the target manifest) — but only if the
     // user is told, instead of being shown "Update complete" (#1998).
-    const unmaterialized = missingFromTargetManifest(remoteSystemPaths);
+    const unmaterialized = missingFromTargetManifest(remoteSystemPaths, targetRef);
     if (unmaterialized.length > 0) {
       console.error(`\nUpdate incomplete: v${local} → v${remote}`);
       console.error(`${unmaterialized.length} path(s) from the target manifest were not checked out:`);
@@ -2611,97 +2787,160 @@ async function apply() {
 
 // ── ROLLBACK ────────────────────────────────────────────────────
 
+// A concrete manifest filename is still unsafe to access when one of its
+// existing parent directories has been replaced by a symlink/junction. Both
+// checkout and rm could otherwise follow that parent outside the repository.
+function symlinkedAncestor(path, root = ROOT) {
+  const segments = path.split('/');
+  let current = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    current = join(current, segments[i]);
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        return segments.slice(0, i + 1).join('/');
+      }
+    } catch (err) {
+      if (err?.code === 'ENOENT') return null;
+      throw err;
+    }
+  }
+  return null;
+}
+
 function rollback() {
   // Same precondition as apply(): a nested .git-less install would look its
   // backup branches up — and check files out — in the enclosing repo (#3334).
   assertOwnGitToplevel();
-  // Find most recent backup branch
   try {
     const branches = git('for-each-ref', '--sort=-committerdate', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');
     const latest = newestBackupBranch(branches);
-
     if (!latest) {
       console.error('No backup branches found. Nothing to rollback.');
       process.exit(1);
     }
 
     console.log(`Rolling back to: ${latest}`);
+    const userPaths = effectiveUserPaths();
+    const warnRejected = (origin) => (path, reason) => {
+      console.error(`Rollback: ignoring unsafe ${origin} path ${JSON.stringify(path)} — ${reason}.`);
+    };
+    const safeCurrentPaths = filterSafeManifestPaths(
+      mergePathLists(SYSTEM_PATHS, BOOTSTRAP_PATHS),
+      userPaths,
+      warnRejected('current-manifest'),
+    );
 
-    // Checkout system files from backup branch.
-    //
-    // Two failure modes for `git checkout` here:
-    //   (a) the path didn't exist in the backup branch — the apply()
-    //       that produced this backup was on an older version that
-    //       didn't track this path yet. Rollback must DELETE the path
-    //       so the working tree mirrors the backup state.
-    //   (b) anything else — propagate so we don't silently leave the
-    //       working tree in a partially-restored state.
-    //
-    // Limitation: `git checkout <ref> -- <dir>` restores blobs from
-    // the backup tree but doesn't remove files that were added INSIDE
-    // an already-tracked directory between backup and rollback. Rolling
-    // back per-file via `git diff --name-status <backup>` would catch
-    // that but is a larger change; tracked separately if it ever bites.
+    // The backup's own updater knows files that may have retired from the
+    // current manifest. If it is a legacy backup without a readable manifest,
+    // current+bootstrap coverage still gives a conservative restore set.
+    let backupManifestPaths = [];
+    try {
+      const backupSource = git('show', `${latest}:update-system.mjs`);
+      const backupSystemPaths = extractArrayFromSource(backupSource, 'SYSTEM_PATHS');
+      const backupBootstrapPaths = extractArrayFromSource(backupSource, 'BOOTSTRAP_PATHS');
+      if (backupSystemPaths.length === 0) throw new Error('SYSTEM_PATHS is missing or empty');
+      backupManifestPaths = filterSafeManifestPaths(
+        mergePathLists(backupSystemPaths, backupBootstrapPaths),
+        userPaths,
+        warnRejected('backup-manifest'),
+      );
+    } catch (err) {
+      console.error(`Rollback warning: backup manifest is unavailable (${err.message}); restoring safe files known to the current updater.`);
+    }
+
+    const restoreCandidates = mergePathLists(safeCurrentPaths, backupManifestPaths);
+    const concreteWarnings = warnRejected('tree');
+    const backupFiles = manifestTreeFiles(restoreCandidates, latest, userPaths, {
+      onRejected: concreteWarnings,
+    });
+
+    // A paired target ref records exactly which release this backup preceded.
+    // It is the only safe source for target-only removals: FETCH_HEAD is mutable
+    // process-global state and may now identify an unrelated fetch.
+    let targetFiles = [];
+    let targetPairAvailable = false;
+    let targetRef = '';
+    try {
+      targetRef = targetRefForBackup(latest);
+      git('show-ref', '--verify', '--quiet', targetRef);
+      const targetSource = git('show', `${targetRef}:update-system.mjs`);
+      const targetSystemPaths = extractArrayFromSource(targetSource, 'SYSTEM_PATHS');
+      const targetBootstrapPaths = extractArrayFromSource(targetSource, 'BOOTSTRAP_PATHS');
+      if (targetSystemPaths.length === 0) throw new Error('target SYSTEM_PATHS is missing or empty');
+      const safeTargetPaths = filterSafeManifestPaths(
+        mergePathLists(targetSystemPaths, targetBootstrapPaths),
+        userPaths,
+        warnRejected('target-manifest'),
+      );
+      targetFiles = manifestTreeFiles(safeTargetPaths, targetRef, userPaths, {
+        onRejected: concreteWarnings,
+      });
+      targetPairAvailable = true;
+    } catch (err) {
+      console.error(`Rollback warning: paired target is missing or unavailable (${err.message}).`);
+      console.error('Target-only system files may remain as leftovers; mutable FETCH_HEAD was not consulted.');
+    }
+
     const restored = [];
-    const removed = [];
-    for (const path of SYSTEM_PATHS) {
+    for (const file of backupFiles) {
       try {
-        git('checkout', latest, '--', path);
-        restored.push(path);
+        const symlink = symlinkedAncestor(file);
+        if (symlink) {
+          console.error(`Rollback warning: ${file} has symlinked parent ${symlink}; leaving it untouched.`);
+          continue;
+        }
+        if (existsSync(join(ROOT, file)) && lstatSync(join(ROOT, file)).isDirectory()) {
+          console.error(`Rollback warning: ${file} is now a directory; leaving it and its children untouched.`);
+          continue;
+        }
+        git('--literal-pathspecs', 'checkout', latest, '--', file);
+        restored.push(file);
       } catch (err) {
-        const pathspec = path.endsWith('/') ? path.slice(0, -1) : path;
-        let existedInBackup = true;
-        try {
-          git('cat-file', '-e', `${latest}:${pathspec}`);
-        } catch {
-          existedInBackup = false;
-        }
-        if (existedInBackup) {
-          throw err;
-        }
-        // Path was introduced by a later apply() — remove it so the
-        // tree truly matches the backup. `git rm` stages the deletion
-        // for tracked files; `rmSync` cleans up the untracked-but-
-        // on-disk case (e.g. an apply() that crashed between checkout
-        // and commit, leaving the path untracked locally).
-        git('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec);
-        try {
-          rmSync(join(ROOT, pathspec), { recursive: true, force: true });
-        } catch {
-          // Already gone, or not present on disk — fine.
-        }
-        removed.push(pathspec);
+        throw new Error(`could not restore ${file}: ${err.message}`);
       }
     }
 
-    // Same expansion as apply(), against the backup tree this rollback is
-    // restoring from. `restored` comes straight off SYSTEM_PATHS, so it carries
-    // the 53 directory entries, and addPaths forces every path it is given —
-    // `git add -f -- docs/` here would sweep the user's ignored files into the
-    // rollback commit exactly as it would have in apply().
-    if (restored.length > 0) addPaths(expandToShippedFiles(restored, latest));
-    const rollbackPaths = [...restored, ...removed];
-    // Keep rollback's scoped commit aligned with the file-level staging list.
-    // A directory pathspec would otherwise include tracked files still present
-    // in the worktree but absent from the backup tree (#3504).
-    const expandedRollbackPaths = expandToShippedFiles(rollbackPaths, latest);
+    const backupFileSet = new Set(backupFiles);
+    const removalCandidates = targetPairAvailable
+      ? targetFiles.filter((file) => !backupFileSet.has(file))
+      : [];
+    const removed = [];
+    for (const file of removalCandidates) {
+      const absolute = join(ROOT, file);
+      try {
+        const symlink = symlinkedAncestor(file);
+        if (symlink) {
+          console.error(`Rollback warning: ${file} has symlinked parent ${symlink}; leaving it untouched.`);
+          continue;
+        }
+        if (existsSync(absolute) && lstatSync(absolute).isDirectory()) {
+          console.error(`Rollback warning: ${file} became a directory; leaving it and its children untouched.`);
+          continue;
+        }
+        git('--literal-pathspecs', 'rm', '-f', '--ignore-unmatch', '--', file);
+        try { unlinkSync(absolute); } catch (err) {
+          if (existsSync(absolute)) throw err;
+        }
+        removed.push(file);
+      } catch (err) {
+        throw new Error(`could not remove target-only file ${file}: ${err.message}`);
+      }
+    }
+
+    // Restore and stage only concrete backup files. `git rm` already staged
+    // target-only deletions; no directory pathspec is ever passed to add/commit.
+    if (restored.length > 0) addPaths(restored);
+    const concreteRollbackPaths = mergePathLists(restored, removed);
     try {
-      // Scope the commit to the rollback paths (#915 bug 2). A bare
-      // `git commit` would sweep unrelated staged files into the rollback.
-      if (expandedRollbackPaths.length > 0) {
-        git('commit', '-m', `chore: rollback system files from ${latest}`, '--', ...expandedRollbackPaths);
+      if (concreteRollbackPaths.length > 0) {
+        git('--literal-pathspecs', 'commit', '-m', `chore: rollback system files from ${latest}`, '--', ...concreteRollbackPaths);
       }
     } catch {
-      // Tolerate any commit failure here — the common case is the
-      // "nothing to commit" no-op when the working tree already
-      // matched the backup (e.g. user ran rollback twice). This
-      // mirrors apply()'s broad-catch in the commit step; narrowing
-      // to a specific git-error string is fragile and would diverge
-      // from that pattern. Genuine setup problems (hooks, signing,
-      // disk full) will resurface on the next normal git operation.
+      // A second rollback commonly has nothing to commit. Match apply()'s
+      // established broad tolerance; real setup failures surface on later git.
     }
 
-    console.log(`Rollback complete. Restored ${restored.length} path(s) from ${latest}, removed ${removed.length} path(s) added after the backup.`);
+    console.log(`Rollback complete. Restored ${restored.length} file(s) from ${latest}, removed ${removed.length} target-only file(s).`);
     console.log('Your data (CV, profile, tracker, reports) was not affected.');
   } catch (err) {
     console.error('Rollback failed:', err.message);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -611,6 +611,16 @@ export function localUserPaths(root = ROOT) {
       reject(path, 'paths must be written plainly, with no "." segment (use "merge-tracker.mjs", not "./merge-tracker.mjs")');
     }
     const pathSegments = manifestPathSegments(path);
+    // A declaration from an older install may repeat a built-in USER_PATHS
+    // directory (for example `documents/`). It became a SYSTEM_PATHS collision
+    // only when that directory gained a tracked scaffold. The built-in path
+    // already protects the declaration's complete scope, so ignore the
+    // redundant line rather than making apply()/rollback fail on upgrade.
+    const alreadyProtected = USER_PATHS.some((userPath) =>
+      userPathCoversDeclaration(userPath, path),
+    );
+    if (alreadyProtected) continue;
+
     const collision = SYSTEM_PATHS.find((sys) => {
       const systemSegments = manifestPathSegments(sys);
       const shared = Math.min(pathSegments.length, systemSegments.length);
@@ -620,11 +630,25 @@ export function localUserPaths(root = ROOT) {
       reject(
         path,
         `the system layer ships it (SYSTEM_PATHS entry "${collision}"). `
-        + 'Declaring it would stop updates to it with no other signal',
+        + 'Remove this line if USER_PATHS already protects it, or narrow it to a fork-owned path upstream does not ship.',
       );
     }
   }
-  return declared;
+  return declared.filter((path) => !USER_PATHS.some((userPath) =>
+    userPathCoversDeclaration(userPath, path),
+  ));
+}
+
+/** Whether a built-in user path fully covers a local declaration's scope. */
+function userPathCoversDeclaration(userPath, declaration) {
+  const userSegments = manifestPathSegments(userPath);
+  const declaredSegments = manifestPathSegments(declaration);
+  if (userPath.endsWith('/')) {
+    return userSegments.length <= declaredSegments.length
+      && userSegments.every((segment, index) => segment === declaredSegments[index]);
+  }
+  return userSegments.length === declaredSegments.length
+    && userSegments.every((segment, index) => segment === declaredSegments[index]);
 }
 
 /**
@@ -792,6 +816,33 @@ export function targetRefForBackup(backupBranch) {
     throw new Error(`Invalid updater backup branch: ${backupBranch}`);
   }
   return `refs/backup-pre-update-target/${backupBranch}`;
+}
+
+/**
+ * Remove target refs whose strict updater backup branch has been deleted.
+ * Paired refs remain for every existing backup so rollback can still identify
+ * target-only files; unrecognised/manual names in this namespace are retained.
+ * @param {{git?: Function}} [ctx] - Test seam; defaults to the ROOT-bound runner.
+ * @returns {string[]} Pruned ref names.
+ */
+export function pruneStaleTargetRefs(ctx = {}) {
+  const runGit = ctx.git || git;
+  const branches = new Set(
+    runGit('for-each-ref', '--format=%(refname)', 'refs/heads/backup-pre-update-*')
+      .split('\n').filter(Boolean),
+  );
+  const prefix = 'refs/backup-pre-update-target/';
+  const targetRefs = runGit('for-each-ref', '--format=%(refname)', prefix)
+    .split('\n').filter(Boolean);
+  const pruned = [];
+  for (const targetRef of targetRefs) {
+    const backupBranch = targetRef.slice(prefix.length);
+    if (!BACKUP_BRANCH_RE.test(backupBranch)) continue;
+    if (branches.has(`refs/heads/${backupBranch}`)) continue;
+    runGit('update-ref', '-d', targetRef);
+    pruned.push(targetRef);
+  }
+  return pruned;
 }
 
 function backupTimestamp(branchName) {
@@ -2246,9 +2297,9 @@ async function apply() {
     // stack, giving a recoverable ref for WIP even if the update fails.
     const inheritedBackupBranch = process.env.CAREER_OPS_UPDATE_BACKUP_BRANCH || '';
     const backupBranch = isReexec ? inheritedBackupBranch : updateBackupBranchName(local);
-    if (isReexec && !BACKUP_BRANCH_RE.test(backupBranch)) {
-      throw new Error('Authenticated updater re-exec did not carry a valid backup branch');
-    }
+    // Validate before any backup side effect. A malformed local VERSION must not
+    // leave an unpaired branch behind when targetRefForBackup() rejects it later.
+    const targetRef = targetRefForBackup(backupBranch);
     if (!isReexec) {
       try {
         const wip = git('stash', 'create');
@@ -2269,8 +2320,15 @@ async function apply() {
     // FETCH_HEAD is process-global and any later fetch can mutate it. Pair the
     // attempted target with this run's backup immediately, then use only that
     // durable ref for every read and checkout below.
-    const targetRef = targetRefForBackup(backupBranch);
     git('update-ref', targetRef, 'FETCH_HEAD');
+    if (!isReexec) {
+      try {
+        pruneStaleTargetRefs();
+      } catch (err) {
+        // Retention housekeeping must not prevent an otherwise safe update.
+        console.error(`Updater warning: could not prune stale backup target refs (${err.message}).`);
+      }
+    }
 
     // The fetched manifest is trusted updater code, but its paths still have to
     // obey the canonical data-contract boundary. Validate before even the

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -487,12 +487,26 @@ const gitBetweenFetchAndPair = fetchAt >= 0 && pairAt >= 0
   : true;
 if (appearsInOrder(applySource, [
   fetchCall,
-  'const targetRef = targetRefForBackup(backupBranch);',
   pairCall,
 ]) && !gitBetweenFetchAndPair) {
   pass('apply pins FETCH_HEAD to the backup-paired target ref immediately after the canonical fetch');
 } else {
   fail('apply does not pin the canonical fetch to its backup-paired target before another git operation');
+}
+
+const targetRefDeclaration = 'const targetRef = targetRefForBackup(backupBranch);';
+const branchCreation = "git('branch', backupBranch);";
+if (applySource.indexOf(targetRefDeclaration) >= 0
+  && applySource.indexOf(branchCreation) > applySource.indexOf(targetRefDeclaration)) {
+  pass('apply validates the paired target-ref name before creating its backup branch');
+} else {
+  fail('apply can create a backup branch before validating its paired target-ref name');
+}
+
+if (appearsInOrder(applySource, [pairCall, 'pruneStaleTargetRefs();'])) {
+  pass('apply prunes stale paired target refs after creating the new pair');
+} else {
+  fail('apply does not prune stale paired target refs after creating the new pair');
 }
 
 if (appearsInOrder(applySource, [

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -10,7 +10,12 @@
 import { readFileSync, existsSync, rmSync } from 'fs';
 import { execFileSync, spawnSync } from 'child_process';
 import { dirname } from 'path';
-import { createReexecMarker, consumeReexecMarker } from './update-system.mjs';
+import {
+  MANIFEST_USER_PATH_OVERLAPS,
+  createReexecMarker,
+  consumeReexecMarker,
+  isSafeManifestPath,
+} from './update-system.mjs';
 
 let passed = 0;
 let failed = 0;
@@ -275,12 +280,20 @@ const twoPassManifestChecks = [
     pattern: /CAREER_OPS_UPDATE_REEXEC/,
   },
   {
-    name: 'apply resolves the re-exec checkout closure from FETCH_HEAD (#1245)',
-    pattern: /resolveReexecCheckout\('FETCH_HEAD',\s*'update-system\.mjs'\)/,
+    name: 'apply resolves the re-exec checkout closure from the durable paired target (#1245)',
+    pattern: /resolveReexecCheckout\(targetRef,\s*'update-system\.mjs'\)/,
   },
   {
-    name: 'apply checks out the resolved re-exec files from FETCH_HEAD (#1245)',
-    pattern: /git\('checkout',\s*'FETCH_HEAD',\s*'--',\s*\.\.\.reexecFiles\)/,
+    name: 'apply checks out the resolved re-exec files literally from the durable paired target (#1245)',
+    pattern: /git\('--literal-pathspecs',\s*'checkout',\s*targetRef,\s*'--',\s*\.\.\.reexecFiles\)/,
+  },
+  {
+    name: 'apply validates the self-bootstrap import closure against protected user paths',
+    pattern: /const reexecFiles = assertSafeManifestPaths\([\s\S]{0,240}?resolveReexecCheckout\(targetRef,\s*'update-system\.mjs'\)[\s\S]{0,240}?'Target updater import closure'/,
+  },
+  {
+    name: 'apply rejects self-bootstrap files outside the validated merged manifest',
+    pattern: /uncoveredReexecFiles = reexecFiles\.filter\([\s\S]{0,200}?pathMatchesManifest\(file, path\)[\s\S]{0,240}?uncoveredReexecFiles\.length > 0/,
   },
   {
     name: 're-exec fallback still covers the skill-entrypoints import (#1245)',
@@ -292,11 +305,15 @@ const twoPassManifestChecks = [
   },
   {
     name: 'apply carries the original backup branch across re-exec',
-    pattern: /CAREER_OPS_UPDATE_BACKUP_BRANCH/,
+    pattern: /CAREER_OPS_UPDATE_BACKUP_BRANCH:\s*backupBranch/,
   },
   {
-    name: 'apply reads the target updater manifest from FETCH_HEAD',
-    pattern: /git\('show',\s*'FETCH_HEAD:update-system\.mjs'\)/,
+    name: 'authenticated re-exec consumes the inherited backup branch instead of generating another',
+    pattern: /const inheritedBackupBranch = process\.env\.CAREER_OPS_UPDATE_BACKUP_BRANCH[^;]*;[\s\S]{0,160}?const backupBranch = isReexec \? inheritedBackupBranch : updateBackupBranchName\(local\)/,
+  },
+  {
+    name: 'apply reads the target updater manifest from the durable paired target',
+    pattern: /git\('show',\s*`\$\{targetRef\}:update-system\.mjs`\)/,
   },
   {
     name: 'apply extracts SYSTEM_PATHS from the target updater',
@@ -319,8 +336,20 @@ const twoPassManifestChecks = [
     pattern: /git\('commit',\s*'-m',[^)]+'--',\s*\.\.\.expandedPathsToStage\)/,
   },
   {
-    name: 'rollback commit is scoped to expanded backup files, not directories (#3504)',
-    pattern: /git\('commit',\s*'-m',[^)]+'--',\s*\.\.\.expandedRollbackPaths\)/,
+    name: 'rollback expands backup and target manifests to safe concrete tree files',
+    pattern: /const backupFiles = manifestTreeFiles\(restoreCandidates, latest,[\s\S]{0,1400}?targetFiles = manifestTreeFiles\(safeTargetPaths, targetRef/,
+  },
+  {
+    name: 'rollback restores and stages only concrete backup files',
+    pattern: /if \(restored\.length > 0\) addPaths\(restored\)/,
+  },
+  {
+    name: 'rollback removes only concrete target files absent from the backup tree',
+    pattern: /targetFiles\.filter\(\(file\) => !backupFileSet\.has\(file\)\)/,
+  },
+  {
+    name: 'rollback commit is scoped to concrete restore/removal files under literal pathspecs (#3504)',
+    pattern: /git\('--literal-pathspecs',\s*'commit',\s*'-m',[^)]*'--',\s*\.\.\.concreteRollbackPaths\)/,
   },
   {
     name: 'apply captures uncommitted work via git stash create before branching (#915)',
@@ -331,7 +360,7 @@ const twoPassManifestChecks = [
     // paths, so everything added upstream since is silently absent and apply
     // still printed "Update complete" (#1998).
     name: 'apply verifies the target manifest materialized before claiming success (#1998)',
-    pattern: /missingFromTargetManifest\(remoteSystemPaths\)/,
+    pattern: /missingFromTargetManifest\(remoteSystemPaths,\s*targetRef\)/,
   },
   {
     name: 'an incomplete apply exits non-zero instead of reporting success (#1998)',
@@ -343,13 +372,13 @@ const twoPassManifestChecks = [
     // The trailing spread is the #2337 preserve-exclusions; the property this
     // pins is the runner (gitQuiet, not git) and the ref, not the arity.
     name: 'per-path checkout pipes stderr so expected skips stay quiet (#1998)',
-    pattern: /gitQuiet\('checkout',\s*'FETCH_HEAD',\s*'--',\s*path(?:,\s*\.\.\.\w+)?\)/,
+    pattern: /gitQuiet\('checkout',\s*targetRef,\s*'--',\s*path(?:,\s*\.\.\.\w+)?\)/,
   },
   {
     // #2337: a system file this install edited must be listed and backed up
     // before the checkout, not overwritten in silence.
     name: 'locally edited system files are detected before checkout (#2337)',
-    pattern: /const atRisk = locallyModifiedSystemFiles\(updatePaths, 'FETCH_HEAD'\)/,
+    pattern: /const atRisk = locallyModifiedSystemFiles\(updatePaths, targetRef\)/,
   },
   {
     name: 'the local copy is saved as .bak before any overwrite (#2337)',
@@ -374,13 +403,14 @@ const twoPassManifestChecks = [
   {
     // existsSync on a pre-existing directory (docs/) would call it materialized
     // even when the target added files under it — the verification must recurse
-    // into directory entries against FETCH_HEAD (#1998 CodeRabbit review).
+    // into directory entries against the durable paired target (#1998
+    // CodeRabbit review).
     name: 'manifest verification recurses into directory entries via ls-tree (#1998)',
-    pattern: /ls-tree', '-r', '--name-only', 'FETCH_HEAD'[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
+    pattern: /ls-tree', '-r', '--name-only', targetRef[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
   },
   {
     // A checkout failure is only an expected skip when the path is truly absent
-    // from FETCH_HEAD; timeouts/permission errors must rethrow, not report
+    // from the durable paired target; timeouts/permission errors must rethrow, not report
     // success (#1998 CodeRabbit review).
     name: 'a checkout failure only skips when the path is absent upstream, else rethrows (#1998)',
     pattern: /catch \{ absentUpstream = true; \}\s*if \(!absentUpstream\) throw err;/,
@@ -425,6 +455,73 @@ for (const check of twoPassManifestChecks) {
   else fail(check.name);
 }
 
+function appearsInOrder(text, tokens) {
+  let cursor = 0;
+  for (const token of tokens) {
+    const index = text.indexOf(token, cursor);
+    if (index === -1) return false;
+    cursor = index + token.length;
+  }
+  return true;
+}
+
+const applyStart = source.indexOf('async function apply()');
+const rollbackMarker = source.indexOf('// ── ROLLBACK', applyStart);
+const rollbackStart = source.indexOf('function rollback()', rollbackMarker);
+const dismissMarker = source.indexOf('// ── DISMISS', rollbackStart);
+const applySource = applyStart >= 0 && rollbackMarker > applyStart
+  ? source.slice(applyStart, rollbackMarker)
+  : '';
+const rollbackSource = rollbackStart >= 0 && dismissMarker > rollbackStart
+  ? source.slice(rollbackStart, dismissMarker)
+  : '';
+
+const fetchCall = "git('fetch', CANONICAL_REPO, 'main');";
+const pairCall = "git('update-ref', targetRef, 'FETCH_HEAD');";
+const fetchAt = applySource.indexOf(fetchCall);
+const pairAt = applySource.indexOf(pairCall, fetchAt + fetchCall.length);
+const gitBetweenFetchAndPair = fetchAt >= 0 && pairAt >= 0
+  ? /\b(?:git|gitQuiet|gitShowRaw|runGit|gitIn|gitRawIn)\(/.test(
+      applySource.slice(fetchAt + fetchCall.length, pairAt),
+    )
+  : true;
+if (appearsInOrder(applySource, [
+  fetchCall,
+  'const targetRef = targetRefForBackup(backupBranch);',
+  pairCall,
+]) && !gitBetweenFetchAndPair) {
+  pass('apply pins FETCH_HEAD to the backup-paired target ref immediately after the canonical fetch');
+} else {
+  fail('apply does not pin the canonical fetch to its backup-paired target before another git operation');
+}
+
+if (appearsInOrder(applySource, [
+  pairCall,
+  "remoteUpdaterSource = git('show', `${targetRef}:update-system.mjs`);",
+  "remoteSystemPaths = assertSafeManifestPaths(remoteSystemPaths, manifestUserPaths, 'Target SYSTEM_PATHS');",
+  'const updatePaths = assertSafeManifestPaths(',
+  "'Merged updater manifest',",
+  "resolveReexecCheckout(targetRef, 'update-system.mjs')",
+  "'Target updater import closure',",
+  'uncoveredReexecFiles.length > 0',
+  "git('--literal-pathspecs', 'checkout', targetRef, '--', ...reexecFiles)",
+])) {
+  pass('apply validates target and merged manifests before any self-bootstrap checkout');
+} else {
+  fail('apply does not validate target and merged manifests before self-bootstrap checkout');
+}
+
+if (appearsInOrder(rollbackSource, [
+  'targetRef = targetRefForBackup(latest);',
+  "git('show-ref', '--verify', '--quiet', targetRef);",
+  "git('show', `${targetRef}:update-system.mjs`);",
+  'manifestTreeFiles(safeTargetPaths, targetRef, userPaths,',
+]) && !/\b(?:git|gitQuiet|gitShowRaw)\([^)]*\bFETCH_HEAD\b[^)]*\)/s.test(rollbackSource)) {
+  pass('rollback derives target removals only from the durable backup-paired ref, never FETCH_HEAD');
+} else {
+  fail('rollback can derive target removals from a mutable or unpaired ref');
+}
+
 // #1706: update-system.mjs must be self-loading — no static (top-level) relative
 // imports. A pre-#1245 client's apply() self-reexec checks out ONLY
 // update-system.mjs before re-execing it, so any top-level `import ... from
@@ -443,30 +540,20 @@ for (const userPath of ['cv.md', 'config/profile.yml', 'modes/_profile.md', 'por
   else fail(`USER_PATHS missing ${userPath}`);
 }
 
-const allowedSystemUserOverlap = new Set([
-  'writing-samples/README.md',
-  // System-owned scaffold inside the user-layer interview-prep/ dir (#1242):
-  // the updater ships these two, but never the real session files alongside them.
-  'interview-prep/sessions/.gitkeep',
-  'interview-prep/sessions/README.md',
-  // Same pattern for the user-layer documents/ intake dir (#1723): the
-  // updater ships the scaffold, never the user's source documents.
-  'documents/.gitkeep',
-  'documents/README.md',
-]);
-let hasSystemUserCollision = false;
+for (const overlap of MANIFEST_USER_PATH_OVERLAPS) {
+  if (systemPaths.includes(overlap)) pass(`SYSTEM_PATHS includes documented user-layer scaffold ${overlap}`);
+  else fail(`SYSTEM_PATHS missing documented user-layer scaffold ${overlap}`);
+}
+
+let hasUnsafeSystemPath = false;
 for (const systemPath of systemPaths) {
-  const overlapsUserPath = userPaths.some((userPath) => {
-    if (allowedSystemUserOverlap.has(systemPath)) return false;
-    return systemPath === userPath || systemPath.startsWith(userPath);
-  });
-  if (overlapsUserPath) {
-    hasSystemUserCollision = true;
-    fail(`SYSTEM_PATHS must not update user path ${systemPath}`);
+  if (!isSafeManifestPath(systemPath, userPaths)) {
+    hasUnsafeSystemPath = true;
+    fail(`SYSTEM_PATHS must not update unsafe or protected path ${systemPath}`);
   }
 }
-if (!hasSystemUserCollision) {
-  pass('SYSTEM_PATHS does not collide with USER_PATHS');
+if (!hasUnsafeSystemPath) {
+  pass('SYSTEM_PATHS passes the production canonical path policy');
 }
 
 if (failed > 0) {

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -326,16 +326,24 @@ function canary() {
   const { failures } = runLeg({
     oldTag: newestOld, targetSha, label: 'canary',
     mutateMirror: (mirror, work) => {
-      // Poison commit: track cv.md and add it to SYSTEM_PATHS so the old
-      // updater checks it out over the user's CV.
+      // Poison only the throwaway target updater: after its own safety checks
+      // and coherent-install verification have passed, write a sentinel over
+      // the user's CV. This keeps the canary independent of manifest policy —
+      // including when the old release already validates target manifests —
+      // and asks whether the harness's byte-integrity oracle catches a clobber.
       const wt = join(work, 'poison-wt');
       git(mirror, 'worktree', 'add', wt, 'main');
-      writeFileSync(join(wt, 'cv.md'), '# CLOBBERED BY UPDATE\n');
+      const completion = "    console.log(`\\nUpdate complete: v${local} → v${remote}`);";
       const updater = readFileSync(join(wt, 'update-system.mjs'), 'utf-8')
-        .replace(/const\s+SYSTEM_PATHS\s*=\s*\[/, "const SYSTEM_PATHS = [\n  'cv.md',");
+        .replace(
+          completion,
+          `    writeFileSync(join(ROOT, 'cv.md'), '# CLOBBERED BY UPDATE\\n');\n${completion}`,
+        );
+      if (updater === readFileSync(join(wt, 'update-system.mjs'), 'utf-8')) {
+        throw new Error('Could not inject the canary user-file clobber');
+      }
       writeFileSync(join(wt, 'update-system.mjs'), updater);
-      // -f: cv.md is gitignored (user layer) — the poison must force-track it.
-      git(wt, 'add', '-f', 'cv.md', 'update-system.mjs');
+      git(wt, 'add', 'update-system.mjs');
       git(wt, '-c', 'user.name=canary', '-c', 'user.email=canary@test', 'commit', '-qm', 'canary: poison');
       const sha = git(wt, 'rev-parse', 'HEAD');
       git(mirror, 'worktree', 'remove', '--force', wt);


### PR DESCRIPTION
## Status

Ready for full maintainer review.

This revision implements @santifer’s ruling on the target-manifest source and user-layer boundary. It is rebased onto current `main`, contains one commit, and all GitHub checks pass.

Fixes #3780.

## Problem

After a partial update failure, `rollback()` used the updater manifest present on disk. That manifest can describe the old release rather than the failed target release, so files introduced only by the target can survive rollback as untracked orphans.

`FETCH_HEAD` cannot identify that target durably: routine later fetches—including the session-start update check—can overwrite it before rollback runs.

## Implementation

### Durable target identity

- `apply()` creates a target ref paired with its backup branch immediately after the canonical fetch:
  `refs/backup-pre-update-target/<backup-branch>`
- The authenticated self-reexec carries the original backup branch forward.
- All subsequent target reads and checkouts use the paired ref rather than mutable `FETCH_HEAD`.
- `rollback()` derives the target ref strictly from the selected backup branch.

### User-layer boundary

- Target and merged manifests are validated before any self-bootstrap checkout.
- The target updater’s import closure must also be safe and covered by the validated manifest.
- Manifest entries are canonicalized and checked against protected paths in both directions, so a protected path, its descendants, and its ancestors are rejected.
- Comparisons are case-folded and NFC-normalized for macOS and Windows aliases.
- Only the five documented system-owned scaffolds inside user directories are permitted, by exact byte spelling.
- Apply and rollback use literal pathspecs.

### Concrete rollback

- Backup and target manifests are expanded against their respective trees into concrete, NUL-delimited filenames.
- Rollback restores concrete backup files and removes concrete target-only files.
- Directory pathspecs are never used for deletion or rollback commits.
- Symlinked parents and files replaced by directories are left untouched with visible warnings.
- Legacy backups without a readable paired target degrade conservatively: known backup files are restored, target-only files are not removed, and the limitation is reported. `FETCH_HEAD` is never used as a fallback.

## Coverage

The end-to-end rollback fixtures cover:

- an intervening fetch that deliberately repoints `FETCH_HEAD`;
- removal of target-only top-level and nested files;
- exact user/system scaffold overlaps;
- protected files and siblings remaining byte-identical;
- a missing paired target;
- symlinked-parent traversal;
- a target-only file replaced by a directory;
- canonical path, Unicode, case, control-character, and pathspec validation.

The upgrade canary now plants a direct post-verification `cv.md` clobber in a throwaway target updater. The inner apply succeeds, the byte-integrity oracle catches only that clobber, and the outer canary reports green. This remains effective even when the old release already validates manifests.

## Validation

- [x] Rollback target-manifest suite
- [x] `node upgrade-tests.mjs --pr-gate`
- [x] `node upgrade-tests.mjs --canary`
- [x] `node upgrade-tests.mjs --local-paths`
- [x] `node updater-migration-tests.mjs` — 382 passed, 0 failed
- [x] Syntax check — 694 `.mjs` files
- [x] `node test-all.mjs --quick` — 8,715 passed, 0 failed
- [x] GitHub CI — all 12 checks pass, including Ubuntu, macOS, Windows, and the upgrade regression gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Rollback now restores the pre-update working tree after a partial `apply()` failure.

- `update-system.mjs:721`: Validates manifest paths and protects user paths, ancestors, and descendants.
- `update-system.mjs:814`: Uses a durable target ref paired with the backup branch instead of mutable `FETCH_HEAD`.
- `update-system.mjs:1684`: Expands manifests into concrete files for literal-path rollback.
- `update-system.mjs:2933`: Restores backup files and removes files introduced only by the failed target.
- `docs/SCRIPTS.md:566`: Documents target-ref retention and pruning.

From the user’s point of view: rollback removes files introduced by a failed update. It preserves protected user files and handles file-to-directory changes, symlinked parents, and missing target refs conservatively. Unsafe manifests are rejected or skipped with diagnostics.

Touched system files: `update-system.mjs` and `docs/SCRIPTS.md`. `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not touched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->