### PR TITLE
fix(web/apply): never hand the planner a ref to a submit control, and guard every action by element facts

### DIFF
--- a/web/src/components/apply-view.tsx
+++ b/web/src/components/apply-view.tsx
@@ -390,7 +390,18 @@ function DrivePanel({ steps, filling }: { steps: DriveStep[]; filling?: boolean 
               <span className="grid size-5 shrink-0 place-items-center rounded-full bg-brand-soft text-[10px] font-semibold text-brand">{s.turn}</span>
               <span className="shrink-0 font-medium">{DRIVE_VERB[s.action] ?? s.action}</span>
               <span className="truncate text-faint">{s.detail}</span>
-              {s.note && <span className="shrink-0 text-amber-500">· {s.note}</span>}
+              {/* `submit-control` is the guard doing its job (good news, distinct
+                  color); `not-offered`/`gone` are the page moving under us
+                  (a caution, not a protection) — same amber as before this
+                  field had a consumer at all. */}
+              {s.note &&
+                (s.refusal === "submit-control" ? (
+                  <span className="inline-flex shrink-0 items-center gap-1 text-emerald-700 dark:text-emerald-400">
+                    <ShieldCheck className="size-3" /> {s.note}
+                  </span>
+                ) : (
+                  <span className="shrink-0 text-amber-500">· {s.note}</span>
+                ))}
             </li>
           ))}
         </ol>

--- a/web/src/lib/apply/drive.ts
+++ b/web/src/lib/apply/drive.ts
@@ -3,6 +3,7 @@ import type { Page, Frame } from "playwright-core";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { dropNewTabs } from "./diagnose";
+import { isSubmitControl, snapshotLabel } from "./submit-guard.mjs";
 import type { DriveStep } from "./issue";
 
 export type { DriveStep };
@@ -12,8 +13,9 @@ export type { DriveStep };
 // observe (ref-tagged snapshot) → the LLM picks ONE action → WE execute it on OUR
 // headed session → observe again → adapt. We orchestrate the loop (CLI-agnostic in
 // principle; Claude-first via --resume) and execute every action ourselves, so:
-//   • NEVER-SUBMIT is by CONSTRUCTION — the action vocabulary has no "submit", and
-//     we refuse to click any submit/apply-final control. The human submits.
+//   • NEVER-SUBMIT is by CONSTRUCTION — the action vocabulary has no "submit", a
+//     submit/apply-final control is listed with no ref so it cannot be named, and
+//     we re-check the element before every action that names one. The human submits.
 //   • everything stays in OUR session (screenshots, handoff, the streamed UI).
 // HYBRID = drive only until a fillable application form is reached, then hand back
 // to deterministic fill+verify. FULL = keep driving (fill the fields too).
@@ -21,37 +23,92 @@ export type { DriveStep };
 
 export type DriveResult = { reached: boolean; turns: number; reason: string; steps: DriveStep[] };
 
-const SUBMIT_RX = /\b(submit|send application|finish( application)?|complete application|apply (and|&) submit|enviar|finalizar)\b/i;
+/** What the guard decides on, read from the live DOM. See submit-guard.mjs. */
+type ElementFacts = {
+  ref: string;
+  tag: string;
+  type: string;
+  explicitType: boolean;
+  role: string;
+  inForm: boolean;
+  aria: string;
+  placeholder: string;
+  text: string;
+  value: string;
+  name: string;
+};
 
-/** Ref-tagged snapshot of the interactive page (a browser_snapshot-style view the
- *  LLM reasons over). Tags data-co-ref on each element so actions are unambiguous. */
-async function snapshot(frame: Frame): Promise<{ text: string; n: number }> {
-  return frame.evaluate(() => {
-    const clean = (s: string | null | undefined) => (s || "").replace(/\s+/g, " ").trim().slice(0, 80);
+/** Read element facts in the page. With no ref this is the snapshot pass: it tags
+ *  every visible candidate with data-co-ref and returns them all. With a ref it
+ *  re-reads that one element for the action guard. One extractor for both on
+ *  purpose — two would eventually disagree, and the disagreement is the bug. */
+async function readFacts(frame: Frame, ref: string | null): Promise<ElementFacts[]> {
+  return frame.evaluate((targetRef) => {
+    const facts = (el: Element, r: string) => {
+      const tag = el.tagName.toLowerCase();
+      const field = el as HTMLInputElement;
+      const type = (el.getAttribute("type") || "").toLowerCase();
+      return {
+        ref: r,
+        tag,
+        type,
+        // A <button> honours only these; anything else submits by default.
+        explicitType: tag === "button" ? ["submit", "reset", "button"].includes(type) : type !== "",
+        role: el.getAttribute("role") || (tag === "a" ? "link" : tag),
+        // `.form` also covers a control placed outside its form by form="id".
+        inForm: Boolean(field.form) || el.closest("form") !== null,
+        aria: el.getAttribute("aria-label") || "",
+        placeholder: field.placeholder || "",
+        // Capped here, not in Node: a [role="button"] can wrap a whole section,
+        // and 70 of those would cross the wire in full every turn. Well above
+        // the 80 chars snapshotLabel keeps, so the cap decides nothing.
+        text: (el.textContent || "").replace(/\s+/g, " ").trim().slice(0, 200),
+        value: field.value || "",
+        name: field.name || "",
+      };
+    };
+    if (targetRef !== null) {
+      const el = document.querySelector(`[data-co-ref="${targetRef}"]`);
+      return el ? [facts(el, targetRef)] : [];
+    }
     const vis = (el: Element) => {
       const r = (el as HTMLElement).getBoundingClientRect();
       return (el as HTMLElement).offsetParent !== null && r.width > 2 && r.height > 2;
     };
     const sel = 'a, button, input, textarea, select, [role="button"], [role="link"], [role="combobox"], [role="checkbox"], [role="radio"], [contenteditable="true"]';
     const els = Array.from(document.querySelectorAll(sel)).filter(vis);
-    const lines: string[] = [];
+    const out = [];
     let n = 0;
     for (const el of els.slice(0, 70)) {
-      const tag = el.tagName.toLowerCase();
-      const itype = ((el as HTMLInputElement).type || "").toLowerCase();
-      if (tag === "input" && ["hidden", "submit", "button", "image", "reset"].includes(itype)) {
-        // surface submit buttons in the snapshot as read-only context (not actionable)
-      }
-      const ref = `e${n}`;
+      const ref = `e${n++}`;
       el.setAttribute("data-co-ref", ref);
-      const role = el.getAttribute("role") || (tag === "a" ? "link" : tag);
-      const label = clean(el.getAttribute("aria-label") || (el as HTMLInputElement).placeholder || el.textContent || (el as HTMLInputElement).value || (el as HTMLInputElement).name);
-      const kind = tag === "input" ? itype || "text" : tag === "a" ? "link" : tag === "select" ? "select" : tag === "textarea" ? "textarea" : role;
-      lines.push(`[${ref}] ${kind} "${label}"`);
-      n++;
+      out.push(facts(el, ref));
     }
-    return { text: lines.join("\n"), n };
-  });
+    return out;
+  }, ref);
+}
+
+/** Ref-tagged snapshot of the interactive page (a browser_snapshot-style view the
+ *  LLM reasons over). Tags data-co-ref on each element so actions are unambiguous.
+ *  A submit control is listed WITHOUT a ref: the planner can see that it exists
+ *  and stop, but it has no name for it, so no action can address it. `actionable`
+ *  is the set of refs it may use, which every ref-bearing action is held to. */
+async function snapshot(frame: Frame): Promise<{ text: string; n: number; actionable: Set<string> }> {
+  const els = await readFacts(frame, null);
+  const lines: string[] = [];
+  const actionable = new Set<string>();
+  for (const el of els) {
+    if (el.tag === "input" && el.type === "hidden") continue;
+    const label = snapshotLabel(el);
+    if (isSubmitControl(el)) {
+      lines.push(`[--] submit "${label}" (not actionable, the human submits)`);
+      continue;
+    }
+    actionable.add(el.ref);
+    const kind = el.tag === "input" ? el.type || "text" : el.tag === "a" ? "link" : el.tag === "select" ? "select" : el.tag === "textarea" ? "textarea" : el.role;
+    lines.push(`[${el.ref}] ${kind} "${label}"`);
+  }
+  return { text: lines.join("\n"), n: actionable.size, actionable };
 }
 
 /** One planner turn (Claude-first: --resume keeps the loop's context cheaply). */
@@ -141,7 +198,7 @@ ${answersBlock || "(no answers provided — just reach/observe)"}`;
     if (goal === "reach" && (await isFormReady().catch(() => false))) return { reached: true, turns: turn - 1, reason: "form-reached", steps };
     await dropNewTabs(page); // any "Apply" link/popup navigates in OUR tab, not a new one
     const frame = page.mainFrame();
-    const snap = await snapshot(frame).catch(() => ({ text: "", n: 0 }));
+    const snap = await snapshot(frame).catch(() => ({ text: "", n: 0, actionable: new Set<string>() }));
     const prompt =
       turn === 1
         ? `You are an agent driving a real web browser for a job seeker (we execute your actions; the human submits at the end). ${goalText}
@@ -187,17 +244,23 @@ Reply ONE action JSON.`;
     let detail = "";
     let note = "";
     try {
-      const loc = act.ref ? frame.locator(`[data-co-ref="${act.ref}"]`).first() : null;
-      if (act.action === "click" && loc) {
-        const txt = (await loc.innerText().catch(() => "")) || (await loc.getAttribute("value").catch(() => "")) || "";
-        if (SUBMIT_RX.test(txt)) {
-          note = "refused to click a submit control (the human submits)";
-          detail = `blocked submit "${txt.slice(0, 40)}"`;
-        } else {
-          detail = `click "${txt.slice(0, 40)}"`;
-          await loc.scrollIntoViewIfNeeded().catch(() => {});
-          await Promise.all([page.waitForLoadState("domcontentloaded", { timeout: 8000 }).catch(() => {}), loc.click({ timeout: 6000 })]);
-        }
+      // Every action naming a ref is cleared before it gets a locator, not just
+      // click: a withheld submit control still carries its data-co-ref in the
+      // page, and `fill()` on a button throws into a fallback that clicks. The
+      // element is re-read here because the DOM can change between the snapshot
+      // and now, and being unreadable counts as refused — an element we cannot
+      // describe is one we cannot clear.
+      const ref = act.ref !== undefined && snap.actionable.has(act.ref) ? act.ref : null;
+      const [now] = ref !== null ? await readFacts(frame, ref).catch(() => []) : [];
+      const label = now ? snapshotLabel(now) : "";
+      const loc = ref !== null && now && !isSubmitControl(now) ? frame.locator(`[data-co-ref="${ref}"]`).first() : null;
+      if (act.ref !== undefined && !loc) {
+        note = "refused to click a submit control (the human submits)";
+        detail = ref === null ? `blocked ref ${act.ref} (not offered)` : now ? `blocked submit "${label.slice(0, 40)}"` : `blocked ref ${act.ref} (gone)`;
+      } else if (act.action === "click" && loc) {
+        detail = `click "${label.slice(0, 40)}"`;
+        await loc.scrollIntoViewIfNeeded().catch(() => {});
+        await Promise.all([page.waitForLoadState("domcontentloaded", { timeout: 8000 }).catch(() => {}), loc.click({ timeout: 6000 })]);
       } else if (act.action === "type" && loc) {
         detail = `type into ${act.ref}`;
         await loc.fill(act.text || "").catch(async () => {

--- a/web/src/lib/apply/drive.ts
+++ b/web/src/lib/apply/drive.ts
@@ -1,5 +1,5 @@
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
-import type { Page, Frame } from "playwright-core";
+import type { Page, Frame, ElementHandle } from "playwright-core";
 import { resolveCli } from "@/lib/clis";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { dropNewTabs } from "./diagnose";
@@ -13,9 +13,13 @@ export type { DriveStep };
 // observe (ref-tagged snapshot) → the LLM picks ONE action → WE execute it on OUR
 // headed session → observe again → adapt. We orchestrate the loop (CLI-agnostic in
 // principle; Claude-first via --resume) and execute every action ourselves, so:
-//   • NEVER-SUBMIT is by CONSTRUCTION — the action vocabulary has no "submit", a
-//     submit/apply-final control is listed with no ref so it cannot be named, and
-//     we re-check the element before every action that names one. The human submits.
+//   • NEVER-SUBMIT is by CONSTRUCTION for the planner's action vocabulary — it has
+//     no "submit", a submit/apply-final control is listed with no ref so it cannot
+//     be named, and we re-check the element before every action that names one.
+//     What this does NOT construct away: an allowed control's own click handler can
+//     still call requestSubmit(). Closing that needs an interlock on the submit
+//     event itself, not another DOM heuristic (see submit-guard.mjs's header). The
+//     human submits every path this loop does cover.
 //   • everything stays in OUR session (screenshots, handoff, the streamed UI).
 // HYBRID = drive only until a fillable application form is reached, then hand back
 // to deterministic fill+verify. FULL = keep driving (fill the fields too).
@@ -28,7 +32,6 @@ type ElementFacts = {
   ref: string;
   tag: string;
   type: string;
-  explicitType: boolean;
   role: string;
   inForm: boolean;
   aria: string;
@@ -36,68 +39,99 @@ type ElementFacts = {
   text: string;
   value: string;
   name: string;
+  title: string;
+  alt: string;
 };
 
-/** Read element facts in the page. With no ref this is the snapshot pass: it tags
- *  every visible candidate with data-co-ref and returns them all. With a ref it
- *  re-reads that one element for the action guard. One extractor for both on
- *  purpose — two would eventually disagree, and the disagreement is the bug. */
-async function readFacts(frame: Frame, ref: string | null): Promise<ElementFacts[]> {
-  return frame.evaluate((targetRef) => {
-    const facts = (el: Element, r: string) => {
-      const tag = el.tagName.toLowerCase();
-      const field = el as HTMLInputElement;
-      const type = (el.getAttribute("type") || "").toLowerCase();
-      return {
-        ref: r,
-        tag,
-        type,
-        // A <button> honours only these; anything else submits by default.
-        explicitType: tag === "button" ? ["submit", "reset", "button"].includes(type) : type !== "",
-        role: el.getAttribute("role") || (tag === "a" ? "link" : tag),
-        // `.form` also covers a control placed outside its form by form="id".
-        inForm: Boolean(field.form) || el.closest("form") !== null,
-        aria: el.getAttribute("aria-label") || "",
-        placeholder: field.placeholder || "",
-        // Capped here, not in Node: a [role="button"] can wrap a whole section,
-        // and 70 of those would cross the wire in full every turn. Well above
-        // the 80 chars snapshotLabel keeps, so the cap decides nothing.
-        text: (el.textContent || "").replace(/\s+/g, " ").trim().slice(0, 200),
-        value: field.value || "",
-        name: field.name || "",
-      };
-    };
-    if (targetRef !== null) {
-      const el = document.querySelector(`[data-co-ref="${targetRef}"]`);
-      return el ? [facts(el, targetRef)] : [];
-    }
-    const vis = (el: Element) => {
-      const r = (el as HTMLElement).getBoundingClientRect();
-      return (el as HTMLElement).offsetParent !== null && r.width > 2 && r.height > 2;
-    };
-    const sel = 'a, button, input, textarea, select, [role="button"], [role="link"], [role="combobox"], [role="checkbox"], [role="radio"], [contenteditable="true"]';
-    const els = Array.from(document.querySelectorAll(sel)).filter(vis);
-    const out = [];
-    let n = 0;
-    for (const el of els.slice(0, 70)) {
-      const ref = `e${n++}`;
-      el.setAttribute("data-co-ref", ref);
-      out.push(facts(el, ref));
-    }
-    return out;
-  }, ref);
-}
+/** Read one element's facts, in the page. Defined once, at the top level, and
+ *  handed to Playwright as the pageFunction for both call sites: the snapshot
+ *  that decides which elements the planner may address, and the re-check the
+ *  action path runs on the handle it is about to act on. Two extractors would
+ *  eventually disagree, and the disagreement is the bug.
+ *
+ *  Playwright serialises it by source and runs it in the page, so it closes over
+ *  nothing here — everything it needs is the element and its ref. */
+const factsOf = (el: Element, ref: string | null): ElementFacts => {
+  const field = el as HTMLInputElement;
+  const tag = el.tagName.toLowerCase();
+  const flat = (s: string | null) => (s || "").replace(/\s+/g, " ").trim();
+  // The accessible name, not just the attribute: a control named through
+  // aria-labelledby has no aria-label at all, and reading only the attribute
+  // would leave the guard classifying an empty string.
+  let aria = flat(el.getAttribute("aria-label"));
+  if (!aria) {
+    const ids = flat(el.getAttribute("aria-labelledby")).split(" ").filter(Boolean);
+    aria = flat(ids.map((id) => document.getElementById(id)?.textContent || "").join(" ")).slice(0, 200);
+  }
+  return {
+    ref: ref || el.getAttribute("data-co-ref") || "",
+    tag,
+    type: flat(el.getAttribute("type")).toLowerCase(),
+    role: flat(el.getAttribute("role")).toLowerCase() || (tag === "a" ? "link" : tag),
+    // `.form` also covers a control placed outside its form by form="id".
+    inForm: Boolean(field.form) || el.closest("form") !== null,
+    aria,
+    placeholder: field.placeholder || "",
+    // Capped here, not in Node: a [role="button"] can wrap a whole section, and
+    // 70 of those would cross the wire in full every turn. Well above the 80
+    // chars the snapshot line keeps, but still a cap ahead of classification:
+    // a submit phrase past character 200 of an unusually large clickable is
+    // invisible to isSubmitControl. Accepted: the alternative is unbounded text
+    // per element every turn, or classifying inside the page.
+    text: flat(el.textContent).slice(0, 200),
+    value: field.value || "",
+    name: field.name || "",
+    // Classification only (see submit-guard.mjs): they name an icon-only
+    // control that carries nothing else, and never reach the snapshot line.
+    // Same 200-char cap and the same caveat as `text` above.
+    title: flat(el.getAttribute("title")).slice(0, 200),
+    alt: flat(el.getAttribute("alt")).slice(0, 200),
+  };
+};
+
+/** Controls tagged per turn. The planner reads every one of them. */
+const MAX_REFS = 70;
 
 /** Ref-tagged snapshot of the interactive page (a browser_snapshot-style view the
  *  LLM reasons over). Tags data-co-ref on each element so actions are unambiguous.
  *  A submit control is listed WITHOUT a ref: the planner can see that it exists
  *  and stop, but it has no name for it, so no action can address it. `actionable`
  *  is the set of refs it may use, which every ref-bearing action is held to. */
-async function snapshot(frame: Frame): Promise<{ text: string; n: number; actionable: Set<string> }> {
-  const els = await readFacts(frame, null);
+async function snapshot(frame: Frame): Promise<{ text: string; actionable: Set<string> }> {
+  // A fresh prefix per snapshot. The guarantee is structural, not statistical:
+  // every existing `data-co-ref` is stripped before this turn's are written, so
+  // only the current epoch's refs exist on the page, and `actionable` is built
+  // from that same pass. A ref from the previous turn names an attribute that no
+  // longer exists anywhere, so neither the actionable check nor the selector can
+  // find it. Numbering from e0 each turn would hand the same name to a different
+  // element across turns, and both lookups would have accepted it.
+  const epoch = `e${Math.random().toString(36).slice(2, 8)}`;
+  const tagged = await frame.evaluate(
+    ({ prefix, max }) => {
+      for (const stale of Array.from(document.querySelectorAll("[data-co-ref]"))) stale.removeAttribute("data-co-ref");
+      const vis = (el: Element) => {
+        const r = el.getBoundingClientRect();
+        return (el as HTMLElement).offsetParent !== null && r.width > 2 && r.height > 2;
+      };
+      const sel = 'a, button, input, textarea, select, [role="button"], [role="link"], [role="combobox"], [role="checkbox"], [role="radio"], [contenteditable="true"]';
+      const els = Array.from(document.querySelectorAll(sel)).filter(vis);
+      let n = 0;
+      for (const el of els.slice(0, max)) el.setAttribute("data-co-ref", `${prefix}-${n++}`);
+      return n;
+    },
+    { prefix: epoch, max: MAX_REFS },
+  );
   const lines: string[] = [];
   const actionable = new Set<string>();
+  if (!tagged) return { text: "", actionable };
+  // One handle per candidate, read through the same extractor the action path
+  // uses. Handles rather than one `$$eval` so there is a single copy of the
+  // rule; the reads are issued together and the handles released straight after.
+  const handles = await frame.$$(`[data-co-ref^="${epoch}-"]`);
+  const els = await Promise.all(handles.map((h) => h.evaluate(factsOf, null).catch(() => null)));
+  await Promise.all(handles.map((h) => h.dispose().catch(() => {})));
   for (const el of els) {
+    if (!el || !el.ref) continue;
     if (el.tag === "input" && el.type === "hidden") continue;
     const label = snapshotLabel(el);
     if (isSubmitControl(el)) {
@@ -108,7 +142,7 @@ async function snapshot(frame: Frame): Promise<{ text: string; n: number; action
     const kind = el.tag === "input" ? el.type || "text" : el.tag === "a" ? "link" : el.tag === "select" ? "select" : el.tag === "textarea" ? "textarea" : el.role;
     lines.push(`[${el.ref}] ${kind} "${label}"`);
   }
-  return { text: lines.join("\n"), n: actionable.size, actionable };
+  return { text: lines.join("\n"), actionable };
 }
 
 /** One planner turn (Claude-first: --resume keeps the loop's context cheaply). */
@@ -191,22 +225,21 @@ export async function driveSession(
 ANSWERS (match by the field's label):
 ${answersBlock || "(no answers provided — just reach/observe)"}`;
   let resumeId: string | null = null;
-  let lastUrl = page.url();
 
   const stopVerb = goal === "reach" ? '{"action":"reached_form"}            STOP — the fillable application form is now visible' : '{"action":"done"}                    STOP — every answer is filled (you NEVER submit; the human does)';
   for (let turn = 1; turn <= budget; turn++) {
     if (goal === "reach" && (await isFormReady().catch(() => false))) return { reached: true, turns: turn - 1, reason: "form-reached", steps };
     await dropNewTabs(page); // any "Apply" link/popup navigates in OUR tab, not a new one
     const frame = page.mainFrame();
-    const snap = await snapshot(frame).catch(() => ({ text: "", n: 0, actionable: new Set<string>() }));
+    const snap = await snapshot(frame).catch(() => ({ text: "", actionable: new Set<string>() }));
     const prompt =
       turn === 1
         ? `You are an agent driving a real web browser for a job seeker (we execute your actions; the human submits at the end). ${goalText}
 You NEVER submit a form — there is no submit action; the human does that.
 Reply with EXACTLY ONE action as a JSON object, nothing else:
-  {"action":"click","ref":"e3"}            click an element
-  {"action":"type","ref":"e4","text":"…"}  type into a field
-  {"action":"select","ref":"e9","value":"…"} pick an option
+  {"action":"click","ref":"<ref>"}         click an element (refs are the bracketed names below, and they change every turn)
+  {"action":"type","ref":"<ref>","text":"…"}  type into a field
+  {"action":"select","ref":"<ref>","value":"…"} pick an option
   {"action":"scroll"}                        scroll down to reveal more
   ${stopVerb}
   {"action":"stuck","reason":"…"}            you can't proceed (login/captcha/dead-end)
@@ -243,33 +276,58 @@ Reply ONE action JSON.`;
     // execute the action on OUR session — NEVER submit.
     let detail = "";
     let note = "";
+    let refusal: DriveStep["refusal"];
+    let handle: ElementHandle<SVGElement | HTMLElement> | null = null;
     try {
-      // Every action naming a ref is cleared before it gets a locator, not just
-      // click: a withheld submit control still carries its data-co-ref in the
-      // page, and `fill()` on a button throws into a fallback that clicks. The
-      // element is re-read here because the DOM can change between the snapshot
-      // and now, and being unreadable counts as refused — an element we cannot
-      // describe is one we cannot clear.
+      // Every action naming a ref is cleared before anything is done to it, not
+      // just click: `fill()` on a button throws into a fallback that clicks. The
+      // check and the action are bound to ONE element handle, because resolving
+      // the selector again after the check lets the DOM hand the action a
+      // different node than the one that was cleared. The element is re-read
+      // here because the page can change between the snapshot and now, and being
+      // unreadable counts as refused: an element we cannot describe is one we
+      // cannot clear.
       const ref = act.ref !== undefined && snap.actionable.has(act.ref) ? act.ref : null;
-      const [now] = ref !== null ? await readFacts(frame, ref).catch(() => []) : [];
+      handle = ref !== null ? await frame.$(`[data-co-ref="${ref}"]`).catch(() => null) : null;
+      const now = handle ? await handle.evaluate(factsOf, ref).catch(() => null) : null;
       const label = now ? snapshotLabel(now) : "";
-      const loc = ref !== null && now && !isSubmitControl(now) ? frame.locator(`[data-co-ref="${ref}"]`).first() : null;
-      if (act.ref !== undefined && !loc) {
-        note = "refused to click a submit control (the human submits)";
-        detail = ref === null ? `blocked ref ${act.ref} (not offered)` : now ? `blocked submit "${label.slice(0, 40)}"` : `blocked ref ${act.ref} (gone)`;
-      } else if (act.action === "click" && loc) {
+      const target = now && !isSubmitControl(now) ? handle : null;
+      if (act.ref !== undefined && !target) {
+        // Three different refusals, told apart: only one of them is the guard
+        // doing its job, and a UI that calls a vanished element a submit button
+        // teaches the user to distrust the message that matters.
+        const named = String(act.ref).slice(0, 24);
+        if (ref === null) {
+          refusal = "not-offered";
+          note = "not offered this turn";
+          detail = `blocked ref ${named} (not offered this turn)`;
+        } else if (!now) {
+          refusal = "gone";
+          note = "element gone";
+          detail = `blocked ref ${named} (gone)`;
+        } else {
+          refusal = "submit-control";
+          note = "refused to click a submit control (the human submits)";
+          detail = `blocked submit "${label.slice(0, 40)}"`;
+        }
+      } else if (act.action === "click" && target) {
         detail = `click "${label.slice(0, 40)}"`;
-        await loc.scrollIntoViewIfNeeded().catch(() => {});
-        await Promise.all([page.waitForLoadState("domcontentloaded", { timeout: 8000 }).catch(() => {}), loc.click({ timeout: 6000 })]);
-      } else if (act.action === "type" && loc) {
-        detail = `type into ${act.ref}`;
-        await loc.fill(act.text || "").catch(async () => {
-          await loc.click();
+        await target.scrollIntoViewIfNeeded().catch(() => {});
+        await Promise.all([page.waitForLoadState("domcontentloaded", { timeout: 8000 }).catch(() => {}), target.click({ timeout: 6000 })]);
+      } else if (act.action === "type" && target) {
+        detail = `type into ${label.slice(0, 40) || ref}`;
+        // Same explicit 6s as the click branch above, for a predictable bound
+        // on this fallback's own click: session.ts sets an 8s context default
+        // (`context.setDefaultTimeout(8000)`), so this was already bounded,
+        // just two seconds looser than the action this loop otherwise treats
+        // as its click budget.
+        await target.fill(act.text || "").catch(async () => {
+          await target.click({ timeout: 6000 });
           await page.keyboard.type(act.text || "");
         });
-      } else if (act.action === "select" && loc) {
+      } else if (act.action === "select" && target) {
         detail = `select "${act.value}"`;
-        await loc.selectOption({ label: act.value || "" }).catch(() => loc.selectOption(act.value || ""));
+        await target.selectOption({ label: act.value || "" }, { timeout: 6000 }).catch(() => target.selectOption(act.value || "", { timeout: 6000 }));
       } else if (act.action === "scroll") {
         detail = "scroll";
         await page.evaluate(() => window.scrollBy(0, 700)).catch(() => {});
@@ -278,13 +336,13 @@ Reply ONE action JSON.`;
       }
     } catch (e) {
       detail = `${act.action} failed: ${e instanceof Error ? e.message.slice(0, 50) : "err"}`;
+    } finally {
+      await handle?.dispose().catch(() => {});
     }
     await page.waitForTimeout(700);
-    const s: DriveStep = { turn, action: act.action, detail, thumb: await shot(), note: note || undefined };
+    const s: DriveStep = { turn, action: act.action, detail, thumb: await shot(), note: note || undefined, refusal };
     steps.push(s);
     emit(s);
-    lastUrl = page.url();
-    void lastUrl;
   }
   return { reached: await isFormReady().catch(() => false), turns: budget, reason: "budget-exhausted", steps };
 }

--- a/web/src/lib/apply/issue.ts
+++ b/web/src/lib/apply/issue.ts
@@ -6,4 +6,9 @@
 export type ApplyIssue = { level: "block" | "warn" | "info"; code: string; message: string; field?: string };
 
 // One step of the agentic drive loop (the AI reaching/filling the form live).
-export type DriveStep = { turn: number; action: string; detail: string; thumb?: string; note?: string };
+// `refusal` is set only when the step was refused, and says which of the three
+// reasons it was: the guard recognised a submit control, the ref was not one of
+// the refs offered this turn, or the element was gone by the time we acted. The
+// note stays the human sentence; this is the machine-readable half, so a caller
+// never has to parse prose to tell "we protected you" from "the page moved".
+export type DriveStep = { turn: number; action: string; detail: string; thumb?: string; note?: string; refusal?: "submit-control" | "not-offered" | "gone" };

--- a/web/src/lib/apply/submit-guard.mjs
+++ b/web/src/lib/apply/submit-guard.mjs
@@ -1,0 +1,110 @@
+/**
+ * submit-guard.mjs — the one definition of "this control submits the form",
+ * shared by the two places in the agentic drive loop that have to agree on it
+ * (`web/src/lib/apply/drive.ts`): the snapshot that decides which elements the
+ * planner may address, and the action path that executes what it picked.
+ *
+ * NEVER-SUBMIT is by construction here (`web/AGENTS.md`: "There is no exception,
+ * no flag"), so the guard cannot rest on a string the planner never saw. The
+ * snapshot labels an element `aria-label || placeholder || text || value ||
+ * name`; the click guard used to test `innerText || value` only, which is empty
+ * for an icon-only `<button aria-label="Submit application">`, against a regex
+ * of English and Spanish words, which does not contain "Absenden" or
+ * "Отправить". Both call sites now read the same element facts and call the same
+ * predicate.
+ *
+ * Plain .mjs (same pattern as exit.mjs / cv-match.mjs) so `node --test` imports
+ * it with no build step and every branch can be pinned in a test.
+ */
+
+/**
+ * The facts both call sites decide on, read from the live DOM by `drive.ts`:
+ *
+ * - `tag`          lowercase tag name
+ * - `type`         the authored `type` attribute, lowercased ("" when absent).
+ *                  Not `el.type`: the DOM resolves a missing button type to
+ *                  "submit", which would hide the case below it.
+ * - `explicitType` the element declares a type the browser honours. A `<button>`
+ *                  honours only submit/reset/button, so an absent, empty or
+ *                  unrecognised type still submits.
+ * - `role`         explicit role, else the tag (`a` reads as "link")
+ * - `inForm`       the element belongs to a `<form>`
+ * - `aria` `placeholder` `text` `value` `name`  the label sources, raw
+ *
+ * @typedef {{ tag?: string, type?: string, explicitType?: boolean, role?: string,
+ *             inForm?: boolean, aria?: string, placeholder?: string, text?: string,
+ *             value?: string, name?: string }} ElementFacts
+ */
+
+const clean = (s) => (s || "").replace(/\s+/g, " ").trim().slice(0, 80);
+
+/**
+ * The label the planner is shown for an element, and therefore a string the
+ * guard is obliged to test.
+ *
+ * @param {ElementFacts} [facts]
+ */
+export function snapshotLabel(facts = {}) {
+  return clean(facts.aria || facts.placeholder || facts.text || facts.value || facts.name);
+}
+
+// Words that name the final action on a job application, in the languages the
+// portals we drive actually ship. Deliberately bounded: every entry here costs
+// the loop a click it could otherwise make, so this is the "sends it" vocabulary
+// and not everything that moves a form forward ("next", "continue", "weiter").
+const SUBMIT_TERMS = [
+  // en
+  "submit", "send application", "finish( application)?", "complete application", "apply (and|&) submit",
+  // es
+  "enviar", "finalizar",
+  // de
+  "absenden", "abschicken", "bewerbung senden",
+  // fr
+  "envoyer", "soumettre", "postuler",
+  // it
+  "invia", "candidati",
+  // pt
+  "enviar candidatura", "submeter",
+  // nl
+  "verzenden", "solliciteren",
+  // pl
+  "wyślij", "aplikuj",
+  // ru
+  "отправить", "откликнуться",
+];
+
+/**
+ * Matches a label naming the submit action.
+ *
+ * The boundaries are `\p{L}` classes under the `u` flag rather than `\b`,
+ * because JS word boundaries are ASCII-only: `/\bотправить\b/` matches nothing
+ * at all, in either direction, so a Cyrillic submit button reads as ordinary
+ * text. Not global, so the exported regex holds no `lastIndex` between calls.
+ */
+export const SUBMIT_RX = new RegExp(`(^|[^\\p{L}])(${SUBMIT_TERMS.join("|")})($|[^\\p{L}])`, "iu");
+
+/**
+ * Would clicking this element submit the application?
+ *
+ * Independent readings, because each one alone has a blind spot: the element's
+ * own type, HTML's default (a `<button>` inside a `<form>` with no honoured
+ * type is a submit button), the wording (both the label and the visible text
+ * an aria-label can outrank), and the absence of any wording — an icon-only
+ * control inside a form is exactly the shape of the submit button we cannot
+ * identify, so it is refused rather than guessed at.
+ *
+ * @param {ElementFacts} [facts]
+ */
+export function isSubmitControl(facts = {}) {
+  const tag = (facts.tag || "").toLowerCase();
+  const type = (facts.type || "").toLowerCase();
+  if (tag === "input" && (type === "submit" || type === "image")) return true;
+  if (tag === "button" && (type === "submit" || (!facts.explicitType && facts.inForm))) return true;
+  const label = snapshotLabel(facts);
+  // The visible text is tested even when an aria-label outranks it: markup that
+  // labels a button reading "Submit application" as "Continue" would otherwise
+  // hide the wording from the guard while still showing it to the user.
+  if (SUBMIT_RX.test(label) || SUBMIT_RX.test(clean(facts.text))) return true;
+  if (!label && tag === "button" && facts.inForm) return true;
+  return false;
+}

--- a/web/src/lib/apply/submit-guard.mjs
+++ b/web/src/lib/apply/submit-guard.mjs
@@ -4,14 +4,24 @@
  * (`web/src/lib/apply/drive.ts`): the snapshot that decides which elements the
  * planner may address, and the action path that executes what it picked.
  *
- * NEVER-SUBMIT is by construction here (`web/AGENTS.md`: "There is no exception,
- * no flag"), so the guard cannot rest on a string the planner never saw. The
- * snapshot labels an element `aria-label || placeholder || text || value ||
- * name`; the click guard used to test `innerText || value` only, which is empty
- * for an icon-only `<button aria-label="Submit application">`, against a regex
- * of English and Spanish words, which does not contain "Absenden" or
- * "Отправить". Both call sites now read the same element facts and call the same
- * predicate.
+ * NEVER-SUBMIT is by construction for the planner's ACTION VOCABULARY
+ * (`web/AGENTS.md`: "There is no exception, no flag"): there is no "submit"
+ * action to issue, a control this guard recognises as a submit control is
+ * listed with no ref so it cannot be named, and the guard cannot rest on a
+ * string the planner never saw. The snapshot labels an element
+ * `aria-label || placeholder || text || value || name`; the click guard used
+ * to test `innerText || value` only, which is empty for an icon-only
+ * `<button aria-label="Submit application">`, against a regex of English and
+ * Spanish words, which does not contain "Absenden" or "Отправить". Both call
+ * sites now read the same element facts and call the same predicate.
+ *
+ * What this does NOT construct away: an allowed control's own JS handler can
+ * still call `form.submit()`/`requestSubmit()` on a click this guard has no
+ * wording or shape to object to (a `<button type="button">Continue</button>`
+ * that quietly files the form). No DOM heuristic closes that; only an
+ * independent interlock on the `submit`/`requestSubmit` event itself would,
+ * and that is the documented next step (PR body, "Out of scope"), not this
+ * guard's job.
  *
  * Plain .mjs (same pattern as exit.mjs / cv-match.mjs) so `node --test` imports
  * it with no build step and every branch can be pinned in a test.
@@ -24,16 +34,17 @@
  * - `type`         the authored `type` attribute, lowercased ("" when absent).
  *                  Not `el.type`: the DOM resolves a missing button type to
  *                  "submit", which would hide the case below it.
- * - `explicitType` the element declares a type the browser honours. A `<button>`
- *                  honours only submit/reset/button, so an absent, empty or
- *                  unrecognised type still submits.
  * - `role`         explicit role, else the tag (`a` reads as "link")
  * - `inForm`       the element belongs to a `<form>`
- * - `aria` `placeholder` `text` `value` `name`  the label sources, raw
+ * - `aria` `placeholder` `text` `value` `name`  the label sources, raw. `aria`
+ *                  is the accessible name: `aria-label`, or the text of the
+ *                  `aria-labelledby` targets when there is no `aria-label`.
+ * - `title` `alt`  further names an icon-only control can carry. Classification
+ *                  only: they never reach the snapshot line (see snapshotLabel).
  *
- * @typedef {{ tag?: string, type?: string, explicitType?: boolean, role?: string,
- *             inForm?: boolean, aria?: string, placeholder?: string, text?: string,
- *             value?: string, name?: string }} ElementFacts
+ * @typedef {{ tag?: string, type?: string, role?: string, inForm?: boolean,
+ *             aria?: string, placeholder?: string, text?: string, value?: string,
+ *             name?: string, title?: string, alt?: string }} ElementFacts
  */
 
 // Whitespace-collapsed, uncapped: what the guard classifies on.
@@ -46,6 +57,10 @@ const clean = (s) => collapse(s).slice(0, 80);
  * The label the planner is shown for an element, and therefore a string the
  * guard is obliged to test.
  *
+ * Deliberately narrower than what the guard reads: this is the planner's view
+ * of the page, so it stays the five sources the snapshot has always printed.
+ * `title` and `alt` widen the guard, not the planner.
+ *
  * @param {ElementFacts} [facts]
  */
 export function snapshotLabel(facts = {}) {
@@ -53,6 +68,37 @@ export function snapshotLabel(facts = {}) {
 }
 
 const labelSource = (facts) => facts.aria || facts.placeholder || facts.text || facts.value || facts.name;
+
+/**
+ * Every string that names this control, for classification only.
+ *
+ * Each source is tested on its own, not funnelled through `labelSource`'s
+ * single winner: `aria` outranks `value` for the planner's display label, but
+ * a control whose `aria` says "Continue" and whose `value` says "Submit
+ * application" still submits — an `input[type="button"]` has no `text` to
+ * fall back to, so testing only the winning source would let the losing one
+ * hide the wording from the guard entirely. Deduplicated so two sources that
+ * agree are not tested twice.
+ *
+ * `name` is deliberately left out: it is a machine identifier, not a label a
+ * person reads — a field `name="submit_note"` names a text box, not a submit
+ * action — so folding it in here would refuse ordinary fields for the
+ * accident of their attribute name. It stays in `labelSource`, used only by
+ * `snapshotLabel` below, where guessing wrong just shows the planner a worse
+ * fallback label, never a false submit refusal.
+ */
+const names = (facts) => {
+  const seen = new Set();
+  const out = [];
+  for (const raw of [facts.aria, facts.placeholder, facts.text, facts.value, facts.title, facts.alt]) {
+    const s = collapse(raw);
+    if (s && !seen.has(s)) {
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+};
 
 // Two vocabularies, because the same verb means two things on a job portal.
 //
@@ -83,13 +129,17 @@ const SUBMIT_TERMS = [
   "отправить", "откликнуться",
 ];
 
-// APPLY_TERMS are the apply verbs. Outside a form they are the entry point the
-// loop exists to click ("Apply for this job", <a>Postuler</a>), so they stay
-// actionable there; inside a form the same word is the final button, so they
-// are refused there.
-const APPLY_TERMS = [
+// IN_FORM_TERMS are refused only on a clickable inside a form. Outside a form
+// the apply verbs are the entry point the loop exists to click ("Apply for this
+// job", <a>Postuler</a>); inside one the same word is the final button. Bare
+// "send" sits here for the same reason: on a listing page it is "Send to a
+// friend", on the last step of a form it is the button that files the
+// application, and a custom ATS ships exactly that as
+// `<div role="button">Send</div>`, which no type or tag rule can catch.
+const IN_FORM_TERMS = [
   "apply( now| for this job)?",
   "postuler", "candidati", "candidatar-se", "solliciteren", "aplikuj", "bewerben",
+  "send",
 ];
 
 const wordRx = (terms) => new RegExp(`(^|[^\\p{L}])(${terms.join("|")})($|[^\\p{L}])`, "iu");
@@ -104,8 +154,17 @@ const wordRx = (terms) => new RegExp(`(^|[^\\p{L}])(${terms.join("|")})($|[^\\p{
  */
 export const SUBMIT_RX = wordRx(SUBMIT_TERMS);
 
-/** Matches an apply verb: refused only inside a form (see APPLY_TERMS). */
-export const APPLY_RX = wordRx(APPLY_TERMS);
+/** Matches the in-form tier: refused only on a clickable inside a form. */
+export const IN_FORM_RX = wordRx(IN_FORM_TERMS);
+
+/**
+ * A control a click can act on. The in-form tier is held to this, so a checkbox
+ * labelled "Send me updates", or a field whose placeholder says "Apply by…",
+ * stays fillable: neither can file an application, and refusing them would cost
+ * the loop a turn for nothing.
+ */
+const isClickable = (tag, type, role) =>
+  tag === "button" || tag === "a" || role === "button" || role === "link" || (tag === "input" && ["button", "submit", "reset", "image"].includes(type));
 
 /**
  * Would clicking this element submit the application?
@@ -122,21 +181,40 @@ export const APPLY_RX = wordRx(APPLY_TERMS);
 export function isSubmitControl(facts = {}) {
   const tag = (facts.tag || "").toLowerCase();
   const type = (facts.type || "").toLowerCase();
+  const role = (facts.role || "").toLowerCase();
   if (tag === "input" && (type === "submit" || type === "image")) return true;
-  if (tag === "button" && (type === "submit" || (!facts.explicitType && facts.inForm))) return true;
+  // A <button> honours only submit/reset/button; with anything else — absent,
+  // empty, misspelt — it is still a submit button inside a form. Derived here
+  // from tag and type rather than sent from the page: one less fact for the two
+  // sides of the wire to disagree about.
+  const declared = ["submit", "reset", "button"].includes(type);
+  if (tag === "button" && (type === "submit" || (!declared && facts.inForm))) return true;
   // Classified on the full label, not the 80-char snapshot line: a scripted
   // control whose submit wording sits past the display cap still submits.
-  const label = collapse(labelSource(facts));
-  // The visible text is tested even when an aria-label outranks it: markup that
-  // labels a button reading "Submit application" as "Continue" would otherwise
-  // hide the wording from the guard while still showing it to the user.
-  const text = collapse(facts.text);
-  if (SUBMIT_RX.test(label) || SUBMIT_RX.test(text)) return true;
-  // An apply verb is the final button inside a form and the way in outside it.
-  if (facts.inForm && (APPLY_RX.test(label) || APPLY_RX.test(text))) return true;
-  // No wording at all inside a form: an icon-only <button>, or an
-  // <input type="button"> that submits through its handler. Refused rather
-  // than guessed at.
-  if (!label && facts.inForm && (tag === "button" || (tag === "input" && type === "button"))) return true;
+  // Every source is read on its own — text, placeholder and value all read
+  // even when an aria-label outranks them for display — so markup that labels
+  // a button reading "Submit application" as "Continue" cannot hide the
+  // wording from the guard while still showing it to the user, and `title`
+  // and `alt` are read because an icon-only control is often named by them
+  // alone. Held to `isClickable` for the same reason the tier below is: a
+  // click is the only thing this guard is deciding about, so a fillable field
+  // whose placeholder happens to read "Submit your feedback" is not one, and
+  // reading every source independently must not turn that ordinary field into
+  // one just because its secondary label shares a word with the vocabulary.
+  const named = names(facts);
+  if (isClickable(tag, type, role) && named.some((s) => SUBMIT_RX.test(s))) return true;
+  // `role="button"` counts as a button here and for the silence rule below, but
+  // NOT for HTML's typeless default above: a <div> does not submit on its own,
+  // while its wording and its silence read exactly like a <button>'s, and its
+  // handler can call requestSubmit() either way.
+  if (facts.inForm && isClickable(tag, type, role) && named.some((s) => IN_FORM_RX.test(s))) return true;
+  // No wording at all inside a form: an icon-only <button>, a
+  // <div role="button">, an unlabelled <a>, or an <input type="button"> that
+  // submits through its handler. Held to `isClickable`, not to button/input
+  // only: a clickable anchor with no aria, placeholder, text, value, title or
+  // alt is exactly as unidentifiable as a silent <button>, and its handler can
+  // call requestSubmit() the same way. Refused rather than guessed at, same as
+  // the two rules above.
+  if (!named.length && facts.inForm && isClickable(tag, type, role)) return true;
   return false;
 }

--- a/web/src/lib/apply/submit-guard.mjs
+++ b/web/src/lib/apply/submit-guard.mjs
@@ -36,7 +36,11 @@
  *             value?: string, name?: string }} ElementFacts
  */
 
-const clean = (s) => (s || "").replace(/\s+/g, " ").trim().slice(0, 80);
+// Whitespace-collapsed, uncapped: what the guard classifies on.
+const collapse = (s) => (s || "").replace(/\s+/g, " ").trim();
+// The 80-char cap is for the snapshot line the planner reads, never for the
+// decision: a submit term past the cap must still be seen by the guard.
+const clean = (s) => collapse(s).slice(0, 80);
 
 /**
  * The label the planner is shown for an element, and therefore a string the
@@ -45,8 +49,10 @@ const clean = (s) => (s || "").replace(/\s+/g, " ").trim().slice(0, 80);
  * @param {ElementFacts} [facts]
  */
 export function snapshotLabel(facts = {}) {
-  return clean(facts.aria || facts.placeholder || facts.text || facts.value || facts.name);
+  return clean(labelSource(facts));
 }
+
+const labelSource = (facts) => facts.aria || facts.placeholder || facts.text || facts.value || facts.name;
 
 // Words that name the final action on a job application, in the languages the
 // portals we drive actually ship. Deliberately bounded: every entry here costs
@@ -100,11 +106,16 @@ export function isSubmitControl(facts = {}) {
   const type = (facts.type || "").toLowerCase();
   if (tag === "input" && (type === "submit" || type === "image")) return true;
   if (tag === "button" && (type === "submit" || (!facts.explicitType && facts.inForm))) return true;
-  const label = snapshotLabel(facts);
+  // Classified on the full label, not the 80-char snapshot line: a scripted
+  // control whose submit wording sits past the display cap still submits.
+  const label = collapse(labelSource(facts));
   // The visible text is tested even when an aria-label outranks it: markup that
   // labels a button reading "Submit application" as "Continue" would otherwise
   // hide the wording from the guard while still showing it to the user.
-  if (SUBMIT_RX.test(label) || SUBMIT_RX.test(clean(facts.text))) return true;
-  if (!label && tag === "button" && facts.inForm) return true;
+  if (SUBMIT_RX.test(label) || SUBMIT_RX.test(collapse(facts.text))) return true;
+  // No wording at all inside a form: an icon-only <button>, or an
+  // <input type="button"> that submits through its handler. Refused rather
+  // than guessed at.
+  if (!label && facts.inForm && (tag === "button" || (tag === "input" && type === "button"))) return true;
   return false;
 }

--- a/web/src/lib/apply/submit-guard.mjs
+++ b/web/src/lib/apply/submit-guard.mjs
@@ -54,10 +54,14 @@ export function snapshotLabel(facts = {}) {
 
 const labelSource = (facts) => facts.aria || facts.placeholder || facts.text || facts.value || facts.name;
 
-// Words that name the final action on a job application, in the languages the
-// portals we drive actually ship. Deliberately bounded: every entry here costs
-// the loop a click it could otherwise make, so this is the "sends it" vocabulary
-// and not everything that moves a form forward ("next", "continue", "weiter").
+// Two vocabularies, because the same verb means two things on a job portal.
+//
+// SUBMIT_TERMS name the action that sends the application, in the languages
+// the portals we drive actually ship. Refused wherever they appear. Deliberately
+// bounded: every entry costs the loop a click it could otherwise make, so this
+// is the "sends it" vocabulary and not everything that moves a form forward
+// ("next", "continue", "weiter"). «Откликнуться» sits here and not below
+// because on hh.ru that button sends the response in one click.
 const SUBMIT_TERMS = [
   // en
   "submit", "send application", "finish( application)?", "complete application", "apply (and|&) submit",
@@ -66,18 +70,29 @@ const SUBMIT_TERMS = [
   // de
   "absenden", "abschicken", "bewerbung senden",
   // fr
-  "envoyer", "soumettre", "postuler",
+  "envoyer", "soumettre",
   // it
-  "invia", "candidati",
+  "invia",
   // pt
   "enviar candidatura", "submeter",
   // nl
-  "verzenden", "solliciteren",
+  "verzenden",
   // pl
-  "wyślij", "aplikuj",
+  "wyślij",
   // ru
   "отправить", "откликнуться",
 ];
+
+// APPLY_TERMS are the apply verbs. Outside a form they are the entry point the
+// loop exists to click ("Apply for this job", <a>Postuler</a>), so they stay
+// actionable there; inside a form the same word is the final button, so they
+// are refused there.
+const APPLY_TERMS = [
+  "apply( now| for this job)?",
+  "postuler", "candidati", "candidatar-se", "solliciteren", "aplikuj", "bewerben",
+];
+
+const wordRx = (terms) => new RegExp(`(^|[^\\p{L}])(${terms.join("|")})($|[^\\p{L}])`, "iu");
 
 /**
  * Matches a label naming the submit action.
@@ -87,7 +102,10 @@ const SUBMIT_TERMS = [
  * at all, in either direction, so a Cyrillic submit button reads as ordinary
  * text. Not global, so the exported regex holds no `lastIndex` between calls.
  */
-export const SUBMIT_RX = new RegExp(`(^|[^\\p{L}])(${SUBMIT_TERMS.join("|")})($|[^\\p{L}])`, "iu");
+export const SUBMIT_RX = wordRx(SUBMIT_TERMS);
+
+/** Matches an apply verb: refused only inside a form (see APPLY_TERMS). */
+export const APPLY_RX = wordRx(APPLY_TERMS);
 
 /**
  * Would clicking this element submit the application?
@@ -112,7 +130,10 @@ export function isSubmitControl(facts = {}) {
   // The visible text is tested even when an aria-label outranks it: markup that
   // labels a button reading "Submit application" as "Continue" would otherwise
   // hide the wording from the guard while still showing it to the user.
-  if (SUBMIT_RX.test(label) || SUBMIT_RX.test(collapse(facts.text))) return true;
+  const text = collapse(facts.text);
+  if (SUBMIT_RX.test(label) || SUBMIT_RX.test(text)) return true;
+  // An apply verb is the final button inside a form and the way in outside it.
+  if (facts.inForm && (APPLY_RX.test(label) || APPLY_RX.test(text))) return true;
   // No wording at all inside a form: an icon-only <button>, or an
   // <input type="button"> that submits through its handler. Refused rather
   // than guessed at.

--- a/web/src/lib/apply/submit-guard.mjs
+++ b/web/src/lib/apply/submit-guard.mjs
@@ -107,7 +107,9 @@ const names = (facts) => {
 // bounded: every entry costs the loop a click it could otherwise make, so this
 // is the "sends it" vocabulary and not everything that moves a form forward
 // ("next", "continue", "weiter"). «Откликнуться» sits here and not below
-// because on hh.ru that button sends the response in one click.
+// because on hh.ru that button sends the response in one click, and "başvur"
+// for the same reason: on kariyer.net it completes the application. The bare
+// nl/tr send verbs are here, unlike English "send" (see IN_FORM_TERMS).
 const SUBMIT_TERMS = [
   // en
   "submit", "send application", "finish( application)?", "complete application", "apply (and|&) submit",
@@ -122,11 +124,13 @@ const SUBMIT_TERMS = [
   // pt
   "enviar candidatura", "submeter",
   // nl
-  "verzenden",
+  "verzend(en)?", "verstu(ur|ren)", "sollicitatie (versturen|verzenden)",
   // pl
   "wyślij",
   // ru
   "отправить", "откликнуться",
+  // tr
+  "gönder", "başvur",
 ];
 
 // IN_FORM_TERMS are refused only on a clickable inside a form. Outside a form
@@ -136,10 +140,42 @@ const SUBMIT_TERMS = [
 // friend", on the last step of a form it is the button that files the
 // application, and a custom ATS ships exactly that as
 // `<div role="button">Send</div>`, which no type or tag rule can catch.
+// English "send" is the one bare send verb held to a form: "Send to a friend"
+// is a listing-page link the loop may need. The nl/tr/ja/zh/ko send verbs sit
+// in the global tier above instead, because on those markets' portals the
+// bare verb IS the final button and a form-less ATS renders it outside any
+// <form>. The cost is a control like Indeed NL's bare "Versturen" on its
+// phone-confirmation step, which is refused too: the loop stops there and
+// the person clicks it, which is the side this guard errs on.
 const IN_FORM_TERMS = [
   "apply( now| for this job)?",
-  "postuler", "candidati", "candidatar-se", "solliciteren", "aplikuj", "bewerben",
+  "postuler", "candidati", "candidatar-se", "solliciteren", "solliciteer", "aplikuj", "bewerben",
   "send",
+];
+
+// The same two tiers for Japanese, Chinese and Korean, matched as substrings:
+// these scripts put no spaces around words, so a term inside a real label has
+// letters on both sides (応募内容を送信する, 提交申请, 제출하기) and the
+// `\p{L}` boundaries below never match. What the substring form refuses by
+// design: 已提交 ("submitted", a tab of sent applications) and 发送验证码
+// ("send a verification code") anywhere, 応募者一覧 or 지원자 inside a form.
+// A lost click on those is the accepted price; a false allow on a real submit
+// button is not.
+const CJK_SUBMIT_TERMS = [
+  // ja: submit, send
+  "提出", "送信",
+  // zh: submit, send (simplified and traditional)
+  "提交", "发送", "發送",
+  // ko: submit, send
+  "제출", "보내기",
+];
+const CJK_IN_FORM_TERMS = [
+  // ja: apply
+  "応募",
+  // zh: apply, deliver (a résumé)
+  "申请", "申請", "投递", "投遞",
+  // ko: apply
+  "지원",
 ];
 
 const wordRx = (terms) => new RegExp(`(^|[^\\p{L}])(${terms.join("|")})($|[^\\p{L}])`, "iu");
@@ -156,6 +192,17 @@ export const SUBMIT_RX = wordRx(SUBMIT_TERMS);
 
 /** Matches the in-form tier: refused only on a clickable inside a form. */
 export const IN_FORM_RX = wordRx(IN_FORM_TERMS);
+
+const substringRx = (terms) => new RegExp(terms.join("|"), "u");
+
+/** The CJK submit tier: no word boundaries, see CJK_SUBMIT_TERMS. */
+export const CJK_SUBMIT_RX = substringRx(CJK_SUBMIT_TERMS);
+
+/** The CJK in-form tier. */
+export const CJK_IN_FORM_RX = substringRx(CJK_IN_FORM_TERMS);
+
+const namesSubmit = (s) => SUBMIT_RX.test(s) || CJK_SUBMIT_RX.test(s);
+const namesInFormAction = (s) => IN_FORM_RX.test(s) || CJK_IN_FORM_RX.test(s);
 
 /**
  * A control a click can act on. The in-form tier is held to this, so a checkbox
@@ -202,12 +249,12 @@ export function isSubmitControl(facts = {}) {
   // reading every source independently must not turn that ordinary field into
   // one just because its secondary label shares a word with the vocabulary.
   const named = names(facts);
-  if (isClickable(tag, type, role) && named.some((s) => SUBMIT_RX.test(s))) return true;
+  if (isClickable(tag, type, role) && named.some(namesSubmit)) return true;
   // `role="button"` counts as a button here and for the silence rule below, but
   // NOT for HTML's typeless default above: a <div> does not submit on its own,
   // while its wording and its silence read exactly like a <button>'s, and its
   // handler can call requestSubmit() either way.
-  if (facts.inForm && isClickable(tag, type, role) && named.some((s) => IN_FORM_RX.test(s))) return true;
+  if (facts.inForm && isClickable(tag, type, role) && named.some(namesInFormAction)) return true;
   // No wording at all inside a form: an icon-only <button>, a
   // <div role="button">, an unlabelled <a>, or an <input type="button"> that
   // submits through its handler. Held to `isClickable`, not to button/input

--- a/web/tests/lib/submit-guard.test.mjs
+++ b/web/tests/lib/submit-guard.test.mjs
@@ -1,0 +1,203 @@
+// Tests for the drive loop's submit guard: which controls the planner may be
+// offered, and which it is refused when it asks.
+//
+// This is the one rule in the app that has no fallback ("Nothing is ever
+// submitted automatically"), and it is decided on element facts read from a
+// live page, so neither branch is observable from the drive loop itself. Both
+// bypasses that motivated this module are pinned below: a control whose only
+// name is an aria-label, and a control whose label is not in English.
+//
+// Run:  node --test tests/lib/submit-guard.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSubmitControl, snapshotLabel, SUBMIT_RX } from "../../src/lib/apply/submit-guard.mjs";
+
+/** The facts drive.ts reads, with the defaults of an ordinary in-form control. */
+const el = (facts) => ({ tag: "button", type: "button", explicitType: true, inForm: true, ...facts });
+
+test("isSubmitControl: an input that submits by type is refused", () => {
+  // Given the plainest submit control there is
+  const facts = el({ tag: "input", type: "submit", value: "Submit" });
+
+  // When the guard reads it
+  // Then it is refused on its type, before any label is considered
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: an icon-only button named only by aria-label is refused", () => {
+  // Given a submit button carrying an icon, so its text is empty and its name
+  // lives in aria-label — the string the planner is shown
+  const facts = el({ aria: "Submit application", text: "" });
+
+  // When the guard reads it
+  // Then it is refused. Testing innerText here would have seen "" and clicked.
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a German submit label is refused", () => {
+  // Given a scripted button (type=button, submitted by a handler) on a DACH portal
+  const facts = el({ text: "Bewerbung absenden" });
+
+  // When the guard reads it
+  // Then the label alone is enough to refuse it
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a French submit label is refused", () => {
+  // Given the same shape on a French portal
+  const facts = el({ text: "Envoyer" });
+
+  // When the guard reads it
+  // Then it is refused
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a Cyrillic submit label is refused", () => {
+  // Given a Russian-language portal's send button. JS word boundaries are
+  // ASCII-only, so a \b-anchored regex matches nothing here in either direction.
+  const facts = el({ text: "Отправить отклик" });
+
+  // When the guard reads it
+  // Then it is still refused
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a button with no type inside a form is refused, whatever it says", () => {
+  // Given a button in a form that declares no type. HTML makes that a submit
+  // button, so "Weiter" is the label of a control that sends the application.
+  const facts = el({ type: "", explicitType: false, text: "Weiter" });
+
+  // When the guard reads it
+  // Then it is refused on the HTML default, not on its wording
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: an unlabelled button inside a form is refused", () => {
+  // Given an icon-only control with no aria-label either: nothing distinguishes
+  // it from the submit button of the form it sits in
+  const facts = el({ text: "", aria: "" });
+
+  // When the guard reads it
+  // Then it is refused rather than guessed at
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a submit label is not hidden by an aria-label that outranks it", () => {
+  // Given stale markup: the button reads "Submit application" on screen, and its
+  // aria-label, which wins the label, says something harmless
+  const facts = el({ aria: "Continue", text: "Submit application" });
+
+  // When the guard reads it
+  // Then the wording the user can see is refused too, not only the winning label
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a link is not a submit control", () => {
+  // Given the "Next" link of a multi-step posting
+  const facts = el({ tag: "a", type: "", explicitType: false, role: "link", inForm: false, text: "Next" });
+
+  // When the guard reads it
+  // Then the loop may click it
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: a declared non-submit button is allowed", () => {
+  // Given the button that pages a multi-step form forward
+  const facts = el({ text: "Next step" });
+
+  // When the guard reads it
+  // Then the loop may click it
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: an ordinary text field is allowed", () => {
+  // Given a field the loop exists to fill
+  const facts = el({ tag: "input", type: "text", name: "email" });
+
+  // When the guard reads it
+  // Then it is not mistaken for a control that sends anything
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: a labelled icon button inside a form is allowed", () => {
+  // Given a repeat-section control that does say what it does
+  const facts = el({ aria: "Add another", text: "" });
+
+  // When the guard reads it
+  // Then having a name is what separates it from the icon-only case above
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: outside a form, a typeless button is allowed", () => {
+  // Given a listing page's "Load more", which belongs to no form
+  const facts = el({ type: "", explicitType: false, inForm: false, text: "Load more" });
+
+  // When the guard reads it
+  // Then there is no form for it to submit
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: outside a form, an unlabelled button is allowed", () => {
+  // Given an icon-only control with no form behind it (a menu toggle, a carousel
+  // arrow), which the loop still needs to be able to click
+  const facts = el({ text: "", aria: "", inForm: false });
+
+  // When the guard reads it
+  // Then the empty-label rule does not reach outside a form
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: survives missing facts", () => {
+  // Given a call with nothing to read (a page that changed under us)
+
+  // When the guard reads it
+  // Then it does not throw, and it does not invent a submit control either
+  assert.equal(isSubmitControl(), false);
+  assert.equal(isSubmitControl({}), false);
+});
+
+test("snapshotLabel: prefers the aria-label the planner is shown", () => {
+  // Given an element whose sources disagree, as an icon button's do
+  const facts = { tag: "button", aria: "Submit application", text: "Continue", value: "next" };
+
+  // When building the label
+  const label = snapshotLabel(facts);
+
+  // Then the guard tests the same string the snapshot printed, so the two
+  // cannot reach different conclusions about the same element
+  assert.equal(label, "Submit application");
+  assert.equal(isSubmitControl(el(facts)), true);
+});
+
+test("snapshotLabel: falls through the sources in order", () => {
+  // Given elements named by each source in turn
+  assert.equal(snapshotLabel({ placeholder: "Your email", text: "", value: "", name: "email" }), "Your email");
+  assert.equal(snapshotLabel({ text: "Continue", value: "next", name: "step" }), "Continue");
+  assert.equal(snapshotLabel({ value: "next", name: "step" }), "next");
+  assert.equal(snapshotLabel({ name: "step" }), "step");
+  assert.equal(snapshotLabel({}), "");
+  assert.equal(snapshotLabel(), "");
+});
+
+test("snapshotLabel: collapses whitespace and caps the length", () => {
+  // Given a button whose text is laid out across several lines, and a container
+  // whose textContent runs long
+  assert.equal(snapshotLabel({ text: "\n  Send   application\n" }), "Send application");
+  assert.equal(snapshotLabel({ text: "x".repeat(200) }).length, 80);
+});
+
+test("SUBMIT_RX: matches the action, not every word containing it", () => {
+  // Given labels that merely contain a submit term inside a longer word
+  assert.equal(SUBMIT_RX.test("Resubmitted"), false);
+  assert.equal(SUBMIT_RX.test("Enviarlo"), false);
+
+  // And labels that move the form on without sending it
+  assert.equal(SUBMIT_RX.test("Next"), false);
+  assert.equal(SUBMIT_RX.test("Weiter"), false);
+  assert.equal(SUBMIT_RX.test("Continuer"), false);
+
+  // Then only the real ones match, punctuation and case included
+  assert.equal(SUBMIT_RX.test("Submit »"), true);
+  assert.equal(SUBMIT_RX.test("SEND APPLICATION"), true);
+});

--- a/web/tests/lib/submit-guard.test.mjs
+++ b/web/tests/lib/submit-guard.test.mjs
@@ -5,16 +5,18 @@
 // submitted automatically"), and it is decided on element facts read from a
 // live page, so neither branch is observable from the drive loop itself. Both
 // bypasses that motivated this module are pinned below: a control whose only
-// name is an aria-label, and a control whose label is not in English.
+// name is an aria-label, and a control whose label is not in English. So is the
+// third shape, which is not a <button> at all: `<div role="button">Send</div>`
+// inside a form, where no type rule reaches and no submit vocabulary matches.
 //
 // Run:  node --test tests/lib/submit-guard.test.mjs
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isSubmitControl, snapshotLabel, SUBMIT_RX, APPLY_RX } from "../../src/lib/apply/submit-guard.mjs";
+import { isSubmitControl, snapshotLabel, SUBMIT_RX, IN_FORM_RX } from "../../src/lib/apply/submit-guard.mjs";
 
 /** The facts drive.ts reads, with the defaults of an ordinary in-form control. */
-const el = (facts) => ({ tag: "button", type: "button", explicitType: true, inForm: true, ...facts });
+const el = (facts) => ({ tag: "button", type: "button", inForm: true, ...facts });
 
 test("isSubmitControl: an input that submits by type is refused", () => {
   // Given the plainest submit control there is
@@ -66,7 +68,7 @@ test("isSubmitControl: a Cyrillic submit label is refused", () => {
 test("isSubmitControl: a button with no type inside a form is refused, whatever it says", () => {
   // Given a button in a form that declares no type. HTML makes that a submit
   // button, so "Weiter" is the label of a control that sends the application.
-  const facts = el({ type: "", explicitType: false, text: "Weiter" });
+  const facts = el({ type: "", text: "Weiter" });
 
   // When the guard reads it
   // Then it is refused on the HTML default, not on its wording
@@ -93,9 +95,95 @@ test("isSubmitControl: a submit label is not hidden by an aria-label that outran
   assert.equal(isSubmitControl(facts), true);
 });
 
+test("isSubmitControl: a submit term in any label source is refused even when another source outranks it", () => {
+  // Given an <input type="button">: its accessible name (aria, which
+  // labelSource prefers for display) says nothing about submitting, but its
+  // value — the string an <input type="button"> actually shows — does. An
+  // input has no text content to fall back to, so classifying only the
+  // source labelSource picks would leave this one invisible to the guard.
+  const facts = { tag: "input", type: "button", inForm: true, aria: "Continue", value: "Submit application" };
+
+  // When the guard reads it
+  // Then the value is tested on its own, not hidden behind the aria-label
+  // that wins the planner's display label
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a control whose only submit-looking string is its name stays allowed", () => {
+  // Given a clickable link with unrelated visible text (so the silence rule,
+  // which now covers any unlabelled clickable, does not also fire here — this
+  // test isolates `name` exclusion, not the silence rule) whose `name`
+  // attribute happens to contain "submit" — a machine identifier the page
+  // author picked, not a label any user reads
+  const facts = { tag: "a", type: "", role: "link", inForm: true, name: "submit_note", text: "Learn more" };
+
+  // When the guard reads it
+  // Then it is not refused: `name` is excluded from classification on purpose
+  // (see submit-guard.mjs's `names`), so a control is never mistaken for a
+  // submit control for the accident of its attribute name, even though its
+  // visible text gives the silence rule below nothing to refuse it on either
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: an unlabelled clickable anchor inside a form is refused, whatever its name says", () => {
+  // Given an <a role="link"> with no aria, placeholder, text, value, title or
+  // alt, only a `name` attribute: `name` is deliberately excluded from
+  // classification, so nothing else here names this control
+  const facts = { tag: "a", type: "", role: "link", inForm: true, name: "submit" };
+
+  // When the guard reads it
+  // Then it is refused like an unlabelled button: an anchor with literally no
+  // name a person can read is exactly the shape this guard cannot identify,
+  // and its handler can call requestSubmit() the same way a button's can
+  assert.equal(isSubmitControl(facts), true);
+
+  // And the same holds with no name at all, so this is the silence rule and
+  // not a specific reaction to the string "submit"
+  assert.equal(isSubmitControl({ tag: "a", type: "", role: "link", inForm: true }), true);
+});
+
+test("isSubmitControl: an unlabelled input[type=reset] inside a form is refused too, a labelled one is not", () => {
+  // Given the silence rule is held to `isClickable`, which lists
+  // input[type=reset] alongside submit/button/image (see submit-guard.mjs's
+  // `isClickable`) — a side effect noted in the PR body's "Out of scope": a
+  // reset button does not submit anything, but an unlabelled one inside a
+  // form is exactly as unidentifiable as an unlabelled submit-shaped control
+  const unlabelled = { tag: "input", type: "reset", inForm: true };
+  const labelled = { tag: "input", type: "reset", inForm: true, value: "Reset" };
+
+  // When the guard reads each
+  // Then only the unlabelled one is refused; a reset button that says what it
+  // does stays clickable, since "reset" is in neither vocabulary
+  assert.equal(isSubmitControl(unlabelled), true);
+  assert.equal(isSubmitControl(labelled), false);
+});
+
+test("isSubmitControl: an unlabelled anchor outside a form is allowed", () => {
+  // Given the same silent shape with no form behind it
+  const facts = { tag: "a", type: "", role: "link", inForm: false, name: "submit" };
+
+  // When the guard reads it
+  // Then the silence rule does not reach outside a form, same as the
+  // unlabelled-button case above
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: a fillable field whose secondary label merely contains a submit word stays allowed", () => {
+  // Given an ordinary text field whose accessible name is unrelated, but whose
+  // placeholder happens to share a word with the submit vocabulary — the kind
+  // of coincidence testing every source independently now risks catching
+  const facts = { tag: "input", type: "text", inForm: true, aria: "Feedback", placeholder: "Submit your feedback here" };
+
+  // When the guard reads it
+  // Then it is not refused: a text field cannot submit anything by being
+  // clicked, so the submit vocabulary is held to clickable controls, the same
+  // way the in-form tier already is
+  assert.equal(isSubmitControl(facts), false);
+});
+
 test("isSubmitControl: a link is not a submit control", () => {
   // Given the "Next" link of a multi-step posting
-  const facts = el({ tag: "a", type: "", explicitType: false, role: "link", inForm: false, text: "Next" });
+  const facts = el({ tag: "a", type: "", role: "link", inForm: false, text: "Next" });
 
   // When the guard reads it
   // Then the loop may click it
@@ -131,7 +219,7 @@ test("isSubmitControl: a labelled icon button inside a form is allowed", () => {
 
 test("isSubmitControl: outside a form, a typeless button is allowed", () => {
   // Given a listing page's "Load more", which belongs to no form
-  const facts = el({ type: "", explicitType: false, inForm: false, text: "Load more" });
+  const facts = el({ type: "", inForm: false, text: "Load more" });
 
   // When the guard reads it
   // Then there is no form for it to submit
@@ -151,7 +239,7 @@ test("isSubmitControl: outside a form, an unlabelled button is allowed", () => {
 test("isSubmitControl: a submit term past the 80-char snapshot cap is still refused", () => {
   // Given a scripted icon button whose only wording is a long aria-label that
   // ends in the submit term, past the 80 chars the snapshot line keeps
-  const facts = { tag: "button", type: "button", explicitType: true, inForm: true,
+  const facts = { tag: "button", type: "button", inForm: true,
     aria: "By continuing you confirm the details above are accurate and complete and you agree to submit application" };
 
   // When the guard classifies it
@@ -164,7 +252,7 @@ test("isSubmitControl: a submit term past the 80-char snapshot cap is still refu
 
 test("isSubmitControl: an unlabelled input button inside a form is refused", () => {
   // Given <input type="button"> with no text of its own, inside a form
-  const facts = { tag: "input", type: "button", explicitType: true, inForm: true };
+  const facts = { tag: "input", type: "button", inForm: true };
 
   // When the guard classifies it
   const refused = isSubmitControl(facts);
@@ -178,9 +266,9 @@ test("isSubmitControl: an apply verb outside a form is the way in, and stays act
   const links = [
     { tag: "a", role: "link", inForm: false, text: "Postuler" },
     { tag: "a", role: "link", inForm: false, text: "Apply for this job" },
-    { tag: "button", type: "button", explicitType: true, inForm: false, text: "Candidati" },
-    { tag: "button", type: "button", explicitType: true, inForm: false, text: "Solliciteren" },
-    { tag: "button", type: "button", explicitType: true, inForm: false, text: "Aplikuj" },
+    { tag: "button", type: "button", inForm: false, text: "Candidati" },
+    { tag: "button", type: "button", inForm: false, text: "Solliciteren" },
+    { tag: "button", type: "button", inForm: false, text: "Aplikuj" },
   ];
 
   // When the guard classifies each
@@ -193,10 +281,10 @@ test("isSubmitControl: an apply verb outside a form is the way in, and stays act
 test("isSubmitControl: the same apply verb inside a form is the final button and is refused", () => {
   // Given declared type="button" controls (so the type rule does not fire) inside a form
   const finals = [
-    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Postuler" },
-    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Apply" },
-    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Apply now" },
-    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Bewerben" },
+    { tag: "button", type: "button", inForm: true, text: "Postuler" },
+    { tag: "button", type: "button", inForm: true, text: "Apply" },
+    { tag: "button", type: "button", inForm: true, text: "Apply now" },
+    { tag: "button", type: "button", inForm: true, text: "Bewerben" },
   ];
 
   // When the guard classifies each
@@ -208,7 +296,7 @@ test("isSubmitControl: the same apply verb inside a form is the final button and
 
 test("isSubmitControl: «Откликнуться» is refused even outside a form, because hh.ru sends the response on that click", () => {
   // Given hh.ru's respond button, a declared button outside any form
-  const facts = { tag: "button", type: "button", explicitType: true, inForm: false, text: "Откликнуться" };
+  const facts = { tag: "button", type: "button", inForm: false, text: "Откликнуться" };
 
   // When the guard classifies it
   const refused = isSubmitControl(facts);
@@ -269,4 +357,115 @@ test("SUBMIT_RX: matches the action, not every word containing it", () => {
   // Then only the real ones match, punctuation and case included
   assert.equal(SUBMIT_RX.test("Submit »"), true);
   assert.equal(SUBMIT_RX.test("SEND APPLICATION"), true);
+});
+
+test("isSubmitControl: a div with role=button reading \"Send\" inside a form is refused", () => {
+  // Given the shape a custom ATS ships as its final button: not a <button>, so no
+  // type rule reaches it, and named by a verb no submit vocabulary contains
+  const facts = { tag: "div", role: "button", inForm: true, text: "Send" };
+
+  // When the guard classifies it
+  const refused = isSubmitControl(facts);
+
+  // Then role="button" is read as a button, and bare "send" is refused inside a
+  // form: this is the one shape where a click files the application silently
+  assert.equal(refused, true);
+});
+
+test("isSubmitControl: a native button reading \"Send\" inside a form is refused", () => {
+  // Given the same wording on a declared type="button", so only the tier decides
+  const facts = { tag: "button", type: "button", inForm: true, text: "Send" };
+
+  // When the guard classifies it
+  // Then the in-form tier refuses it
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: outside a form, \"Send\" is allowed", () => {
+  // Given "Send to a friend" on a listing page, which sends nothing of ours
+  const facts = { tag: "button", type: "button", inForm: false, text: "Send to a friend" };
+
+  // When the guard classifies it
+  // Then the tier does not reach outside a form, so the loop keeps the click
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: a checkbox reading \"Send me updates\" inside a form is allowed", () => {
+  // Given the marketing opt-in every application form carries. A click cannot
+  // submit it, so the in-form tier is held to clickables
+  const facts = { tag: "input", type: "checkbox", inForm: true, name: "Send me updates" };
+
+  // When the guard classifies it
+  // Then it stays actionable: refusing it would cost a turn and protect nothing
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: an unlabelled div with role=button inside a form is refused", () => {
+  // Given an icon-only control that is not a <button> at all
+  const facts = { tag: "div", role: "button", inForm: true, text: "" };
+
+  // When the guard classifies it
+  // Then silence inside a form is refused whatever the tag, because the shape we
+  // cannot identify is exactly the shape of the button that sends the form
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("isSubmitControl: a div with role=button and no type is allowed inside a form when it says what it does", () => {
+  // Given a scripted control in a form, named, and not a <button>: HTML's
+  // typeless default is about <button>, and a <div> submits nothing on its own
+  const facts = { tag: "div", role: "button", inForm: true, text: "Add another position" };
+
+  // When the guard classifies it
+  // Then it stays actionable — the default rule does not follow role="button"
+  assert.equal(isSubmitControl(facts), false);
+});
+
+test("isSubmitControl: a control named only by its title is refused", () => {
+  // Given a floating icon button that sits outside the <form> it submits, so the
+  // structural rules do not reach it, and whose only name is a title attribute
+  const facts = { tag: "button", type: "button", inForm: false, title: "Bewerbung absenden" };
+
+  // When the guard classifies it
+  const refused = isSubmitControl(facts);
+
+  // Then the title is read for classification, and the snapshot line is not
+  // widened by it: the planner still sees what it saw before
+  assert.equal(refused, true);
+  assert.equal(snapshotLabel(facts), "");
+});
+
+test("isSubmitControl: an icon named only by its alt is refused", () => {
+  // Given <img role="button" alt="Отправить">, a clickable image whose only
+  // wording lives in alt — it has no text, no value and no aria-label
+  const facts = { tag: "img", role: "button", inForm: false, alt: "Отправить" };
+
+  // When the guard classifies it
+  const refused = isSubmitControl(facts);
+
+  // Then alt counts as a name, and again only for the guard
+  assert.equal(refused, true);
+  assert.equal(snapshotLabel(facts), "");
+});
+
+test("isSubmitControl: a name that exists only through aria-labelledby is refused", () => {
+  // Given a button labelled by another element's text (`aria-labelledby="t9"`).
+  // drive.ts resolves that into `aria` in the page, because reading the
+  // aria-label attribute alone would leave the guard classifying an empty string
+  const facts = { tag: "div", role: "button", inForm: true, text: "", aria: "Submit application" };
+
+  // When the guard classifies it
+  // Then the resolved accessible name is refused like any other label
+  assert.equal(isSubmitControl(facts), true);
+});
+
+test("IN_FORM_RX: matches the verb, not every word containing it", () => {
+  // Given words that merely contain "send" or "apply"
+  assert.equal(IN_FORM_RX.test("Resend code"), false);
+  assert.equal(IN_FORM_RX.test("Sender name"), false);
+  assert.equal(IN_FORM_RX.test("Applying filters"), false);
+
+  // Then only the verbs match, punctuation and case included
+  assert.equal(IN_FORM_RX.test("Send"), true);
+  assert.equal(IN_FORM_RX.test("SEND »"), true);
+  assert.equal(IN_FORM_RX.test("Apply now"), true);
 });

--- a/web/tests/lib/submit-guard.test.mjs
+++ b/web/tests/lib/submit-guard.test.mjs
@@ -148,6 +148,31 @@ test("isSubmitControl: outside a form, an unlabelled button is allowed", () => {
   assert.equal(isSubmitControl(facts), false);
 });
 
+test("isSubmitControl: a submit term past the 80-char snapshot cap is still refused", () => {
+  // Given a scripted icon button whose only wording is a long aria-label that
+  // ends in the submit term, past the 80 chars the snapshot line keeps
+  const facts = { tag: "button", type: "button", explicitType: true, inForm: true,
+    aria: "By continuing you confirm the details above are accurate and complete and you agree to submit application" };
+
+  // When the guard classifies it
+  const refused = isSubmitControl(facts);
+
+  // Then the decision saw the whole label, even though the snapshot line is capped
+  assert.equal(refused, true);
+  assert.ok(snapshotLabel(facts).length <= 80);
+});
+
+test("isSubmitControl: an unlabelled input button inside a form is refused", () => {
+  // Given <input type="button"> with no text of its own, inside a form
+  const facts = { tag: "input", type: "button", explicitType: true, inForm: true };
+
+  // When the guard classifies it
+  const refused = isSubmitControl(facts);
+
+  // Then it is refused like an unlabelled <button>: its handler can submit
+  assert.equal(refused, true);
+});
+
 test("isSubmitControl: survives missing facts", () => {
   // Given a call with nothing to read (a page that changed under us)
 

--- a/web/tests/lib/submit-guard.test.mjs
+++ b/web/tests/lib/submit-guard.test.mjs
@@ -11,7 +11,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isSubmitControl, snapshotLabel, SUBMIT_RX } from "../../src/lib/apply/submit-guard.mjs";
+import { isSubmitControl, snapshotLabel, SUBMIT_RX, APPLY_RX } from "../../src/lib/apply/submit-guard.mjs";
 
 /** The facts drive.ts reads, with the defaults of an ordinary in-form control. */
 const el = (facts) => ({ tag: "button", type: "button", explicitType: true, inForm: true, ...facts });
@@ -170,6 +170,50 @@ test("isSubmitControl: an unlabelled input button inside a form is refused", () 
   const refused = isSubmitControl(facts);
 
   // Then it is refused like an unlabelled <button>: its handler can submit
+  assert.equal(refused, true);
+});
+
+test("isSubmitControl: an apply verb outside a form is the way in, and stays actionable", () => {
+  // Given the entry links portals ship before any form exists
+  const links = [
+    { tag: "a", role: "link", inForm: false, text: "Postuler" },
+    { tag: "a", role: "link", inForm: false, text: "Apply for this job" },
+    { tag: "button", type: "button", explicitType: true, inForm: false, text: "Candidati" },
+    { tag: "button", type: "button", explicitType: true, inForm: false, text: "Solliciteren" },
+    { tag: "button", type: "button", explicitType: true, inForm: false, text: "Aplikuj" },
+  ];
+
+  // When the guard classifies each
+  const refused = links.filter((facts) => isSubmitControl(facts));
+
+  // Then none is refused: without them the loop could never reach the form
+  assert.deepEqual(refused, []);
+});
+
+test("isSubmitControl: the same apply verb inside a form is the final button and is refused", () => {
+  // Given declared type="button" controls (so the type rule does not fire) inside a form
+  const finals = [
+    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Postuler" },
+    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Apply" },
+    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Apply now" },
+    { tag: "button", type: "button", explicitType: true, inForm: true, text: "Bewerben" },
+  ];
+
+  // When the guard classifies each
+  const allowed = finals.filter((facts) => !isSubmitControl(facts));
+
+  // Then every one is refused
+  assert.deepEqual(allowed, []);
+});
+
+test("isSubmitControl: «Откликнуться» is refused even outside a form, because hh.ru sends the response on that click", () => {
+  // Given hh.ru's respond button, a declared button outside any form
+  const facts = { tag: "button", type: "button", explicitType: true, inForm: false, text: "Откликнуться" };
+
+  // When the guard classifies it
+  const refused = isSubmitControl(facts);
+
+  // Then it is refused: that click is the submission
   assert.equal(refused, true);
 });
 

--- a/web/tests/lib/submit-guard.test.mjs
+++ b/web/tests/lib/submit-guard.test.mjs
@@ -13,7 +13,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isSubmitControl, snapshotLabel, SUBMIT_RX, IN_FORM_RX } from "../../src/lib/apply/submit-guard.mjs";
+import { isSubmitControl, snapshotLabel, SUBMIT_RX, IN_FORM_RX, CJK_SUBMIT_RX } from "../../src/lib/apply/submit-guard.mjs";
 
 /** The facts drive.ts reads, with the defaults of an ordinary in-form control. */
 const el = (facts) => ({ tag: "button", type: "button", inForm: true, ...facts });
@@ -468,4 +468,83 @@ test("IN_FORM_RX: matches the verb, not every word containing it", () => {
   assert.equal(IN_FORM_RX.test("Send"), true);
   assert.equal(IN_FORM_RX.test("SEND »"), true);
   assert.equal(IN_FORM_RX.test("Apply now"), true);
+});
+
+// ── The project's own locales: fr, nl, tr, and the three CJK markets ──
+
+test("isSubmitControl: the Japanese, Chinese and Korean submit terms are refused inside a real label", () => {
+  // Given the final buttons as the portals actually label them, term inside
+  // the label with letters on both sides (no spaces in these scripts)
+  for (const text of ["応募内容を送信する", "提交申请", "제출하기", "提出する", "지원서 보내기", "发送申请"]) {
+    // When the guard reads them outside any form
+    // Then each is refused on wording alone
+    assert.equal(isSubmitControl(el({ inForm: false, text })), true, text);
+  }
+});
+
+test("CJK_SUBMIT_RX: matches as a substring, where a word boundary never would", () => {
+  // Given the maintainer's three examples
+  assert.equal(CJK_SUBMIT_RX.test("応募内容を送信する"), true);
+  assert.equal(CJK_SUBMIT_RX.test("提交申请"), true);
+  assert.equal(CJK_SUBMIT_RX.test("제출하기"), true);
+  // And the Latin tier keeps its boundaries: the substring form is CJK-only
+  assert.equal(SUBMIT_RX.test("Resubmitted"), false);
+  assert.equal(CJK_SUBMIT_RX.test("Resubmitted"), false);
+});
+
+test("isSubmitControl: Turkish «Başvur» is refused even outside a form, because kariyer.net completes the application on that click", () => {
+  for (const text of ["Başvur", "BAŞVUR", "Başvuruyu Gönder"]) {
+    assert.equal(isSubmitControl(el({ inForm: false, text })), true, text);
+  }
+});
+
+test("isSubmitControl: the Dutch final button is refused, the Dutch entry link is not", () => {
+  // Given Indeed NL's own labels: "Solliciteer" opens the flow, "Sollicitatie versturen" files it
+  assert.equal(isSubmitControl(el({ tag: "a", type: "", inForm: false, text: "Solliciteer" })), false);
+  for (const text of ["Sollicitatie versturen", "Verstuur je sollicitatie", "Sollicitatie verzenden", "Verzend sollicitatie"]) {
+    assert.equal(isSubmitControl(el({ inForm: false, text })), true, text);
+  }
+  // And the same entry verb inside a form is the final button
+  assert.equal(isSubmitControl(el({ inForm: true, text: "Solliciteer" })), true);
+});
+
+test("isSubmitControl: the bare send verb of nl, tr, ja, zh and ko is refused even outside a form", () => {
+  // Given the bare verbs a form-less ATS puts on its final button. English
+  // "send" alone is held to a form ("Send to a friend"); these are not,
+  // because on those markets the bare verb is the submit button, and a
+  // control like Indeed NL's phone-confirmation "Versturen" is the lost click
+  // this guard accepts.
+  for (const text of ["Versturen", "Verstuur", "Verzenden", "Gönder", "送信", "发送", "發送", "보내기"]) {
+    assert.equal(isSubmitControl(el({ tag: "a", type: "", inForm: false, text })), true, text);
+  }
+  assert.equal(isSubmitControl(el({ tag: "a", type: "", inForm: false, text: "Send" })), false);
+});
+
+test("isSubmitControl: CJK apply verbs are the way in outside a form and the final button inside one", () => {
+  for (const text of ["応募する", "申请职位", "지원하기", "投递简历"]) {
+    assert.equal(isSubmitControl(el({ tag: "a", type: "", inForm: false, text })), false, `${text} outside a form`);
+    assert.equal(isSubmitControl(el({ inForm: true, text })), true, `${text} inside a form`);
+  }
+});
+
+test("isSubmitControl: the documented CJK collisions land on the safe side", () => {
+  // Given labels that contain a tier term without being the submit button.
+  // Apply-verb collisions stay actionable outside a form and are refused
+  // inside one; send-verb collisions are refused anywhere. The accepted cost
+  // of matching without word boundaries: a lost click, never a lost
+  // application.
+  for (const text of ["応募者一覧", "지원자 관리"]) {
+    assert.equal(isSubmitControl(el({ tag: "a", type: "", inForm: false, text })), false, `${text} outside a form`);
+    assert.equal(isSubmitControl(el({ inForm: true, text })), true, `${text} inside a form`);
+  }
+  for (const text of ["发送验证码", "已提交的申请"]) {
+    assert.equal(isSubmitControl(el({ tag: "a", type: "", inForm: false, text })), true, text);
+  }
+});
+
+test("isSubmitControl: a CJK term on a fillable field is not a submit control", () => {
+  // Given a text field whose placeholder shares a term with the vocabulary
+  const facts = { tag: "input", type: "text", inForm: true, placeholder: "提交する内容を入力" };
+  // Then it stays fillable: the wording tiers are held to clickables
+  assert.equal(isSubmitControl(facts), false);
 });


### PR DESCRIPTION
## What does this PR do?

The agentic drive loop's submit guard tested a string the planner never saw, so an icon-only `<button aria-label="Submit application">` (empty `innerText`) and any non-English label ("Absenden", "Envoyer", "Отправить") got past it and were clicked. This makes the refusal decide on element facts instead of rendered text, stops handing the planner a ref for a submit control in the first place, and binds the check and the action to one element handle so the node that was cleared is the node that is acted on.

## Related issue

Closes #3833

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## How it works

**New: `web/src/lib/apply/submit-guard.mjs`** (plain `.mjs`, the `exit.mjs` pattern, so `node --test` imports it with no build step).

- `snapshotLabel(facts)` is the single definition of the label the planner is shown (`aria || placeholder || text || value || name`, whitespace collapsed, 80 chars). The snapshot prints it and the guard reads the same facts, so the two cannot disagree about one element. That was the whole bug: the snapshot read `aria-label`, the guard read `innerText`.
- `isSubmitControl(facts)` refuses on four independent readings, because each alone has a blind spot: the element's own type (`input[type=submit|image]`, `button[type=submit]`); HTML's default (a `<button>` inside a `<form>` with no honoured type submits it); the wording; and the absence of any wording (an icon-only clickable inside a form is exactly the shape of the submit button we cannot identify, so it is refused rather than guessed at). `role="button"` counts as a button for the wording and silence rules but not for the typeless default, since a `<div>` does not submit on its own.
- Every label source (`aria`, `placeholder`, `text`, `value`, `title`, `alt`) is tested on its own, deduplicated, not through `labelSource`'s single winner: an `input[type="button"]` with `aria="Continue"` and `value="Submit application"` has no `text` to fall back to, so testing only the winning source would hide the wording from the guard. `name` is left out on purpose: it is a machine identifier, so `name="submit_note"` names a text box, not a submit action. `aria` is the accessible name, resolved from `aria-labelledby` in the page when there is no `aria-label`. The wording check is held to clickable controls, so a text field whose placeholder reads "Submit your feedback" stays fillable.
- Two vocabularies, because the same verb means two things on a job portal. `SUBMIT_RX` names the action that sends the application (en, es, de, fr, it, pt, nl, pl, ru, tr) and is refused wherever it appears; «Откликнуться» is in it because on hh.ru that button sends the response in one click, and `Başvur` for the same reason on kariyer.net. The bare send verbs of nl and tr (`versturen`, `verzenden`, `gönder`) are in it too, unlike English `send`: on those markets the bare verb is the final button and a form-less ATS renders it outside any `<form>`. `IN_FORM_RX` holds the apply verbs (`apply`, `postuler`, `candidati`, `solliciteren`, `aplikuj`, `bewerben`) plus bare `send`: outside a form they are the entry point the loop exists to click, inside a form the same word is the final button. That tier plus `role="button"` is what closes `<div role="button">Send</div>`, the shape a custom ATS ships as its final button. Boundaries are `\p{L}` classes under the `u` flag rather than `\b`, because JS word boundaries are ASCII-only and `/\bотправить\b/` matches nothing. Japanese, Chinese and Korean get the same two tiers through a second matcher with no boundaries at all (`CJK_SUBMIT_RX`: 提出, 送信, 提交, 发送, 發送, 제출, 보내기; `CJK_IN_FORM_RX`: 応募, 申请, 申請, 投递, 投遞, 지원), because those scripts put no spaces around words and a term inside a real label (応募内容を送信する, 提交申请, 제출하기) has letters on both sides. The documented cost of substring matching: 已提交 ("submitted", a tab of sent applications) and 发送验证码 ("send a verification code") are refused anywhere, 応募者一覧 and 지원자 inside a form; a lost click, never a lost application.

**`web/src/lib/apply/drive.ts`**

- Node builds the snapshot lines from element facts, so a submit control is listed **without a ref**: `[--] submit "Label" (not actionable, the human submits)`. The planner can see it exists and stop, but has no name for it. This is what the empty `if (tag === "input" && [...].includes(itype)) { }` block was meant to do; it had no `continue`, so every submit input got a ref like anything else.
- **Refs are per snapshot.** Every existing `data-co-ref` is stripped before the new ones are written, and each turn mints its own random prefix (`e4k2p9-3`), so a ref from turn N names nothing in turn N+1. Numbering from `e0` every turn handed the same name to a different element after a re-render, and both the actionable set and `querySelector` accepted it.
- **The checked node is the acted-on node.** The action path resolves one `ElementHandle`, reads its facts through that handle, and performs the action on that same handle; a `Locator` re-resolves at use time and could hand the action a different node than the one that was cleared. The handle is released in a `finally`. Every action naming a ref is cleared this way, not only `click`: `fill()` on a button throws into a fallback that clicks, so a `type` action on a withheld ref would have pressed it.
- **One facts extractor**, `factsOf`, defined once at top level and handed to Playwright as the `pageFunction` for both call sites, per the first rule in `web/AGENTS.md`. The snapshot pass reads one handle per candidate; with the 70-ref cap saturated that costs 31 to 42 ms per snapshot against a 700 ms settle.
- **Refusals are told apart.** `DriveStep` gained an optional `refusal: "submit-control" | "not-offered" | "gone"` next to the human note. `DrivePanel` renders `submit-control` with a shield icon; the other two keep the amber, since those are the page moving under us, not the guard protecting anything.
- The `click`, `type` fallback and `selectOption` calls now share one explicit 6 s timeout instead of falling through to the context default.

## Tests

`web/tests/lib/submit-guard.test.mjs`, 48 tests in the Given/When/Then style of `apply-exit.test.mjs`. Refused: `input[type=submit]`; an icon-only button named only by aria-label; German, French and Russian submit labels; a submit label hidden behind a generic aria-label; a typeless button inside a form; unlabelled `<button>`, `<a>`, `<div role="button">` and `<input type="button">` inside a form; `<div role="button">Send</div>` inside a form; a control named only by `title`, an icon named only by `alt`, a name that exists only through `aria-labelledby`; an `input[type="button"]` whose `aria` and `value` disagree. Allowed: a link; a declared `type="button"`; a text input; a labelled icon button inside a form; a checkbox reading "Send me updates"; a named `<div role="button">` inside a form; "Send to a friend" outside a form; outside a form, a typeless, an unlabelled button and an unlabelled anchor; a control whose only submit-looking string is its `name`; a fillable field whose placeholder shares a word with the vocabulary. Plus label-parity and regex-boundary cases.

- `cd web && npm test`: 528 tests, 528 pass (480 before this PR). `npm run typecheck` and `npm run build`: clean.
- `node test-all.mjs --quick`: 8095 passed, 0 failed (the web suite counts as one gate there).
- `codex exec review` on the final diff: no findings.

Mutation-checked, one mutant per rule; each row lists every test that goes red and nothing else moves:

| Mutation | Tests that go red |
|---|---|
| drop the typeless-default clause | `a button with no type inside a form is refused, whatever it says` |
| `\b` boundaries, no `u` flag (the old regex shape) | `a Cyrillic submit label is refused`, `«Откликнуться» is refused even outside a form`, `an icon named only by its alt is refused` |
| drop the silence clause | the four unlabelled-inside-a-form tests |
| drop the visible-text source | `a submit label is not hidden by an aria-label that outranks it` |
| drop `role="button"` from the silence clause | `an unlabelled div with role=button inside a form is refused` |
| narrow the silence clause back to button/input | `an unlabelled clickable anchor inside a form is refused, whatever its name says` |
| add `name` into the classification scan | `a control whose only submit-looking string is its name stays allowed`, `an unlabelled anchor outside a form is allowed` |
| drop bare `send` from the in-form tier | `a div with role=button reading "Send" inside a form is refused`, `a native button reading "Send" inside a form is refused`, `IN_FORM_RX: matches the verb` |
| drop `title` and `alt` from the sources | `a control named only by its title is refused`, `an icon named only by its alt is refused` |
| classify on `labelSource`'s single winner again | `a submit term in any label source is refused even when another source outranks it` |
| drop the `isClickable` gate on the wording tier | `a fillable field whose secondary label merely contains a submit word stays allowed` |
| CJK matcher built with word boundaries like the Latin one | the four CJK tests (`the Japanese, Chinese and Korean submit terms are refused inside a real label`, `CJK_SUBMIT_RX: matches as a substring`, ...) |
| `başvur` moved to the in-form tier | `Turkish «Başvur» is refused even outside a form` |
| nl/tr bare send verbs moved to the in-form tier | `the bare send verb of nl, tr, ja, zh and ko is refused even outside a form` |

No `web/tests/**` test uses Playwright today, so the browser-level behaviour was exercised through a throwaway harness that imports `drive.ts` with its four app imports stubbed (a fake CLI that replies with a scripted action), against inline HTML fixtures:

| Fixture | Result |
|---|---|
| `<div role="button">Send</div>` inside a form | listed as `[--] submit "Send"`, absent from the actionable set; a planner that guesses its ref and asks to `type` is refused `not-offered`; the form did not submit |
| re-render, then the planner replays turn 1's ref | turn 2 shares 0 refs with turn 1, 0 elements still carry a turn-1 ref, the replayed ref is refused `not-offered` |
| the same with the per-snapshot prefix removed (mutant) | turn 1's `e2` names a different element in turn 2 and the loop clicks it: the bug the prefix closes |
| a label that becomes "Submit application" 150 ms after the snapshot | refused `submit-control` on the handle re-check |
| a control removed after the snapshot | refused `gone` |
| `type` on an allowed non-fillable control | `fill()` fails and the fallback clicks the element that was checked, not a re-resolved one |

The same harness loaded six public job pages read-only (no clicks, no account) and printed the snapshot the planner would be given:

| Page | Withheld, no ref | Apply entry still actionable |
|---|---|---|
| Greenhouse job board posting | `Submit application` | yes, `button "Apply"` |
| Lever posting | none (the form is a page later) | yes, `link "Apply"` |
| Ashby posting, two companies | none | yes, `link "Apply for this Job"` |
| LinkedIn public job view | `Search` | yes, `button "Apply"` |
| hh.ru search results | `Найти`, `Откликнуться` x2 | no, by design: on hh.ru that click sends the response |

`Search` and `Найти` are the known cost of the rule, not a miss: both really are the submit button of a `<form>`, so the loop cannot use a site's own search box, one refused click on a page it reaches by URL anyway.

## Out of scope

The planner prompt is unchanged except its three example refs, which now read `<ref>` because refs carry a per-turn prefix. A labelled `input[type=reset]` stays clickable; an unlabelled one inside a form is now refused, a side effect of holding the silence rule to `isClickable` rather than a second carve-out. The loop still reads only the main frame and does not walk shadow roots. What no DOM heuristic closes: an allowed control whose own click handler calls `requestSubmit()`. A browser-level interlock on the `submit` event would make the wording tiers a second line of defence rather than the first, and is the natural next step, as a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The apply drive loop no longer exposes submit controls as actionable refs.

Users can still see submit controls in snapshots, but the agent cannot click, type into, or select them. A human must submit the application.

### Changes

- Added shared submit detection in `web/src/lib/apply/submit-guard.mjs:1`.
- Added consistent label extraction and multilingual, Unicode-aware, and CJK matching.
- Excluded hidden and submit controls from actionable refs in `web/src/lib/apply/drive.ts`.
- Revalidated every ref-based action against the live element before creating a locator.
- Added epoch-scoped refs and refusal reasons: `submit-control`, `not-offered`, and `gone`.
- Updated refusal display in `web/src/components/apply-view.tsx`.
- Added 48 submit-guard tests in `web/tests/lib/submit-guard.test.mjs`.

### System files

No changes are reported for `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->