### PR TITLE
fix(linkedin-join): use the real people-search route

### DIFF
--- a/linkedin-join.mjs
+++ b/linkedin-join.mjs
@@ -496,7 +496,7 @@ export function parseKnownContacts(content) {
  */
 export function secondDegreeSearchUrl(company) {
   const q = encodeURIComponent(String(company || '').trim());
-  return `https://www.linkedin.com/search/people/?keywords=${q}&network=%5B%22S%22%5D`;
+  return `https://www.linkedin.com/search/results/people/?keywords=${q}&network=%5B%22S%22%5D`;
 }
 
 // --- Join ------------------------------------------------------------------
@@ -790,7 +790,7 @@ function selfTest() {
   check('2nd-degree url encodes the company', url.includes('keywords=Acme%20%26%20Co'));
   check('2nd-degree url filters to 2nd degree', url.includes('network=%5B%22S%22%5D'));
   check('2nd-degree url is linkedin people search',
-    url.startsWith('https://www.linkedin.com/search/people/?'));
+    url.startsWith('https://www.linkedin.com/search/results/people/?'));
 
   const placeholders = parseTrackerTargets([
     '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',

--- a/tests/linkedin-join.test.mjs
+++ b/tests/linkedin-join.test.mjs
@@ -155,7 +155,7 @@ test('people already in the phonebook are marked, not re-suggested', () => {
 
 test('every target carries a second-degree link the user opens themselves (#2679 criterion 3)', () => {
   const url = secondDegreeSearchUrl('Acme & Co');
-  assert.ok(url.startsWith('https://www.linkedin.com/search/people/?'));
+  assert.ok(url.startsWith('https://www.linkedin.com/search/results/people/?'));
   assert.ok(url.includes('keywords=Acme%20%26%20Co'));
   assert.ok(url.includes('network=%5B%22S%22%5D'), 'must filter to 2nd degree');
 });


### PR DESCRIPTION
`secondDegreeSearchUrl()` builds `https://www.linkedin.com/search/people/?…`. That path is not a LinkedIn route — it renders a "Page doesn't exist" error — so every second-degree link the warm-intro finder prints is dead on arrival.

Found the ordinary way: a user clicked one of the links `linkedin-join.mjs --summary` had just printed and got the error page.

The working route is `/search/results/people/`. The query string was already correct; only the path was wrong.

### Why the test didn't catch it

```js
assert.ok(url.startsWith('https://www.linkedin.com/search/people/?'));
```

The assertion encoded the same wrong path as the implementation, so it passed against the bug. Corrected alongside, and the inline `--self-test` check had the same issue.

### Verification

```
node --test tests/linkedin-join.test.mjs   → 22 pass, 0 fail
node linkedin-join.mjs --self-test         → PASS 43/43
```

Behaviour is otherwise unchanged: still constructed and never fetched, so the #2679 criterion-3 property (career-ops builds the string, the user opens it) still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118pmJ5jiXf3ggjd7bHQCWu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated `secondDegreeSearchUrl()` in `linkedin-join.mjs` to use LinkedIn’s working `/search/results/people/` route. The query string remains unchanged.

Updated the matching test and inline self-test in `tests/linkedin-join.test.mjs` and `linkedin-join.mjs`.

Users receive a valid LinkedIn people-search URL instead of the previous “Page doesn’t exist” route. The URL is constructed but not fetched.

## Verification

22 unit tests and 43 self-tests pass.

## Files changed

: `linkedin-join.mjs`
: `tests/linkedin-join.test.mjs`

The following system files were not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->