### PR TITLE
docs(web): correct the localized-mode count I got wrong in review

### DIFF
--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -152,7 +152,8 @@ export function ReportView({
             // Identified by the heading, never by the letter: reading "whatever is
             // lettered F" as the verdict rendered the Interview Plan table into a
             // callout built for one sentence — in the canonical mode and in all
-            // eight localized `oferta.md` files alike (#3416). No mode writes a Verdict block today, so today there is
+            // eighteen localized modes alike (#3416). No mode writes a Verdict
+            // block today, so today there is
             // simply no callout and every block renders below.
             const verdict = sections.find((s) => isVerdictHeading(s.heading));
             const rest = sections.filter((s) => s !== verdict);

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -82,9 +82,13 @@ export function authorLetter(heading) {
  * lettered F" as the verdict, but no mode has ever written a Verdict block:
  * the callout landed in #1535 when `modes/oferta.md` already read
  * `## F) Interview Plan`, so every report has rendered the Interview Plan
- * table into a callout built for one sentence (#3416). All eight localized
- * `oferta.md` files write Interview Plan at F too, so this was never an
- * English-only slip.
+ * table into a callout built for one sentence (#3416). All eighteen localized
+ * modes write Interview Plan at F too, so this was never an English-only slip.
+ * Counted by the property rather than the filename — `grep -rlE "^## F\\)" modes/`
+ * returns 19 (18 localized + canonical). Only eight of those are named
+ * `oferta.md`; the rest are `fursah.md`, `angebot.md`, `offre.md`, `naukri.md`,
+ * `lowongan.md`, `annuncio.md`, `kyujin.md`, `gonggo.md`, `vacature.md`,
+ * `is-ilani.md`. A sweep by expected filename misses exactly those.
  *
  * The marker is what the core actually promises: `cleanHeading` has always
  * stripped a trailing `(lead)` / `(verdict)`, which is a deliberate authoring

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -139,8 +139,8 @@ test("the Interview Plan at F is not a verdict", () => {
 });
 
 test("no localized mode heading is mistaken for a verdict", () => {
-  // All eight localized `oferta.md` files write Interview Plan at F, so this was
-  // never an English-only slip. A letter-based rule is wrong in every language at once.
+  // All eighteen localized modes write Interview Plan at F, so this was never an
+  // English-only slip. A letter-based rule is wrong in every language at once.
   for (const heading of [
     "F) Plan rozmów kwalifikacyjnych",
     "F) План співбесід",


### PR DESCRIPTION
Follow-up to #3502, fixing a factual error **I** introduced in review rather than anything @maxmilian wrote.

His original comment said *"All 19 localized modes write Interview Plan at F"*. I asked him to change it to *"eight localized `oferta.md` files"* and gave a reason that is false — I wrote that ten locales ship no mode of their own and fall back to canonical English. They all ship one; they just don't name the file `oferta.md`.

Counted by the property rather than by the filename:

```
$ grep -rlE "^## F\)" modes/ | wc -l
19          # 18 localized + the canonical mode
```

The ten I claimed had none: `ar/fursah.md` · `de/angebot.md` · `fr/offre.md` · `hi/naukri.md` · `id/lowongan.md` · `it/annuncio.md` · `ja/kyujin.md` · `ko/gonggo.md` · `nl/vacature.md` · `tr/is-ilani.md` — each writing the Interview Plan at F in its own language (`## F) Vorstellungsgesprächs-Plan`, `## F) 면접 준비 계획`, `## F) Mülakat Hazırlığı`, …).

**The verdict in #3502 is unaffected and this changes no behaviour** — three comments only. If anything the true number strengthens it: a letter-based verdict rule was wrong in eighteen languages at once, not eight.

### Why the mistake is worth a paragraph in the code

A sweep by *expected filename* silently drops whatever is not named as expected. That is the same shape as the bug #3502 fixes — trusting the letter instead of reading the heading — so the corrected comment now says how the number was obtained, not just what it is.

### Why there's no test

Nothing under `web/tests` reads `modes/` from disk today; the ones that mention it use inline headings. Adding the first such reader would cross `web/`'s own CI boundary. The core already owns that ground (`tracker-columns-tests.mjs`, behind its `HAS_WEB` guard) and is the right home if we want the count enforced — happy to open that separately if you'd like it.

Credit for the fix this corrects: @maxmilian in #3502.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Corrects comments about localized modes. The comments now state that 18 localized modes define the Interview Plan at section F. The change does not affect behavior or tests.

Touched files: `web/src/components/report-view.tsx`, `web/src/lib/report-sections.mjs`, and `web/tests/lib/report-sections.test.mjs`.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->