### PR TITLE
fix(pdf): recognize Chinese section titles in SECTION_ALIASES (#3658)

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -231,10 +231,11 @@ function foldDiacritics(text) {
 /**
  * Heading spelling -> canonical section key.
  *
- * Polish (modes/pl) is here because without these aliases the rendered Polish
- * titles match nothing derived from the English cv.md: validateCvSectionOrder()
- * finds fewer than two comparable sections and silently returns, leaving the
- * section-order guard disabled on every CV rendered in that mode.
+ * Polish (modes/pl) and Chinese (modes/zh-TW, modes/zh) are here because without
+ * these aliases the rendered non-English titles match nothing derived from the
+ * English cv.md: validateCvSectionOrder() finds fewer than two comparable
+ * sections and silently returns, leaving the section-order guard disabled on
+ * every CV rendered in those modes, and cv.sections resolves no block at all.
  *
  * Keys are folded on construction so authored diacritics match stripped input.
  */
@@ -289,6 +290,72 @@ const SECTION_ALIASES = new Map([
   ['nagrody i wyróżnienia', 'awards'],
   ['umiejętności', 'skills'],
   ['umiejętności techniczne', 'skills'],
+  // Chinese — the same failure the Polish block above fixes, for the two Chinese
+  // markets this repo ships modes for: Traditional (modes/zh-TW) and Simplified
+  // (modes/zh), rendered through templates/cv-template.zh-minimal.html. Both
+  // scripts are listed against every key because a CV written in either renders
+  // through this one alias table. The vocabulary is the repo's own: the
+  // `sections` payload in tests/zh-minimal-template.test.mjs (个人简介, 核心能力,
+  // 工作经历, 精选项目, 教育经历, 认证, 技术栈) and the modes' wording
+  // (e.g. "專業摘要" in modes/zh-TW/oferta.md), plus the everyday synonyms of
+  // each — the titles have no single canonical spelling because they come from
+  // a user-supplied `sections` override, not from DEFAULT_SECTION_TITLES.
+  ['專業摘要', 'summary'],
+  ['专业摘要', 'summary'],
+  ['摘要', 'summary'],
+  ['個人簡介', 'summary'],
+  ['个人简介', 'summary'],
+  ['簡介', 'summary'],
+  ['简介', 'summary'],
+  ['核心能力', 'competencies'],
+  ['核心競爭力', 'competencies'],
+  ['核心竞争力', 'competencies'],
+  ['工作經歷', 'experience'],
+  ['工作经历', 'experience'],
+  ['工作經驗', 'experience'],
+  ['工作经验', 'experience'],
+  ['專業經歷', 'experience'],
+  ['专业经历', 'experience'],
+  ['專案', 'projects'],
+  ['项目', 'projects'],
+  ['專案經驗', 'projects'],
+  ['项目经验', 'projects'],
+  ['專案經歷', 'projects'],
+  ['项目经历', 'projects'],
+  ['專案成就', 'projects'],
+  ['项目成就', 'projects'],
+  ['精選專案', 'projects'],
+  ['精选项目', 'projects'],
+  ['學歷', 'education'],
+  ['学历', 'education'],
+  ['教育背景', 'education'],
+  ['教育經歷', 'education'],
+  ['教育经历', 'education'],
+  ['證照', 'certifications'],
+  ['证照', 'certifications'],
+  ['證書', 'certifications'],
+  ['证书', 'certifications'],
+  ['專業證照', 'certifications'],
+  ['专业证书', 'certifications'],
+  ['認證', 'certifications'],
+  ['认证', 'certifications'],
+  ['資格認證', 'certifications'],
+  ['资格认证', 'certifications'],
+  ['獲獎', 'awards'],
+  ['获奖', 'awards'],
+  ['獎項', 'awards'],
+  ['奖项', 'awards'],
+  ['榮譽', 'awards'],
+  ['荣誉', 'awards'],
+  ['技能', 'skills'],
+  ['專長', 'skills'],
+  ['专长', 'skills'],
+  ['技術能力', 'skills'],
+  ['技术能力', 'skills'],
+  ['技術棧', 'skills'],
+  ['技术栈', 'skills'],
+  ['興趣', 'interests'],
+  ['兴趣', 'interests'],
 ].map(([alias, key]) => [foldDiacritics(alias), key]));
 
 function normalizeSectionTitle(text) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2504,6 +2504,18 @@ for (const header of ['podsumowanie zawodowe', 'doświadczenie zawodowe', 'wyksz
   }
 }
 
+// Same gap, same two shipped Chinese markets (#3658): modes/zh-TW and modes/zh
+// rendered titles the alias table could not name, so the guard was disabled AND
+// cv.sections — the documented way to correct an order — silently did nothing.
+// Both scripts are required: a CV written in either renders through this table.
+for (const header of ['專業摘要', '工作經歷', '學歷', '證照', '技能', '专业摘要', '工作经历', '学历', '证书', '项目']) {
+  if (generatePdfScript.includes(`['${header}',`)) {
+    pass(`SECTION_ALIASES maps Chinese header: ${header}`);
+  } else {
+    fail(`SECTION_ALIASES missing Chinese header: ${header}`);
+  }
+}
+
 // generate-pdf.mjs imports playwright at module scope; degrade to a warning
 // rather than crashing the suite where it is not installed.
 let pdfModule = null;
@@ -2530,6 +2542,12 @@ if (pdfModule) {
     ['Umiejetnosci', 'skills'],      // diacritics stripped
     ['Work Experience', 'experience'], // English must be unchanged
     ['Core Competencies', 'competencies'],
+    ['專業摘要', 'summary'],       // Traditional (modes/zh-TW)
+    ['工作經歷', 'experience'],
+    ['學歷', 'education'],
+    ['专业摘要', 'summary'],       // Simplified (modes/zh)
+    ['工作经历', 'experience'],
+    ['学历', 'education'],
   ];
   let keysOk = true;
   for (const [title, expected] of keyCases) {
@@ -2539,7 +2557,7 @@ if (pdfModule) {
       keysOk = false;
     }
   }
-  if (keysOk) pass(`sectionKey resolves all ${keyCases.length} PL/EN heading spellings`);
+  if (keysOk) pass(`sectionKey resolves all ${keyCases.length} PL/EN/ZH heading spellings`);
 
   // Hermetic cv.md stand-in: passed in directly, so the test does not depend on
   // a cv.md existing in the checkout (it is gitignored).
@@ -2559,6 +2577,13 @@ if (pdfModule) {
   ]);
   const enMisordered = titlesToHtml([
     'Professional Summary', 'Education', 'Work Experience',
+  ]);
+  // Education hoisted above 工作經歷 — the Chinese half of #3658.
+  const zhMisordered = titlesToHtml([
+    '專業摘要', '學歷', '工作經歷',
+  ]);
+  const zhCorrect = titlesToHtml([
+    '专业摘要', '工作经历', '学历', '证书', '技能',
   ]);
 
   const throws = (html, opts) => {
@@ -2581,6 +2606,18 @@ if (pdfModule) {
     pass('English CV order check still rejects divergence (no regression)');
   } else {
     fail('English CV order check regressed');
+  }
+
+  if (throws(zhMisordered)) {
+    pass('Traditional Chinese CV with Education before Work Experience is rejected');
+  } else {
+    fail('Traditional Chinese CV with Education before Work Experience was NOT rejected (guard is a no-op)');
+  }
+
+  if (!throws(zhCorrect)) {
+    pass('Simplified Chinese CV in cv.md order is accepted');
+  } else {
+    fail('Simplified Chinese CV in cv.md order was wrongly rejected');
   }
 
   // --allow-reorder must keep downgrading the divergence to a warning now that

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -116,7 +116,7 @@ function captureWarnings(fn) {
 try {
   const { cvSectionOrderFrom, readCvSectionOrder } =
     await import(pathToFileURL(join(ROOT, 'theme-style.mjs')).href);
-  const { reorderCvSections, CV_SECTION_KEYS, validateCvSectionOrder } =
+  const { reorderCvSections, CV_SECTION_KEYS, validateCvSectionOrder, sectionKey } =
     await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
 
   // ── Reading the config ────────────────────────────────────────────────────
@@ -832,6 +832,143 @@ try {
     pass('--allow-reorder still downgrades a genuinely scrambled order from a thrown error to a warning');
   } else {
     fail(`--allow-reorder should warn instead of throwing on a genuinely scrambled order: threw=${scrambledAllowRun.value} warnings=${JSON.stringify(scrambledAllowRun.warnings)}`);
+  }
+
+  // ── #3658: Chinese CVs reach the same two mechanisms ──────────────────────
+
+  // SECTION_ALIASES carried English and Polish only, so for the two Chinese
+  // markets this repo ships modes for (modes/zh-TW, modes/zh) every rendered
+  // title fell through sectionKey()'s "return the normalized title" branch.
+  // Nothing then matched a canonical key, so cv.sections resolved fewer than
+  // two blocks and returned the document untouched — a silent no-op, and the
+  // only documented way to correct an order the guard rejects.
+  //
+  // Built the same way as scrambledHtml above (marker comments stay English:
+  // they come from the template, not from the CV's language) and validated
+  // against the same English cvMarkdown, because cv.md is the source of truth
+  // in every mode.
+  const zhSection = (marker, title, body) =>
+    `  <!-- ${marker} -->\n  <div class="section">\n    <div class="section-title">${title}</div>\n    ${body}\n  </div>\n`;
+  const zhDocument = sections => `<!DOCTYPE html>
+<html lang="zh-Hant">
+<head><title>Test</title></head>
+<body>
+<div class="cv">
+  <!-- HEADER -->
+  <div class="header"><h1>Test Candidate</h1></div>
+
+${sections.join('\n')}</div>
+</body>
+</html>
+`;
+
+  // Traditional (modes/zh-TW), scrambled exactly like scrambledHtml: Education
+  // and Certifications hoisted ahead of Experience and Projects.
+  const zhTwScrambled = zhDocument([
+    zhSection('PROFESSIONAL SUMMARY', '專業摘要', '<div class="summary-text">Summary body.</div>'),
+    zhSection('EDUCATION', '學歷', '<div class="edu-item">E</div>'),
+    zhSection('CERTIFICATIONS', '證照', '<div class="cert-table">C</div>'),
+    zhSection('WORK EXPERIENCE', '工作經歷', '<div class="job">J</div>'),
+    zhSection('PROJECTS', '專案', '<div class="project">P</div>'),
+    zhSection('SKILLS', '技能', '<div class="skills-grid">K</div>'),
+  ]);
+  // Simplified (modes/zh), with the vocabulary that market actually uses.
+  const zhCnScrambled = zhDocument([
+    zhSection('PROFESSIONAL SUMMARY', '专业摘要', '<div class="summary-text">Summary body.</div>'),
+    zhSection('EDUCATION', '学历', '<div class="edu-item">E</div>'),
+    zhSection('CERTIFICATIONS', '证书', '<div class="cert-table">C</div>'),
+    zhSection('WORK EXPERIENCE', '工作经历', '<div class="job">J</div>'),
+    zhSection('PROJECTS', '项目', '<div class="project">P</div>'),
+    zhSection('SKILLS', '技能', '<div class="skills-grid">K</div>'),
+  ]);
+
+  const zhOrder = ['experience', 'projects', 'skills', 'education', 'certifications'];
+  const zhCases = [
+    ['Traditional (modes/zh-TW)', zhTwScrambled, ['專業摘要', '工作經歷', '專案', '技能', '學歷', '證照']],
+    ['Simplified (modes/zh)', zhCnScrambled, ['专业摘要', '工作经历', '项目', '技能', '学历', '证书']],
+  ];
+
+  for (const [label, html, expectedTitles] of zhCases) {
+    // The bug, stated as an observable: the document came back byte-identical.
+    const run = captureWarnings(() => reorderCvSections(html, zhOrder));
+    if (run.value === html) {
+      fail(`${label}: cv.sections left the CV byte-identical — the order is still a no-op`);
+      continue;
+    }
+    const got = renderedTitles(run.value);
+    if (JSON.stringify(got) !== JSON.stringify(expectedTitles)) {
+      fail(`${label}: reordered => ${JSON.stringify(got)}, expected ${JSON.stringify(expectedTitles)}`);
+      continue;
+    }
+    // Every body survives exactly once — the permutation must not lose or
+    // duplicate content just because the titles are non-Latin.
+    const zhIntact = ['Summary body.', 'class="edu-item">E', 'class="cert-table">C', 'class="job">J', 'class="project">P', 'class="skills-grid">K']
+      .every(b => run.value.split(b).length === 2);
+    if (!zhIntact) {
+      fail(`${label}: reordering lost or duplicated a section body`);
+      continue;
+    }
+    // "matched no section" is precisely the warning #3658 quoted as the symptom.
+    if (run.warnings.some(w => w.includes('matched no section'))) {
+      fail(`${label}: still reported names that matched no section: ${JSON.stringify(run.warnings)}`);
+      continue;
+    }
+    // And the reason the feature matters here: the guard rejects the scrambled
+    // CV and accepts it once cv.sections declares cv.md's own order. Chinese
+    // reaches the guard already (it compares titles), so before this change the
+    // render was blocked with no working way to fix it.
+    let zhThrewBefore = false;
+    try {
+      validateCvSectionOrder(html, cvMarkdown);
+    } catch {
+      zhThrewBefore = true;
+    }
+    if (!zhThrewBefore) {
+      fail(`${label}: the scrambled CV was not rejected — the end-to-end assertion proves nothing`);
+      continue;
+    }
+    try {
+      validateCvSectionOrder(run.value, cvMarkdown);
+    } catch (e) {
+      fail(`${label}: the guard still rejected the reordered CV: ${e.message}`);
+      continue;
+    }
+    pass(`${label}: cv.sections reorders a Chinese CV and the section-order guard then accepts it (#3658)`);
+  }
+
+  // Spellings that do not appear in the fixtures above still have to resolve:
+  // both scripts, and the synonyms each market writes in practice.
+  const zhKeyCases = [
+    ['個人簡介', 'summary'], ['个人简介', 'summary'],
+    ['核心競爭力', 'competencies'], ['核心竞争力', 'competencies'],
+    ['工作經驗', 'experience'], ['工作经验', 'experience'],
+    ['專案經驗', 'projects'], ['项目经验', 'projects'],
+    ['教育背景', 'education'], ['教育经历', 'education'],
+    ['專業證照', 'certifications'], ['资格认证', 'certifications'],
+    ['獲獎', 'awards'], ['荣誉', 'awards'],
+    ['技術能力', 'skills'], ['专长', 'skills'],
+    ['興趣', 'interests'], ['兴趣', 'interests'],
+    // The lookup folds diacritics through NFD before matching. Han characters
+    // have no combining marks to strip, so a Chinese title must survive that
+    // pass unchanged — asserted here rather than assumed.
+    ['專業摘要', 'summary'],
+  ];
+  // The repo's own Chinese vocabulary, not an invented one: this is the
+  // `sections` override rendered by tests/zh-minimal-template.test.mjs through
+  // templates/cv-template.zh-minimal.html. Every title a shipped fixture
+  // renders must be nameable, or cv.sections is still a no-op for it.
+  const ZH_MINIMAL_FIXTURE_TITLES = [
+    ['个人简介', 'summary'], ['核心能力', 'competencies'], ['工作经历', 'experience'],
+    ['精选项目', 'projects'], ['教育经历', 'education'], ['认证', 'certifications'],
+    ['技术栈', 'skills'],
+  ];
+  zhKeyCases.push(...ZH_MINIMAL_FIXTURE_TITLES);
+
+  const zhKeyFailures = zhKeyCases.filter(([title, expected]) => sectionKey(title) !== expected);
+  if (zhKeyFailures.length === 0) {
+    pass(`sectionKey resolves all ${zhKeyCases.length} Traditional/Simplified heading spellings`);
+  } else {
+    fail(`sectionKey missed: ${zhKeyFailures.map(([t, e]) => `"${t}" => "${sectionKey(t)}" (expected "${e}")`).join(', ')}`);
   }
 } catch (e) {
   fail(`cv-section-order tests crashed: ${e.message}`);


### PR DESCRIPTION
Closes #3658.

## The problem

`SECTION_ALIASES` in `generate-pdf.mjs` held English and Polish spellings only. This repo ships modes for two Chinese markets — `modes/zh-TW` and `modes/zh`, rendered through `templates/cv-template.zh-minimal.html` — and every title those CVs render fell through `sectionKey()`'s "return the normalized title" fallback, matching no canonical key.

The two mechanisms that depend on the table then broke **asymmetrically**:

- `validateCvSectionOrder()` compares titles verbatim, so it *does* work for Chinese: a Chinese CV whose order diverges from `cv.md` is rejected.
- `reorderCvSections()` — `cv.sections` in `config/profile.yml`, the documented way to declare that order on purpose — resolved fewer than two blocks and silently returned the document untouched.

So a Chinese CV could be blocked by the guard with no working way to fix it. `generate-pdf.mjs` already prints the right diagnosis ("its title needs an entry in `SECTION_ALIASES`"), but that advice is not actionable for users: `update-system.mjs` restores the core scripts on update.

The sharpest illustration is in this repo rather than in a user's CV. `tests/zh-minimal-template.test.mjs` renders a Simplified fixture whose `sections` override is `个人简介 / 核心能力 / 工作经历 / 精选项目 / 教育经历 / 认证 / 技术栈` — **before this change, none of those seven titles resolved to a canonical key.**

## The change

56 Traditional/Simplified entries covering all nine canonical keys, added after the Polish block in the same style, with a comment stating where the vocabulary comes from.

The vocabulary is the repo's own rather than invented:

- the `sections` payload in `tests/zh-minimal-template.test.mjs` (the seven titles above), and
- the modes' own wording (e.g. 專業摘要 in `modes/zh-TW/oferta.md`),

plus the everyday synonyms of each. Section titles here come from a user-supplied `sections` override rather than from `DEFAULT_SECTION_TITLES`, so they have no single canonical spelling — which is exactly why an alias table is the right place for them.

Both scripts are listed against every key because a CV written in either renders through this one table. Note these are genuine cross-strait pairs, not character conversion: Traditional CVs say 專案 where Simplified ones say 项目, and 專業證照 pairs with 专业证书.

`foldDiacritics()` is a no-op on Han characters — NFD leaves them undecomposed and there are no combining marks to strip — so the entries survive the fold unchanged. The tests assert that rather than assume it.

No User Layer file is touched: only `generate-pdf.mjs` and tests.

## Tests

Following the shape the Polish entries already use:

- `test-all.mjs` §7e — alias presence in both scripts, `sectionKey()` spellings, and the guard rejecting a Traditional CV with Education hoisted above 工作經歷 while accepting a Simplified CV in `cv.md` order.
- `tests/cv-section-order.test.mjs` — end-to-end for both scripts against the same English `cv.md` (the source of truth in every mode): a scrambled Chinese CV is rejected by the guard, `cv.sections` then permutes it (the document is no longer byte-identical — the observable symptom of the no-op disappearing — every section body survives exactly once, and the "matched no section" warning is gone), and the guard accepts the result. Plus every title the shipped zh-minimal fixture renders, and an explicit assertion that the NFD fold does not disturb Han characters.

`node test-all.mjs --quick`: 8108 passed, 0 failed. The 14 warnings are the pre-existing ones on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Chinese CVs can now use `cv.sections` to reorder sections.

`generate-pdf.mjs:241` adds 56 Traditional and Simplified Chinese aliases for all nine canonical section keys. The aliases match headings used by the `zh-TW` and `zh` modes.

This fixes the previous silent no-op when Chinese section names matched fewer than two aliases. Section-order validation continues to detect incorrect order and now works with configured reordering.

## Tests

Coverage now includes Chinese alias presence, `sectionKey` resolution, section reordering, order validation, fixture titles, warning behavior, body preservation, and Han-character preservation during diacritic folding.

The quick test suite passes with 8,108 tests.

## Files changed

: `generate-pdf.mjs`
: `test-all.mjs`
: `tests/cv-section-order.test.mjs`

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->