### PR TITLE
docs: point the last two i-got-hired links at career-ops-hq

### DIFF
--- a/README.hi.md
+++ b/README.hi.md
@@ -22,7 +22,7 @@
   <a href="HIRED.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsantifer%2Fcareer-ops%2Fmain%2Fdocs%2Fhired-count.json&query=%24.count&label=%F0%9F%8E%89%20HIRED%20WITH%20CAREER-OPS&suffix=%20verified&color=2ea44f&style=for-the-badge&labelColor=2b3137" alt="Hired with career-ops: verified count"></a>
 </p>
 
-<p align="center"><sub>आपको भी मिल गई? <a href="https://github.com/santifer/career-ops/issues/new?template=i-got-hired.yml">अपनी कहानी share करें →</a> · आपका card किसी ऐसे व्यक्ति को दिखाएगा जो अभी तलाश में है — कि आगे बढ़ने का रास्ता मौजूद है।</sub></p>
+<p align="center"><sub>आपको भी मिल गई? <a href="https://github.com/career-ops-hq/career-ops/issues/new?template=i-got-hired.yml">अपनी कहानी share करें →</a> · आपका card किसी ऐसे व्यक्ति को दिखाएगा जो अभी तलाश में है — कि आगे बढ़ने का रास्ता मौजूद है।</sub></p>
 
 <p align="center">
   <a href="HIRED.md"><img src="docs/hired-wall.svg" alt="सबसे हाल की तीन नौकरी मिलने की कहानियाँ" width="800"></a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -22,7 +22,7 @@
   <a href="HIRED.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsantifer%2Fcareer-ops%2Fmain%2Fdocs%2Fhired-count.json&query=%24.count&label=%F0%9F%8E%89%20%E7%94%A8%20CAREER-OPS%20%E6%89%BE%E5%88%B0%E5%B7%A5%E4%BD%9C&suffix=%20%E4%BA%BA%E5%B7%B2%E9%A9%97%E8%AD%89&color=2ea44f&style=for-the-badge&labelColor=2b3137" alt="用 career-ops 找到工作：已驗證人數"></a>
 </p>
 
-<p align="center"><sub>你也上岸了嗎？<a href="https://github.com/santifer/career-ops/issues/new?template=i-got-hired.yml">分享你的故事 →</a> · 你的卡片會讓還在找的人看見：出路真的存在。</sub></p>
+<p align="center"><sub>你也上岸了嗎？<a href="https://github.com/career-ops-hq/career-ops/issues/new?template=i-got-hired.yml">分享你的故事 →</a> · 你的卡片會讓還在找的人看見：出路真的存在。</sub></p>
 
 <p align="center">
   <a href="HIRED.md"><img src="docs/hired-wall.svg" alt="最近三則成功入職的故事" width="800"></a>


### PR DESCRIPTION
Leftovers from my own link migration (#3611, #3613), so this is my debt rather than a new finding.

Of the twelve READMEs carrying the *"I got hired"* call to action, ten already point at the new home. These two did not:

```
README.hi.md:25      github.com/santifer/career-ops/issues/new?template=i-got-hired.yml
README.zh-TW.md:25   github.com/santifer/career-ops/issues/new?template=i-got-hired.yml
```

One line each. GitHub redirects, so nothing was broken — it is hygiene, and a reader of a translated README shouldn't be sent to the pre-move org.

### Why the earlier sweeps missed them

Both files carry that link **twice** — one already migrated, plus this one. So a sweep asking *"does this file link to career-ops-hq?"* answers **yes** for both and reports nothing wrong. The question that finds them is the negative one: *"does any old link remain?"* Both answers were true; only one was useful.

### Deliberately not touched

`CHANGELOG.md` (1140 occurrences) and `SIGNATURES.md` (104) still carry the old URL. Those are a historical record — rewriting it so the links look tidy would falsify the archive, not fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the remaining hiring-story links:

- `README.hi.md`: Users can open the hiring-story link in `career-ops-hq/career-ops`.
- `README.zh-TW.md`: Users can open the hiring-story link in `career-ops-hq/career-ops`.

No system files were changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->