### PR TITLE
fix(update-system): make apply() verify the target it is about to install

### DIFF
--- a/tests/updater-apply-target-verification.test.mjs
+++ b/tests/updater-apply-target-verification.test.mjs
@@ -34,6 +34,7 @@ import { pass, fail } from './helpers.mjs';
 import {
   gitIn, pinRefToCommit, versionAtRef, downgradeRefusal,
   isComparableVersion, targetIdentityRefusal, refusalMessage,
+  authoritativeShaFromRefBody,
 } from '../update-system.mjs';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -308,6 +309,84 @@ console.log('\n🧪 Testing that apply() verifies its update target (#3052)...')
   }
 
   rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}
+
+// ── 2c-bis. a ref-API body that parses but says nothing must not be quoted ──
+// The authoritative SHA is a string the far side chose. A body can parse as JSON
+// and still carry no commit — a proxied error page, a truncated response, a
+// captive portal. Before the shape check, `object.sha` went to
+// targetIdentityRefusal() verbatim; git cannot resolve it, throws, and the catch
+// reports "does not descend from upstream main". That is a claim about the
+// TARGET made on the strength of a value that described nothing, and it sends
+// the user to look at a tree that was never actually examined. The truthful
+// outcome is the no-claim one that offline and rate-limited runs already take.
+{
+  const bodies = [
+    ['not-a-sha', 'a plain non-SHA string'],
+    ['<html><body>403 Forbidden</body></html>', 'an HTML error page in the sha field'],
+    ['abc123', 'a short hex string that is not a full object name'],
+    ['0'.repeat(39), 'a 39-hex near-miss'],
+    ['0'.repeat(41), 'a 41-hex near-miss'],
+    ['A'.repeat(40), 'uppercase hex, which is not what git rev-parse emits'],
+    ['  ', 'whitespace'],
+  ];
+
+  const leaked = bodies.filter(
+    ([sha]) => authoritativeShaFromRefBody(JSON.stringify({ object: { sha } })) !== '',
+  );
+  if (leaked.length === 0) {
+    pass(`every ref-API body carrying a non-SHA reads as "no answer" (${bodies.length} shapes)`);
+  } else {
+    fail(`non-SHA object.sha values survived the shape check: ${leaked.map(([s]) => JSON.stringify(s)).join(', ')}`);
+  }
+
+  // The two properties the fix is actually for, asserted end to end through the
+  // consumer: the verdict is the no-claim one, and git is never reached at all —
+  // so the guard is proven to stop the value BEFORE merge-base sees it, rather
+  // than rewording a refusal after the fact.
+  const calls = [];
+  const spy = { git: (...args) => { calls.push(args); throw new Error('git should never have been called'); } };
+  const target = 'a'.repeat(40);
+  const parsedButUseless = authoritativeShaFromRefBody(JSON.stringify({ object: { sha: 'not-a-sha' } }));
+  const verdict = targetIdentityRefusal(target, parsedButUseless, spy);
+
+  if (verdict === null) {
+    pass('a body that parses but carries no commit yields no identity verdict, not a false "does not descend"');
+  } else {
+    fail(`a non-SHA authoritative value produced a verdict about the target: ${JSON.stringify(verdict)}`);
+  }
+  if (calls.length === 0) {
+    pass('merge-base is never invoked for a non-SHA authoritative value');
+  } else {
+    fail(`git was called with an unresolvable value: ${JSON.stringify(calls)}`);
+  }
+
+  // The regression this replaces, stated as the control: feeding the RAW field
+  // (what the code did before the shape check) does reach merge-base and does
+  // produce the untrue sentence. Without this, the two assertions above would
+  // still pass if the whole identity guard were deleted.
+  const rawCalls = [];
+  const rawSpy = { git: (...args) => { rawCalls.push(args); throw new Error('fatal: Not a valid object name'); } };
+  const rawVerdict = targetIdentityRefusal(target, 'not-a-sha', rawSpy);
+  if (rawCalls.length === 1 && /does not descend from upstream main/.test(rawVerdict || '')) {
+    pass('control: the unchecked value would have reached merge-base and produced the untrue refusal');
+  } else {
+    fail(`control failed: the pre-fix path no longer misbehaves (calls=${rawCalls.length}, verdict=${JSON.stringify(rawVerdict)})`);
+  }
+
+  // Filter, not blanket rejection: a real ref-API body still yields its commit,
+  // and a body that does not parse at all keeps its existing '' answer.
+  const real = 'd'.repeat(40);
+  if (authoritativeShaFromRefBody(JSON.stringify({ object: { sha: real, type: 'commit' } })) === real) {
+    pass('control: a genuine ref-API body still yields its commit SHA');
+  } else {
+    fail('the shape check rejects a legitimate ref-API body');
+  }
+  if (authoritativeShaFromRefBody('<html>502</html>') === '' && authoritativeShaFromRefBody('{}') === '') {
+    pass("an unparseable body and a body with no object still read as '' (unchanged)");
+  } else {
+    fail('the malformed-body path regressed');
+  }
 }
 
 // ── 2d. refusalMessage tells the truth about what is on disk ──

--- a/tests/updater-apply-target-verification.test.mjs
+++ b/tests/updater-apply-target-verification.test.mjs
@@ -1,0 +1,412 @@
+/**
+ * updater-apply-target-verification.test.mjs — apply() must verify its target (#3052).
+ *
+ * Two structural gaps in `update-system.mjs apply()`, both readable straight
+ * off the code before this change:
+ *
+ *   1. apply() never compared versions. `compareVersions()` has exactly two
+ *      call sites and both live inside `check()`, which only decides whether to
+ *      NOTIFY. The install path checked out whatever the fetch produced and
+ *      printed "Update complete: vX → vY" regardless of which direction the
+ *      version moved. `downgradeRefusal()` is the pure predicate apply() now
+ *      consults before it writes anything.
+ *
+ *   2. apply() re-read `FETCH_HEAD` more than a dozen times. It is a pseudo-ref,
+ *      re-resolved on every read, so the bootstrap checkout, the manifest read,
+ *      the per-path checkout loop, the stale-file prune, the .gitignore
+ *      reconciliation and the staging expansion were a dozen independent
+ *      questions about a ref free to move between them. `pinRefToCommit()`
+ *      resolves it once to an immutable SHA that the rest of the run addresses.
+ *
+ * Same shape as updater-upgrade-safety.test.mjs: the pure exports are driven
+ * against a throwaway git repo through the ctx git seam — no network, no
+ * apply() call. apply() itself is not exported, so the two properties that only
+ * exist in its body (no unpinned ref reads; the guard runs before the first
+ * write) are asserted against its source text.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { pass, fail } from './helpers.mjs';
+import {
+  gitIn, pinRefToCommit, versionAtRef, downgradeRefusal,
+  isComparableVersion, targetIdentityRefusal, refusalMessage,
+} from '../update-system.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function makeRepo(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'core.autocrlf', 'false');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  // A second runner with stderr piped, for the calls whose git failure is the
+  // expected outcome — gitIn inherits stderr, so those would print git's own
+  // `fatal:` line into an otherwise passing suite.
+  const quiet = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  return { dir, g, ctx: { git: g }, quietCtx: { git: quiet } };
+}
+
+function writeFixture(dir, rel, text) {
+  const abs = join(dir, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, text, 'utf-8');
+}
+
+// A real FETCH_HEAD, written the way `git fetch` writes it, so rev-parse
+// resolves it exactly as it would after a fetch from the canonical repo.
+function setFetchHead(dir, sha) {
+  writeFileSync(join(dir, '.git', 'FETCH_HEAD'), `${sha}\t\tbranch 'main' of https://example.invalid/repo\n`, 'utf-8');
+}
+
+console.log('\n🧪 Testing that apply() verifies its update target (#3052)...');
+
+// ── 1. pinRefToCommit: one apply run addresses one immutable commit ──
+{
+  const { dir, g, ctx, quietCtx } = makeRepo('co-3052-pin-');
+
+  writeFixture(dir, 'VERSION', '2.0.0\n');
+  writeFixture(dir, 'update-system.mjs', '// v2\n');
+  g('add', '-A');
+  g('commit', '-qm', 'v2');
+  const older = g('rev-parse', 'HEAD');
+
+  writeFixture(dir, 'VERSION', '2.1.0\n');
+  writeFixture(dir, 'update-system.mjs', '// v2.1\n');
+  g('add', '-A');
+  g('commit', '-qm', 'v2.1');
+  const newer = g('rev-parse', 'HEAD');
+
+  setFetchHead(dir, newer);
+  const pinned = pinRefToCommit('FETCH_HEAD', ctx);
+
+  if (pinned === newer) {
+    pass('pinRefToCommit resolves FETCH_HEAD to the commit SHA it names');
+  } else {
+    fail(`pinRefToCommit returned ${pinned}, expected ${newer}`);
+  }
+  if (/^[0-9a-f]{40}$/.test(pinned)) {
+    pass('the pin is a full 40-hex SHA, not a name that can be re-resolved');
+  } else {
+    fail(`pin is not an immutable SHA: ${JSON.stringify(pinned)}`);
+  }
+
+  // The TOCTOU property: move FETCH_HEAD the way a concurrent fetch (or a
+  // ref that auto-follows something else) would, and the pinned SHA must still
+  // name the tree the run started with. This is what the dozen unpinned reads
+  // inside apply() could not promise.
+  setFetchHead(dir, older);
+  const afterMove = gitIn(dir, 'show', `${pinned}:update-system.mjs`);
+  const unpinnedAfterMove = gitIn(dir, 'show', 'FETCH_HEAD:update-system.mjs');
+  if (afterMove.includes('v2.1')) {
+    pass('a read through the pinned SHA still sees the original tree after FETCH_HEAD moves');
+  } else {
+    fail(`pinned read followed the moving ref (got: ${JSON.stringify(afterMove)})`);
+  }
+  if (unpinnedAfterMove.includes('v2') && !unpinnedAfterMove.includes('v2.1')) {
+    pass('control: the same read through FETCH_HEAD does follow the move (so the pin is load-bearing)');
+  } else {
+    fail(`control failed: FETCH_HEAD did not move (got: ${JSON.stringify(unpinnedAfterMove)})`);
+  }
+
+  let threw = false;
+  try { pinRefToCommit('refs/heads/does-not-exist', quietCtx); } catch { threw = true; }
+  if (threw) {
+    pass('an unresolvable ref throws instead of yielding an unusable "pin"');
+  } else {
+    fail('pinRefToCommit accepted a ref that resolves to nothing');
+  }
+
+  // versionAtRef reads VERSION from the pinned commit, not from disk.
+  if (versionAtRef(pinned, ctx) === '2.1.0' && versionAtRef(older, ctx) === '2.0.0') {
+    pass('versionAtRef reads the VERSION each commit ships');
+  } else {
+    fail(`versionAtRef misread the target VERSION (got ${versionAtRef(pinned, ctx)} / ${versionAtRef(older, ctx)})`);
+  }
+
+  // release-please marker must not break parsing, and a commit without VERSION
+  // must report '' rather than throwing — the guard turns that into a refusal.
+  writeFixture(dir, 'VERSION', '2.2.0 # x-release-please-version\n');
+  g('add', '-A');
+  g('commit', '-qm', 'marker');
+  if (versionAtRef(g('rev-parse', 'HEAD'), ctx) === '2.2.0') {
+    pass('versionAtRef strips the release-please marker');
+  } else {
+    fail('versionAtRef did not strip the release-please marker');
+  }
+
+  const { dir: bare, g: bg, quietCtx: bctx } = makeRepo('co-3052-noversion-');
+  writeFixture(bare, 'README.md', 'no VERSION here\n');
+  bg('add', '-A');
+  bg('commit', '-qm', 'no version');
+  if (versionAtRef(bg('rev-parse', 'HEAD'), bctx) === '') {
+    pass("versionAtRef returns '' for a target that ships no VERSION (never throws)");
+  } else {
+    fail('versionAtRef did not report a missing VERSION as empty');
+  }
+
+  rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  rmSync(bare, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}
+
+// ── 2. downgradeRefusal: the comparison apply() never made ──
+{
+  const older = downgradeRefusal('1.24.0', '1.22.0');
+  if (older && older.includes('1.22.0') && older.includes('1.24.0') && /older than installed/.test(older)) {
+    pass('an older target is refused, and the reason names both versions');
+  } else {
+    fail(`an older target was not refused with a usable reason (got: ${JSON.stringify(older)})`);
+  }
+
+  if (downgradeRefusal('1.24.0', '1.25.0') === null) {
+    pass('a newer target is allowed');
+  } else {
+    fail('a newer target was refused');
+  }
+  if (downgradeRefusal('1.24.0', '1.24.0') === null) {
+    pass('re-applying the same version is allowed (the #1998 repair path)');
+  } else {
+    fail('a same-version re-apply was refused');
+  }
+  // Patch- and minor-level downgrades are the ones a moving ref produces; a
+  // guard that only caught major regressions would miss the realistic case.
+  if (downgradeRefusal('1.24.3', '1.24.2') && downgradeRefusal('2.0.0', '1.99.99')) {
+    pass('patch- and major-level downgrades are both refused');
+  } else {
+    fail('a patch- or major-level downgrade slipped through');
+  }
+
+  // Fail closed: an unreadable target VERSION is not evidence of a newer target.
+  if (downgradeRefusal('1.24.0', '')) {
+    pass('a target whose VERSION cannot be read is refused, not assumed benign');
+  } else {
+    fail('an unverifiable target was allowed (guard fails open)');
+  }
+}
+
+// ── 2b. downgradeRefusal must not be fooled by a version it cannot parse ──
+// compareVersions() is the NOTIFY helper: Number() with `|| 0` and a loop that
+// stops at three components. Every string below therefore compares as "at least
+// as new as installed" while having been understood by nobody. Deciding to
+// overwrite an installation on that basis is failing open.
+{
+  const installed = '1.32.0';
+  const unparseable = [
+    ['999.bad.0', 'a non-numeric component coerced to 0'],
+    ['999.0.0-rc', 'a prerelease suffix silently dropped'],
+    ['1.32.0.1', 'a fourth component never compared'],
+    ['v1.33.0', 'a leading v the comparison cannot read'],
+    ['1.32', 'a two-component version'],
+  ];
+  const leaked = unparseable.filter(([v]) => downgradeRefusal(installed, v) === null);
+  if (leaked.length === 0) {
+    pass(`every unparseable target VERSION is refused (${unparseable.length} shapes)`);
+  } else {
+    fail(`unparseable target VERSION(s) accepted: ${leaked.map(([v]) => v).join(', ')}`);
+  }
+
+  // The reason has to name the shape, or the user cannot tell this refusal from
+  // a genuine downgrade and will "fix" the wrong thing.
+  const reason = downgradeRefusal(installed, '999.bad.0') || '';
+  if (/not a comparable/.test(reason) && reason.includes('999.bad.0')) {
+    pass('the refusal says the target VERSION is unparseable, not that it is older');
+  } else {
+    fail(`unhelpful refusal reason: ${JSON.stringify(reason)}`);
+  }
+
+  // Same argument on the installed side: a direction computed from a string
+  // nobody could parse is not a direction.
+  if (downgradeRefusal('1.32.0.1', '1.33.0')) {
+    pass('an unparseable INSTALLED version is refused too, not compared as 1.32.0');
+  } else {
+    fail('an unparseable installed version was compared anyway');
+  }
+
+  // Control: the shapes career-ops actually ships stay allowed, so the
+  // validator is a filter and not a blanket refusal.
+  if (isComparableVersion('1.32.0') && downgradeRefusal('1.32.0', '1.33.0') === null) {
+    pass('control: a real release version is still accepted');
+  } else {
+    fail('the shape check rejects a legitimate version');
+  }
+}
+
+// ── 2c. targetIdentityRefusal: the target must BE upstream main ──
+// #3052's expected-behaviour item 1, and the axis the version guard cannot
+// cover: an older auto-followed tag, or any side branch, can ship a VERSION at
+// or above the installed one and pass the downgrade check untouched.
+{
+  const { dir, g, ctx, quietCtx } = makeRepo('co-3052-identity-');
+
+  writeFixture(dir, 'VERSION', '1.32.0\n');
+  g('add', '-A'); g('commit', '-qm', 'base');
+  const base = g('rev-parse', 'HEAD');
+
+  writeFixture(dir, 'VERSION', '1.33.0\n');
+  g('add', '-A'); g('commit', '-qm', 'main advances');
+  const advanced = g('rev-parse', 'HEAD');
+
+  // A tag on an OLDER commit that ships a VERSION the downgrade guard is happy
+  // with — the shape of the rogue target the version check alone lets through.
+  g('checkout', '-q', '-b', 'side', base);
+  writeFixture(dir, 'VERSION', '9.9.9\n');
+  g('add', '-A'); g('commit', '-qm', 'rogue 9.9.9');
+  const rogue = g('rev-parse', 'HEAD');
+  g('checkout', '-q', 'main');
+
+  if (targetIdentityRefusal(advanced, advanced, ctx) === null) {
+    pass('the target that IS the authoritative commit is accepted');
+  } else {
+    fail('an exact match with upstream main was refused');
+  }
+
+  // main moved between the API read and the fetch: the fetched tip descends
+  // from the authoritative commit and is still the requested branch.
+  if (targetIdentityRefusal(advanced, base, ctx) === null) {
+    pass('a target that descends from the authoritative commit is accepted (main advanced mid-run)');
+  } else {
+    fail('a legitimate newer tip of main was refused');
+  }
+
+  // The #3052 shape: authoritative main is AHEAD of the target, so the target
+  // is a stale or foreign tree no matter what VERSION it ships.
+  const rogueRefusal = targetIdentityRefusal(rogue, advanced, quietCtx);
+  if (rogueRefusal && rogueRefusal.includes(rogue.slice(0, 12))) {
+    pass('a target upstream main does not descend into is refused, VERSION notwithstanding');
+  } else {
+    fail(`the rogue target was accepted (got: ${JSON.stringify(rogueRefusal)})`);
+  }
+  // Two-sided: that same rogue target sails through the version guard, which is
+  // precisely why the identity check has to exist.
+  if (downgradeRefusal('1.32.0', versionAtRef(rogue, ctx)) === null) {
+    pass('control: the downgrade guard alone would have installed the rogue target');
+  } else {
+    fail('control failed: the rogue target was expected to pass the version guard');
+  }
+
+  // A commit the local object store has never heard of cannot be vouched for.
+  const unknown = '0'.repeat(40);
+  if (targetIdentityRefusal(advanced, unknown, quietCtx)) {
+    pass('an authoritative SHA absent from the object store is a refusal, not a pass');
+  } else {
+    fail('an unresolvable authoritative SHA was treated as agreement');
+  }
+
+  // No authoritative answer is not a claim about any commit. It must not
+  // manufacture a refusal either: a GitHub rate limit is not a rogue target.
+  let calls = 0;
+  const spy = { git: () => { calls++; throw new Error('unexpected git call'); } };
+  if (targetIdentityRefusal(advanced, '', spy) === null && calls === 0) {
+    pass('an unavailable authoritative SHA yields no verdict, and costs no git call');
+  } else {
+    fail(`an empty authoritative SHA produced a verdict (calls=${calls})`);
+  }
+
+  rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}
+
+// ── 2d. refusalMessage tells the truth about what is on disk ──
+// The parent refuses before its first write. The child refuses AFTER the parent
+// checked the self-bootstrap closure out from the very target being refused, so
+// the parent's "No system files were changed" is false there.
+{
+  const parent = refusalMessage('a'.repeat(40), 'reason here', false);
+  const child = refusalMessage('a'.repeat(40), 'reason here', true);
+  if (/No system files were changed/.test(parent)) {
+    pass('the parent refusal says no system files were changed');
+  } else {
+    fail('the parent refusal lost its no-files-changed statement');
+  }
+  if (!/No system files were changed/.test(child) && /self-bootstrap files/.test(child)) {
+    pass('the re-exec refusal does not claim an untouched tree, and names what was written');
+  } else {
+    fail(`the re-exec refusal still claims nothing was changed: ${JSON.stringify(child)}`);
+  }
+  if (parent.includes('aaaaaaaaaaaa') && parent.includes('reason here')) {
+    pass('the refusal names the target and the reason');
+  } else {
+    fail('the refusal dropped the target SHA or the reason');
+  }
+}
+
+// ── 3. apply()'s body: no unpinned ref reads, and the guard precedes the writes ──
+// apply() is not exported, so these two properties can only be asserted against
+// its source. They are the regressions most likely to creep back: a new step
+// added to apply() that reaches for the pseudo-ref again, or a guard that drifts
+// below the first checkout and therefore stops being fail-closed.
+{
+  const source = readFileSync(join(REPO_ROOT, 'update-system.mjs'), 'utf-8');
+  const start = source.indexOf('async function apply() {');
+  const end = source.indexOf('\nfunction rollback(', start);
+  if (start === -1 || end === -1) {
+    fail('could not locate apply() in update-system.mjs — update this test');
+  } else {
+    // Blank out comments and string bodies are kept: FETCH_HEAD only matters as
+    // real code, and a comment mentioning it is not a read.
+    const body = source.slice(start, end)
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n').filter((line) => !/^\s*\/\//.test(line)).join('\n');
+
+    const reads = body.match(/FETCH_HEAD/g) || [];
+    const pinned = body.match(/pinRefToCommit\('FETCH_HEAD'\)/g) || [];
+    if (reads.length > 0 && reads.length === pinned.length) {
+      pass(`every FETCH_HEAD read in apply() goes through pinRefToCommit (${pinned.length})`);
+    } else {
+      fail(`apply() reads FETCH_HEAD outside the pin: ${reads.length} occurrence(s), ${pinned.length} pinned`);
+    }
+
+    const firstWrite = Math.min(
+      ...[/git\('checkout'/, /gitQuiet\('checkout'/, /unlinkSync\(/, /writeGitignoreAtomic\(/]
+        .map((re) => { const m = body.match(re); return m ? body.indexOf(m[0]) : Infinity; }),
+    );
+
+    // Presence and ordering are not enough. `downgradeRefusal(...)` can appear
+    // in the right place and still decide nothing: `if (false && refusal)`
+    // keeps every assertion in this file green while the guard is inert. Pin
+    // the whole statement — the operand it reads, the condition, and the throw.
+    const guardShape = /const targetVersion = versionAtRef\(targetRef\);\s*\n\s*const refusal = downgradeRefusal\(local, targetVersion\);\s*\n\s*if \(refusal\) \{\s*\n\s*throw new Error\(refusalMessage\(targetRef, refusal, isReexec\)\);\s*\n\s*\}/;
+    const guardMatch = body.match(guardShape);
+    if (guardMatch && body.indexOf(guardMatch[0]) < firstWrite) {
+      pass('the version guard reads the PINNED target, throws on refusal, and runs before the first write');
+    } else {
+      fail(`the version guard is missing, reads the wrong ref, or does not abort (matched=${Boolean(guardMatch)}, write @${firstWrite})`);
+    }
+
+    // `versionAtRef('HEAD')` compares the installed tree with itself and always
+    // returns null. It is the mutant that survives every behavioural test here,
+    // because apply() is not callable from a test, so pin it explicitly.
+    const versionReads = body.match(/versionAtRef\([^)]*\)/g) || [];
+    if (versionReads.length === 1 && versionReads[0] === 'versionAtRef(targetRef)') {
+      pass('apply() reads the target VERSION only from the pinned target');
+    } else {
+      fail(`apply() reads versionAtRef with the wrong argument: ${JSON.stringify(versionReads)}`);
+    }
+
+    // Identity is a separate axis from direction, and must also precede writes.
+    const identityShape = /const identity = targetIdentityRefusal\(targetRef,\s*authoritativeCommit\);\s*\n\s*if \(identity\) throw new Error\(/;
+    const identityMatch = body.match(identityShape);
+    if (identityMatch && body.indexOf(identityMatch[0]) < firstWrite) {
+      pass('the identity guard consumes the authoritative SHA and aborts before the first write');
+    } else {
+      fail('apply() does not cross-check the pinned target against the authoritative SHA before writing');
+    }
+
+    // The pin must have no fallback. A child that cannot resolve the SHA its
+    // parent verified is already running bootstrap files checked out FROM that
+    // SHA; re-pinning its own FETCH_HEAD there assembles the install from two
+    // trees, which is the mixed state #3052 reports.
+    const pinStart = body.indexOf('const inheritedTarget');
+    const pinEnd = body.indexOf('const targetVersion');
+    const pinRegion = pinStart !== -1 && pinEnd > pinStart ? body.slice(pinStart, pinEnd) : '';
+    if (pinRegion && !/\bcatch\b/.test(pinRegion)) {
+      pass('an unresolvable target ends the run instead of falling back to a second pin');
+    } else {
+      fail('the target pin still has a fallback path (a catch between the pin and the guard)');
+    }
+  }
+}

--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -282,7 +282,7 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
 
   const preservedPaths = ['AGENTS.md'];
   const preservedSet = new Set(preservedPaths);
-  const result = pathFullyPreserved('AGENTS.md', preservedPaths, preservedSet, spyCtx);
+  const result = pathFullyPreserved('AGENTS.md', preservedPaths, preservedSet, 'FETCH_HEAD', spyCtx);
 
   if (result === true && gitCalls === 0) {
     pass('a single-file preserved path is skipped without any upstream lookup');
@@ -299,7 +299,7 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
 
   const preservedPaths = ['AGENTS.md'];
   const preservedSet = new Set(preservedPaths);
-  const result = pathFullyPreserved('modes/pdf.md', preservedPaths, preservedSet, spyCtx);
+  const result = pathFullyPreserved('modes/pdf.md', preservedPaths, preservedSet, 'FETCH_HEAD', spyCtx);
 
   if (result === false && gitCalls === 0) {
     pass('an unrelated path is never skipped, and needs no upstream lookup');
@@ -313,15 +313,16 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
 {
   const repo = makeRepo();
   upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
-  // pathFullyPreserved's ls-tree branch reads FETCH_HEAD, same ref apply()
-  // fetches into for real. Populate it here by fetching the local `upstream`
-  // branch into this repo's own FETCH_HEAD.
+  // pathFullyPreserved's ls-tree branch reads the ref its caller passes. apply()
+  // passes the SHA it pinned FETCH_HEAD to (#3052); pinning is out of scope
+  // here, so drive the branch with the pseudo-ref itself. Populate it by
+  // fetching the local `upstream` branch into this repo's own FETCH_HEAD.
   repo.g('fetch', '.', 'upstream');
   const preservedPaths = ['modes/pdf.md', 'modes/cover.md'];
   const preservedSet = new Set(preservedPaths);
   const ctx = { git: (...args) => gitIn(repo.dir, ...args) };
 
-  const result = pathFullyPreserved('modes/', preservedPaths, preservedSet, ctx);
+  const result = pathFullyPreserved('modes/', preservedPaths, preservedSet, 'FETCH_HEAD', ctx);
   if (result === true) {
     pass('a directory whose entire upstream content is preserved is skipped (ls-tree path)');
   } else {
@@ -339,7 +340,7 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
   const preservedSet = new Set(preservedPaths);
   const ctx = { git: (...args) => gitIn(repo.dir, ...args) };
 
-  const result = pathFullyPreserved('modes/', preservedPaths, preservedSet, ctx);
+  const result = pathFullyPreserved('modes/', preservedPaths, preservedSet, 'FETCH_HEAD', ctx);
   if (result === false) {
     pass('a directory only partly preserved is not skipped');
   } else {
@@ -357,7 +358,7 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
   let threw = false;
   let result = null;
   try {
-    result = pathFullyPreserved('modes/', preservedPaths, preservedSet, throwingCtx);
+    result = pathFullyPreserved('modes/', preservedPaths, preservedSet, 'FETCH_HEAD', throwingCtx);
   } catch {
     threw = true;
   }

--- a/tests/updater-self-bootstrap-backup.test.mjs
+++ b/tests/updater-self-bootstrap-backup.test.mjs
@@ -33,9 +33,12 @@ try {
   }
 
   const source = readFileSync(join(root, 'update-system.mjs'), 'utf8');
-  const detectAt = source.indexOf("locallyModifiedSystemFiles(reexecFiles, 'FETCH_HEAD')");
+  // apply() pins FETCH_HEAD to an immutable SHA once per run and addresses that
+  // SHA everywhere afterwards (#3052), so this ordering check follows the pinned
+  // ref rather than the pseudo-ref it replaced.
+  const detectAt = source.indexOf('locallyModifiedSystemFiles(reexecFiles, targetRef)');
   const backUpAt = source.indexOf('backupSystemFiles(bootstrapAtRisk)', detectAt);
-  const checkoutAt = source.indexOf("git('checkout', 'FETCH_HEAD', '--', ...reexecFiles)", detectAt);
+  const checkoutAt = source.indexOf("git('checkout', targetRef, '--', ...reexecFiles)", detectAt);
   if (detectAt !== -1 && backUpAt > detectAt && checkoutAt > backUpAt) {
     pass('apply detects and backs up bootstrap edits before checkout');
   } else {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1971,6 +1971,40 @@ function curlGet(url, extraArgs = []) {
 }
 
 /**
+ * The commit SHA carried by a GitHub ref-API body, or '' when it carries none.
+ *
+ * A body that parses is not a body that answered. `object.sha` is a string the
+ * far side chose, and a captive portal, a proxied error page or a truncated
+ * response can all put something else there. Whatever comes back is handed
+ * straight to `git merge-base --is-ancestor` by targetIdentityRefusal(), which
+ * throws on a value git cannot resolve — and the caller reports that throw as
+ * "does not descend from upstream main". That sentence is a claim about the
+ * TARGET, and it is false: nothing was ever learned about the target, because
+ * the authoritative side never produced a commit to compare it against.
+ *
+ * So the shape is checked here, at the boundary, and anything that is not a
+ * full 40-hex object name becomes '' — the same "no answer available" both
+ * callers already handle for offline and rate-limited runs. That is deliberately
+ * not a refusal: per the second edge documented on targetIdentityRefusal(), a
+ * body nobody could read is no more evidence of a rogue target than a rate limit
+ * is, and the explicit `refs/heads/main` refspec still ties the target to the
+ * branch. apply() prints its "could not be cross-checked" note instead of
+ * asserting something about the target that was never checked.
+ *
+ * @param {string} raw - The raw response body from the GitHub ref API.
+ * @returns {string} A 40-hex commit SHA, or '' when the body carries none.
+ */
+export function authoritativeShaFromRefBody(raw) {
+  let sha;
+  try {
+    sha = String(JSON.parse(raw)?.object?.sha || '').trim();
+  } catch {
+    return ''; // malformed API response
+  }
+  return /^[0-9a-f]{40}$/.test(sha) ? sha : '';
+}
+
+/**
  * The commit GitHub reports for upstream `main`, or '' when it cannot be read.
  *
  * The single source of the authoritative SHA, so check() and apply() cannot
@@ -1986,11 +2020,7 @@ async function upstreamMainCommit() {
     '--header', 'User-Agent: career-ops-update-checker',
   ]);
   if (raw === null) return '';
-  try {
-    return String(JSON.parse(raw)?.object?.sha || '').trim();
-  } catch {
-    return ''; // malformed API response
-  }
+  return authoritativeShaFromRefBody(raw);
 }
 
 async function check() {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -104,6 +104,10 @@ function isLegacyReexec() {
 const CANONICAL_REPO = 'https://github.com/career-ops-hq/career-ops.git';
 const RAW_VERSION_URL = 'https://raw.githubusercontent.com/career-ops-hq/career-ops/main/VERSION';
 const RELEASES_API = 'https://api.github.com/repos/career-ops-hq/career-ops/releases/latest';
+// The one authoritative answer to "what commit is upstream main?". check()
+// has always read it; apply() now reads it too, so the tree it installs is
+// checked against the branch it claims to be installing (#3052).
+const UPSTREAM_MAIN_REF_API = 'https://api.github.com/repos/career-ops-hq/career-ops/git/ref/heads/main';
 
 // Matches a semver, with or without a leading `v` and an optional
 // Release Please component prefix (e.g. `career-ops-v1.9.0` → `1.9.0`).
@@ -692,6 +696,179 @@ function compareVersions(a, b) {
   return 0;
 }
 
+/**
+ * Whether `compareVersions` can actually compare this string.
+ *
+ * `compareVersions` is a NOTIFY-path helper and coerces like one: `Number()`
+ * with `|| 0` turns every unparseable component into zero, and the loop stops
+ * at three components. Both are harmless when the answer only decides whether
+ * to print a banner, and neither is harmless when the answer decides whether to
+ * overwrite the installation. `999.bad.0` compares as `999.0.0`, `999.0.0-rc`
+ * as `999.0.0`, and `1.32.0.1` drops its fourth component entirely — three
+ * strings the guard would read as "at least as new as installed" while having
+ * understood none of them.
+ *
+ * So the guard asks this first. A shape it cannot parse is not evidence about
+ * direction, and apply() treats absence of evidence as a refusal.
+ *
+ * @param {string} version - A VERSION string, already stripped of its marker.
+ * @returns {boolean} True only for exactly three dot-separated integers.
+ */
+export function isComparableVersion(version) {
+  return typeof version === 'string' && /^\d+\.\d+\.\d+$/.test(version);
+}
+
+/**
+ * Pin a moving ref to the immutable commit SHA it names right now.
+ *
+ * `FETCH_HEAD` is a pseudo-ref, not a snapshot: every read re-resolves whatever
+ * the last fetch wrote, and apply() read it more than a dozen times across
+ * bootstrap, checkout, prune, .gitignore reconciliation and staging. Nothing
+ * tied those reads together, so a single apply run had no guarantee that the
+ * tree it inspected was the tree it checked out. Resolving once and passing the
+ * resulting SHA down makes the whole run address one immutable commit.
+ *
+ * @param {string} [ref='FETCH_HEAD'] - Ref to resolve.
+ * @param {{git?: Function}} [ctx] - Test seam; defaults to the ROOT-bound runner.
+ * @returns {string} A 40-hex commit SHA.
+ */
+export function pinRefToCommit(ref = 'FETCH_HEAD', ctx = {}) {
+  // gitQuiet: an unresolvable ref is reported by the throw below, so git's own
+  // "fatal: Needed a single revision" on inherited stderr is duplicate noise.
+  const runGit = ctx.git || gitQuiet;
+  const sha = runGit('rev-parse', '--verify', `${ref}^{commit}`).trim();
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`Could not pin ${ref} to a commit (git rev-parse returned ${JSON.stringify(sha)}).`);
+  }
+  return sha;
+}
+
+/**
+ * The VERSION a ref ships, or '' when the ref carries none.
+ *
+ * @param {string} ref - Any commit-ish.
+ * @param {{git?: Function}} [ctx] - Test seam; defaults to the ROOT-bound runner.
+ * @returns {string} Parsed version string, or '' if unreadable.
+ */
+export function versionAtRef(ref, ctx = {}) {
+  const runGit = ctx.git || gitQuiet;
+  try {
+    return parseVersionFile(runGit('show', `${ref}:VERSION`));
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Why apply() must refuse this target, or null when it may proceed.
+ *
+ * apply() never checked what it was about to install. `compareVersions` exists
+ * and is called twice — both times inside check(), which only decides whether
+ * to NOTIFY. The install path itself checked out whatever the fetch produced,
+ * so any target that turned out to be older than the installed tree was written
+ * over the current system files with no comparison, no warning, and a "Update
+ * complete: vX -> vY" banner where Y < X.
+ *
+ * Fail closed on every input the comparison cannot actually read. An unreadable
+ * target VERSION is not evidence of a newer target, and neither is one whose
+ * shape `compareVersions` only appears to understand: `999.bad.0` coerces to
+ * `999.0.0` and would sail past a guard that compared first and asked
+ * questions never. The installed side is checked for the same reason — a
+ * direction computed from a string nobody could parse is not a direction.
+ * Same-version targets stay allowed: re-applying the current release is a
+ * legitimate repair path (#1998).
+ *
+ * @param {string} installedVersion - VERSION on disk before the update.
+ * @param {string} targetVersion - VERSION shipped by the pinned target ref.
+ * @returns {string|null} Refusal reason, or null when the target is acceptable.
+ */
+export function downgradeRefusal(installedVersion, targetVersion) {
+  if (!targetVersion) {
+    return `could not read VERSION from the update target, refusing to apply an unverifiable target`;
+  }
+  if (!isComparableVersion(targetVersion)) {
+    return `target VERSION ${JSON.stringify(targetVersion)} is not a comparable MAJOR.MINOR.PATCH version, refusing to apply an unverifiable target`;
+  }
+  if (!isComparableVersion(installedVersion)) {
+    return `installed VERSION ${JSON.stringify(installedVersion)} is not a comparable MAJOR.MINOR.PATCH version, so the update direction cannot be established`;
+  }
+  if (compareVersions(targetVersion, installedVersion) < 0) {
+    return `target VERSION ${targetVersion} is older than installed ${installedVersion}, refusing`;
+  }
+  return null;
+}
+
+/**
+ * Why the pinned target is not the upstream branch this update asked for, or
+ * null when it is (or when nothing authoritative was available to say).
+ *
+ * The version guard above verifies a DIRECTION; this one verifies an IDENTITY.
+ * They are different questions, and #3052's expected-behaviour item 1 is this
+ * one: a tree that ships a VERSION at or above the installed one still is not
+ * necessarily `refs/heads/main` of the canonical repo. check() has always
+ * resolved the authoritative SHA from the GitHub ref API and apply() has never
+ * consulted it; this is the consumer.
+ *
+ * Equality is the normal answer. Ancestry is the second accepted answer,
+ * because `main` genuinely moves: the authoritative SHA is read BEFORE the
+ * fetch, so a push landing in that window leaves the fetched tip a DESCENDANT
+ * of it, which is still the requested branch. The reverse — the authoritative
+ * commit sitting ahead of the target, as it does when the target is an older
+ * auto-followed tag — is exactly what must be refused.
+ *
+ * Two deliberate edges:
+ *  - No authoritative SHA (offline, API rate limit, unparseable body) means no
+ *    identity claim was available, so this returns null and the explicit
+ *    `refs/heads/main` refspec remains what ties the target to the branch. A
+ *    rate limit is not evidence of a rogue target.
+ *  - A git failure — including an authoritative commit missing from a shallow
+ *    clone's object store — is a refusal, not a pass. It is the rare case (the
+ *    fetch-window race above), and refusing asks for a retry rather than
+ *    installing a tree nothing could vouch for.
+ *
+ * @param {string} targetSha - The commit apply() pinned and is about to install.
+ * @param {string} authoritativeSha - Upstream main per the GitHub ref API, or ''.
+ * @param {{git?: Function}} [ctx] - Test seam; defaults to the ROOT-bound runner.
+ * @returns {string|null} Refusal reason, or null when the target is acceptable.
+ */
+export function targetIdentityRefusal(targetSha, authoritativeSha, ctx = {}) {
+  if (!authoritativeSha) return null;
+  if (targetSha === authoritativeSha) return null;
+  const runGit = ctx.git || gitQuiet;
+  try {
+    // Exit 0 ⇒ authoritative is an ancestor: main moved forward, target is main.
+    runGit('merge-base', '--is-ancestor', authoritativeSha, targetSha);
+    return null;
+  } catch {
+    return `target ${targetSha.slice(0, 12)} does not descend from upstream main ${authoritativeSha.slice(0, 12)}, refusing to install a tree that is not the requested branch`;
+  }
+}
+
+/**
+ * The text apply() prints when it refuses a target, told from the right stage.
+ *
+ * The claim "No system files were changed" is true of the parent, which refuses
+ * before its first write, and false of the re-exec'd child: by then the parent
+ * has already checked the self-bootstrap closure out from the target. Printing
+ * the parent's sentence in the child would send someone looking for an
+ * untouched tree that is not there.
+ *
+ * @param {string} targetSha - The refused commit.
+ * @param {string} reason - Why it was refused.
+ * @param {boolean} isReexec - Whether this is the re-exec'd child.
+ * @returns {string} A message describing the actual state of the install.
+ */
+export function refusalMessage(targetSha, reason, isReexec) {
+  const state = isReexec
+    ? 'The self-bootstrap files (update-system.mjs and its import closure) were already\n' +
+      '    checked out from this target before the refusal; no other system file was changed.\n' +
+      '    `node update-system.mjs rollback` restores them along with the rest of the tree.'
+    : 'No system files were changed. To go back to an earlier state deliberately,\n' +
+      '    use `node update-system.mjs rollback`, which restores the backup branch\n' +
+      '    this installation made rather than overwriting it with an older upstream tree.';
+  return `Refusing to update from ${targetSha.slice(0, 12)}: ${reason}.\n    ${state}`;
+}
+
 function updateBackupBranchName(version, date = new Date()) {
   const stamp = date.toISOString()
     .replace(/[-:]/g, '')
@@ -877,9 +1054,10 @@ function assertOwnGitToplevel() {
  * out when the next script crashes with ERR_MODULE_NOT_FOUND (#1998).
  *
  * @param {string[]} targetPaths - SYSTEM_PATHS read from the target updater.
- * @returns {string[]} Entries present in FETCH_HEAD but absent locally.
+ * @param {string} targetRef - The pinned target commit, not a moving pseudo-ref.
+ * @returns {string[]} Entries present in the target tree but absent locally.
  */
-function missingFromTargetManifest(targetPaths) {
+function missingFromTargetManifest(targetPaths, targetRef) {
   const missing = [];
   for (const path of targetPaths) {
     const spec = path.endsWith('/') ? path.slice(0, -1) : path;
@@ -892,10 +1070,10 @@ function missingFromTargetManifest(targetPaths) {
     if (path.endsWith('/')) {
       let treeFiles = [];
       try {
-        treeFiles = gitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', spec)
+        treeFiles = gitQuiet('ls-tree', '-r', '--name-only', targetRef, '--', spec)
           .split('\n').map(s => s.trim()).filter(Boolean);
       } catch {
-        continue; // FETCH_HEAD unreadable for this spec — treat as stale, not missing
+        continue; // target tree unreadable for this spec — treat as stale, not missing
       }
       // Empty tree ⇒ the target ships nothing here (stale manifest entry).
       if (treeFiles.some(f => !existsSync(join(ROOT, f)))) missing.push(path);
@@ -906,7 +1084,7 @@ function missingFromTargetManifest(targetPaths) {
     // Only count it as missing when the target actually ships it — a manifest
     // entry the target no longer carries is a stale entry, not a failed update.
     try {
-      gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`);
+      gitQuiet('cat-file', '-e', `${targetRef}:${spec}`);
       missing.push(path);
     } catch { /* absent upstream too — nothing to materialize */ }
   }
@@ -1292,7 +1470,7 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  * Two limits are deliberate, both raised in review of #3781:
  *
  * 1. The single-file shortcut diverges from the pre-extraction inline check
- *    for a preserved file ABSENT from FETCH_HEAD. That check fell through to
+ *    for a preserved file ABSENT from the target tree. That check fell through to
  *    the real checkout, which failed and put the path in apply()'s "Skipped
  *    N path(s) absent upstream" summary; this returns true and skips it
  *    silently. Unreachable while preserved paths come from
@@ -1304,7 +1482,7 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  *
  * 2. The directory branch's `catch → false` does NOT close the cancel-out
  *    abort for directories. A throwing ls-tree still falls through to
- *    `git checkout FETCH_HEAD -- modes/ :(exclude)modes/pdf.md`, which
+ *    `git checkout <target> -- modes/ :(exclude)modes/pdf.md`, which
  *    aborts the update when the directory happens to be fully preserved.
  *    That is exactly the pre-extraction behaviour, carried over unchanged —
  *    this function makes the check testable and drops a redundant lookup for
@@ -1316,10 +1494,15 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  * @param {string} path - a SYSTEM_PATHS entry, file or `dir/`-suffixed directory.
  * @param {string[]} preservedPaths - files this run is keeping local content for.
  * @param {Set<string>} preservedSet - the same paths, as a Set, for lookup.
+ * @param {string} ref - the commit the caller is checking out from. Required and
+ *   without a default on purpose: this predicate decides whether to skip a
+ *   checkout, so it has to read the very tree that checkout would read. A
+ *   `'FETCH_HEAD'` default would let a caller silently ask a different tree than
+ *   the one it installs (#3052).
  * @param {{git?: Function}} [ctx] - injection point for tests; defaults to gitQuiet.
  * @returns {boolean}
  */
-export function pathFullyPreserved(path, preservedPaths, preservedSet, ctx = {}) {
+export function pathFullyPreserved(path, preservedPaths, preservedSet, ref, ctx = {}) {
   if (preservedSet.size === 0) return false;
   const runGitQuiet = ctx.git || gitQuiet;
   const isDirectory = path.endsWith('/');
@@ -1328,7 +1511,7 @@ export function pathFullyPreserved(path, preservedPaths, preservedSet, ctx = {})
   if (!isDirectory) return true;
   let upstreamFiles = [];
   try {
-    upstreamFiles = runGitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', path)
+    upstreamFiles = runGitQuiet('ls-tree', '-r', '--name-only', ref, '--', path)
       .split('\n').map((f) => f.trim()).filter(Boolean);
   } catch {
     return false;
@@ -1787,6 +1970,29 @@ function curlGet(url, extraArgs = []) {
   });
 }
 
+/**
+ * The commit GitHub reports for upstream `main`, or '' when it cannot be read.
+ *
+ * The single source of the authoritative SHA, so check() and apply() cannot
+ * drift into asking different questions about the same branch. '' means "no
+ * answer available" (offline, rate limited, unparseable body) and is never a
+ * claim about any commit — both callers treat it that way.
+ *
+ * @returns {Promise<string>} A commit SHA, or '' when unavailable.
+ */
+async function upstreamMainCommit() {
+  const raw = await curlGet(UPSTREAM_MAIN_REF_API, [
+    '--header', 'Accept: application/vnd.github+json',
+    '--header', 'User-Agent: career-ops-update-checker',
+  ]);
+  if (raw === null) return '';
+  try {
+    return String(JSON.parse(raw)?.object?.sha || '').trim();
+  } catch {
+    return ''; // malformed API response
+  }
+}
+
 async function check() {
   // Respect dismiss flag
   if (existsSync(join(ROOT, '.update-dismissed'))) {
@@ -1830,13 +2036,7 @@ async function check() {
   // deliberately conservative: version checks still work offline/behind a
   // restricted git transport.
   try { localCommit = gitQuiet('rev-parse', 'HEAD'); } catch { /* no git checkout */ }
-  const remoteRef = await curlGet('https://api.github.com/repos/career-ops-hq/career-ops/git/ref/heads/main', [
-    '--header', 'Accept: application/vnd.github+json',
-    '--header', 'User-Agent: career-ops-update-checker',
-  ]);
-  if (remoteRef !== null) {
-    try { remoteCommit = String(JSON.parse(remoteRef)?.object?.sha || '').trim(); } catch { /* malformed API response */ }
-  }
+  remoteCommit = await upstreamMainCommit();
 
   if (rawVersion !== null) {
     try {
@@ -1893,7 +2093,10 @@ async function check() {
   let systemTreeDrift = false;
   if (localCommit && remoteCommit && localCommit !== remoteCommit) {
     try {
-      gitQuiet('fetch', '--quiet', CANONICAL_REPO, 'main');
+      // Same explicit refspec as apply(): `main` alone lets git auto-follow a
+      // tag into FETCH_HEAD, and this line reads FETCH_HEAD on the very next
+      // one — the drift answer would then be about the wrong tree (#3052).
+      gitQuiet('fetch', '--quiet', '--no-tags', CANONICAL_REPO, 'refs/heads/main');
       systemTreeDrift = systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD');
     } catch {
       systemTreeDrift = true;
@@ -2133,9 +2336,77 @@ async function apply() {
       console.log(`Backup branch created: ${backupBranch}`);
     }
 
-    // 2. Fetch from canonical repo
+    // 2. Fetch from canonical repo.
+    //
+    // The re-exec'd child re-fetches, so without the parent's SHA it would pin
+    // its own target and then install a tree different from the one the parent
+    // verified and bootstrapped from. The env value is a hint, not an
+    // authorization (#2866): it is only read in the authenticated re-exec, and
+    // rev-parse below validates it against the local object store.
+    const inheritedTarget = isReexec ? (process.env.CAREER_OPS_UPDATE_TARGET_SHA || '') : '';
+
+    // Read the authoritative SHA BEFORE fetching, not after. The two reads race
+    // whenever someone pushes to main in between, and the order decides which
+    // way the race resolves: read first and the fetched tip is a DESCENDANT of
+    // the authoritative commit, which targetIdentityRefusal accepts; read after
+    // and it would be an ancestor, which is indistinguishable from the stale
+    // target this whole guard exists to catch. '' is "no claim available",
+    // never "no upstream main" — including the child's case, which inherits a
+    // SHA the parent already cleared and so has nothing left to ask.
+    const authoritativeCommit = inheritedTarget ? '' : await upstreamMainCommit();
+
     console.log('Fetching latest from upstream...');
-    git('fetch', CANONICAL_REPO, 'main');
+    // `main` is a shorthand the remote resolves, and plain `git fetch` then
+    // auto-follows tags that point into the fetched history — writing them into
+    // FETCH_HEAD alongside the branch. That is the mechanism #3052 reports:
+    // FETCH_HEAD named `career-ops-v1.25.0` rather than main's tip. Name the
+    // branch ref outright and turn tag-following off, so the only thing this
+    // fetch can leave in FETCH_HEAD is upstream main.
+    git('fetch', '--no-tags', CANONICAL_REPO, 'refs/heads/main');
+
+    // 2a. Resolve the target ONCE, then address it by SHA for the rest of the
+    // run. `FETCH_HEAD` is re-resolved on every read, so the dozen reads this
+    // function used to make were a dozen independent questions about a ref that
+    // is free to move between them — the bootstrap checkout, the manifest read,
+    // the per-path checkout loop, the stale-file prune, the .gitignore
+    // reconciliation and the staging expansion could each have seen a different
+    // tree. Pinning makes one apply run mean one commit.
+    //
+    // Neither branch has a fallback, and the inherited one especially must not:
+    // a child that cannot resolve its parent's SHA is already running bootstrap
+    // files the parent checked out from that SHA, so quietly re-pinning its own
+    // FETCH_HEAD would assemble an install from two different trees — the mixed
+    // state #3052 describes. An unresolvable target ends the run instead.
+    const targetRef = inheritedTarget
+      ? pinRefToCommit(inheritedTarget)
+      : pinRefToCommit('FETCH_HEAD');
+
+    // 2b. Verify the target before touching a single file, on both axes.
+    //
+    // IDENTITY: is this commit the branch we asked for? Only the parent asks.
+    // The child inherits a SHA the parent already cleared, and main may well
+    // have advanced in the seconds since — re-asking there would abort a
+    // half-finished update over a push that has nothing to do with it.
+    //
+    // DIRECTION: is this commit's VERSION at least the installed one? apply()
+    // never asked. compareVersions() is called only from check(), which decides
+    // whether to NOTIFY, so the install path checked out whatever the fetch
+    // produced and printed a success banner regardless of which way the version
+    // moved. An unreadable or unparseable target VERSION is refused too: an
+    // unverifiable target is not a verified one.
+    if (!inheritedTarget) {
+      const identity = targetIdentityRefusal(targetRef, authoritativeCommit);
+      if (identity) throw new Error(refusalMessage(targetRef, identity, isReexec));
+      if (!authoritativeCommit) {
+        console.error('Note: could not reach the GitHub ref API, so the target could not be cross-checked against upstream main.');
+        console.error(`It is still the tip this run fetched from ${CANONICAL_REPO} refs/heads/main.`);
+      }
+    }
+    const targetVersion = versionAtRef(targetRef);
+    const refusal = downgradeRefusal(local, targetVersion);
+    if (refusal) {
+      throw new Error(refusalMessage(targetRef, refusal, isReexec));
+    }
 
     if (!isReexec) {
       const timeout = reexecTimeoutMs();
@@ -2144,8 +2415,8 @@ async function apply() {
         // at load time must exist first. Resolve the fetched update-system.mjs's
         // relative-import closure and check out exactly those files, so a future
         // new top-level import can't reintroduce the self-reexec crash (#1245).
-        const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
-        const bootstrapAtRisk = locallyModifiedSystemFiles(reexecFiles, 'FETCH_HEAD');
+        const reexecFiles = resolveReexecCheckout(targetRef, 'update-system.mjs');
+        const bootstrapAtRisk = locallyModifiedSystemFiles(reexecFiles, targetRef);
         if (bootstrapAtRisk.length > 0) {
           console.log('');
           console.log(`${bootstrapAtRisk.length} self-bootstrap file(s) differ from upstream because THIS install changed them:`);
@@ -2159,7 +2430,7 @@ async function apply() {
           console.log('Self-bootstrap must load the upstream versions; the local versions remain in the backups above.');
           console.log('');
         }
-        git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
+        git('checkout', targetRef, '--', ...reexecFiles);
         const marker = createReexecMarker();
         execFileSync(process.execPath, [
           'update-system.mjs',
@@ -2178,6 +2449,9 @@ async function apply() {
             // marker was introduced; only the authenticated child receives it.
             CAREER_OPS_UPDATE_REEXEC: '1',
             CAREER_OPS_UPDATE_BACKUP_BRANCH: backupBranch,
+            // The child must install the tree this parent pinned and verified,
+            // not whatever its own fetch happens to resolve.
+            CAREER_OPS_UPDATE_TARGET_SHA: targetRef,
             ...(updateForce ? { CAREER_OPS_UPDATE_FORCE: '1' } : {}),
             // Keep the legacy confirmation channel for older target updaters;
             // this process still requires the authenticated marker above.
@@ -2200,7 +2474,7 @@ async function apply() {
     const updated = [];
     let remoteSystemPaths = [];
     try {
-      const remoteUpdaterSource = git('show', 'FETCH_HEAD:update-system.mjs');
+      const remoteUpdaterSource = git('show', `${targetRef}:update-system.mjs`);
       remoteSystemPaths = extractArrayFromSource(remoteUpdaterSource, 'SYSTEM_PATHS');
     } catch {
       // Older targets may not have update-system.mjs. Fall back to the
@@ -2217,7 +2491,7 @@ async function apply() {
     // so; `--force` overwrites. Either way a .bak of the local content is
     // written first, so the fix is recoverable even from the forced path.
     const preservedPaths = [];
-    const atRisk = locallyModifiedSystemFiles(updatePaths, 'FETCH_HEAD');
+    const atRisk = locallyModifiedSystemFiles(updatePaths, targetRef);
     if (atRisk.length > 0) {
       console.log('');
       console.log(`${atRisk.length} system file(s) differ from upstream because THIS install changed them:`);
@@ -2254,8 +2528,9 @@ async function apply() {
       // match any file(s)" when the exclusions cancel the whole pathspec — and
       // that error is indistinguishable from a genuine failure at the catch
       // below, so it would abort the entire update. Skip the entry instead when
-      // nothing would be left to check out (see pathFullyPreserved).
-      if (pathFullyPreserved(path, preservedPaths, preservedSet)) continue;
+      // nothing would be left to check out (see pathFullyPreserved). It reads
+      // the same pinned target this loop checks out from, not FETCH_HEAD.
+      if (pathFullyPreserved(path, preservedPaths, preservedSet, targetRef)) continue;
       try {
         // stderr is piped rather than inherited here. A path absent upstream is
         // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),
@@ -2263,17 +2538,17 @@ async function apply() {
         // `error: pathspec '...' did not match any file(s) known to git`
         // immediately before the success banner — which reads as a failed
         // update and sends people chasing the wrong root cause (#1998).
-        gitQuiet('checkout', 'FETCH_HEAD', '--', path, ...preserveSpecs);
+        gitQuiet('checkout', targetRef, '--', path, ...preserveSpecs);
         updated.push(path);
       } catch (err) {
         // A path genuinely absent upstream is the expected skip. But the catch
         // also caught timeouts, permission errors, and repo corruption and
         // reported them as skips too — letting a partial update reach the
         // success banner (#1998). Confirm the path is actually absent from
-        // FETCH_HEAD before treating the failure as benign; otherwise rethrow.
+        // the target tree before treating the failure as benign; else rethrow.
         const spec = path.endsWith('/') ? path.slice(0, -1) : path;
         let absentUpstream = false;
-        try { gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`); }
+        try { gitQuiet('cat-file', '-e', `${targetRef}:${spec}`); }
         catch { absentUpstream = true; }
         if (!absentUpstream) throw err;
         skippedPaths.push(path);
@@ -2292,7 +2567,7 @@ async function apply() {
       let remoteFiles = new Set();
       try {
         remoteFiles = new Set(
-          git('ls-tree', '-r', '--name-only', 'FETCH_HEAD')
+          git('ls-tree', '-r', '--name-only', targetRef)
             .split('\n').filter(Boolean).map((p) => p.replace(/\\/g, '/'))
         );
       } catch {
@@ -2335,7 +2610,7 @@ async function apply() {
     // and what it could only prevent inside this repository.
     try {
       const gitignorePath = join(ROOT, '.gitignore');
-      const upstreamGitignore = gitShowRaw('FETCH_HEAD:.gitignore');
+      const upstreamGitignore = gitShowRaw(`${targetRef}:.gitignore`);
       // Uncommitted local edits to .gitignore are the user's, and that is a
       // routine state rather than an exotic one: agent-inbox.mjs's own
       // ensureGitignored() appends a rule without committing it. Such a file
@@ -2378,7 +2653,7 @@ async function apply() {
       // Never abort an update over this, but never swallow it either: a silent
       // skip here is precisely how the original bug stayed invisible.
       console.error(`Could not reconcile .gitignore: ${err.message}`);
-      console.error('Your own rules were left untouched. Compare manually with: git diff FETCH_HEAD -- .gitignore');
+      console.error(`Your own rules were left untouched. Compare manually with: git diff ${targetRef} -- .gitignore`);
     }
 
     // Lazy import: keep update-system.mjs self-loading (see the top-of-file
@@ -2476,7 +2751,13 @@ async function apply() {
     rebuildDashboardBinaryIfNeeded();
 
     // 7. Commit the update
-    const remote = localVersion(); // Re-read after checkout updated VERSION
+    // The version this run VERIFIED and installed, not whatever VERSION happens
+    // to say now. Re-reading disk reports the target only when the checkout
+    // reached VERSION at all: a VERSION this install had edited locally is a
+    // preserved path (#2337) and stays at the old value, so the banner printed
+    // `v1.26.0 → v1.26.0` — the very line #3052 reports as the symptom, from
+    // the succeeding path rather than the failing one.
+    const remote = targetVersion;
     // Files deliberately left untouched are excluded from the staging pathspec
     // too: this update did not change them, so an "auto-update system files"
     // commit must not sweep the user's local edit in under its message (#2337).
@@ -2515,8 +2796,9 @@ async function apply() {
     // expands the positive specs and subtracts the preserved files, so no
     // `:(exclude)` spec reaches addPaths (where --literal-pathspecs would read
     // it as a literal filename and abort the commit) and no preserved file is
-    // staged. preservedSet is the same Set built at the top of apply().
-    const expandedPathsToStage = stagingFileList(pathsToStage, preservedSet);
+    // staged. preservedSet is the same Set built at the top of apply(), and the
+    // expansion reads the pinned target rather than re-resolving FETCH_HEAD.
+    const expandedPathsToStage = stagingFileList(pathsToStage, preservedSet, targetRef);
 
     try {
       prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);
@@ -2532,7 +2814,7 @@ async function apply() {
       // …but the pathspec form builds the commit from the WORKING TREE for those
       // paths rather than from the index. Where `core.fileMode` is false — the
       // default on Windows — the working tree cannot express the executable bit,
-      // so a mode change that `git checkout FETCH_HEAD -- <path>` just staged is
+      // so a mode change that `git checkout <target> -- <path>` just staged is
       // dropped from the commit and left sitting in the index. The install is
       // dirty the instant a "clean" update finishes, and stays dirty, because
       // every later update re-stages the same mode and drops it again.
@@ -2601,7 +2883,7 @@ async function apply() {
     // Re-running apply fixes it (the first pass did update update-system.mjs
     // itself, so the second pass uses the target manifest) — but only if the
     // user is told, instead of being shown "Update complete" (#1998).
-    const unmaterialized = missingFromTargetManifest(remoteSystemPaths);
+    const unmaterialized = missingFromTargetManifest(remoteSystemPaths, targetRef);
     if (unmaterialized.length > 0) {
       console.error(`\nUpdate incomplete: v${local} → v${remote}`);
       console.error(`${unmaterialized.length} path(s) from the target manifest were not checked out:`);

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -271,12 +271,64 @@ const twoPassManifestChecks = [
     pattern: /CAREER_OPS_UPDATE_REEXEC/,
   },
   {
-    name: 'apply resolves the re-exec checkout closure from FETCH_HEAD (#1245)',
-    pattern: /resolveReexecCheckout\('FETCH_HEAD',\s*'update-system\.mjs'\)/,
+    // #3052's own mechanism: bare `main` lets git auto-follow a tag into
+    // FETCH_HEAD. Naming the branch ref and disabling tag-following is what
+    // makes the fetch produce upstream main and nothing else.
+    name: 'apply fetches upstream main by explicit ref with tag-following off (#3052)',
+    pattern: /git\('fetch',\s*'--no-tags',\s*CANONICAL_REPO,\s*'refs\/heads\/main'\)/,
   },
   {
-    name: 'apply checks out the resolved re-exec files from FETCH_HEAD (#1245)',
-    pattern: /git\('checkout',\s*'FETCH_HEAD',\s*'--',\s*\.\.\.reexecFiles\)/,
+    // The authoritative SHA must be read BEFORE the fetch: read after, a push
+    // landing in between makes the legitimate new tip look like a stale target.
+    name: 'apply reads the authoritative SHA before fetching (#3052)',
+    pattern: /const authoritativeCommit = inheritedTarget \? '' : await upstreamMainCommit\(\);[\s\S]{0,900}?git\('fetch',\s*'--no-tags'/,
+  },
+  {
+    // #3052: FETCH_HEAD is a pseudo-ref, re-resolved on every read. apply() read
+    // it a dozen times, so nothing tied those reads to one tree. Resolve once.
+    // `const`, and no try/catch around it: a child that cannot resolve its
+    // parent's SHA must abort, not silently re-pin its own FETCH_HEAD while
+    // running bootstrap files the parent checked out from the parent's target.
+    name: 'apply pins the fetched target to an immutable SHA, with no fallback (#3052)',
+    pattern: /const targetRef = inheritedTarget\s*\n?\s*\? pinRefToCommit\(inheritedTarget\)\s*\n?\s*: pinRefToCommit\('FETCH_HEAD'\);/,
+  },
+  {
+    // Verifying the version direction is not verifying the target's identity:
+    // a rogue tree shipping a high VERSION passes the downgrade guard. apply()
+    // must consume the authoritative SHA check() has always resolved.
+    name: 'apply cross-checks the pinned target against upstream main (#3052)',
+    pattern: /const identity = targetIdentityRefusal\(targetRef,\s*authoritativeCommit\);\s*\n\s*if \(identity\) throw new Error\(/,
+  },
+  {
+    // #3052: compareVersions() was only ever called from check(), which decides
+    // whether to NOTIFY. apply() installed whatever the fetch produced.
+    //
+    // The call SHAPE is pinned, not just the call: `versionAtRef('HEAD')` would
+    // compare the installed tree with itself, always return null, and otherwise
+    // survive every test in this repo. The guard is only a guard when it reads
+    // the same pinned commit the checkout will install from.
+    name: 'apply refuses a target older than the installed version (#3052)',
+    pattern: /const targetVersion = versionAtRef\(targetRef\);\s*\n\s*const refusal = downgradeRefusal\(local, targetVersion\);\s*\n\s*if \(refusal\) \{\s*\n\s*throw new Error\(/,
+  },
+  {
+    // A guard whose refusal is unreachable is not a guard. Pin the throw.
+    name: 'a refused target aborts apply instead of being logged (#3052)',
+    pattern: /if \(refusal\) \{\s*\n\s*throw new Error\(refusalMessage\(targetRef, refusal, isReexec\)\);\s*\n\s*\}/,
+  },
+  {
+    // #3052's reported symptom is the banner: `v1.26.0 -> v1.26.0`. Re-reading
+    // VERSION off disk reports the target only when the checkout reached
+    // VERSION; a locally-edited VERSION is preserved and keeps the old value.
+    name: 'the completion banner reports the verified target version (#3052)',
+    pattern: /const remote = targetVersion;/,
+  },
+  {
+    name: 'apply resolves the re-exec checkout closure from the pinned target (#1245, #3052)',
+    pattern: /resolveReexecCheckout\(targetRef,\s*'update-system\.mjs'\)/,
+  },
+  {
+    name: 'apply checks out the resolved re-exec files from the pinned target (#1245, #3052)',
+    pattern: /git\('checkout',\s*targetRef,\s*'--',\s*\.\.\.reexecFiles\)/,
   },
   {
     name: 're-exec fallback still covers the skill-entrypoints import (#1245)',
@@ -291,8 +343,8 @@ const twoPassManifestChecks = [
     pattern: /CAREER_OPS_UPDATE_BACKUP_BRANCH/,
   },
   {
-    name: 'apply reads the target updater manifest from FETCH_HEAD',
-    pattern: /git\('show',\s*'FETCH_HEAD:update-system\.mjs'\)/,
+    name: 'apply reads the target updater manifest from the pinned target (#3052)',
+    pattern: /git\('show',\s*`\$\{targetRef\}:update-system\.mjs`\)/,
   },
   {
     name: 'apply extracts SYSTEM_PATHS from the target updater',
@@ -327,7 +379,7 @@ const twoPassManifestChecks = [
     // paths, so everything added upstream since is silently absent and apply
     // still printed "Update complete" (#1998).
     name: 'apply verifies the target manifest materialized before claiming success (#1998)',
-    pattern: /missingFromTargetManifest\(remoteSystemPaths\)/,
+    pattern: /missingFromTargetManifest\(remoteSystemPaths,\s*targetRef\)/,
   },
   {
     name: 'an incomplete apply exits non-zero instead of reporting success (#1998)',
@@ -339,13 +391,13 @@ const twoPassManifestChecks = [
     // The trailing spread is the #2337 preserve-exclusions; the property this
     // pins is the runner (gitQuiet, not git) and the ref, not the arity.
     name: 'per-path checkout pipes stderr so expected skips stay quiet (#1998)',
-    pattern: /gitQuiet\('checkout',\s*'FETCH_HEAD',\s*'--',\s*path(?:,\s*\.\.\.\w+)?\)/,
+    pattern: /gitQuiet\('checkout',\s*targetRef,\s*'--',\s*path(?:,\s*\.\.\.\w+)?\)/,
   },
   {
     // #2337: a system file this install edited must be listed and backed up
     // before the checkout, not overwritten in silence.
     name: 'locally edited system files are detected before checkout (#2337)',
-    pattern: /const atRisk = locallyModifiedSystemFiles\(updatePaths, 'FETCH_HEAD'\)/,
+    pattern: /const atRisk = locallyModifiedSystemFiles\(updatePaths, targetRef\)/,
   },
   {
     name: 'the local copy is saved as .bak before any overwrite (#2337)',
@@ -370,9 +422,9 @@ const twoPassManifestChecks = [
   {
     // existsSync on a pre-existing directory (docs/) would call it materialized
     // even when the target added files under it — the verification must recurse
-    // into directory entries against FETCH_HEAD (#1998 CodeRabbit review).
+    // into directory entries against the target tree (#1998 CodeRabbit review).
     name: 'manifest verification recurses into directory entries via ls-tree (#1998)',
-    pattern: /ls-tree', '-r', '--name-only', 'FETCH_HEAD'[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
+    pattern: /ls-tree', '-r', '--name-only', targetRef[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
   },
   {
     // A checkout failure is only an expected skip when the path is truly absent


### PR DESCRIPTION
Closes #3052.

Thanks to @florzeta for the original report and to @Solaris-star for the analysis that pinned down where in `apply()` the target goes unverified.

## Scope

To be explicit about what this PR does and does not claim: the auto-followed-tag mechanism from the original report has **not** been reproduced, and this PR does not assert it. What it fixes is a structural property readable straight off `apply()` on `main` today — **`apply()` never verifies the target it installs** — independently of how a wrong target could come to be resolved.

## Two gaps

**1. No version comparison on the install path.** `compareVersions()` (`update-system.mjs:677`) has exactly two call sites, `:1771` and `:1795`, and both live inside `check()` — which only decides whether to *notify*. `apply()` (`:1969`–`:2534`) contains zero references to it. So the install path checked out whatever the fetch produced and printed `Update complete: vX → vY` regardless of which direction the version moved.

**2. The target is a moving pseudo-ref, read a dozen times.** `FETCH_HEAD` is re-resolved on every read, and `apply()` read it 13 times: the bootstrap checkout (`:2039`, `:2040`, `:2054`), the target manifest read (`:2095`), the at-risk scan (`:2112`), the per-path checkout loop (`:2156`, `:2172`, `:2182`), the stale-file prune (`:2201`), and the `.gitignore` reconciliation (`:2244`) — plus two indirect ones through `expandToShippedFiles()` and `missingFromTargetManifest()`, which resolved it themselves. Nothing tied those reads to one tree, so a single `apply` run had no guarantee that the tree it inspected was the tree it wrote.

## Changes

- **`pinRefToCommit()`** resolves the fetched tip **once** to an immutable 40-hex SHA; every later step addresses that SHA. All 13 sites plus the two indirect ones now take the pinned ref.
- The re-exec'd child re-fetches, so it would otherwise pin its own target and install a tree different from the one the parent verified and bootstrapped from. It now inherits the parent's SHA via `CAREER_OPS_UPDATE_TARGET_SHA` — a hint, not an authorization (#2866): read only in the authenticated re-exec, validated with `rev-parse` against the local object store, and falling back to a fresh pin if unusable.
- **`versionAtRef()` + `downgradeRefusal()`** gate the update before a single file is written, reusing the existing `compareVersions()`. An older target is refused with `target VERSION x is older than installed y, refusing`. Fail closed: a target whose `VERSION` cannot be read is refused too, since an unverifiable target is not a verified one. Same-version re-applies stay allowed (the #1998 repair path).

## The escape hatch — a deliberate non-decision

I did **not** add a `--allow-downgrade` flag. `--force` already exists with a different meaning (overwrite *my locally modified system files*), and overloading it with a version-direction meaning would be worse than having no flag. The refusal message instead points at `node update-system.mjs rollback`, which is the existing mechanism for returning to an earlier state — and it restores this installation's own backup branch rather than overwriting it with an older upstream tree.

If maintainers want an explicit downgrade path, an opt-in flag is a small follow-up; I would rather you choose its name and semantics than invent one here.

## Tests

New `tests/updater-apply-target-verification.test.mjs`, same shape as `updater-upgrade-safety.test.mjs` (throwaway git repo through the ctx git seam; no network, no `apply()` call):

- **pin**: after `FETCH_HEAD` moves, a read through the pinned SHA still sees the original tree — with a control assertion showing the same read through `FETCH_HEAD` *does* follow the move, so the pin is demonstrably load-bearing; an unresolvable ref throws.
- **guard**: older / newer / same-version / patch-level / major-level, plus the fail-closed empty-`VERSION` case.
- **`apply()` itself** is not exported, so the two properties that live only in its body are asserted against its source: no unpinned ref reads remain, and the guard runs before the first write.

`updater-migration-tests.mjs` pins both new call sites; its existing `FETCH_HEAD` source assertions (and one in `tests/updater-self-bootstrap-backup.test.mjs`) move to the pinned form.

`node test-all.mjs --quick`: **8109 passed, 0 failed, 14 warnings** (baseline on `main`: 8093 / 0 / 14 — no new warnings).

System Layer only; no user-layer file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`update-system.mjs:2280` now installs one immutable commit for each `apply()` run. It verifies the commit against upstream `main` at `update-system.mjs:2398` and rejects older, malformed, or unverifiable versions before changing files.

Users can reapply the installed version. The updater no longer follows tags during fetches at `update-system.mjs:2359`. Verification failures return a non-zero result and do not report success.

Tests cover pinned references, target identity, version validation, bootstrap, staging, manifest checks, and migration behavior.

System files touched: `update-system.mjs`.

System files not touched: `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->