### PR TITLE
fix(merge-tracker): a corporate-form merge keeps the row's employer name and prefers an exact company match

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -1268,7 +1268,12 @@ for (const file of tsvFiles) {
   if (!duplicate) {
     // Company + role fuzzy match
     const additionReqNum = extractReqNumber(addition.notes);
-    duplicate = existingApps.find(app => {
+    // Two passes, exact company first. With a single find() the wider
+    // corporate-form comparison (#3665) let an EARLIER "Acme Technologies" row
+    // claim an addition for "Acme" while an exact "Acme" row sat further down
+    // the table: the duplicate that comparison exists to prevent was written
+    // to a second time and the exact row never updated.
+    const fuzzyTierMatch = (app, widenToCorporateForm) => {
       // Two different posting URLs are two different postings — a fuzzy title
       // collision must never collapse them. This is the structural version of
       // the #1524 req-number guard, and the tier where an unkeyed addition is
@@ -1281,7 +1286,7 @@ for (const file of tsvFiles) {
       // tier already requires a fuzzy role match, and the req-number and URL
       // guards below and above still get to prove the rows distinct.
       if (!companiesMatch(app.company, addition.company)
-          && !companiesMatchIgnoringCorporateForm(app.company, addition.company)) return false;
+          && !(widenToCorporateForm && companiesMatchIgnoringCorporateForm(app.company, addition.company))) return false;
       if (!roleFuzzyMatch(addition.role, app.role)) return false;
       // Cross-channel guard (#1596): unknown-employer rows (`?`) all normalize
       // to the same empty company key, but the same role via two DIFFERENT
@@ -1339,7 +1344,9 @@ for (const file of tsvFiles) {
       const appReqNum = extractReqNumber(app.notes);
       if (additionReqNum && appReqNum && additionReqNum !== appReqNum) return false;
       return true;
-    });
+    };
+    duplicate = existingApps.find(app => fuzzyTierMatch(app, false))
+      || existingApps.find(app => fuzzyTierMatch(app, true));
   }
 
   if (duplicate) {
@@ -1405,7 +1412,16 @@ for (const file of tsvFiles) {
       ? '✅'
       : (reportChanged ? '❌' : duplicate.pdf);
     const updatedLine = buildRow({
-      num: duplicate.num, date: addition.date, company: addition.company,
+      num: duplicate.num, date: addition.date,
+      // A corporate-form match (#3665) pairs the row with a VARIANT spelling of
+      // its employer, so the row keeps the name it was filed under, the same
+      // rule the fuzzy tiers apply to the role below. Renaming it breaks every
+      // company-keyed join (company-history, blacklist, follow-ups,
+      // linkedin-join) and, on a table already holding both spellings, leaves
+      // two rows under one literal name. An exact, URL or report match carries
+      // the incoming spelling, as before.
+      company: (reportNumMatched || dupReason === 'url' || companiesMatch(duplicate.company, addition.company))
+        ? addition.company : duplicate.company,
       // A URL match is a CONFIRMED same-posting identity, so the incoming title
       // is authoritative the same way a report-number match is — employers do
       // edit a live posting's title. The fuzzy tiers stay conservative and keep

--- a/tests/merge-tracker-company-suffix.test.mjs
+++ b/tests/merge-tracker-company-suffix.test.mjs
@@ -137,6 +137,25 @@ ok('an employer-board URL mismatch still proves two postings apart', () => {
   } finally { cleanup(env); }
 });
 
+ok('a URL match carries the incoming company spelling onto the row', () => {
+  // The URL tier is a CONFIRMED same-posting identity (a normalized-URL
+  // match), unlike the fuzzy company+role tier above: the incoming spelling
+  // is authoritative here even though the row otherwise keeps its own name.
+  // A tracking-param tail (utm_source) must still normalize to the same key.
+  const env = makeEnv();
+  try {
+    const H = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL |';
+    const S = '|---|---|---|---|---|---|---|---|---|---|';
+    writeFileSync(env.tracker, ['# Applications Tracker', '', H, S,
+      '| 1 | 2026-06-01 | Acme Technologies Inc. | Director of Marketing | 4.0/5 | Evaluated | ❌ | [1](reports/1-a.md) | n | https://boards.greenhouse.io/acme/jobs/7001 |', ''].join('\n'));
+    addTsv(env, '2-b.tsv', ['2', '2026-06-03', 'Acme', 'Director of Marketing', 'Evaluated', '4.1/5', '❌', '[2](reports/2-b.md)', 'n', 'https://boards.greenhouse.io/acme/jobs/7001?utm_source=x']);
+    runMerge(env);
+    const rows = trackerRows(env);
+    assert.equal(rows.length, 1, `expected the same posting to update in place, got ${rows.length} rows`);
+    assert.ok(rows[0].includes('| Acme |'), `row did not take the incoming spelling: ${rows[0]}`);
+  } finally { cleanup(env); }
+});
+
 ok('a role that does not fuzzy-match is unaffected by the wider company match', () => {
   const rows = mergeOne({
     existingCompany: 'Acme Technologies', existingRole: 'Director of Marketing',

--- a/tests/merge-tracker-company-suffix.test.mjs
+++ b/tests/merge-tracker-company-suffix.test.mjs
@@ -168,3 +168,43 @@ ok('CONTROL: a blind-employer row cannot reach the tier (empty stem)', () => {
   });
   assert.equal(rows.length, 2, 'an unknown employer never matches a named one');
 });
+
+ok('THE ROW KEEPS ITS NAME: a corporate-form merge does not rename the employer', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme Technologies Inc.', existingRole: 'Director of Marketing',
+    addCompany: 'Acme', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 1, `expected 1 row, got ${rows.length}`);
+  assert.ok(rows[0].includes('| Acme Technologies Inc. |'), `row renamed: ${rows[0]}`);
+  assert.ok(rows[0].includes('4.1/5'), 're-eval score still written through');
+});
+
+ok('THE ROW KEEPS ITS NAME: with the variant on the incoming side too', () => {
+  const rows = mergeOne({
+    existingCompany: 'Acme', existingRole: 'Director of Marketing',
+    addCompany: 'Acme Canada', addRole: 'Director of Marketing',
+  });
+  assert.equal(rows.length, 1, `expected 1 row, got ${rows.length}`);
+  assert.ok(rows[0].includes('| Acme |'), `row renamed: ${rows[0]}`);
+});
+
+ok('EXACT BEFORE WIDE: an exact-company row further down wins over an earlier corporate-form row', () => {
+  // The state the wider match exists to prevent, already on disk: both
+  // spellings present. The addition must update the row that IS "Acme", not
+  // the first row that merely resembles it.
+  const env = makeEnv();
+  try {
+    writeTracker(env, [
+      '| 1 | 2026-06-01 | Acme Technologies | Director of Marketing | 4.0/5 | Applied | ❌ | [1](reports/1-a.md) | n |',
+      '| 5 | 2026-06-02 | Acme | Director of Marketing | 3.5/5 | Evaluated | ❌ | [5](reports/5-a.md) | n |',
+    ]);
+    addTsv(env, '9-b.tsv', ['9', '2026-06-03', 'Acme', 'Director of Marketing', 'Evaluated', '4.1/5', '❌', '[9](reports/9-b.md)', 'n']);
+    runMerge(env);
+    const rows = trackerRows(env);
+    assert.equal(rows.length, 2, `both rows survive, got ${rows.length}`);
+    const row1 = rows.find(r => r.startsWith('| 1 |'));
+    const row5 = rows.find(r => r.startsWith('| 5 |'));
+    assert.ok(row1 && row1.includes('| Acme Technologies |') && row1.includes('4.0/5'), `row 1 was touched: ${row1}`);
+    assert.ok(row5 && row5.includes('4.1/5') && row5.includes('9-b.md'), `row 5 was not updated: ${row5}`);
+  } finally { cleanup(env); }
+});


### PR DESCRIPTION
## What does this PR do?

Follow-up to #3666 (the corporate-form company match, #3665). Two things the wider match did once it fired, both reproduced on current main (`71044b4c`) with the real `merge-tracker.mjs` CLI against a temp tracker:

1. **The row was renamed.** The merged row took `addition.company`, so an existing `Acme Technologies Inc.` (Applied) plus an addition for `Acme` came back as `| 1 | … | Acme | … | Applied |`, and `Acme` plus `Acme Canada` came back as `Acme Canada`. Every company-keyed join (`company-history.mjs`, `data/blacklist.md`, follow-ups, `linkedin-join.mjs`) loses the row under its old name. The fuzzy tiers already keep the existing *role* because the pairing is a guess; the company now follows the same rule. An exact, URL or report-number match still carries the incoming spelling, as before.
2. **The first look-alike row won over the exact one.** One `find()` accepted `companiesMatch || companiesMatchIgnoringCorporateForm` in file order, so on a tracker that already held `#1 Acme Technologies` and `#5 Acme` (the very state the wider match exists to prevent), an addition for `Acme` merged into #1, renamed it to `Acme`, and left two literal `Acme` rows. The tier now runs two passes: exact company first, corporate-form second.

## Related issue

Bug fix on the #3665 change; no new issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

---

## Tests

Three cases in `tests/merge-tracker-company-suffix.test.mjs`, driving the CLI like the existing ones: the row keeps `Acme Technologies Inc.` on a merge with `Acme` (score still written through), keeps `Acme` on a merge with `Acme Canada`, and an exact `#5 Acme` further down the table is the row updated while `#1 Acme Technologies` is untouched. Each was run against the mutant it names: restoring `company: addition.company` reddens the first two, collapsing the two passes into one reddens the third. `node test-all.mjs --only merge-tracker` 96/0, quick suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Corporate-form matches preserve the existing employer name at `merge-tracker.mjs:1416`.
- Exact, URL, and report-number matches use the incoming employer name at `merge-tracker.mjs:1423`.
- Exact company matching runs before corporate-form matching at `merge-tracker.mjs:1271`.
- Added CLI-driven regression tests for URL matching, name preservation, and exact-match precedence at `tests/merge-tracker-company-suffix.test.mjs:140`, `:191`, and `:210`.
- `node test-all.mjs --only merge-tracker` passes with 97 tests.

## Files

Changed: `merge-tracker.mjs`, `tests/merge-tracker-company-suffix.test.mjs`.

Not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->