### PR TITLE
fix(templates): make job_break_inside an opt-in style token

### DIFF
--- a/templates/ats/cv-template.ats.html
+++ b/templates/ats/cv-template.ats.html
@@ -13,6 +13,8 @@ version: 1.0.0
     --font-family: "Liberation Sans", "Helvetica Neue", Arial, "DejaVu Sans", sans-serif;
     --font-size: 11px;
     --page-margin: 0.6in;
+    /* #3242: unchanged default — this template has always kept a role whole. */
+    --job-break-inside: avoid;
   }
   @page { margin: var(--page-margin); }
 
@@ -314,10 +316,15 @@ version: 1.0.0
   .edu-item,
   .cert-item,
   .competency-item,
-  .skill-item,
-  .job {
+  .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, avoid);
+    page-break-inside: var(--job-break-inside, avoid);
   }
 
   .section-title,

--- a/templates/cv-template.compact.html
+++ b/templates/cv-template.compact.html
@@ -33,6 +33,8 @@ version: 1.0.0
        appended later by injectPrintPageCss reading this same variable. */
     --page-margin: 0.6in;
     --rail-width: 96px;
+    /* #3242: unchanged default — see templates/cv-template.html. */
+    --job-break-inside: auto;
   }
   @page { margin: var(--page-margin); }
 
@@ -276,6 +278,12 @@ version: 1.0.0
   .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
   }
 
   .section-title,

--- a/templates/cv-template.executive.html
+++ b/templates/cv-template.executive.html
@@ -27,6 +27,8 @@ version: 1.0.0
     /* Must match generate-pdf.mjs's PDF_PAGE_MARGIN — the real @page margin is
        appended later by injectPrintPageCss reading this same variable. */
     --page-margin: 0.6in;
+    /* #3242: unchanged default — see templates/cv-template.html. */
+    --job-break-inside: auto;
   }
   @page { margin: var(--page-margin); }
 
@@ -267,6 +269,12 @@ version: 1.0.0
   .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
   }
 
   .section-title,

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -16,6 +16,10 @@
        comes from the later @page rule injectPrintPageCss appends (which reads
        this same variable), so this default must match it exactly. */
     --page-margin: 0.6in;
+    /* #3242: unchanged default — a role may still flow across a page break to
+       keep the CV compact (see #1145). Override via config/profile.yml
+       `style.job_break_inside: avoid` for "a role is one unit, never split". */
+    --job-break-inside: auto;
   }
   @page { margin: var(--page-margin); }
 
@@ -444,6 +448,12 @@
   .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
   }
 
   /* Keep a heading attached to the content that follows it, so headings are not

--- a/templates/cv-template.jake.html
+++ b/templates/cv-template.jake.html
@@ -35,6 +35,8 @@ version: 1.0.0
     /* Must match generate-pdf.mjs's PDF_PAGE_MARGIN — the real @page margin is
        appended later by injectPrintPageCss reading this same variable. */
     --page-margin: 0.5in;
+    /* #3242: unchanged default — see templates/cv-template.html. */
+    --job-break-inside: auto;
   }
   @page { margin: var(--page-margin); }
 
@@ -260,6 +262,12 @@ version: 1.0.0
   .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
   }
 
   .section-title,

--- a/templates/cv-template.leadership.html
+++ b/templates/cv-template.leadership.html
@@ -34,6 +34,8 @@ version: 1.0.0
     /* Must match generate-pdf.mjs's PDF_PAGE_MARGIN — the real @page margin is
        appended later by injectPrintPageCss reading this same variable. */
     --page-margin: 0.6in;
+    /* #3242: unchanged default — see templates/cv-template.html. */
+    --job-break-inside: auto;
   }
   @page { margin: var(--page-margin); }
 
@@ -277,6 +279,12 @@ version: 1.0.0
   .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
   }
 
   .section-title,

--- a/templates/cv-template.modern.html
+++ b/templates/cv-template.modern.html
@@ -30,6 +30,8 @@ version: 1.0.0
     /* Must match generate-pdf.mjs's PDF_PAGE_MARGIN — the real @page margin is
        appended later by injectPrintPageCss reading this same variable. */
     --page-margin: 0.6in;
+    /* #3242: unchanged default — see templates/cv-template.html. */
+    --job-break-inside: auto;
   }
   @page { margin: var(--page-margin); }
 
@@ -310,6 +312,12 @@ version: 1.0.0
   .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — see the --job-break-inside default above. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
   }
 
   .section-title,

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -415,6 +415,15 @@ version: 1.0.0
     page-break-inside: avoid;
   }
 
+  /* #3242: opt-in, unchanged default (see templates/cv-template.html) — this
+     template has no :root theme-token block of its own, so the fallback below
+     is the only default; a config/profile.yml style.job_break_inside override
+     still reaches it via the injected :root block. */
+  .job {
+    break-inside: var(--job-break-inside, auto);
+    page-break-inside: var(--job-break-inside, auto);
+  }
+
   /* Keep a heading attached to the content that follows it, so headings are not
      orphaned at the bottom of a page. */
   .section-title,

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -400,11 +400,19 @@
 
   /* === PAGE BREAK CONTROL === */
   .avoid-break,
-  .job,
   .project,
   .edu-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* #3242: opt-in — unchanged default (this template has always kept a role
+     whole; override via config/profile.yml style.job_break_inside: auto to
+     let a role flow across a page break instead). No :root token block exists
+     in this template yet, so the fallback below is the only default. */
+  .job {
+    break-inside: var(--job-break-inside, avoid);
+    page-break-inside: var(--job-break-inside, avoid);
   }
 
   /* === RTL (Arabic) Support === */

--- a/tests/theme-style.test.mjs
+++ b/tests/theme-style.test.mjs
@@ -15,10 +15,10 @@ try {
   } = await import(pathToFileURL(join(ROOT, 'theme-style.mjs')).href);
 
   // styleTokensFrom: recognized keys → css vars; ignore unknown/non-string/missing
-  const t = styleTokensFrom({ accent_color: '#2563eb', font_family: 'Outfit, sans-serif', font_size: '10pt', margin: '0.5in', nope: 'x', font_weight: 700 });
+  const t = styleTokensFrom({ accent_color: '#2563eb', font_family: 'Outfit, sans-serif', font_size: '10pt', margin: '0.5in', job_break_inside: 'avoid', nope: 'x', font_weight: 700 });
   if (t['--accent-color'] === '#2563eb' && t['--font-family'] === 'Outfit, sans-serif' && t['--font-size'] === '10pt' && t['--page-margin'] === '0.5in'
-      && !('--font-weight' in t) && Object.keys(t).length === 4) {
-    pass('styleTokensFrom maps the 4 recognized keys and ignores unknown/non-string');
+      && t['--job-break-inside'] === 'avoid' && !('--font-weight' in t) && Object.keys(t).length === 5) {
+    pass('styleTokensFrom maps the 5 recognized keys and ignores unknown/non-string');
   } else {
     fail(`styleTokensFrom => ${JSON.stringify(t)}`);
   }
@@ -86,6 +86,36 @@ try {
     if (hasRoot && usesVars && !circular) pass(`${tpl} declares :root theme defaults and reads them via var() (no circular refs)`);
     else fail(`${tpl}: hasRoot=${hasRoot} usesVars=${usesVars} circular=${circular}`);
   }
+  // Template contract (#3242): every shipped template's .job rule reads
+  // --job-break-inside with ITS OWN current pagination behavior as the var()
+  // fallback, so the opt-in token changes nobody's default. resume-template.html
+  // and templates/ats/cv-template.ats.html have always kept a role whole
+  // (avoid); the rest let a role flow across a page break (auto, per #1145).
+  {
+    const expected = {
+      'templates/cv-template.html': 'auto',
+      'templates/cv-template.compact.html': 'auto',
+      'templates/cv-template.executive.html': 'auto',
+      'templates/cv-template.jake.html': 'auto',
+      'templates/cv-template.leadership.html': 'auto',
+      'templates/cv-template.modern.html': 'auto',
+      'templates/cv-template.zh-minimal.html': 'auto',
+      'templates/resume-template.html': 'avoid',
+      'templates/ats/cv-template.ats.html': 'avoid',
+    };
+    for (const [tpl, fallback] of Object.entries(expected)) {
+      const src = readFileSync(join(ROOT, tpl), 'utf-8');
+      const jobRule = src.match(/\.job\s*\{[^}]*break-inside:[^}]*\}/s)?.[0] || '';
+      const usesVar = new RegExp(`break-inside:\\s*var\\(--job-break-inside,\\s*${fallback}\\)`).test(jobRule);
+      const noHardcoded = !/break-inside:\s*(avoid|auto)\s*;/.test(jobRule.replace(/var\([^)]*\)/g, ''));
+      if (usesVar && noHardcoded) {
+        pass(`${tpl}: .job reads --job-break-inside with its own default (${fallback}) as the fallback`);
+      } else {
+        fail(`${tpl}: .job break-inside contract broken => ${jobRule}`);
+      }
+    }
+  }
+
   // Regression: localized CJK body font stacks must honor the profile
   // --font-family override while keeping their curated fallback stacks.
   {

--- a/theme-style.mjs
+++ b/theme-style.mjs
@@ -7,10 +7,11 @@
  * Users declare a `style:` block in config/profile.yml:
  *
  *   style:
- *     accent_color: "#2563eb"
- *     font_family:  "Outfit, Inter, sans-serif"
- *     font_size:    "10pt"
- *     margin:       "0.5in"
+ *     accent_color:     "#2563eb"
+ *     font_family:      "Outfit, Inter, sans-serif"
+ *     font_size:        "10pt"
+ *     margin:           "0.5in"
+ *     job_break_inside: "avoid"
  *
  * These are injected as CSS custom properties into the rendered HTML before it
  * hits the PDF pipeline. The templates read them via `var(--x, <default>)`, so a
@@ -31,10 +32,18 @@ import * as yaml from 'js-yaml';
 // Recognized style tokens → the CSS custom property each maps to. Anything not
 // listed here is ignored, so a typo or an unrelated `style:` key is inert.
 export const STYLE_VAR_MAP = {
-  accent_color: '--accent-color',
-  font_family:  '--font-family',
-  font_size:    '--font-size',
-  margin:       '--page-margin',
+  accent_color:     '--accent-color',
+  font_family:      '--font-family',
+  font_size:        '--font-size',
+  margin:           '--page-margin',
+  // #3242: whether a Work Experience entry may split across a page break.
+  // Each template supplies its OWN current behavior as the var() fallback, so
+  // this is purely additive — no shipped template's default pagination
+  // changes for anyone who doesn't set this. Raw CSS keyword (e.g. "avoid" or
+  // "auto"), same contract as the other tokens. Trade-off worth knowing:
+  // "avoid" cannot help an entry taller than a full page — it still splits,
+  // just after leaving a bottom gap on the page before it.
+  job_break_inside: '--job-break-inside',
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds `job_break_inside` to the existing #1837 theming mechanism (`theme-style.mjs` `STYLE_VAR_MAP`), so a user can set `style.job_break_inside: avoid` in `config/profile.yml` to keep every Work Experience entry whole, without forking a `SYSTEM_PATHS` template file.
- Each of the 9 templates carrying a `.job` rule keeps its **current** pagination behavior as the `var()` fallback (`auto` for `cv-template.html` + its 6 packs, matching #1145; `avoid` for `resume-template.html` and `templates/ats/cv-template.ats.html`, unchanged) — strictly additive, no default repaginates anyone's CV on update.
- `templates/sections/experience.html` is markup-only (no `<style>`), out of scope per the issue.

Fixes #3242.

## Test plan
- [x] Extended `tests/theme-style.test.mjs`: `styleTokensFrom` recognizes the new token; a new template-contract block asserts every `.job` rule in all 9 templates reads `var(--job-break-inside, <its own current default>)` with no leftover hardcoded `break-inside`/`page-break-inside` value.
- [x] `node tests/theme-style.test.mjs` — all pass (25/25, including the new assertions)
- [x] `node tests/template-page-breaks.test.mjs` — unaffected, still passes
- [x] `node test-all.mjs` — 7576 passed, 0 failed (14 pre-existing, unrelated warnings: personal-data-leak checks on maintainer's own docs, opt-in live-API test skips, deliberate negative-path fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can set `style.job_break_inside: avoid` in `config/profile.yml` without copying system templates. The token maps to `--job-break-inside` in `theme-style.mjs:13`.

The `.job` rules in all shipped templates now use this variable for `break-inside` and `page-break-inside`:

: `auto` remains the default for CV templates and template packs.
: `avoid` remains the default for resume and ATS templates.

Existing users keep the current pagination behavior. Users who select `avoid` can keep a complete work entry together when space permits. Entries taller than one page can still split.

Tests cover token mapping and `.job` template contracts in `tests/theme-style.test.mjs`.

Changed system files: `theme-style.mjs` and `tests/theme-style.test.mjs`. No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->