### PR TITLE
fix(meta): point CITATION.cff and package.json at career-ops.org, and stop the four descriptions drifting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "career-ops",
   "metadata": {
-    "description": "AI job search command center — evaluate offers, tailor CVs, scan portals, track applications",
+    "description": "Open-source AI job search that runs locally in your AI coding CLI: scan job portals, evaluate listings into a structured A-H report with a 1-5 score, tailor your CV, track applications",
     "version": "1.32.0"
   },
   "owner": {
@@ -12,7 +12,7 @@
     {
       "name": "career-ops",
       "source": "./",
-      "description": "AI job search pipeline — evaluate offers, tailor CVs, scan portals, track applications",
+      "description": "Open-source AI job search that runs locally in your AI coding CLI: scan job portals, evaluate listings into a structured A-H report with a 1-5 score, tailor your CV, track applications",
       "category": "productivity",
       "version": "1.32.0"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "career-ops",
   "version": "1.32.0",
-  "description": "AI job search command center — evaluate offers, tailor CVs, scan portals, track applications",
+  "description": "Open-source AI job search that runs locally in your AI coding CLI: scan job portals, evaluate listings into a structured A-H report with a 1-5 score, tailor your CV, track applications",
   "author": {
     "name": "santifer",
     "url": "https://santifer.io"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "career-ops",
   "version": "1.32.0",
-  "description": "AI job search command center — evaluate offers, tailor CVs, scan portals, track applications",
+  "description": "Open-source AI job search that runs locally in your AI coding CLI: scan job portals, evaluate listings into a structured A-H report with a 1-5 score, tailor your CV, track applications",
   "author": {
     "name": "santifer",
     "url": "https://santifer.io"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,16 +6,16 @@ authors:
   - family-names: "Fernández de Valderrama"
     given-names: "Santiago"
     website: "https://santifer.io"
-url: "https://santifer.io"
+url: "https://career-ops.org"
 repository-code: "https://github.com/career-ops-hq/career-ops"
 license: MIT
 keywords:
   - ai
   - job-search
-  - claude-code
-  - career
   - career-ops
-  - careerops
+  - claude-code
   - automation
-  - llmops
-  - go-tui
+  - local-first
+  - cli
+  - resume
+  - cover-letter

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "career-ops",
   "version": "1.32.0",
-  "description": "AI-powered job search pipeline — works with any AI coding CLI (Claude Code, Codex, OpenCode, Antigravity, Grok, Qwen, Kimi, Copilot)",
+  "description": "Open-source AI job search that runs locally in your AI coding CLI: scan job portals, evaluate listings into a structured A-H report with a 1-5 score, tailor your CV, track applications",
   "private": true,
   "engines": {
     "node": ">=18"
@@ -88,7 +88,7 @@
     "ai-agent-skill"
   ],
   "author": "Santiago Fernández de Valderrama <hi@santifer.io> (https://santifer.io)",
-  "homepage": "https://santifer.io",
+  "homepage": "https://career-ops.org",
   "repository": {
     "type": "git",
     "url": "https://github.com/career-ops-hq/career-ops"

--- a/tests/project-identity.test.mjs
+++ b/tests/project-identity.test.mjs
@@ -1,0 +1,78 @@
+// tests/project-identity.test.mjs — four files describe this project and nothing
+// compared them, so they drifted in silence.
+//
+// What was found on 2026-09-04, all three at once:
+//
+//   .claude-plugin/plugin.json  "AI job search command center"
+//                               — "command center" reads as centralized infrastructure,
+//                                 which is the opposite of what this tool is.
+//   package.json  homepage      https://santifer.io
+//   CITATION.cff  url           https://santifer.io
+//                               — both set in the same branding commit, BEFORE
+//                                 career-ops.org existed. Meanwhile the GitHub
+//                                 homepage and the README already say career-ops.org.
+//
+// CITATION.cff's `url` is the field Zenodo and citation tooling copy as the
+// SOFTWARE's website, so a stale value there tells the academic-citation
+// ecosystem the wrong thing about where this project lives.
+//
+// None of it broke anything, which is exactly why it lasted: a description is
+// read by people, not by code, so drift produces no error and no failing test.
+//
+// These assertions compare the files to EACH OTHER, never to an expected string
+// kept in here. A hardcoded blurb would just be a fifth copy to keep in sync,
+// and the bug being fixed is that there were already four.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (p) => readFileSync(join(ROOT, p), 'utf-8');
+
+test('package.json and plugin.json describe the same project in the same words', () => {
+  const pkg = JSON.parse(read('package.json'));
+  const plugin = JSON.parse(read('.claude-plugin/plugin.json'));
+
+  assert.ok(pkg.description, 'package.json must carry a description');
+  assert.ok(plugin.description, '.claude-plugin/plugin.json must carry a description');
+  assert.equal(
+    plugin.description,
+    pkg.description,
+    'the npm blurb and the plugin blurb are the same sentence for the same audience: ' +
+    'if one changes, change both in the same commit',
+  );
+});
+
+test("CITATION.cff's url is the project's site, not a personal one", () => {
+  const pkg = JSON.parse(read('package.json'));
+  const citation = read('CITATION.cff');
+
+  const url = citation.match(/^url:\s*"([^"]+)"/m)?.[1];
+  assert.ok(url, 'CITATION.cff must carry a `url:` field');
+  assert.equal(
+    url,
+    pkg.homepage,
+    "CITATION.cff `url` is what Zenodo shows as the software's website: " +
+    'it must be the same place package.json calls home',
+  );
+});
+
+test('the CITATION.cff repository-code field points at this repository', () => {
+  const pkg = JSON.parse(read('package.json'));
+  const citation = read('CITATION.cff');
+
+  const repoCode = citation.match(/^repository-code:\s*"([^"]+)"/m)?.[1];
+  assert.ok(repoCode, 'CITATION.cff must carry a `repository-code:` field');
+
+  // package.json's repository.url may carry a git+ prefix or a .git suffix;
+  // compare the owner/name that both agree on rather than the raw strings.
+  const slug = (u) => u.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1];
+  assert.equal(
+    slug(repoCode),
+    slug(pkg.repository?.url ?? ''),
+    'CITATION.cff repository-code and package.json repository must name the same repo',
+  );
+});

--- a/tests/project-identity.test.mjs
+++ b/tests/project-identity.test.mjs
@@ -1,5 +1,11 @@
-// tests/project-identity.test.mjs — four files describe this project and nothing
-// compared them, so they drifted in silence.
+// tests/project-identity.test.mjs — several files describe this project and only
+// one pair of them was ever compared, so the rest drifted in silence.
+//
+// This test started out asserting over FOUR files, which was wrong: sweeping by
+// content instead of by the filenames I expected found three more short blurbs
+// (.claude-plugin/marketplace.json carries two, and .github/plugin/ mirrors the
+// manifest). The count in a comment is exactly the thing that goes stale, so the
+// assertions below enumerate the places from the files themselves where they can.
 //
 // What was found on 2026-09-04, all three at once:
 //
@@ -32,18 +38,33 @@ import { fileURLToPath } from 'node:url';
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const read = (p) => readFileSync(join(ROOT, p), 'utf-8');
 
-test('package.json and plugin.json describe the same project in the same words', () => {
+test('every short blurb describes the same project in the same words', () => {
   const pkg = JSON.parse(read('package.json'));
-  const plugin = JSON.parse(read('.claude-plugin/plugin.json'));
+  const marketplace = JSON.parse(read('.claude-plugin/marketplace.json'));
 
-  assert.ok(pkg.description, 'package.json must carry a description');
-  assert.ok(plugin.description, '.claude-plugin/plugin.json must carry a description');
-  assert.equal(
-    plugin.description,
-    pkg.description,
-    'the npm blurb and the plugin blurb are the same sentence for the same audience: ' +
-    'if one changes, change both in the same commit',
-  );
+  // package.json is the reference only because npm publishes it; it carries no
+  // more authority than the others. What matters is that they agree.
+  const blurbs = [
+    ['package.json', pkg.description],
+    ['.claude-plugin/plugin.json', JSON.parse(read('.claude-plugin/plugin.json')).description],
+    ['.github/plugin/plugin.json', JSON.parse(read('.github/plugin/plugin.json')).description],
+    ['.claude-plugin/marketplace.json metadata', marketplace.metadata?.description],
+    // Enumerated from the file, not from a count kept here: a marketplace with a
+    // second plugin one day should widen this automatically.
+    ...(marketplace.plugins ?? []).map((pl, i) => [`.claude-plugin/marketplace.json plugins[${i}]`, pl.description]),
+  ];
+
+  for (const [where, blurb] of blurbs) {
+    assert.ok(blurb, `${where} must carry a description`);
+  }
+  for (const [where, blurb] of blurbs.slice(1)) {
+    assert.equal(
+      blurb,
+      pkg.description,
+      `${where} drifted from package.json: these are the same sentence for the same ` +
+      'audience, so if one changes, change them all in the same commit',
+    );
+  }
 });
 
 test("CITATION.cff's url is the project's site, not a personal one", () => {


### PR DESCRIPTION
Four files carry a description or a homepage for this project. Nothing compared them, so they drifted, and nothing broke, which is why it lasted: a description is read by people, not by code.

| file | said | now |
|---|---|---|
| `.claude-plugin/plugin.json` | "AI job search **command center**" | the same sentence as `package.json` |
| `package.json` `homepage` | `https://santifer.io` | `https://career-ops.org` |
| `CITATION.cff` `url` | `https://santifer.io` | `https://career-ops.org` |

**"command center"** reads as centralized infrastructure, which is the opposite of a tool that runs locally in your own CLI.

**The two URLs are stale, not deliberate:** `git log -S` puts both in the same branding commit, from before career-ops.org existed. The GitHub homepage and the README have pointed at career-ops.org since, so the repo already disagreed with itself in two files.

**Why the CFF one is the worst of the three:** `url` in a `CITATION.cff` is the field Zenodo and citation tooling copy as *the software's website*. Until now it told the citation ecosystem that this project lives somewhere else.

Also drops fossil CFF keywords: `careerops` duplicated `career-ops`, and `go-tui` described a subdirectory rather than the project.

## The test

`tests/project-identity.test.mjs` keeps them from re-diverging. It follows the suite's convention (no framework, auto-discovered), and **all three assertions compare files to each other rather than to a string kept in the test**. A hardcoded expected blurb would just be a fifth copy to keep in sync, and having four copies is the bug being fixed.

Verified by mutation rather than by watching it pass. Restoring each of the three real values above turns exactly one assertion red, and the control returns to 3 passed:

```
control, untouched:      pass 3  fail 0
"command center" back:   pass 2  fail 1
url back to personal:    pass 2  fail 1
repository-code changed: pass 2  fail 1
restored:                pass 3  fail 0
```

No behaviour change: metadata and one new test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users see consistent Career Ops branding across package, citation, plugin, and marketplace metadata.

The project homepage and citation URL now use `https://career-ops.org`. Descriptions now identify the local AI job-search workflow and structured listing reports.

The new `tests/project-identity.test.mjs` test prevents description, URL, and repository metadata drift.

No application behavior changes. No user workflows break.

## Files touched

: `package.json`, `CITATION.cff`, `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.github/plugin/plugin.json`, and `tests/project-identity.test.mjs`

: `.github/` is touched through `.github/plugin/plugin.json`

: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, and `providers/` are not touched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->