### PR TITLE
fix: persist the default CLI when several are installed, and repair cv-sync-check

### DIFF
--- a/cv-sync-check.mjs
+++ b/cv-sync-check.mjs
@@ -50,10 +50,14 @@ if (!existsSync(profilePath)) {
 }
 
 // 3. Check for hardcoded metrics in prompt files
+// CODE_ROOT, not DATA_ROOT: these three are SYSTEM-layer files that ship with
+// the checkout, and this check exists to catch the template author's own
+// metrics surviving into them. Resolving them against the user's data root
+// would look for system prompts inside the user layer, where they never live.
 const filesToCheck = [
-  { path: join(projectRoot, 'modes', '_shared.md'), name: '_shared.md' },
-  { path: join(projectRoot, 'modes', '_writing.md'), name: '_writing.md' },
-  { path: join(projectRoot, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
+  { path: join(CODE_ROOT, 'modes', '_shared.md'), name: '_shared.md' },
+  { path: join(CODE_ROOT, 'modes', '_writing.md'), name: '_writing.md' },
+  { path: join(CODE_ROOT, 'batch', 'batch-prompt.md'), name: 'batch-prompt.md' },
 ];
 
 // Pattern: numbers that look like hardcoded metrics (e.g., "170+ hours", "90% self-service")

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
-import { persistCliId, readSavedCliId } from "@/lib/saved-cli";
+import { persistCliId, pickDefaultCli, readSavedCliId } from "@/lib/saved-cli";
 
 type Cli = {
   id: string;
@@ -68,14 +68,21 @@ export function ConfigForm() {
       .then((d) => {
         const list: Cli[] = d.clis ?? [];
         setClis(list);
-        // Highlight + persist the only installed CLI when Config was never saved.
-        // Highlight-only used to look configured while jobs still read empty localStorage.
+        // Highlight + persist the default CLI when Config was never saved.
+        //
+        // These two must never diverge. Highlight-only used to look configured
+        // while jobs still read empty localStorage; that was fixed for a single
+        // installed CLI but not for several, so a machine with (say) Claude Code
+        // + Codex + Gemini rendered Claude selected, wrote nothing, and failed
+        // every CLI-backed job with "connect your CLI". Persist whatever we
+        // show — pickDefaultCli explains why "first installed" is safety-ordered
+        // rather than arbitrary.
         setCliId((prev) => {
           if (prev) return prev;
-          const only = list.filter((c) => c.installed);
-          if (only.length !== 1) return list.find((c) => c.installed)?.id || "";
-          if (!readSavedCliId()) persistCliId(only[0].id);
-          return only[0].id;
+          const fallback = pickDefaultCli(list);
+          if (!fallback) return "";
+          if (!readSavedCliId()) persistCliId(fallback);
+          return fallback;
         });
       })
       .catch(() => setClis([]));

--- a/web/src/components/cv/cv-ingest.tsx
+++ b/web/src/components/cv/cv-ingest.tsx
@@ -10,16 +10,9 @@ import { cn } from "@/lib/cn";
 import { instrumentSerif } from "@/lib/fonts";
 import { cvReadiness, parseCvStream, type CvSeed } from "@/lib/cv/quality";
 import { DEFAULT_FILTERS, filtersToParams } from "@/lib/explore";
+import { resolveCliId } from "@/lib/saved-cli";
 
 type Phase = "input" | "parsing" | "review" | "saving" | "error";
-
-function cliId(): string | null {
-  try {
-    return JSON.parse(localStorage.getItem("career-ops:config") || "{}").cliId || null;
-  } catch {
-    return null;
-  }
-}
 
 const STYLE = `
 .co-cvdrop{position:relative;border:1.5px dashed color-mix(in srgb, var(--fg) 22%, transparent);border-radius:1rem;transition:border-color .2s,background .2s}
@@ -89,7 +82,10 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
     }
   }, []);
 
-  const ingestText = (text: string) => {
+  // resolveCliId falls back to the default installed CLI (and persists it) when
+  // Config was never opened — the saved key alone used to be the only source,
+  // so a first-run user with a CLI right there was told to connect one.
+  const ingestText = async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) {
       setErr("That looks empty — paste your CV instead.");
@@ -98,7 +94,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
     }
     // Pasted text is already readable. Same path as a .md/.txt drop — no CLI.
     // (PDF/DOCX still need a CLI below.)
-    const id = cliId();
+    const id = await resolveCliId();
     if (!id) {
       setSeed(null);
       setMd(trimmed);
@@ -108,7 +104,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
     void runStream({ method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ text: trimmed, cliId: id }) });
   };
 
-  const ingestFile = (file: File) => {
+  const ingestFile = async (file: File) => {
     // .md/.txt/.markdown fast path — plain text, NO CLI needed, instant.
     if (/\.(md|markdown|txt)$/i.test(file.name)) {
       file
@@ -130,7 +126,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
       return;
     }
     // PDF/other → the user's CLI parses it. Needs a configured CLI.
-    const id = cliId();
+    const id = await resolveCliId();
     if (!id) {
       setErr("needs-cli");
       setPhase("error");
@@ -192,14 +188,14 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
             e.preventDefault();
             setOver(false);
             const f = e.dataTransfer.files?.[0];
-            if (f) ingestFile(f);
+            if (f) void ingestFile(f);
           }}
         >
           <textarea
             value={paste}
             onChange={(e) => setPaste(e.target.value)}
             onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && paste.trim()) ingestText(paste.trim());
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && paste.trim()) void ingestText(paste.trim());
             }}
             placeholder="Paste your CV here — or drop a PDF / .md file below. Even a rough paste works; we'll clean it up."
             className="h-32 w-full resize-none bg-transparent text-[14px] leading-relaxed outline-none placeholder:text-faint"
@@ -212,14 +208,14 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
             >
               <Upload className="size-3.5" /> Upload PDF / file
             </button>
-            <input ref={fileRef} type="file" accept=".pdf,.md,.markdown,.txt,.docx" hidden onChange={(e) => e.target.files?.[0] && ingestFile(e.target.files[0])} />
+            <input ref={fileRef} type="file" accept=".pdf,.md,.markdown,.txt,.docx" hidden onChange={(e) => e.target.files?.[0] && void ingestFile(e.target.files[0])} />
             <span className="inline-flex items-center gap-1 text-[11px] text-faint">
               <Lock className="size-3" /> Stays on your machine. Parsed by your own AI.
             </span>
             <button
               type="button"
               disabled={!paste.trim()}
-              onClick={() => ingestText(paste.trim())}
+              onClick={() => void ingestText(paste.trim())}
               className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground shadow-sm transition hover:brightness-110 disabled:opacity-50 max-sm:min-h-[44px]"
             >
               Read my CV <ArrowRight className="size-4" />

--- a/web/src/lib/cli-pick.mjs
+++ b/web/src/lib/cli-pick.mjs
@@ -1,0 +1,26 @@
+// The default-CLI pick, in .mjs so the test suite imports THIS code rather than
+// a hand-copied mirror of it (saved-cli.ts is TS; web/tests/*.test.mjs cannot
+// import TS). saved-cli.ts re-exports from here so both entry points agree —
+// same reason report-files.mjs exists.
+
+/**
+ * The CLI to select when Config has nothing saved yet: the first INSTALLED
+ * entry in the caller's order.
+ *
+ * Order matters and is not incidental. Callers pass the list from /api/clis,
+ * which preserves `KNOWN` order in src/lib/clis.ts — Claude Code first. That
+ * makes the default the most-audited runtime available: Claude is the only CLI
+ * with a per-tool deny list (see the permission note on `KNOWN`), and the only
+ * one the CV ingest route grants a Read tool to. Picking "first installed" is
+ * therefore a safety-ordered pick, not an arbitrary one.
+ *
+ * Returns null only when nothing is installed — the one case where there is
+ * genuinely no honest default to show.
+ *
+ * @param {{id: string, installed?: boolean}[] | undefined} clis
+ * @returns {string | null}
+ */
+export function pickDefaultCli(clis) {
+  const installed = (clis || []).filter((c) => c.installed);
+  return installed.length > 0 ? installed[0].id : null;
+}

--- a/web/src/lib/saved-cli.ts
+++ b/web/src/lib/saved-cli.ts
@@ -1,4 +1,8 @@
+import { pickDefaultCli } from "./cli-pick.mjs";
+
 export const CONFIG_KEY = "career-ops:config";
+
+export { pickDefaultCli };
 
 export function readSavedCliId(): string | null {
   try {
@@ -23,24 +27,25 @@ export function persistCliId(cliId: string) {
   }
 }
 
-export function pickSoleInstalled(
-  clis: { id: string; installed?: boolean }[] | undefined,
-): string | null {
-  const installed = (clis || []).filter((c) => c.installed);
-  return installed.length === 1 ? installed[0].id : null;
-}
-
-/** Saved Config cliId, or the only installed CLI (and persist that pick). */
+/**
+ * Saved Config cliId, or the default installed CLI (and persist that pick).
+ *
+ * INVARIANT: whatever this resolves to is what Config renders as selected, and
+ * it is always written to storage. A default that is displayed but not stored
+ * is the bug this function exists to prevent — Config used to highlight the
+ * first installed CLI while every consumer read an empty key, so the page
+ * looked configured and jobs failed with "connect your CLI".
+ */
 export async function resolveCliId(): Promise<string | null> {
   const saved = readSavedCliId();
   if (saved) return saved;
   try {
     const r = await fetch("/api/clis");
     const d = (await r.json()) as { clis?: { id: string; installed?: boolean }[] };
-    const sole = pickSoleInstalled(d.clis);
-    if (!sole) return null;
-    persistCliId(sole);
-    return sole;
+    const fallback = pickDefaultCli(d.clis);
+    if (!fallback) return null;
+    persistCliId(fallback);
+    return fallback;
   } catch {
     return null;
   }

--- a/web/tests/lib/saved-cli-pick.test.mjs
+++ b/web/tests/lib/saved-cli-pick.test.mjs
@@ -1,15 +1,14 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-// Mirror of pickSoleInstalled in src/lib/saved-cli.ts (TS; this suite is .mjs).
-function pickSoleInstalled(clis) {
-  const installed = (clis || []).filter((c) => c.installed);
-  return installed.length === 1 ? installed[0].id : null;
-}
+// Imports the REAL picker (src/lib/cli-pick.mjs). This suite used to hand-copy
+// the function body, which meant it could not fail when the implementation
+// changed — exactly how the multi-install regression below went unnoticed.
+import { pickDefaultCli } from "../../src/lib/cli-pick.mjs";
 
 test("sole installed CLI is the default", () => {
   assert.equal(
-    pickSoleInstalled([
+    pickDefaultCli([
       { id: "claude", installed: false },
       { id: "grok", installed: true },
     ]),
@@ -17,13 +16,49 @@ test("sole installed CLI is the default", () => {
   );
 });
 
-test("zero or two installed CLIs stay unset", () => {
-  assert.equal(pickSoleInstalled([]), null);
+test("nothing installed has no default", () => {
+  assert.equal(pickDefaultCli([]), null);
+  assert.equal(pickDefaultCli(undefined), null);
   assert.equal(
-    pickSoleInstalled([
-      { id: "claude", installed: true },
-      { id: "grok", installed: true },
+    pickDefaultCli([
+      { id: "claude", installed: false },
+      { id: "grok", installed: false },
     ]),
     null,
   );
+});
+
+// The regression. Config renders `c.id === cliId` as selected and persists that
+// same id; a picker returning null here would leave the page showing a
+// highlighted CLI while every consumer read an empty localStorage key, and each
+// CLI-backed job failed with "connect your CLI" on an apparently configured
+// machine.
+test("several installed CLIs still resolve to a default", () => {
+  assert.equal(
+    pickDefaultCli([
+      { id: "claude", installed: true },
+      { id: "codex", installed: true },
+      { id: "gemini", installed: true },
+    ]),
+    "claude",
+  );
+});
+
+// Callers pass /api/clis output, which preserves KNOWN order (Claude first), so
+// "first installed" resolves to the most-audited runtime available rather than
+// an arbitrary one. Order is load-bearing, not incidental.
+test("default follows list order, skipping uninstalled entries", () => {
+  assert.equal(
+    pickDefaultCli([
+      { id: "claude", installed: false },
+      { id: "codex", installed: true },
+      { id: "gemini", installed: true },
+    ]),
+    "codex",
+  );
+});
+
+// `installed` is optional in the type; a missing flag must not count as present.
+test("absent installed flag is not treated as installed", () => {
+  assert.equal(pickDefaultCli([{ id: "claude" }, { id: "codex", installed: true }]), "codex");
 });


### PR DESCRIPTION
## What does this PR do?

Fixes two independent bugs. Config now persists the CLI it displays as selected when more than one CLI is installed (previously it showed a selection and stored nothing, so every CLI-backed job failed on an apparently configured machine). And `cv-sync-check.mjs` no longer crashes on an undefined variable, which had made a step `modes/_shared.md` mandates unrunnable.

## Related issue

None — both are bug fixes, which CONTRIBUTING.md exempts from issue-first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

---

### 1. `fix(web): persist the default CLI when several are installed`

`ConfigForm` rendered the first installed CLI as selected, but only wrote it to `localStorage` when **exactly one** CLI was installed:

```js
const only = list.filter((c) => c.installed);
if (only.length !== 1) return list.find((c) => c.installed)?.id || "";
if (!readSavedCliId()) persistCliId(only[0].id);
```

With two or more installed (e.g. Claude Code + Codex + Gemini CLI) the page showed Claude Code highlighted and checkmarked while `career-ops:config` stayed empty. Every CLI-backed job — CV ingest, AI search, the assistant — then failed with "connect your CLI" on a machine that looked configured. Pressing **Save config** fixed it, with nothing indicating that was required.

The comment above that block shows this class of bug was already fixed for the single-CLI case; the multi-CLI path was missed.

**Fix:** `pickDefaultCli()` returns the first installed entry, `null` only when nothing is installed, so the highlighted and persisted selection are the same value by construction.

"First installed" is safety-ordered, not arbitrary: callers pass `/api/clis` output, which preserves `KNOWN` order in `clis.ts` (Claude Code first). That makes the default the most-audited runtime available — the only CLI with a per-tool deny list, and the only one the CV ingest route grants a `Read` tool to. Noted in the module so it isn't "simplified" away later.

`cv-ingest` now resolves through `resolveCliId`, which additionally covers the case where Config was never opened at all — a first-run user with a CLI installed was previously told to connect one.

**On the test file:** `saved-cli-pick.test.mjs` hand-copied the function body rather than importing it (`// Mirror of pickSoleInstalled in src/lib/saved-cli.ts (TS; this suite is .mjs)`). A mirrored test cannot fail when the implementation changes, which is why this regression was invisible. The picker now lives in `src/lib/cli-pick.mjs` so the suite imports the real code — the same pattern as `run-cli-support.mjs` and `report-files.mjs`. Coverage added for the multi-install case and for an absent `installed` flag.

### 2. `fix(cv-sync-check): resolve system prompt files against CODE_ROOT`

The hardcoded-metrics check referenced an undefined `projectRoot`, so `node cv-sync-check.mjs` threw a `ReferenceError` on every run and never reached the article-digest freshness check below it. `modes/_shared.md` mandates running this before the first evaluation of a session, so the documented path was dead.

The data-root split introduced `CODE_ROOT`/`DATA_ROOT` and left these three references behind. They are SYSTEM-layer files that ship with the checkout, and the check exists to catch the template author's own metrics surviving into them — so they resolve against `CODE_ROOT`. `DATA_ROOT` would look for system prompts inside the user layer, where they never live. Commented in place.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fixes — exempt from issue-first
- [x] My PR does not include personal data (no user-layer files touched; only `web/src`, `web/tests` and `cv-sync-check.mjs`)
- [x] I ran `node test-all.mjs` — **6577 passed, 0 failed** (suite reports 10 warnings separately from failures). Also `npm test` in `web/` (370 pass), `npx tsc --noEmit` clean, `npm run lint` (577 files), and `npm run build` succeeds
- [x] My changes respect the Data Contract — no user-layer files modified
- [x] Aligned with the roadmap (bug fixes only, no behaviour beyond restoring intended behaviour)

## Notes for the reviewer

- Both bugs were found in normal use, not by audit: the first surfaced as a confusing "connect your CLI" error with three CLIs installed; the second when following the `_shared.md` first-evaluation step.
- The picker's move to `.mjs` is the load-bearing part of change 1 — without it the regression test would still be a mirror and still unable to fail.
- `cv-ingest.tsx`'s handlers became `async`, so their four call sites are now `void`-prefixed to match the file's existing convention for floating promises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Multiple installed CLIs now use the first installed CLI in the configured order.
- The selected CLI persists in configuration, so the Config screen and jobs show the same CLI.
- First-run users can ingest CV text or files before opening Config.
- CLI selection logic now lives in `web/src/lib/cli-pick.mjs:1` and has coverage for multiple CLIs and missing `installed` flags.
- System prompt checks now resolve files from `CODE_ROOT` in `cv-sync-check.mjs`, preventing a `ReferenceError`.

## User impact

Users receive a consistent default CLI selection. CV ingestion works on first use. Freshness checks continue after system prompt resolution.

## Files changed

- `cv-sync-check.mjs`
- `web/src/components/config-form.tsx`
- `web/src/components/cv/cv-ingest.tsx`
- `web/src/lib/cli-pick.mjs`
- `web/src/lib/saved-cli.ts`
- `web/tests/lib/saved-cli-pick.test.mjs`

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->