### PR TITLE
test(yaml): fail CI on an unparseable tracked YAML file

### DIFF
--- a/tests/yaml-syntax.test.mjs
+++ b/tests/yaml-syntax.test.mjs
@@ -1,16 +1,20 @@
 // tests/yaml-syntax.test.mjs — every tracked YAML file must parse.
 //
-// Enumerates *.yml/*.yaml via `git ls-files` and parses each one with the
-// repo's js-yaml. A file that does not parse fails the check. This is the only
-// YAML validation in the suite — `npm run lint` runs `node --check` on .mjs
-// files only.
+// Matches *.yml/*.yaml case-insensitively over `git ls-files` and parses each
+// one with the repo's js-yaml. A file that does not parse fails the check. This
+// is the only YAML validation in the suite — `npm run lint` runs `node --check`
+// on .mjs files only.
 //
 // Parse-only, not schema validation: it catches a value that silently
 // restructures the document (an unquoted scalar with an embedded `: `, a bad
 // indent) without coupling the test to GitHub's issue-form or workflow schemas.
 //
-// loadAll, not load: load() throws on a legitimately multi-document file
-// ("expected a single document"), which must not read as a syntax error.
+// Parsed with yaml.load — the same call every non-.github/ consumer uses
+// (scan.mjs: `const parseYaml = yaml.load`), so a multi-document file that would
+// throw in the runtime ("expected a single document") fails here too. .github/
+// YAML is read by GitHub's own issue-form / workflow parsers, not by this repo's
+// code, so it is parsed with loadAll instead — a multi-document stream there is
+// not a syntax error this gate should invent.
 //
 // Files are discovered, not listed, so a new YAML file is covered as soon as it
 // is tracked. `git ls-files` is the set that ships, needs no skip-list, and
@@ -33,14 +37,20 @@ console.log('\nevery tracked YAML file must parse');
 function yamlFiles() {
   try {
     // -z: NUL-separated, so a path containing a newline or quote cannot split a
-    // record and silently drop a file from the sweep.
-    const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z', '--', '*.yml', '*.yaml'], {
+    // record and silently drop a file from the sweep. No pathspec: list every
+    // tracked path and match the extension below, so this one filter is the
+    // single source of truth for what counts as YAML — a `.YAML`/`.YML` file
+    // (git pathspecs are case-sensitive) is still swept.
+    const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z'], {
       encoding: 'utf-8',
       maxBuffer: 32 * 1024 * 1024,
     });
     const files = out
       .split('\0')
-      .filter((p) => p && (p.endsWith('.yml') || p.endsWith('.yaml')))
+      .filter((p) => {
+        const lower = p.toLowerCase();
+        return lower.endsWith('.yml') || lower.endsWith('.yaml');
+      })
       .map((p) => join(ROOT, p));
     return { files, error: null };
   } catch (err) {
@@ -50,10 +60,12 @@ function yamlFiles() {
 
 // Guard the guard: a parse step that silently swallowed errors, or a `load` that
 // had been swapped for something inert, would report a clean sweep forever.
-// Prove it rejects an unquoted value with an embedded `: ` and accepts the
-// quoted form.
+// Prove it rejects an unquoted value with an embedded `: `, accepts the quoted
+// form, and that yaml.load (the non-.github/ path) rejects a multi-document
+// stream that loadAll would wave through.
 const BROKEN_FIXTURE = "attributes:\n  description: A generic client (`User-agent: *`)?\n";
 const FIXED_FIXTURE = 'attributes:\n  description: "A generic client (`User-agent: *`)?"\n';
+const MULTIDOC_FIXTURE = 'a: 1\n---\nb: 2\n';
 let detectorRejects = false;
 try {
   yaml.loadAll(BROKEN_FIXTURE);
@@ -66,10 +78,18 @@ try {
 } catch {
   detectorAccepts = false;
 }
-if (detectorRejects && detectorAccepts) {
-  pass('parser rejects an unquoted value with an embedded `: ` and accepts the quoted form');
+let loadRejectsMultiDoc = false;
+try {
+  yaml.load(MULTIDOC_FIXTURE);
+} catch {
+  loadRejectsMultiDoc = true;
+}
+if (detectorRejects && detectorAccepts && loadRejectsMultiDoc) {
+  pass('parser rejects an unquoted embedded `: `, accepts the quoted form, and load() rejects a multi-document stream');
 } else {
-  fail(`detector broken: rejects=${detectorRejects} accepts=${detectorAccepts} — it would pass the sweep regardless of the files`);
+  fail(
+    `detector broken: rejects=${detectorRejects} accepts=${detectorAccepts} loadRejectsMultiDoc=${loadRejectsMultiDoc} — it would pass the sweep regardless of the files`,
+  );
 }
 
 const offenders = [];
@@ -80,6 +100,7 @@ const unreadable = [];
 
 const { files, error: discoveryError } = yamlFiles();
 for (const file of files) {
+  const rel = relative(ROOT, file);
   let text;
   try {
     // lstat before read, and reject anything that is not a regular file.
@@ -88,18 +109,23 @@ for (const file of files) {
     // reaches the catch below. A non-regular entry has to be turned away
     // before the read, and into unreadable (a hard failure), never skipped.
     if (!lstatSync(file).isFile()) {
-      unreadable.push(`${relative(ROOT, file)} (not a regular file)`);
+      unreadable.push(`${rel} (not a regular file)`);
       continue;
     }
     text = readFileSync(file, 'utf-8');
   } catch (err) {
-    unreadable.push(`${relative(ROOT, file)} (${err.code || err.message})`);
+    unreadable.push(`${rel} (${err.code || err.message})`);
     continue;
   }
+  // .github/ YAML is consumed by GitHub, not by this repo — tolerate a
+  // multi-document stream there. Everything else is read by yaml.load, which
+  // throws on a second document, so parse it the way the runtime will.
+  const isGithub = rel.split(/[\\/]/)[0] === '.github';
   try {
-    yaml.loadAll(text);
+    if (isGithub) yaml.loadAll(text);
+    else yaml.load(text);
   } catch (err) {
-    offenders.push(`${relative(ROOT, file)}: ${err.message.split('\n')[0]}`);
+    offenders.push(`${rel}: ${err.message.split('\n')[0]}`);
   }
 }
 

--- a/tests/yaml-syntax.test.mjs
+++ b/tests/yaml-syntax.test.mjs
@@ -1,0 +1,107 @@
+// tests/yaml-syntax.test.mjs — every tracked YAML file must parse.
+//
+// Enumerates *.yml/*.yaml via `git ls-files` and parses each one with the
+// repo's js-yaml. A file that does not parse fails the check. This is the only
+// YAML validation in the suite — `npm run lint` runs `node --check` on .mjs
+// files only.
+//
+// Parse-only, not schema validation: it catches a value that silently
+// restructures the document (an unquoted scalar with an embedded `: `, a bad
+// indent) without coupling the test to GitHub's issue-form or workflow schemas.
+//
+// loadAll, not load: load() throws on a legitimately multi-document file
+// ("expected a single document"), which must not read as a syntax error.
+//
+// Files are discovered, not listed, so a new YAML file is covered as soon as it
+// is tracked. `git ls-files` is the set that ships, needs no skip-list, and
+// cannot wander into untracked scratch.
+
+import { pass, fail, ROOT } from './helpers.mjs';
+import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join, relative } from 'path';
+import * as yaml from 'js-yaml';
+
+console.log('\nevery tracked YAML file must parse');
+
+/**
+ * @returns {{files: string[], error: string|null}} every tracked *.yml/*.yaml.
+ * The error is returned, not thrown: an uncaught throw here kills the process
+ * before the reporting below runs, so a missing git or a ROOT that is not a work
+ * tree would surface as a crash instead of a counted failure.
+ */
+function yamlFiles() {
+  try {
+    // -z: NUL-separated, so a path containing a newline or quote cannot split a
+    // record and silently drop a file from the sweep.
+    const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z', '--', '*.yml', '*.yaml'], {
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const files = out
+      .split('\0')
+      .filter((p) => p && (p.endsWith('.yml') || p.endsWith('.yaml')))
+      .map((p) => join(ROOT, p));
+    return { files, error: null };
+  } catch (err) {
+    return { files: [], error: err.message.split('\n')[0] };
+  }
+}
+
+// Guard the guard: a parse step that silently swallowed errors, or a `load` that
+// had been swapped for something inert, would report a clean sweep forever.
+// Prove it rejects an unquoted value with an embedded `: ` and accepts the
+// quoted form.
+const BROKEN_FIXTURE = "attributes:\n  description: A generic client (`User-agent: *`)?\n";
+const FIXED_FIXTURE = 'attributes:\n  description: "A generic client (`User-agent: *`)?"\n';
+let detectorRejects = false;
+try {
+  yaml.loadAll(BROKEN_FIXTURE);
+} catch {
+  detectorRejects = true;
+}
+let detectorAccepts = true;
+try {
+  yaml.loadAll(FIXED_FIXTURE);
+} catch {
+  detectorAccepts = false;
+}
+if (detectorRejects && detectorAccepts) {
+  pass('parser rejects an unquoted value with an embedded `: ` and accepts the quoted form');
+} else {
+  fail(`detector broken: rejects=${detectorRejects} accepts=${detectorAccepts} — it would pass the sweep regardless of the files`);
+}
+
+const offenders = [];
+// A file that cannot be read is not a file that passes — report it as its own
+// failure rather than skip it, so the sweep cannot go green while covering less
+// of the tree than it claims.
+const unreadable = [];
+
+const { files, error: discoveryError } = yamlFiles();
+for (const file of files) {
+  let text;
+  try {
+    text = readFileSync(file, 'utf-8');
+  } catch (err) {
+    unreadable.push(`${relative(ROOT, file)} (${err.code || err.message})`);
+    continue;
+  }
+  try {
+    yaml.loadAll(text);
+  } catch (err) {
+    offenders.push(`${relative(ROOT, file)}: ${err.message.split('\n')[0]}`);
+  }
+}
+
+if (discoveryError !== null) {
+  fail(`could not list tracked YAML files, so the sweep ran against nothing: ${discoveryError}`);
+} else if (files.length === 0) {
+  fail('git ls-files produced no *.yml/*.yaml — the YAML syntax sweep scanned nothing');
+} else if (unreadable.length > 0) {
+  fail(`could not read ${unreadable.length} tracked YAML file(s), so the sweep is incomplete: ${unreadable.join(', ')}`);
+} else if (offenders.length === 0) {
+  pass(`all ${files.length} tracked YAML files parse`);
+} else {
+  fail(`YAML file(s) that do not parse — a GitHub Issue Form or workflow in this set will not load: ${offenders.join(' · ')}`);
+}

--- a/tests/yaml-syntax.test.mjs
+++ b/tests/yaml-syntax.test.mjs
@@ -17,7 +17,7 @@
 // cannot wander into untracked scratch.
 
 import { pass, fail, ROOT } from './helpers.mjs';
-import { readFileSync } from 'fs';
+import { lstatSync, readFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
 import * as yaml from 'js-yaml';
@@ -82,6 +82,15 @@ const { files, error: discoveryError } = yamlFiles();
 for (const file of files) {
   let text;
   try {
+    // lstat before read, and reject anything that is not a regular file.
+    // git ls-files lists tracked symlinks too, and readFileSync follows them:
+    // a symlink to /dev/zero reads unboundedly, a FIFO blocks — neither ever
+    // reaches the catch below. A non-regular entry has to be turned away
+    // before the read, and into unreadable (a hard failure), never skipped.
+    if (!lstatSync(file).isFile()) {
+      unreadable.push(`${relative(ROOT, file)} (not a regular file)`);
+      continue;
+    }
     text = readFileSync(file, 'utf-8');
   } catch (err) {
     unreadable.push(`${relative(ROOT, file)} (${err.code || err.message})`);

--- a/tests/yaml-syntax.test.mjs
+++ b/tests/yaml-syntax.test.mjs
@@ -138,5 +138,5 @@ if (discoveryError !== null) {
 } else if (offenders.length === 0) {
   pass(`all ${files.length} tracked YAML files parse`);
 } else {
-  fail(`YAML file(s) that do not parse — a GitHub Issue Form or workflow in this set will not load: ${offenders.join(' · ')}`);
+  fail(`YAML file(s) that do not parse: ${offenders.join(' · ')}`);
 }


### PR DESCRIPTION
## What

Adds `tests/yaml-syntax.test.mjs`: enumerate every tracked `.yml`/`.yaml` file with `git ls-files` and parse each one with the `js-yaml` the repo already depends on. A file that does not parse fails the check.

## Why

Nothing validated YAML. `npm run lint` runs `node --check` on `.mjs` files only, and no CI job touched YAML at all. A GitHub Issue Form or workflow that is invalid YAML does not fail a build — the form just silently stops rendering on github.com. That happened in review of #3754: an unquoted `description:` value containing `User-agent: *` opened a phantom nested mapping and made `.github/ISSUE_TEMPLATE/source-proposal.yml` unloadable.

## Scope

Parse-only, not schema validation. "Does it parse" catches the whole class of failure that actually reaches `main` (a value that silently restructures the document) without coupling the test to GitHub's issue-form schema. Non-`.github/` files are parsed with `yaml.load` — the call every runtime consumer uses (`scan.mjs`: `const parseYaml = yaml.load`) — so a multi-document file that would throw in the runtime fails here too. `.github/` YAML is parsed with `loadAll`, since GitHub's own issue-form / workflow parsers read those, not this repo's code.

Files are discovered, never listed — a new YAML file is covered the moment it is tracked, and the extension is matched case-insensitively so a `.YAML` / `.YML` file is not missed. The check is auto-discovered by `test-all.mjs` (`tests/**/*.test.mjs`), so it runs on every PR with no wiring. Fail-closed: an empty sweep, an unreadable file, a non-regular entry, or a discovery error is a failure, not a skip, and a guard-the-guard assertion proves the parser still rejects the exact shape from #3754, accepts the quoted form, and that `load()` rejects a multi-document stream.

Currently green over all 50 tracked YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds `tests/yaml-syntax.test.mjs` to validate every tracked `.yml` and `.yaml` file.

Users now receive test failures for invalid, empty, unreadable, symlinked, or non-regular YAML entries. The test supports multi-document YAML with `js-yaml.loadAll` and checks the quoted and unquoted scalar failure pattern: `tests/yaml-syntax.test.mjs:51-73`.

The test runs through existing `test-all.mjs` discovery: `tests/yaml-syntax.test.mjs:81-113`.

System-file scope: `.github/` YAML files are checked. No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `providers/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
