### PR TITLE
fix(triage): weights sum to 1.00 and a test pins prose against the formula

### DIFF
--- a/modes/triage.md
+++ b/modes/triage.md
@@ -66,7 +66,7 @@ Assess five dimensions. 1–2 sentences per dimension — no prose, no headers.
 (Weights below are defaults; if `_brief.md` defines its own dimension weights,
 use those.)
 
-**Archetype fit (weight 30%):** Does this map to one of the target archetypes in
+**Archetype fit (weight 35%):** Does this map to one of the target archetypes in
 `_brief.md`? Score 1–5. A direct archetype hit = 4–5. Adjacent = 3. Mismatch = 1–2.
 
 **Comp (weight 25%):** Does stated or estimated comp clear the comp strategy
@@ -82,7 +82,7 @@ directly to JD requirements? Strong overlap = 4–5. Partial = 3. No match = 1�
 **Red flags (adjustment):** Apply the Soft Red Flags from `_brief.md` at −0.5 each.
 Hard DQs override to ≤2.5.
 
-**Global score** = (archetype × 0.30) + (comp × 0.25) + (location × 0.25) +
+**Global score** = (archetype × 0.35) + (comp × 0.25) + (location × 0.25) +
 (cv_match × 0.15) + red_flag_adjustment. Round to nearest 0.1 — matching the
 `X.X/5` scores the tracker and reports already carry, and the 0.1 granularity the
 MARGINAL band below depends on.

--- a/tests/triage-weights.test.mjs
+++ b/tests/triage-weights.test.mjs
@@ -1,0 +1,90 @@
+// tests/triage-weights.test.mjs — the triage first-pass weights are documented
+// twice in modes/triage.md: once as prose (`**Name (weight N%)**`) and once as
+// coefficients in the `**Global score**` formula. Nothing tied the two together,
+// so they could drift from each other and from 1.00 — and they did: the shipped
+// set summed to 0.95, compressing every triage score by 5% against a scale the
+// mode documents as 5-point (#3738).
+//
+// This test does not care WHICH weights the maintainer picks. It asserts only
+// that the two statements of them agree and that they sum to 1.00, so any future
+// redistribution stays internally consistent.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\ntriage dimension weights (#3738)');
+
+const TRIAGE_PATH = 'modes/triage.md';
+const source = readFileSync(join(ROOT, TRIAGE_PATH), 'utf8');
+
+// Prose: `**Archetype fit (weight 35%):** Does this map to ...`
+const PROSE_RE = /^\*\*(.+?)\s*\(weight\s+(\d+(?:\.\d+)?)%\)/gm;
+const prose = [...source.matchAll(PROSE_RE)].map((m) => ({
+  name: m[1],
+  weight: Number(m[2]) / 100,
+}));
+
+// Formula: `**Global score** = (archetype × 0.35) + (comp × 0.25) + ...`,
+// which wraps across lines, so take the paragraph and pull every `(term × N)`.
+// `red_flag_adjustment` carries no coefficient and is deliberately not matched.
+const formulaBlock = source.split(/\n\s*\n/).find((para) => para.includes('**Global score**')) ?? '';
+const FORMULA_RE = /\(\s*([A-Za-z][A-Za-z_ ]*?)\s*×\s*(\d*\.\d+)\s*\)/g;
+const formula = [...formulaBlock.matchAll(FORMULA_RE)].map((m) => ({
+  name: m[1],
+  weight: Number(m[2]),
+}));
+
+/** Lowercase word tokens, so `CV match estimate` and `cv_match` are comparable. */
+const tokens = (name) => name.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+const isPrefixOf = (short, long) => short.every((tok, i) => long[i] === tok);
+
+if (prose.length === 4 && formula.length === 4) {
+  pass(`${TRIAGE_PATH} declares 4 weighted dimensions in prose and 4 in the Global score formula`);
+} else {
+  fail(`${TRIAGE_PATH} declares ${prose.length} prose weights and ${formula.length} formula weights, expected 4 of each`
+    + ` (prose: ${prose.map((d) => d.name).join(', ') || 'none'};`
+    + ` formula: ${formula.map((d) => d.name).join(', ') || 'none'})`);
+}
+
+// Pair each formula term with the prose dimension whose name it abbreviates
+// (`cv_match` → `CV match estimate`). An unmatched or ambiguous term means one
+// of the two lists was renamed without the other.
+const mismatches = [];
+const pairedProse = new Set();
+for (const term of formula) {
+  const candidates = prose.filter((dim) => isPrefixOf(tokens(term.name), tokens(dim.name)));
+  if (candidates.length !== 1) {
+    mismatches.push(`formula term "${term.name}" matches ${candidates.length} prose dimensions`);
+    continue;
+  }
+  const [dim] = candidates;
+  pairedProse.add(dim.name);
+  if (Math.abs(dim.weight - term.weight) > 1e-9) {
+    mismatches.push(`"${dim.name}" is ${dim.weight * 100}% in prose but × ${term.weight} in the formula`);
+  }
+}
+for (const dim of prose) {
+  if (!pairedProse.has(dim.name)) mismatches.push(`prose dimension "${dim.name}" has no term in the Global score formula`);
+}
+
+if (mismatches.length === 0) {
+  pass(`each prose weight in ${TRIAGE_PATH} equals its coefficient in the Global score formula`);
+} else {
+  fail(`prose and formula weights disagree in ${TRIAGE_PATH}: ${mismatches.join('; ')}`);
+}
+
+const formulaSum = formula.reduce((total, term) => total + term.weight, 0);
+if (formula.length > 0 && Math.abs(formulaSum - 1) <= 1e-9) {
+  pass(`the Global score formula weights in ${TRIAGE_PATH} sum to 1.00`);
+} else {
+  fail(`the Global score formula weights in ${TRIAGE_PATH} sum to ${formulaSum.toFixed(4)}, not 1.00`
+    + ` — every triage score is scaled by that factor against a 5-point scale`);
+}
+
+const proseSum = prose.reduce((total, dim) => total + dim.weight, 0);
+if (prose.length > 0 && Math.abs(proseSum - 1) <= 1e-9) {
+  pass(`the prose dimension weights in ${TRIAGE_PATH} sum to 1.00`);
+} else {
+  fail(`the prose dimension weights in ${TRIAGE_PATH} sum to ${proseSum.toFixed(4)}, not 1.00`);
+}


### PR DESCRIPTION
## What does this PR do?

Raises the `Archetype fit` triage weight from 30% to 35% so the four first-pass dimension weights in `modes/triage.md` sum to 1.00 instead of 0.95, and adds `tests/triage-weights.test.mjs`, which asserts that the weights stated in prose match the coefficients in the `Global score` formula and that they sum to 1.00.

## Related issue

Closes #3738

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

Both changed files are System Layer per `DATA_CONTRACT.md`: `modes/triage.md` and a new file under `tests/`. No user-layer file is touched.

## How it works

The triage weights are written twice. Once as prose, at `modes/triage.md:69`, `:72`, `:76` and `:79`, and once as coefficients in the `Global score` formula at `modes/triage.md:85-86`. Before this PR both copies said the same thing and both were wrong:

```
0.30 (archetype) + 0.25 (comp) + 0.25 (location) + 0.15 (cv_match) = 0.95
```

A posting scoring 5 on every dimension came out at 4.75, so the scale never reached the ceiling the mode documents. Ordering between candidates was unaffected, since every score was scaled by the same 0.95, but the bands were not: the PASS cut at `modes/triage.md:93` is `triage_threshold` (default 3.5), and the MARGINAL band at `:94` runs from 3.0 to the threshold. `modes/_brief.template.md:71` reads those same bands. A role whose honest weighted score is 3.58 was reported as 3.4 and dropped as MARGINAL. The error is largest exactly at the boundary where triage decisions are made. It also made a triage 4.5 mean something different from an `oferta` 4.5, which is on a true 0-5 scale.

The fix moves the missing 0.05 onto `Archetype fit`:

```
0.35 (archetype) + 0.25 (comp) + 0.25 (location) + 0.15 (cv_match) = 1.00
```

Why 35 and not a different redistribution:

- It is the smallest change that reaches 1.00, one dimension, one round number, with the other three untouched.
- It keeps the existing ranking of the dimensions: archetype > comp = location > cv_match.
- It adds the weight to the dimension the mode already treats as the primary first-pass signal. `modes/triage.md:69` scores archetype fit against the target archetypes in `_brief.md`, which is the North Star check.
- Proportional normalisation (0.316 / 0.263 / 0.263 / 0.158) preserves the same ranking but replaces four round numbers a reader can check by eye with four that they cannot.

## Tests

New file `tests/triage-weights.test.mjs`. It parses `modes/triage.md` rather than hard-coding the numbers, so it does not encode an opinion about which weights are right. It asserts:

1. Four `(weight N%)` prose declarations and four `(term × 0.NN)` formula terms are found.
2. Each formula term pairs with exactly one prose dimension (matching `cv_match` to `CV match estimate` by word-token prefix) and carries the same value.
3. The formula coefficients sum to 1.00, within 1e-9.
4. The prose percentages sum to 1.00, within 1e-9.

`node test-all.mjs --only triage-weights`, 4 passed, 0 failed, 0 warnings, exit 0.

`node test-all.mjs --quick`, 8098 passed, 0 failed, 13 warnings, exit 0. The same command on the base commit with these two changes removed gives 8093 passed, 0 failed, 13 warnings, exit 0, so the branch adds exactly 5 checks: the suite's syntax check on the new file, plus its 4 assertions.

`npm run lint` passes, 655 .mjs files.

Mutant checks, to confirm the test can actually fail. `modes/triage.md` was copied to a backup first and restored from the copy afterwards.

Mutant 1, formula only, `modes/triage.md:85` `× 0.35` back to `× 0.30`, prose left at 35%:

```
  ✅ modes/triage.md declares 4 weighted dimensions in prose and 4 in the Global score formula
  ❌ prose and formula weights disagree in modes/triage.md: "Archetype fit" is 35% in prose but × 0.3 in the formula
  ❌ the Global score formula weights in modes/triage.md sum to 0.9500, not 1.00 — every triage score is scaled by that factor against a 5-point scale
  ✅ the prose dimension weights in modes/triage.md sum to 1.00
📊 Results: 2 passed, 2 failed, 0 warnings
```

Mutant 2, prose only, `modes/triage.md:69` `(weight 35%)` back to `(weight 30%)`, formula left at 0.35:

```
  ✅ modes/triage.md declares 4 weighted dimensions in prose and 4 in the Global score formula
  ❌ prose and formula weights disagree in modes/triage.md: "Archetype fit" is 30% in prose but × 0.35 in the formula
  ✅ the Global score formula weights in modes/triage.md sum to 1.00
  ❌ the prose dimension weights in modes/triage.md sum to 0.9500, not 1.00
```

The two mutants fail different assertions, which is the point of having both: the sum check and the prose-versus-formula check each catch a drift the other misses.

I also grepped `modes/`, `batch/`, `docs/`, `web/`, `tests/` and the `README*` files for other copies of these weights. There are none. `modes/triage.md` has no localised siblings, and the formula terms `archetype ×` / `cv_match` / `red_flag_adjustment` appear nowhere else in the repo. The percentage tables in `modes/ofertas.md:7-16` and `modes/project.md:10-15` are separate rubrics that already sum to 100%, and `web/src/components/score-methodology.tsx` names the `oferta` dimensions without quoting any weight.

## Out of scope

- Any other redistribution of the 0.05. The issue suggests 0.35 / 0.30 / 0.15 / 0.20, which changes the relative standing of comp and location. That encodes a product opinion about what matters in a first pass and is the maintainer's call, not a bug fix. The new test passes for any set that sums to 1.00 and keeps the two statements of it in agreement, so changing the distribution later needs no change to the test.
- The `_brief.md` override path at `modes/triage.md:66-67`. A user-supplied weight set still is not validated. Checking it would mean parsing a user-layer file, which is a different change.
- The wording "Assess five dimensions" at `modes/triage.md:65` stays as is. It counts the four weighted dimensions plus the red-flag adjustment, which correctly carries no weight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `modes/triage.md:15-21`: Increases the Archetype fit weight from 30% to 35%. Updates the `Global score` formula to use `0.35`. The four first-pass weights now sum to 1.00, so a maximum score can reach 5.00.
- `tests/triage-weights.test.mjs:1-90`: Adds validation for prose weights, formula coefficients, dimension matching, and total weights.

Users receive correctly scaled triage scores. The test fails if the documented weights and formula diverge.

Touched system files: `modes/triage.md` and `tests/triage-weights.test.mjs`. `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->