### PR TITLE
fix(tests): skip nested checkouts in subtree walkers

### DIFF
--- a/seed-fixture.mjs
+++ b/seed-fixture.mjs
@@ -16,6 +16,7 @@ import { tmpdir } from 'os';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { isMainModule } from './lib/is-main-module.mjs';
+import { isNestedCheckout } from './lib/mjs-files.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const FIXTURES = join(ROOT, 'test-fixtures', 'upgrade');
@@ -26,7 +27,10 @@ function walk(dir, base = dir, out = []) {
   // platforms (readdirSync returns filesystem order, which varies).
   for (const name of readdirSync(dir).sort()) {
     const p = join(dir, name);
-    if (statSync(p).isDirectory()) walk(p, base, out);
+    if (statSync(p).isDirectory()) {
+      if (isNestedCheckout(p)) continue;
+      walk(p, base, out);
+    }
     else out.push(relative(base, p).split(sep).join('/'));
   }
   return out;
@@ -36,7 +40,10 @@ export function listStates() {
   if (!existsSync(FIXTURES)) return [];
   // Sort for deterministic state ordering across platforms (readdirSync
   // returns filesystem order, which varies).
-  return readdirSync(FIXTURES).sort().filter((n) => statSync(join(FIXTURES, n)).isDirectory());
+  return readdirSync(FIXTURES).sort().filter((n) => {
+    const path = join(FIXTURES, n);
+    return statSync(path).isDirectory() && !isNestedCheckout(path);
+  });
 }
 
 // Strict allowlist: a state must be one of the real fixture subdirectories.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -112,7 +112,10 @@ function discoverTests(dir) {
   const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   for (const entry of entries) {
     const full = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...discoverTests(full));
+    if (entry.isDirectory()) {
+      if (isNestedCheckout(full)) continue;
+      out.push(...discoverTests(full));
+    }
     else if (entry.name.endsWith('.test.mjs')) out.push(full);
   }
   return out;
@@ -14998,7 +15001,10 @@ try {
   const walkMjs = (d) => {
     for (const e of readdirSync(d, { withFileTypes: true })) {
       const fp = join(d, e.name);
-      if (e.isDirectory()) walkMjs(fp);
+      if (e.isDirectory()) {
+        if (isNestedCheckout(fp)) continue;
+        walkMjs(fp);
+      }
       else if (e.name.endsWith('.mjs')) allPluginMjs.push(fp);
     }
   };
@@ -15850,7 +15856,7 @@ try {
         const webTestsRoot = join(ROOT, 'web', 'tests');
         const walk = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
           const p = join(dir, e.name);
-          if (e.isDirectory()) return walk(p);
+          if (e.isDirectory()) return isNestedCheckout(p) ? [] : walk(p);
           return e.isFile() && e.name.endsWith('.test.mjs') ? [p] : [];
         });
         if (existsSync(webTestsRoot)) {

--- a/tests/mjs-files.test.mjs
+++ b/tests/mjs-files.test.mjs
@@ -22,6 +22,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -162,13 +163,39 @@ test('isNestedCheckout detects the marker, of either type, and nothing else', ()
   }
 });
 
+test('test discovery does not execute suites from a nested checkout', () => {
+  const dir = mkdtempSync(join(ROOT, 'tests', 'nested-checkout-'));
+  const filter = dir.slice(join(ROOT, 'tests').length + 1);
+  try {
+    writeFileSync(join(dir, '.git'), 'gitdir: /elsewhere/.git/worktrees/nested\n');
+    writeFileSync(join(dir, 'must-not-run.test.mjs'), "throw new Error('nested checkout suite executed');\n");
+
+    const result = spawnSync(process.execPath, ['test-all.mjs', '--only', filter], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+    });
+
+    assert.equal(result.status, 1, result.stdout || result.stderr);
+    assert.match(result.stdout, /no test files matched/, 'the nested suite must be absent from discovery');
+    assert.doesNotMatch(result.stdout + result.stderr, /nested checkout suite executed/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('the private repo walkers consult the shared predicate, not their own rule', () => {
   // lib/mjs-files.mjs exists so two walkers cannot drift about what "every
   // file" means; the same reasoning applies to what "not our source" means.
   // These three suites keep private walkers because each filters differently
   // (.test.mjs, dot-dirs, SKIP_DIRS sets), so they import the predicate rather
   // than the collector — but a fourth hand-rolled `.git` rule is the drift.
-  for (const caller of ['tests/local-today-gates.test.mjs', 'tests/main-guard-convention.test.mjs', 'test-all.mjs']) {
+  for (const caller of [
+    'tests/local-today-gates.test.mjs',
+    'tests/main-guard-convention.test.mjs',
+    'tests/mojibake-canary.test.mjs',
+    'seed-fixture.mjs',
+    'test-all.mjs',
+  ]) {
     const src = readFileSync(join(ROOT, caller), 'utf-8');
 
     // The IMPORT is the assertion, not the call. Matching `isNestedCheckout(`
@@ -184,6 +211,44 @@ test('the private repo walkers consult the shared predicate, not their own rule'
     // ...and still use it: an unused import satisfies the check above while the
     // walk descends into every nested checkout exactly as before.
     assert.match(src, /isNestedCheckout\(/, `${caller} must actually call isNestedCheckout (#3499)`);
+  }
+});
+
+test('every subtree-anchored recursive edge checks the nested-checkout boundary', () => {
+  // Checking only that a FILE calls isNestedCheckout is too weak for test-all:
+  // it owns several independent recursive walkers, so one guarded walk can
+  // hide another unguarded one. Pin each recursive edge named in #3762.
+  const assertions = [
+    {
+      caller: 'test-all.mjs',
+      walker: 'test discovery',
+      pattern: /if \(entry\.isDirectory\(\)\) \{\s*if \(isNestedCheckout\(full\)\) continue;\s*out\.push\(\.\.\.discoverTests\(full\)\);/,
+    },
+    {
+      caller: 'test-all.mjs',
+      walker: 'plugin deny-list scan',
+      pattern: /if \(e\.isDirectory\(\)\) \{\s*if \(isNestedCheckout\(fp\)\) continue;\s*walkMjs\(fp\);/,
+    },
+    {
+      caller: 'test-all.mjs',
+      walker: 'web-suite parity scan',
+      pattern: /if \(e\.isDirectory\(\)\) return isNestedCheckout\(p\) \? \[\] : walk\(p\);/,
+    },
+    {
+      caller: 'tests/mojibake-canary.test.mjs',
+      walker: 'mojibake scan',
+      pattern: /if \(entry\.isDirectory\(\)\) \{\s*if \(isNestedCheckout\(fullPath\)\) continue;\s*walkAndCheck\(fullPath, entryRelativePath\);/,
+    },
+    {
+      caller: 'seed-fixture.mjs',
+      walker: 'fixture file scan',
+      pattern: /if \(statSync\(p\)\.isDirectory\(\)\) \{\s*if \(isNestedCheckout\(p\)\) continue;\s*walk\(p, base, out\);/,
+    },
+  ];
+
+  for (const { caller, walker, pattern } of assertions) {
+    const src = readFileSync(join(ROOT, caller), 'utf-8');
+    assert.match(src, pattern, `${caller} ${walker} must guard its own recursive edge (#3762)`);
   }
 });
 

--- a/tests/mojibake-canary.test.mjs
+++ b/tests/mojibake-canary.test.mjs
@@ -11,6 +11,7 @@
 
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { isNestedCheckout } from '../lib/mjs-files.mjs';
 import { pass, fail, ROOT } from './helpers.mjs';
 
 console.log('\nmojibake-canary — double-encoded UTF-8 detection in templates/ and modes/');
@@ -206,6 +207,7 @@ function walkAndCheck(dir, relativePath = '') {
     const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
     
     if (entry.isDirectory()) {
+      if (isNestedCheckout(fullPath)) continue;
       walkAndCheck(fullPath, entryRelativePath);
     } else if (entry.isFile()) {
       filesScanned++;


### PR DESCRIPTION
## Summary

- skip child directories with their own `.git` marker during test discovery
- apply the same boundary to plugin, web-test, mojibake, and fixture subtree walkers
- add a behavioral regression proving nested checkout suites are not executed, plus per-walker convention checks

Closes #3762

## Test plan

- `node --test tests/mjs-files.test.mjs` (11 passed)
- `node test-all.mjs --only mojibake-canary` (8 passed)
- `node seed-fixture.mjs --self-test`
- `npm run lint` (654 files passed)
- `node test-all.mjs` (8092 passed; 2 unrelated live Gemini checks failed with external `fetch failed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Nested checkout directories are now excluded from recursive test and fixture scans.

Users can now place a nested worktree below `tests/`, `plugins/`, `web/tests/`, `templates/`, `modes/`, or `test-fixtures/` without causing its tests or files to be discovered, executed, or checked.

### Changes

- `test-all.mjs`: Guards test, plugin, and web-test walkers with `isNestedCheckout`.
- `seed-fixture.mjs`: Skips nested checkouts during fixture traversal and state discovery.
- `tests/mojibake-canary.test.mjs`: Skips nested checkouts during `templates/` and `modes/` scans.
- `tests/mjs-files.test.mjs`: Adds regression coverage and convention checks for all affected walkers.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->