### PR TITLE
fix(discover-ats): a refused redirect is an answer, not a status to re-run

### DIFF
--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -568,6 +568,7 @@ export async function resolveWorkday(company, coords, ctx) {
   const tried = [];
   let emptyUrl = null;
   let lastError;
+  let lastRefusedRedirect = false;
 
   for (const candidate of candidates) {
     tried.push(candidate.careers_url);
@@ -593,11 +594,22 @@ export async function resolveWorkday(company, coords, ctx) {
       if (!emptyUrl) emptyUrl = candidate.careers_url;
     } catch (err) {
       lastError = err?.message || String(err);
+      // The file's second `.fetch(` site, and workday.mjs passes
+      // redirect:'error' too — so a Workday host that redirects arrives here as
+      // the same bare "fetch failed" probeVendor used to report. Keeping the
+      // cause costs nothing and stops the two error paths from describing the
+      // same failure differently (#3788).
+      if (isRefusedRedirectError(err)) {
+        lastError = `${lastError} (${err.cause.message})`;
+        lastRefusedRedirect = true;
+      } else {
+        lastRefusedRedirect = false;
+      }
     }
   }
   return emptyUrl
     ? { status: 'empty', tried, careers_url: emptyUrl }
-    : { status: 'error', tried, detail: lastError };
+    : { status: 'error', tried, detail: lastError, refusedRedirect: lastRefusedRedirect };
 }
 
 /**
@@ -650,7 +662,15 @@ export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, inc
       // Use the host resolveWorkday actually confirmed empty, not always wd1.
       emptyBoards.push({ vendor: 'workday', careers_url: wd.careers_url });
     } else if (wd.detail) {
-      errors.push({ vendor: 'workday', error: wd.detail });
+      /** @type {any} */
+      const wdEntry = { vendor: 'workday', error: wd.detail };
+      // Carried so errors[] describes a Workday refusal the same way it
+      // describes a BambooHR one. It cannot reach the reason ladder — the
+      // refused-redirect branch is guarded by !coords and a Workday probe only
+      // runs WITH coords — but a machine reading errors[] should not have to
+      // know that (#3788).
+      if (wd.refusedRedirect) wdEntry.refusedRedirect = true;
+      errors.push(wdEntry);
     }
   }
 

--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -37,7 +37,7 @@ import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { renameSyncWithRetry } from './tracker-utils.mjs';
 
-import { makeHttpCtx } from './providers/_http.mjs';
+import { makeHttpCtx, isRefusedRedirectError } from './providers/_http.mjs';
 import greenhouse from './providers/greenhouse.mjs';
 import ashby from './providers/ashby.mjs';
 import lever from './providers/lever.mjs';
@@ -522,6 +522,18 @@ export async function probeVendor(company, candidate, ctx) {
     // what lets the caller tell a definitive 404 from a transient 5xx instead of
     // re-parsing the message text (#2883).
     if (Number.isInteger(err?.status)) out.httpStatus = err.status;
+    // A refused redirect has no status at all: it is a bare `TypeError: fetch
+    // failed`, and the vendor's actual answer lives one level down in
+    // err.cause. Recording only err.message discarded that answer, so a
+    // BambooHR tenant that does not exist — answered with `302 →
+    // www.bamboohr.com`, not a 404 — reached the user as the single word
+    // "fetch failed" under advice to re-run it. Same reasoning as the
+    // httpStatus line above: keep the discriminator on the object rather than
+    // re-parsing prose downstream (#3788).
+    if (isRefusedRedirectError(err)) {
+      out.refusedRedirect = true;
+      out.error = `${out.error} (${err.cause.message})`;
+    }
     return out;
   }
 }
@@ -621,6 +633,7 @@ export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, inc
       /** @type {any} */
       const entry = { vendor: candidate.vendor, error: result.error };
       if (Number.isInteger(result.httpStatus)) entry.httpStatus = result.httpStatus;
+      if (result.refusedRedirect) entry.refusedRedirect = true;
       if (isDefinitiveAbsence(result)) entry.definitive = true;
       errors.push(entry);
     }
@@ -649,36 +662,59 @@ export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, inc
   const workdayHintProvided = includeWorkday
     && (typeof company.workday === 'string' ? !!company.workday.trim()
       : (company.workday && typeof company.workday === 'object'));
+  // A failure is SETTLED when the vendor answered and re-running the identical
+  // probe cannot produce a different answer. Two ways that happens, and they
+  // mean different things:
+  //
+  //   - a definitive 404/410 — the board is not there (#2883);
+  //   - a refused redirect — the vendor pointed us off-tenant, which says "not
+  //     this slug", NOT "no board". BambooHR does not 404 an unknown tenant; it
+  //     answers `302 → www.bamboohr.com`. MaRS Discovery District redirects on
+  //     the derived `mars-discovery-district` and returns three jobs on
+  //     `marsdd`, so calling that absence would be as wrong as calling it
+  //     transient (#3788).
+  //
+  // Both are settled, so neither should advise re-running the same probe; only
+  // the first establishes absence, which is why refusedRedirect gets its own
+  // verdict below instead of joining isDefinitiveAbsence().
+  const isSettled = (e) => isDefinitiveAbsence(e) || e.refusedRedirect === true;
   const reason = emptyBoards.length
     ? 'board(s) found but currently list 0 jobs — re-run later or force-add manually'
     // Every probe errored and nothing was confirmed absent or empty — don't
     // claim "no board found", the status is unknown.
     //
-    // Unless every failure was DEFINITIVE. A 404 from Greenhouse/Ashby/Lever is
+    // Unless every failure was SETTLED. A 404 from Greenhouse/Ashby/Lever is
     // an answer, not a hiccup: the board is not there and re-running will say so
     // again. Advising a retry in that case erased the difference between "this
     // company has no board" and "the network hiccuped", which is exactly the
     // pair a user pruning portals.yml has to tell apart (#2883). One transient
     // failure among them is enough to leave the question open — that vendor
     // never answered, so absence is not established.
-    : (errors.length && !coords && !errors.every(isDefinitiveAbsence))
+    : (errors.length && !coords && !errors.every(isSettled))
       ? 'probe error(s) occurred — board status unknown, see errors[] and re-run'
-      // A hint was given but rejected by parseWorkdayHint (bad chars, missing
-      // tenant/site): tell the user to fix it, not to add one.
-      : (workdayHintProvided && !coords)
-        ? 'Workday hint given but rejected (invalid/missing tenant or site) — check the `workday` field and re-run'
-        : coords
-          ? 'Workday coordinates given but no live board with open jobs found at the probed host(s).'
-          // Nothing was probeable: every vendor's own contract rejected this
-          // slug's shape, so no board was ruled out — say that, rather than
-          // implying we looked and found nothing.
-          : (!candidates.length && unsupported.length)
-            ? `slug "${company.slug || deriveSlug(company.name)}" is not a valid board slug for any probed vendor `
-              + `(${unsupported.join(', ')}) — nothing was probed; fix the \`slug\` field and re-run.`
-            // VENDOR_ORDER covers eleven vendors now, so name none of them here.
-            : 'no supported ATS board found. If this company uses Workday, add a hint — '
-              + 'a full careers URL (workday: https://<tenant>.wd<N>.myworkdayjobs.com/<site>) or '
-              + 'workday: {tenant, site} — and re-run; discover-ats will confirm and add it.';
+      // Settled, but by a redirect rather than a 404: the actionable fix is the
+      // slug, not a retry and not a Workday hint.
+      : (errors.length && !coords && errors.some((e) => e.refusedRedirect))
+        ? 'vendor(s) redirected off-tenant ('
+          + errors.filter((e) => e.refusedRedirect).map((e) => e.vendor).join(', ')
+          + ') — the slug is wrong, or no board exists under it. The same probe '
+          + 'will redirect again, so set an explicit `slug` and re-run.'
+        // A hint was given but rejected by parseWorkdayHint (bad chars, missing
+        // tenant/site): tell the user to fix it, not to add one.
+        : (workdayHintProvided && !coords)
+          ? 'Workday hint given but rejected (invalid/missing tenant or site) — check the `workday` field and re-run'
+          : coords
+            ? 'Workday coordinates given but no live board with open jobs found at the probed host(s).'
+            // Nothing was probeable: every vendor's own contract rejected this
+            // slug's shape, so no board was ruled out — say that, rather than
+            // implying we looked and found nothing.
+            : (!candidates.length && unsupported.length)
+              ? `slug "${company.slug || deriveSlug(company.name)}" is not a valid board slug for any probed vendor `
+                + `(${unsupported.join(', ')}) — nothing was probed; fix the \`slug\` field and re-run.`
+              // VENDOR_ORDER covers eleven vendors now, so name none of them here.
+              : 'no supported ATS board found. If this company uses Workday, add a hint — '
+                + 'a full careers URL (workday: https://<tenant>.wd<N>.myworkdayjobs.com/<site>) or '
+                + 'workday: {tenant, site} — and re-run; discover-ats will confirm and add it.';
 
   /** @type {any} */
   const unresolved = { name: company.name, triedVendors, reason };

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -181,6 +181,28 @@ export function parseRetryAfterMs(value) {
 }
 
 /**
+ * Whether a failure is a redirect refused by the mandatory SSRF guard —
+ * `redirect:'error'` meeting a 3xx (#1440). It arrives as a bare TypeError
+ * with no `.status`, indistinguishable by shape from a timeout or a DNS
+ * failure, and only `err.cause.message` tells them apart.
+ *
+ * Exported because the verdict has two consumers, not one. isRetryableError()
+ * below needs it to stop retrying; discover-ats.mjs needs it to stop telling a
+ * human to re-run. Before it was shared, those two disagreed about the same
+ * error object: the retry layer called it deterministic while the CLI reported
+ * "board status unknown — re-run", and 48 of one user's 62 companies were
+ * BambooHR answering "no such tenant" with a 302 (#3788).
+ *
+ * @param {any} err
+ * @returns {boolean}
+ */
+export function isRefusedRedirectError(err) {
+  return err?.status === undefined
+    && err instanceof TypeError
+    && err?.cause?.message === REDIRECT_REFUSAL_CAUSE_MESSAGE;
+}
+
+/**
  * Whether a failed request is worth retrying: 429, any 5xx, or a transport
  * error (no status — timeout/abort/DNS). A 4xx other than 429 is the server
  * telling us the request itself is wrong, and retrying it just burns time.
@@ -188,13 +210,13 @@ export function parseRetryAfterMs(value) {
  * A refused redirect (redirect:'error' meeting a 3xx) surfaces as a bare
  * TypeError with no .status — the same shape as a transient network error —
  * but it's deterministic and will never succeed on retry. See
- * REDIRECT_REFUSAL_CAUSE_MESSAGE above for how it's distinguished.
+ * isRefusedRedirectError() above for how it's distinguished.
  */
 export function isRetryableError(err) {
   const status = err?.status;
   if (status === 429) return true;
   if (typeof status === 'number' && status >= 500) return true;
-  if (status === undefined && err instanceof TypeError && err?.cause?.message === REDIRECT_REFUSAL_CAUSE_MESSAGE) return false;
+  if (isRefusedRedirectError(err)) return false;
   return status === undefined; // network error / timeout / abort — no status set
 }
 

--- a/tests/discover-ats.test.mjs
+++ b/tests/discover-ats.test.mjs
@@ -32,6 +32,7 @@ import {
   parseWorkdayHint,
   buildWorkdayCandidates,
   resolveCompany,
+  resolveWorkday,
 } from '../discover-ats.mjs';
 import * as yaml from 'js-yaml';
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
@@ -479,6 +480,76 @@ const redirectPlus503 = await resolveCompany({ name: 'Half Answered Co' },
   });
 ok('refused redirect + 503 → still unknown, the 503 vendor never answered',
   /status unknown/i.test(redirectPlus503.unresolved.reason));
+
+// Guard, the direction that costs a user real time. A DNS failure reaches this
+// code as the SAME bare TypeError with no status; only err.cause distinguishes
+// it. Widening the predicate in providers/_http.mjs to accept any cause leaves
+// every assertion above green while turning a network hiccup into "your slug is
+// wrong" — measured, not hypothetical: that mutation reddens --only _http and
+// leaves --only discover-ats at 149/0. This is the case that closes it.
+const dnsFailureCtx = () => ({
+  fetchJson: async () => {
+    throw Object.assign(new TypeError('fetch failed'), {
+      cause: { message: 'getaddrinfo ENOTFOUND unreachable-co.bamboohr.com' },
+    });
+  },
+  fetchText: async () => { throw new Error('unused'); },
+});
+const dnsFailure = await resolveCompany({ name: 'Unreachable Co' },
+  { vendors: ['bamboohr'], includeWorkday: false, ctx: dnsFailureCtx() });
+ok('DNS-shaped TypeError → still an unknown status',
+  /status unknown/i.test(dnsFailure.unresolved.reason));
+ok('DNS-shaped TypeError → still advises a re-run',
+  /errors\[\] and re-run/i.test(dnsFailure.unresolved.reason));
+ok('DNS-shaped TypeError → not marked as a refused redirect',
+  dnsFailure.unresolved.errors.every(e => e.refusedRedirect !== true));
+ok('DNS-shaped TypeError → the slug is never blamed for a transport failure',
+  !/redirected off-tenant/i.test(dnsFailure.unresolved.reason));
+
+// The refused-redirect branch sits ABOVE the workday-hint branch, so a
+// malformed hint alongside a refusal reports the redirect. That order is
+// deliberate and load-bearing: the redirect is an answer a vendor actually
+// gave, while the hint is a field the user must fix in either case — and main
+// said "status unknown" here, so this is a choice between two new messages
+// rather than a regression. Pinned so reshuffling the ladder has to argue.
+const hintPlusRedirect = await resolveCompany(
+  { name: 'Hinted Co', workday: { tenant: 'a/b', site: 'S' } },
+  { vendors: ['bamboohr'], includeWorkday: true, ctx: refusalCtx() });
+ok('malformed workday hint + refused redirect → the measured answer wins the message',
+  /redirected off-tenant/i.test(hintPlusRedirect.unresolved.reason));
+
+// And a malformed hint on its own is untouched — the guard that the branch
+// above did not swallow the Workday case wholesale.
+const hintOnly = await resolveCompany(
+  { name: 'Hint Only Co', workday: { tenant: 'a/b', site: 'S' } },
+  { vendors: [], includeWorkday: true });
+ok('malformed workday hint alone → still the Workday-hint message',
+  /Workday hint given but rejected/i.test(hintOnly.unresolved.reason));
+
+// resolveWorkday is the file's OTHER .fetch( site, and workday.mjs passes
+// redirect:'error' as well — so the same refusal arrives there and used to be
+// flattened to a bare "fetch failed" while probeVendor's copy kept the cause.
+//
+// Injected through ctx.fetchJson, which is where the provider actually reads:
+// a first attempt passing `{}` and stubbing globalThis.fetch produced
+// detail === "ctx.fetchJson is not a function", i.e. a failing assertion that
+// never reached the refusal path at all.
+{
+  const wdRefusalCtx = {
+    fetchJson: async () => {
+      throw Object.assign(new TypeError('fetch failed'), { cause: { message: 'unexpected redirect' } });
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  const wdCoords = parseWorkdayHint({ name: 'WD Co', workday: { tenant: 'acme', site: 'External' } });
+  const wd = await resolveWorkday({ name: 'WD Co' }, wdCoords, wdRefusalCtx);
+  ok('workday refusal → reaches the refusal path, not a ctx shape error',
+    wd.status === 'error' && /fetch failed/.test(String(wd.detail)));
+  ok('workday refusal → the cause survives into detail',
+    /unexpected redirect/.test(String(wd.detail)));
+  ok('workday refusal → carries the same discriminator as a vendor probe',
+    wd.refusedRedirect === true);
+}
 
 // parseCompanyInput warns on a present-but-wrong-typed workday field (e.g. a number).
 const wrongType = parseCompanyInput('companies:\n  - name: X\n    workday: 42\n', []);

--- a/tests/discover-ats.test.mjs
+++ b/tests/discover-ats.test.mjs
@@ -415,6 +415,71 @@ const mixed = await resolveCompany({ name: 'Mixed Co' },
   { vendors: SLUG_VENDORS, includeWorkday: false, ctx: httpErrorCtx({ gh: 404, ashby: 503, lever: 404 }) });
 ok('mixed 404/503 → still unknown, absence not established', /status unknown/i.test(mixed.unresolved.reason));
 
+// ── Refused redirect: a third answer, neither transient nor absence (#3788) ──
+//
+// Subdomain vendors don't 404 an unknown tenant. BambooHR answers
+// `302 → www.bamboohr.com`, which redirect:'error' (#1440) turns into a bare
+// `TypeError: fetch failed` — the same SHAPE as a timeout, so it was reported
+// as an unknown status with advice to re-run. It is deterministic: the same
+// probe redirects again, forever. providers/_http.mjs already said so for the
+// retry layer; this pins the user-facing half to the same verdict.
+//
+// The cause message is hardcoded, not imported, for the same reason
+// tests/providers/_http.test.mjs hardcodes it: comparing the constant to
+// itself would pin nothing.
+const refusalCtx = () => ({
+  fetchJson: async () => {
+    throw Object.assign(new TypeError('fetch failed'), { cause: { message: 'unexpected redirect' } });
+  },
+  fetchText: async () => { throw new Error('unused'); },
+});
+const redirected = await resolveCompany({ name: 'MaRS Discovery District' },
+  { vendors: ['bamboohr'], includeWorkday: false, ctx: refusalCtx() });
+
+ok('refused redirect → not reported as an unknown status',
+  !/status unknown/i.test(redirected.unresolved.reason));
+ok('refused redirect → no advice to re-run the same probe',
+  !/errors\[\] and re-run/i.test(redirected.unresolved.reason));
+ok('refused redirect → names the slug as the fix',
+  /slug/i.test(redirected.unresolved.reason));
+ok('refused redirect → names the vendor that redirected',
+  /bamboohr/i.test(redirected.unresolved.reason));
+// Not absence: the board may well exist under a different tenant label —
+// mars-discovery-district redirects, marsdd serves jobs. Saying "no supported
+// ATS board found" here would be as wrong as saying "re-run".
+ok('refused redirect → does NOT claim no board was found',
+  !/no .*board found/i.test(redirected.unresolved.reason));
+ok('refused redirect → error entry carries the discriminator',
+  redirected.unresolved.errors.every(e => e.refusedRedirect === true));
+ok('refused redirect → error entry is not marked definitive',
+  redirected.unresolved.errors.every(e => e.definitive !== true));
+// The cause is what says "not this tenant"; keeping only err.message left
+// errors[] reading the single word "fetch failed".
+ok('refused redirect → the dropped cause survives into errors[]',
+  redirected.unresolved.errors.every(e => /unexpected redirect/.test(e.error)));
+
+// Guard, the direction that matters most: a redirect refusal must not swallow
+// a genuinely transient failure alongside it. That vendor never answered, so
+// the status really is unknown and a re-run really is the right advice.
+const redirectPlus503 = await resolveCompany({ name: 'Half Answered Co' },
+  {
+    vendors: ['gh', 'bamboohr'],
+    includeWorkday: false,
+    ctx: {
+      fetchJson: async (url) => {
+        if (/bamboohr/.test(url)) {
+          throw Object.assign(new TypeError('fetch failed'), { cause: { message: 'unexpected redirect' } });
+        }
+        const err = new Error('HTTP 503');
+        err.status = 503;
+        throw err;
+      },
+      fetchText: async () => { throw new Error('unused'); },
+    },
+  });
+ok('refused redirect + 503 → still unknown, the 503 vendor never answered',
+  /status unknown/i.test(redirectPlus503.unresolved.reason));
+
 // parseCompanyInput warns on a present-but-wrong-typed workday field (e.g. a number).
 const wrongType = parseCompanyInput('companies:\n  - name: X\n    workday: 42\n', []);
 ok('wrong-typed workday hint → warning emitted', wrongType.warnings.some(w => /workday/i.test(w)));

--- a/tests/providers/_http.test.mjs
+++ b/tests/providers/_http.test.mjs
@@ -12,7 +12,7 @@ import { pathToFileURL } from 'url';
 
 console.log('\nProvider — _http retry helpers');
 
-const { isRetryableError, fetchJsonWithRetry, fetchResponse } =
+const { isRetryableError, isRefusedRedirectError, fetchJsonWithRetry, fetchResponse } =
   await import(pathToFileURL(join(ROOT, 'providers/_http.mjs')).href);
 
 // isRetryableError() — status-based classification.
@@ -71,6 +71,50 @@ if (isRetryableError(nonTypeErrorLookalike) === true) {
   pass('isRetryableError(non-TypeError with matching cause.message) is true');
 } else {
   fail('isRetryableError(non-TypeError with matching cause.message) should stay retryable');
+}
+
+// isRefusedRedirectError() — the same verdict, now reachable by name so a
+// second consumer (discover-ats.mjs, which reports it to a human) cannot drift
+// from the retry layer's answer. Asserted directly rather than only through
+// isRetryableError: a caller that needs "is this a refused redirect" gets a
+// wrong answer from "is this retryable" for every 4xx, which is not a redirect
+// and is equally non-retryable.
+if (isRefusedRedirectError(redirectRefusal) === true) {
+  pass('isRefusedRedirectError(refused redirect) is true');
+} else {
+  fail('isRefusedRedirectError(refused redirect) should be true');
+}
+
+if (isRefusedRedirectError(nonTypeErrorLookalike) === false) {
+  pass('isRefusedRedirectError(non-TypeError with matching cause.message) is false');
+} else {
+  fail('isRefusedRedirectError(non-TypeError with matching cause.message) should be false');
+}
+
+if (isRefusedRedirectError(oldNodeShape) === false) {
+  pass('isRefusedRedirectError(cause===undefined, old-Node fallback) is false');
+} else {
+  fail('isRefusedRedirectError(cause===undefined) should be false — nothing identifies it');
+}
+
+// The discriminating pair: a 404 is non-retryable but is NOT a refused
+// redirect. Without this, a predicate that simply returned !isRetryableError()
+// would pass every assertion above.
+if (isRefusedRedirectError({ status: 404 }) === false && isRetryableError({ status: 404 }) === false) {
+  pass('isRefusedRedirectError(404) is false while isRetryableError(404) is also false');
+} else {
+  fail('isRefusedRedirectError must not fire on a 404 — non-retryable is a wider set than refused-redirect');
+}
+
+// A plain transport failure (timeout/DNS) has the TypeError shape and no
+// status, and must not be mistaken for a redirect.
+const transportFailure = Object.assign(new TypeError('fetch failed'), {
+  cause: { message: 'getaddrinfo ENOTFOUND example.invalid' },
+});
+if (isRefusedRedirectError(transportFailure) === false) {
+  pass('isRefusedRedirectError(DNS-shaped TypeError) is false');
+} else {
+  fail('isRefusedRedirectError(DNS-shaped TypeError) should be false');
 }
 
 // End-to-end: fetchJsonWithRetry must call ctx.fetchJson exactly once on a


### PR DESCRIPTION
## What does this PR do?

Closes the reproducible half of #3788: `discover-ats.mjs` reported 48 of one user's 62 BambooHR companies as an unknown board status with advice to re-run, when the vendor had in fact answered on the first request.

**BambooHR does not 404 an unknown tenant.** It redirects:

```
mars-discovery-district.bamboohr.com   302 → https://www.bamboohr.com   text/html
definitely-not-a-real-tenant-xyz123    302 → https://www.bamboohr.com   text/html
rocscience.bamboohr.com                200                              application/json
marsdd.bamboohr.com                    200                              application/json
```

`redirect: 'error'` (mandatory, #1440) turns that 302 into a bare `TypeError: fetch failed` — byte-for-byte the shape of a timeout or a DNS failure. The only thing separating them is `err.cause.message === 'unexpected redirect'`, and `probeVendor` kept `err.message` only:

```json
"errors": [ { "vendor": "bamboohr", "error": "fetch failed" } ]
```

With the cause gone, `isDefinitiveAbsence` (404/410 only) classified it as transient, and the user got *"probe error(s) occurred — board status unknown, see errors[] and re-run"*. The same probe redirects again, forever.

### The repo already disagreed with that verdict

`providers/_http.mjs:197` tests for this exact cause string and returns `false` from `isRetryableError`, under a comment that says why:

> it's deterministic and will never succeed on retry

Two files, one error object, opposite conclusions — and the one the user reads was the wrong one. That is the actual defect here; the BambooHR behaviour is just what exposed it.

## The change

- **`providers/_http.mjs`** — export `isRefusedRedirectError()`. The constant and the test were already there; this gives the verdict a second consumer rather than a second copy, and `isRetryableError` now calls it instead of inlining the same three conditions. (Same reasoning as sharing one walker between `npm run lint` and section 1 in #3411: two independent definitions of one predicate are free to re-diverge.)
- **`discover-ats.mjs`** — `probeVendor` keeps the cause (`"fetch failed (unexpected redirect)"`) and sets `refusedRedirect: true`, alongside the existing `httpStatus` discriminator and for the same reason: keep the signal on the object rather than re-parsing prose downstream (#2883).
- **`discover-ats.mjs`** — a refused redirect becomes *settled* (no re-run advice) but **not absence**, with its own reason:

```
MaRS Discovery District: vendor(s) redirected off-tenant (bamboohr) — the slug is
wrong, or no board exists under it. The same probe will redirect again, so set an
explicit `slug` and re-run.
```

`isDefinitiveAbsence` is left alone. A 302 to a marketing page is not the vendor saying "no board" — `mars-discovery-district` redirects while `marsdd` serves three open jobs, so folding this into absence would be as wrong as calling it transient.

## Verification

**Live, before and after, same company:**

```
before:  probe error(s) occurred — board status unknown, see errors[] and re-run
after:   vendor(s) redirected off-tenant (bamboohr) — … set an explicit `slug` and re-run
```

Then following the new advice:

```
Company                 Vendor      Jobs   Board
MaRS Discovery Distric  bamboohr    3      https://marsdd.bamboohr.com
```

The advice the tool now gives, followed literally, turns an unresolved company into three open jobs.

**Suites:** `--only discover-ats` 149 passed / 0 failed; `--only _http` 16 passed / 0 failed. Full `test-all.mjs` 8069 passed / 5 failed — the same 5 as a pristine checkout of this branch's base (8055 passed / 5 failed), all from this being a fresh worktree without `node_modules` (`linkRepoPackage: js-yaml is not installed`), none from this change.

**Mutation, each with proof it applied:**

| mutation | applied | result |
| --- | --- | --- |
| drop the cause enrichment in `probeVendor` | grep 1 → 0 | ❌ `the dropped cause survives into errors[]` |
| revert the guard to `isDefinitiveAbsence` (pre-fix behaviour) | `every(isSettled)` 1 → 0 | ❌ 4 assertions |
| let a refused redirect count as definitive absence | 2 occurrences | ❌ `error entry is not marked definitive` |
| drop the cause check from the predicate, keep the TypeError shape | 1 occurrence | ❌ 3 assertions, including the pre-existing old-Node fallback |

The last one is the one I care about: a predicate that trusted the `TypeError` shape alone would pass every other assertion, and a DNS failure would start reporting as a wrong slug. `isRefusedRedirectError({ status: 404 })` is asserted `false` next to `isRetryableError({ status: 404 })` being `false` too, so a predicate defined as "not retryable" also fails.

## What this does NOT do

The `UV_HANDLE_CLOSING` assertion in #3788's title is untouched. I could not reproduce it in 27 runs across Node 22.22.0, 25.5.0 (the reporter's exact version) and 25.9.0 on Windows 11, at both their two-company scale and 62 companies — including a batch where 61 probes really were refused redirects rather than DNS misses, which I checked. Measurements and the one repo-side trigger I did find (`process.exit(0)` firing with a live `TCPSocketWrap`, at a cost of 1 ms to remove) are in [my comment on the issue](https://github.com/career-ops-hq/career-ops/issues/3788#issuecomment-5534113765). That half needs the reporter's environment, so it stays a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refused redirects now count as settled vendor responses.
- BambooHR and Workday redirect errors preserve their causes and set `refusedRedirect`.
- Discovery reports when a vendor redirects off-tenant.
- Discovery advises users to set an explicit slug.
- DNS failures remain transient and retain re-run guidance.
- Definitive `404` and `410` responses remain separate from refused redirects.

## User impact

Users can identify off-tenant vendor redirects and configure an explicit slug. Refused redirects no longer appear as generic `fetch failed` errors or as definitive slug absence.

## Files changed

- `discover-ats.mjs`: Classifies refused redirects, preserves redirect causes, and produces slug-focused results.
- `providers/_http.mjs`: Adds and exports `isRefusedRedirectError()`. HTTP retry logic reuses this predicate.
- `tests/discover-ats.test.mjs`: Covers redirect, DNS, transient, Workday, and definitive absence cases.
- `tests/providers/_http.test.mjs`: Covers redirect detection and retry behavior.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->