### PR TITLE
fix: add MiniMax-M3 and MiniMax-M2.7 token rates

### DIFF
--- a/tests/token-tracker.test.mjs
+++ b/tests/token-tracker.test.mjs
@@ -79,6 +79,21 @@ try {
   } else {
     fail(`formatBreakdown zero-token step rendering failed:\n${breakdownZero}`);
   }
+
+  // 8. MiniMax model rates include uncached input, cached input, and output
+  const minimaxUsage = { prompt_tokens: 1000000, completion_tokens: 1000000, cached_tokens: 500000 };
+  const minimaxCases = [
+    ['MiniMax-M3', 2.76],
+    ['MiniMax-M2.7', 1.38],
+  ];
+  for (const [model, expected] of minimaxCases) {
+    const actual = estimateCost(model, minimaxUsage, 'minimax');
+    if (actual !== null && Math.abs(actual - expected) < 1e-9) {
+      pass(`estimateCost for ${model} includes its cached-input rate`);
+    } else {
+      fail(`estimateCost for ${model} failed: expected ${expected}, got ${actual}`);
+    }
+  }
 } catch (e) {
   fail(`token-tracker tests crashed: ${e.message}`);
 }

--- a/utils/token-tracker.mjs
+++ b/utils/token-tracker.mjs
@@ -3,6 +3,10 @@
  */
 
 export const RATES = {
+  // MiniMax models
+  'MiniMax-M3': { input: 0.60 / 1000000, output: 2.40 / 1000000, cachedInput: 0.12 / 1000000 },
+  'MiniMax-M2.7': { input: 0.30 / 1000000, output: 1.20 / 1000000, cachedInput: 0.06 / 1000000 },
+
   // OpenAI models
   'gpt-4o-mini': { input: 0.150 / 1000000, output: 0.600 / 1000000 },
   'gpt-4o': { input: 2.50 / 1000000, output: 10.00 / 1000000 },


### PR DESCRIPTION
Reason: Add current pricing for the two supported MiniMax evaluator model IDs so cost estimates no longer use a fallback rate.

Adds input, cached-input, and output rates for MiniMax-M3 and MiniMax-M2.7 in the shared token tracker.

Adds regression coverage that calculates a mixed cached and uncached request for both models.

Checks:
- `node tests/token-tracker.test.mjs`
- `npm run lint -- --quiet`
- Target-rate validation against the configured model facts
- `node test-all.mjs --quick` (8,092 checks passed; one unrelated integration check failed because `cv.md` was absent and its external API request was unavailable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds accurate token cost estimates for `MiniMax-M3` and `MiniMax-M2.7`.

## User impact

Users receive separate rates for uncached input, cached input, and output tokens. Mixed cached and uncached requests no longer use fallback rates.

## Changes

- `utils/token-tracker.mjs:5-8`: Adds both MiniMax models to `RATES`.
- `tests/token-tracker.test.mjs:83-90`: Adds regression coverage for mixed cached and uncached usage.

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->