### PR TITLE
fix(analyze-patterns): parse report headers written in French

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -543,6 +543,41 @@ requirement_importance:
     if (got !== expected) failures.push(`detectVendor(${JSON.stringify(url)}) → ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
   }
 
+  // Report header fields survive the locale they were written in. French output
+  // puts a space before the colon and accents "Archétype"; both used to make the
+  // field parse as absent, silently. parseReport strips `**` first, so the cases
+  // below are given in that post-strip form. Call the pattern rather than the
+  // string: `subject.match(re)` makes CodeQL read these URL fixtures as patterns
+  // (js/incomplete-hostname-regexp) because of their unescaped host dots.
+  const headerCases = [
+    ['URL: https://job-boards.greenhouse.io/acme/jobs/1', REPORT_URL_RE, 'https://job-boards.greenhouse.io/acme/jobs/1'],
+    ['URL : https://job-boards.greenhouse.io/acme/jobs/1', REPORT_URL_RE, 'https://job-boards.greenhouse.io/acme/jobs/1'],
+    ['URL\u00a0: https://jobs.lever.co/acme/x', REPORT_URL_RE, 'https://jobs.lever.co/acme/x'],
+    ['Archetype: Delivery Manager', REPORT_ARCHETYPE_RE, 'Delivery Manager'],
+    ['Archétype : Delivery Manager', REPORT_ARCHETYPE_RE, 'Delivery Manager'],
+    ['Arquetipo: Delivery Manager', REPORT_ARCHETYPE_RE, 'Delivery Manager'],
+  ];
+  for (const [line, re, expected] of headerCases) {
+    const got = re.exec(line)?.[1] ?? null;
+    if (got !== expected) failures.push(`report header ${JSON.stringify(line)} → ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
+  }
+
+  // A header that is genuinely absent must still yield null, so the fix cannot
+  // turn "no field" into a false positive.
+  if (REPORT_URL_RE.test('Score: 4.4/5')) failures.push('REPORT_URL_RE matched a line with no URL field');
+
+  // A header field is single-line. A label split from its colon, or a value pushed to
+  // the next line, must not parse — otherwise the capture picks up whatever URL happens
+  // to follow in the document.
+  const splitHeaderCases = [
+    ['URL\n: https://elsewhere.example.com/x', REPORT_URL_RE],
+    ['URL :\nhttps://elsewhere.example.com/y', REPORT_URL_RE],
+    ['Archétype\n: Delivery Manager', REPORT_ARCHETYPE_RE],
+  ];
+  for (const [text, re] of splitHeaderCases) {
+    if (re.test(text)) failures.push(`split-line header parsed as valid: ${JSON.stringify(text)}`);
+  }
+
   // Via channel analysis (#1596): agency vs direct yield, normalized buckets.
   const viaRows = [
     { via: 'Hays', normalizedStatus: 'interview' },
@@ -831,6 +866,28 @@ function readTextIfExists(path) {
 }
 
 // --- Parse a single report file ---
+// --- Report header field patterns (locale-tolerant) ---
+//
+// A report header is written by the modes in the user's output language, and
+// French typography puts a space before a colon: `**URL :**`, `**Archétype :**`.
+// The original patterns required `URL:` and `Archetype:` with no space and no
+// accent, so every French report parsed as "field absent" — silently, since a
+// missing header field is a legitimate state for older reports and never raises.
+//
+// The failure is invisible and it empties the analysis rather than breaking it:
+// on a 224-report corpus, 128 reports lost their URL (so their ATS vendor fell
+// into the `unknown` bucket, leaving the vendor breakdown to speak for 1 report
+// out of 22 submitted) and 61 lost their archetype. Same shape as #3495.
+//
+// The whitespace class is horizontal-only: space, tab, and U+00A0, the one French
+// editors insert automatically. `\s` would also match a line break, letting a header
+// split across two lines parse as valid and capture a value that belongs to the next
+// line; a header field is single-line by definition, so the class is bounded rather
+// than left permissive. Keep the accent-less spellings: reports written before this
+// fix, and the `Arquetipo` Spanish variant, must keep parsing.
+const REPORT_URL_RE = /^URL[ \t\u00a0]*:[ \t\u00a0]*(https?:\/\/\S+)/im;
+const REPORT_ARCHETYPE_RE = /^(?:Arch[eé]type|Arquetipo)[ \t\u00a0]*:[ \t\u00a0]*(.+?)$/im;
+
 function parseReport(reportPath) {
   const content = readTextIfExists(reportPath);
   if (content === null) return null;
@@ -897,13 +954,13 @@ function parseReport(reportPath) {
   const compRegex = /\|\s*(?:Comp|Salary|Salario|Listed salary)\s*\|\s*(.*?)\s*\|/i;
   const domainRegex = /\|\s*(?:Domain|Dominio|Industry)\s*\|\s*(.*?)\s*\|/i;
 
-  // Fallback: report header field `Archetype: ...` or `Arquetipo: ...` (newer reports use this).
-  const headerArchRegex = /^(?:Archetype|Arquetipo):\s*(.+?)$/im;
+  // Fallback: report header field `Archetype: ...` (newer reports use this).
+  const headerArchRegex = REPORT_ARCHETYPE_RE;
 
   // Report header carries `**URL:**` between Score and PDF (see CLAUDE.md /
   // Pipeline Integrity). Capture the first http(s) URL on that line for vendor
   // detection; reports predating the field simply leave url null (→ unknown bucket).
-  const urlMatch = plain.match(/^URL:\s*(https?:\/\/\S+)/im);
+  const urlMatch = plain.match(REPORT_URL_RE);
   if (urlMatch && !report.url) report.url = urlMatch[1].trim().replace(/[)>\].,]+$/, '');
 
   const archMatch = plain.match(blockARegex) || plain.match(headerArchRegex);


### PR DESCRIPTION
Fixes #3807.

`parseReport()` read the `URL` and `Archetype` header fields with patterns requiring an ASCII colon directly after the label and no accent. French typography puts a space before a colon, and the modes write the header in the user's `language.output`, so `**URL :**` and `**Archétype :**` never matched and both fields parsed as absent.

The failure is silent by construction: a missing header field is a legitimate state for older reports, so nothing warns and nothing throws. The run exits 0 and answers from a fraction of the corpus.

On a 224-report French corpus: **128 reports lost their URL**, 61 lost their archetype. Since the ATS vendor is derived from that URL, the vendor breakdown spoke for 1 submitted application out of 22 while reporting `coveragePct: 5` — indistinguishable from genuinely sparse data.

Same shape as #3495.

### What changed

- The two patterns move to module scope as `REPORT_URL_RE` and `REPORT_ARCHETYPE_RE`, so the behaviour is directly testable rather than buried in a 200-line function.
- Both accept optional whitespace before the colon. `\s` covers U+00A0, which French editors insert automatically.
- `Arch[eé]type` accepts the accented spelling. The accent-less form and the Spanish `Arquetipo` variant are unchanged, so existing reports keep parsing.

### Tests

Self-test coverage for both fields across the EN, FR and ES spellings, including the non-breaking-space form, plus a negative case asserting that a line carrying no URL field still yields `null` — so the fix cannot turn "field absent" into a false positive.

Confirmed the tests are meaningful: the FR cases fail against the previous patterns.

### Verification

- `node analyze-patterns.mjs --self-test` passes.
- `node test-all.mjs` shows **no change against baseline** on the same working tree (8053 passed / 6 failed before and after; the 6 are pre-existing and unrelated — SYSTEM_PATHS coverage, user-layer root resolution, root-level suite discovery).
- End to end: a French report carrying a Greenhouse URL is now detected and appears in the vendor breakdown, where it was previously bucketed as `unknown`.

### Not covered

32 reports in the same corpus use a `**Archétype visé :**` label. That is label drift from the modes rather than a locale issue, so it is left out to keep this diff to one well-defined problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

French reports now retain their URL and archetype fields when parsed.

- `analyze-patterns.mjs:859-860`: Header patterns accept spaces and non-breaking spaces before colons.
- `analyze-patterns.mjs:860`: Archetype parsing supports `Archétype`, `Archetype`, and `Arquetipo`.
- `analyze-patterns.mjs:534-548`: Self-tests cover supported languages, whitespace forms, split-line headers, and absent URLs.
- `analyze-patterns.mjs:928-938`: `parseReport()` uses the shared patterns.
- `Archétype visé` remains out of scope.

System files touched: `analyze-patterns.mjs` only. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->