### PR TITLE
fix(providers): radancy stops trusting totalResults, cache-busts JSON, retries every fetch

### DIFF
--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { randomUUID } from 'node:crypto';
 import { decodeEntities } from './_html-entities.mjs';
+import { fetchJsonWithRetry, fetchTextWithRetry } from './_http.mjs';
 
 // Radancy (TalentBrew) provider — the career sites Radancy hosts for large
 // employers (careers.munichre.com and its ERGO brands, plus many others). The
@@ -56,15 +58,61 @@ import { decodeEntities } from './_html-entities.mjs';
 //
 // The returned fragment re-embeds <section id="search-results"
 // data-total-results data-total-pages …>, so pagination is bounded by the
-// server's own count instead of probing until an empty page.
+// server's own page count instead of probing until an empty page.
+//
+// Neither number is trusted as proof of completeness, for two independent,
+// live-verified reasons:
+//
+// 1. `data-total-results` can simply be wrong. Checked end-to-end against 9
+//    live tenants: 5 collected exactly as many unique postings as they
+//    claimed, but 4 (a small one and a huge one both included) fell short by
+//    10-56% with no duplicate rows anywhere — the banner overstates what the
+//    tenant's own search index actually serves, on both the JSON and the
+//    HTML transport equally. `data-total-pages`, by contrast, matched the
+//    walk's own natural end (a short or empty final page) in every one of
+//    these 9 cases — but not universally: a separate, much larger tenant
+//    claims 229 pages while its backend silently refuses anything past 100
+//    (see the empty-page comment in the fetch loop below). So the page count
+//    is used only to bound the walk, never as proof it's complete — the
+//    walk's own natural end (an empty or short page) is what actually
+//    decides that, with our own caps still applied via Math.min on top. The
+//    results count is display-only and never drives a stop/warn decision —
+//    comparing accumulated postings against it would false-positive on a
+//    majority of tenants.
+// 2. On one tenant (careers.munichre.com), some `CurrentPage` values behind
+//    the JSON fragment endpoint intermittently replayed a stale response —
+//    the same posting would show up again several pages later while another
+//    was never served at all — reproducible on 9/9 consecutive runs. The
+//    `?p=N` HTML transport, hitting the same underlying data over the same
+//    window, showed zero such repeats. Isolated to a caching layer in front
+//    of the JSON route specifically: `Cache-Control`/`Pragma: no-cache`
+//    request headers made no difference (9/9 still broken), but a random
+//    per-request query parameter — forcing a cache-key miss — made it 0/4
+//    broken. Applied to every JSON fragment request below; harmless on
+//    tenants that never had the problem (verified against 11 live tenants,
+//    matching page-1 output with/without it in every case that didn't
+//    already fail on its own, e.g. AT&T's oversized security headers).
 
-const MAX_PAGES = 200; // safety cap (~15/page ⇒ up to ~3000 postings)
+// Safety cap on page count, shared by both transports below — but they walk
+// pages of different sizes: ~3,000 postings via the HTML `?p=N` fallback
+// (15/page, hard-coded by the site), ~20,000 via the preferred JSON fragment
+// transport (100/page — see MAX_JOBS_CAP, the more generous of the two).
+const MAX_PAGES = 200;
 const DEFAULT_MAX_JOBS = 2000; // default cap on total postings pulled
 const PAGE_DELAY_MS = 150; // polite pacing — full walks are >100 sequential requests
 
 // Page size for the JSON fragment transport. 100 is honored live by both known
 // legacy tenants (UHG, Kaiser); the HTML page hard-codes 15.
 const FRAGMENT_RECORDS_PER_PAGE = 100;
+
+// A user-supplied `max_jobs` is not otherwise bounded by anything but
+// `max_pages` (itself capped at MAX_PAGES): a garbage value here doesn't risk
+// an unbounded walk, but it also isn't caught the way an equally garbage
+// `max_pages` already is (`resolveMaxPages` clamps via Math.min). Cap it
+// explicitly for the same reason `MAX_PAGES` exists — defense against an
+// absurd config value, not a known real-world ceiling. Set at the JSON
+// transport's own true ceiling (see the MAX_PAGES comment above).
+const MAX_JOBS_CAP = MAX_PAGES * FRAGMENT_RECORDS_PER_PAGE;
 
 /** @param {string} s */
 function clean(s) {
@@ -93,6 +141,12 @@ export function resolveListUrl(entry) {
  * top of this file. Adding it back re-attaches a multi-megabyte facet blob to
  * every page and is the single most expensive mistake available here.
  *
+ * `_` is a random cache-buster, not a documented TalentBrew parameter — see
+ * the transport note at the top of this file for why. It must be unique per
+ * call (not, say, derived from `page`): a caching layer keying on the URL
+ * still produces a stable, wrong, repeatable mapping if the extra parameter
+ * is itself deterministic.
+ *
  * @param {string} listUrl Base search-jobs URL (no trailing slash).
  * @param {number} page 1-based page number.
  * @param {number} recordsPerPage
@@ -115,6 +169,7 @@ export function buildFragmentUrl(listUrl, page, recordsPerPage = FRAGMENT_RECORD
     SortCriteria: '0',
     SortDirection: '0',
     SearchType: '5',
+    _: randomUUID(),
   });
   return `${listUrl}/results?${q.toString()}`;
 }
@@ -236,9 +291,9 @@ function resolveMaxPages(entry) {
 }
 
 /** Resolve the total-postings cap: positive integer `max_jobs`, else default. */
-function resolveMaxJobs(entry) {
+export function resolveMaxJobs(entry) {
   const v = entry?.max_jobs;
-  if (Number.isInteger(v) && v > 0) return v;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_JOBS_CAP);
   return DEFAULT_MAX_JOBS;
 }
 
@@ -260,6 +315,18 @@ export default {
     const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
     const maxPages = resolveMaxPages(entry);
     const maxJobs = resolveMaxJobs(entry);
+    // ctx.maxPages is set only by verify-portals.mjs's bounded liveness probe
+    // (never during a real scan). While probing: cap the walk to that budget
+    // (SHOULD — reference providers/workday.mjs) so a healthy large board
+    // doesn't burn the probe's whole request allotment on one tenant, and
+    // propagate any ctx.fetch* rejection unwrapped instead of absorbing it
+    // into the normal partial-result handling (MUST). verify-portals
+    // identifies its own budget-exhaustion sentinel, ProbePageBudgetReached,
+    // by `instanceof`, and reads it as "endpoint live, count unknown"; a
+    // per-page catch that swallows it into a normal stopReason/break instead
+    // misreports a healthy board as broken. Reference: providers/vdab.mjs.
+    const probing = Number.isInteger(ctx?.maxPages) && ctx.maxPages > 0;
+    const effectiveMaxPages = probing ? Math.min(maxPages, ctx.maxPages) : maxPages;
     const jobs = [];
     const seen = new Set();
     // Proof of life across BOTH transports: any resolved request — including a
@@ -274,7 +341,8 @@ export default {
     // the HTML walk below, so tenants without this endpoint are unaffected.
     if (typeof ctx.fetchJson === 'function') {
       try {
-        const first = await ctx.fetchJson(buildFragmentUrl(listUrl, 1), {
+        const first = await fetchJsonWithRetry(ctx, buildFragmentUrl(listUrl, 1), {
+          redirect: 'error',
           headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
         });
         const firstIsString = typeof first?.results === 'string';
@@ -290,7 +358,7 @@ export default {
           const { totalResults, totalPages } = readFragmentTotals(firstHtml);
           // Bound by the server's own page count when it gives one; the local
           // caps still apply so a bogus total can't drive an unbounded walk.
-          const lastPage = Math.min(totalPages ?? maxPages, maxPages);
+          const lastPage = Math.min(totalPages ?? effectiveMaxPages, effectiveMaxPages);
           const push = (rows) => {
             let fresh = 0;
             for (const row of rows) {
@@ -303,39 +371,108 @@ export default {
           };
           push(firstRows);
 
-          for (let page = 2; page <= lastPage && jobs.length < maxJobs; page++) {
+          // Why the walk stopped, driving the warning below — never the
+          // results-count mismatch (see the transport note up top: a source
+          // total falling short of what pagination collected is routine here
+          // and does not mean career-ops left postings behind).
+          let stopReason = 'complete';
+          let page = 2;
+          for (; page <= lastPage && jobs.length < maxJobs; page++) {
             await wait(PAGE_DELAY_MS);
             let rows;
             try {
-              const json = await ctx.fetchJson(buildFragmentUrl(listUrl, page), {
+              const json = await fetchJsonWithRetry(ctx, buildFragmentUrl(listUrl, page), {
+                redirect: 'error',
                 headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
               });
-              const frag = typeof json?.results === 'string' ? json.results : '';
-              rows = frag ? parseResults(frag, origin) : [];
-            } catch {
+              // A STRING `results` — even one that parses to zero rows, which
+              // is what a genuine last page looks like live (Walgreens' own
+              // past-the-end page answers hasJobs:false with a non-empty
+              // shell string that simply contains no job rows) — is the only
+              // form the documented "no more jobs" signal takes. A missing,
+              // null, or wrong-typed `results` has never been observed as
+              // that signal, so it's a malformed response, not an empty
+              // page: silently coercing it to [] would end the walk early
+              // exactly like a real empty page does, with no error raised.
+              if (typeof json?.results !== 'string') {
+                throw new Error(`radancy: unexpected fragment response shape at page ${page} (results is not a string)`);
+              }
+              rows = json.results ? parseResults(json.results, origin) : [];
+            } catch (err) {
+              if (probing) throw err; // propagate ProbePageBudgetReached (or any rejection) unwrapped
+              console.error(
+                `⚠️  radancy: ${entry.name} truncated at page ${page} of ${lastPage}`
+                + ` (${jobs.length} jobs): ${err.message}`,
+              );
+              stopReason = 'error';
               break; // keep what we have; a mid-walk blip shouldn't discard earlier pages
             }
-            if (rows.length === 0) break;
-            if (push(rows) === 0) break; // server clamped the page — stop
+            // A clean, structured empty page (`rows.length === 0`, not a
+            // thrown error) is a legitimate natural stop even when it lands
+            // well short of `totalResults`/`totalPages` — no different from
+            // any other tenant undercounting. Observed live on one very
+            // large tenant landing exactly at offset 10,000 (100 pages of
+            // 100 — the default Elasticsearch/Solr `max_result_window`);
+            // unlike `workday.mjs`'s analogous, multi-tenant-confirmed
+            // `WORKDAY_OFFSET_CEILING`, this has one confirmed instance and
+            // TalentBrew's JSON fragment API exposes no documented
+            // facet-style split to route around it, so there is nothing to
+            // detect-and-recover here — the empty page already handles it.
+            if (rows.length === 0) break; // source ran out on its own — complete
+            if (push(rows) === 0) break; // fully-duplicate page — source ran out — complete
+          }
+          // The loop only reaches here without an early break when it walked
+          // every page up to `lastPage`. That is only OUR cap, not the
+          // source's own end, when `lastPage` is our effective ceiling
+          // (`max_pages`, or `ctx.maxPages` while probing) and the source
+          // either gave no page count or claimed more pages than that.
+          if (stopReason === 'complete' && page > lastPage && lastPage === effectiveMaxPages
+            && (totalPages == null || totalPages > effectiveMaxPages)) {
+            stopReason = 'cap';
+          }
+          // `jobs.length >= maxJobs` alone isn't enough: a tenant whose real
+          // total happens to exactly fill the pages already walked (natural
+          // end reached, `page > lastPage`) would false-positive into 'cap'
+          // here even though nothing was left unfetched. Only the overshoot
+          // case (a page pushed the buffer strictly past maxJobs in one
+          // jump — real fetched rows that the final slice below still has to
+          // drop) is unconditionally a cap; an exact match only counts when
+          // the loop stopped WITH page budget still available (`page <=
+          // lastPage`) — i.e. max_jobs itself is what kept a further page
+          // from being tried, not a coincidence of how many rows fit.
+          if (stopReason === 'complete'
+            && (jobs.length > maxJobs || (jobs.length === maxJobs && page <= lastPage))) {
+            stopReason = 'cap';
           }
 
-          // Never truncate silently (AGENTS.md): say what was left behind — and
-          // report the count actually RETURNED. `jobs.length` is the pre-slice
-          // buffer: the page loop only checks `jobs.length < maxJobs` before
+          // Never truncate silently on OUR OWN limit (AGENTS.md) — report the
+          // count actually RETURNED. `jobs.length` is the pre-slice buffer:
+          // the page loop only checks `jobs.length < maxJobs` before
           // fetching, so the final page can push the buffer past the cap (100
-          // rows landing on a buffer of 1,950 with max_jobs 2,000). Logging the
-          // pre-slice length would overstate delivery in the one message whose
-          // entire job is to be accurate about what the caller did not get.
-          const returned = Math.min(jobs.length, maxJobs);
-          if (totalResults && returned < totalResults) {
+          // rows landing on a buffer of 1,950 with max_jobs 2,000). Logging
+          // the pre-slice length would overstate delivery in the one message
+          // whose entire job is to be accurate about what the caller did not
+          // get. `totalResults`, when present, is context only here — the
+          // decision to warn never depends on it (see the transport note).
+          // Never while probing (SHOULD): the probe's own ctx.maxPages is
+          // what bounded this, not the tenant's real config, and "raise
+          // max_pages" is not advice a liveness check has any use for.
+          if (!probing && stopReason === 'cap') {
+            const returned = Math.min(jobs.length, maxJobs);
             console.error(
-              `⚠️  radancy: ${entry.name} truncated at ${returned} of ${totalResults} postings`
-              + ` — raise max_jobs/max_pages on this entry for more`,
+              `⚠️  radancy: ${entry.name} truncated at ${returned}${totalResults ? ` of ${totalResults}` : ''} jobs`
+              + ` (max_pages/max_jobs reached) — raise max_jobs/max_pages on this entry for more`,
             );
           }
           return jobs.slice(0, maxJobs);
         }
-      } catch {
+      } catch (err) {
+        // succeededOnce can only still be false here (the one JSON request
+        // attempted above is what just threw), so this is already covered
+        // by the HTML loop's own !succeededOnce check below — propagated
+        // explicitly anyway so a probe's budget sentinel doesn't depend on
+        // that chain of reasoning to be read correctly.
+        if (probing) throw err;
         // fall through to the HTML transport
       }
     }
@@ -345,13 +482,14 @@ export default {
     // THROW so scan/portal-health record a failure instead of "live but empty"
     // (meituan/tencent idiom). A resolved fragment request above, or a mid-scan
     // failure here, keeps partials instead.
-    for (let page = 1; page <= maxPages; page++) {
+    for (let page = 1; page <= effectiveMaxPages; page++) {
       if (page > 1) await wait(PAGE_DELAY_MS);
       let rows;
       try {
-        const html = await ctx.fetchText(`${listUrl}?p=${page}`, { headers: { accept: 'text/html' } });
+        const html = await fetchTextWithRetry(ctx, `${listUrl}?p=${page}`, { redirect: 'error', headers: { accept: 'text/html' } });
         rows = parseResults(html, origin);
       } catch (err) {
+        if (probing) throw err; // propagate ProbePageBudgetReached (or any rejection) unwrapped
         if (!succeededOnce) throw err;
         break; // keep jobs collected so far — a transient mid-scan failure shouldn't discard earlier pages
       }

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -62,13 +62,18 @@ try {
 
   // fetch — a mid-scan failure preserves jobs already collected, never
   // discards earlier pages.
+  // Non-retryable (a definitive 404, not a transient 5xx/network blip) — this
+  // test is about partial-page preservation, not about how many times
+  // fetchTextWithRetry itself attempts a retryable failure.
   let partialCalls = 0;
   const partialCtx = {
     sleep: async () => {},
     fetchText: async () => {
       partialCalls++;
       if (partialCalls === 1) return html; // 2 jobs
-      throw new Error('network blip on page 2');
+      const err = new Error('network blip on page 2');
+      err.status = 404;
+      throw err;
     },
   };
   const partialJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, partialCtx);
@@ -324,6 +329,358 @@ try {
     pass('radancy truncation warning reports the returned count, not the pre-slice buffer');
   } else {
     fail(`radancy truncation warning: returned ${overshootJobs?.length}, warned "${warned}" (expected 4 / "4")`);
+  }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ctx.maxPages / verify-portals probe handling (ADDING_A_PROVIDER.md's
+  // ctx.maxPages convention — SHOULD cap the walk, MUST propagate a
+  // ctx.fetch* rejection unwrapped instead of swallowing it)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // A non-string json.results on page 2+ must throw descriptively, not be
+  // silently coerced to [] and read as a natural end — a real "no more jobs"
+  // page is still a STRING (confirmed live: it can parse to zero rows
+  // without being empty), so anything else is a malformed response.
+  const malformedWarnings = [];
+  const malformedCtx = {
+    sleep: async () => {},
+    fetchJson: async (u) => {
+      const page = Number(new URL(u).searchParams.get('CurrentPage'));
+      if (page === 2) return { results: { unexpected: 'shape' }, hasJobs: true };
+      return {
+        results: `<section data-total-results="500" data-total-pages="5">${rowFor(page * 10 + 1)}</section>`,
+        hasJobs: true,
+      };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => malformedWarnings.push(String(m));
+  let malformedJobs;
+  try {
+    malformedJobs = await radancy.fetch({ name: 'MalformedResults', careers_url: 'https://t.example/search-jobs' }, malformedCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  if (malformedJobs.length === 1 && malformedWarnings.some((m) => m.includes('unexpected fragment response shape'))) {
+    pass('radancy.fetch() throws on a non-string json.results instead of reading it as a natural end');
+  } else {
+    fail(`radancy.fetch() malformed-results handling: jobs=${malformedJobs?.length} warnings=${JSON.stringify(malformedWarnings)}`);
+  }
+
+  // ctx.maxPages caps the walk (SHOULD) — a source claiming far more pages
+  // than the probe budget must not be walked past that budget, and no
+  // "raise max_pages" advice fires for a limit that was the probe's own,
+  // not the tenant's real config.
+  let probeCapPage = 0;
+  const probeCapWarnings = [];
+  const probeCapCtx = {
+    maxPages: 1,
+    sleep: async () => {},
+    fetchJson: async () => {
+      probeCapPage++;
+      return {
+        results: `<section data-total-results="500" data-total-pages="5">${rowFor(probeCapPage * 10 + 1)}</section>`,
+        hasJobs: true,
+      };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => probeCapWarnings.push(String(m));
+  let probeCapJobs;
+  try {
+    probeCapJobs = await radancy.fetch({ name: 'ProbeCapped', careers_url: 'https://s.example/search-jobs' }, probeCapCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  if (probeCapJobs.length === 1 && probeCapPage === 1 && probeCapWarnings.length === 0) {
+    pass('radancy.fetch() caps the walk to ctx.maxPages while probing, with no cap warning');
+  } else {
+    fail(`radancy.fetch() probe-cap handling: jobs=${probeCapJobs?.length} pages=${probeCapPage} warnings=${JSON.stringify(probeCapWarnings)}`);
+  }
+
+  // A ctx.fetch* rejection while probing — the shape of verify-portals.mjs's
+  // budget-exhaustion sentinel — must propagate unwrapped, not be absorbed
+  // into a normal stopReason/partial-result path: a swallowed sentinel reads
+  // to verify-portals as "board is down" instead of "live, partial".
+  class FakeProbeBudgetReached extends Error {}
+  const probeErrorCtx = {
+    maxPages: 3,
+    sleep: async () => {},
+    fetchJson: async (u) => {
+      const page = Number(new URL(u).searchParams.get('CurrentPage'));
+      if (page === 2) throw new FakeProbeBudgetReached('budget exhausted');
+      return {
+        results: `<section data-total-results="500" data-total-pages="5">${rowFor(page * 10 + 1)}</section>`,
+        hasJobs: true,
+      };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  let probeErrorCaught = null;
+  try {
+    await radancy.fetch({ name: 'ProbeError', careers_url: 'https://r.example/search-jobs' }, probeErrorCtx);
+  } catch (err) {
+    probeErrorCaught = err;
+  }
+  if (probeErrorCaught instanceof FakeProbeBudgetReached) {
+    pass('radancy.fetch() propagates a ctx.fetch* rejection unwrapped while probing (JSON transport)');
+  } else {
+    fail(`radancy.fetch() probe-error propagation (JSON): ${probeErrorCaught?.constructor?.name || probeErrorCaught}`);
+  }
+
+  // Same propagation requirement on the HTML fallback transport.
+  const probeErrorHtmlCtx = {
+    maxPages: 3,
+    sleep: async () => {},
+    fetchText: async (u) => {
+      const p = Number(new URL(u).searchParams.get('p'));
+      if (p === 2) throw new FakeProbeBudgetReached('budget exhausted');
+      return html; // page 1: 2 jobs, proves succeededOnce would otherwise apply
+    },
+  };
+  let probeErrorHtmlCaught = null;
+  try {
+    await radancy.fetch({ name: 'ProbeErrorHtml', api: 'https://qh.example/search-jobs' }, probeErrorHtmlCtx);
+  } catch (err) {
+    probeErrorHtmlCaught = err;
+  }
+  if (probeErrorHtmlCaught instanceof FakeProbeBudgetReached) {
+    pass('radancy.fetch() propagates a ctx.fetch* rejection unwrapped while probing (HTML transport)');
+  } else {
+    fail(`radancy.fetch() probe-error propagation (HTML): ${probeErrorHtmlCaught?.constructor?.name || probeErrorHtmlCaught}`);
+  }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Cache-buster + total-mismatch handling (added after a live investigation
+  // of 11 TalentBrew tenants — see the transport note at the top of the file)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // jobs.length >= maxJobs alone is not proof max_jobs cut anything short —
+  // a tenant whose real total exactly fills the page(s) already walked must
+  // not false-positive into a 'cap' warning just because the count happens
+  // to land exactly on max_jobs.
+  const exactWarnings = [];
+  const exactCtx = {
+    sleep: async () => {},
+    fetchJson: async () => ({
+      results: `<section data-total-results="3" data-total-pages="1">${rowFor(1)}${rowFor(2)}${rowFor(3)}</section>`,
+      hasJobs: true,
+    }),
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => exactWarnings.push(String(m));
+  let exactJobs;
+  try {
+    exactJobs = await radancy.fetch({ name: 'ExactFit', careers_url: 'https://u.example/search-jobs', max_jobs: 3 }, exactCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  if (exactJobs.length === 3 && exactWarnings.length === 0) {
+    pass('radancy.fetch() does not warn when max_jobs exactly matches a naturally-complete result');
+  } else {
+    fail(`radancy.fetch() exact-max_jobs handling: jobs=${exactJobs?.length} warnings=${JSON.stringify(exactWarnings)}`);
+  }
+
+  // Every fetch call — both JSON fragment pages and the HTML fallback — must
+  // refuse a redirect (#1440's mandatory SSRF guard, every peer provider
+  // sets it; flagged as a pre-existing gap on radancy.mjs specifically in
+  // review). A 3xx is still blocked at DNS resolution by the central
+  // _ip-guard.mjs, so this is defense-in-depth, not a live bypass — but the
+  // convention is per-provider, so it belongs here too.
+  const redirectCallsJson = [];
+  const redirectJsonCtx = {
+    sleep: async () => {},
+    fetchJson: async (u, o) => {
+      redirectCallsJson.push(o?.redirect);
+      const page = Number(new URL(u).searchParams.get('CurrentPage'));
+      return page === 1
+        ? { results: `<section data-total-results="4" data-total-pages="2">${rowFor(1)}${rowFor(2)}</section>`, hasJobs: true }
+        : { results: `<section data-total-results="4" data-total-pages="2">${rowFor(3)}</section>`, hasJobs: true };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  await radancy.fetch({ name: 'RedirectCheckJson', careers_url: 'https://redirect-json.example/search-jobs' }, redirectJsonCtx);
+  if (redirectCallsJson.length >= 2 && redirectCallsJson.every((r) => r === 'error')) {
+    pass('radancy.fetch() sets redirect:"error" on every JSON fragment request');
+  } else {
+    fail(`radancy.fetch() JSON redirect option: ${JSON.stringify(redirectCallsJson)}`);
+  }
+
+  const redirectCallsHtml = [];
+  const redirectHtmlCtx = {
+    sleep: async () => {},
+    fetchText: async (u, o) => {
+      redirectCallsHtml.push(o?.redirect);
+      return redirectCallsHtml.length === 1 ? html : '<html></html>';
+    },
+  };
+  await radancy.fetch({ name: 'RedirectCheckHtml', careers_url: 'https://redirect-html.example/search-jobs' }, redirectHtmlCtx);
+  if (redirectCallsHtml.length >= 2 && redirectCallsHtml.every((r) => r === 'error')) {
+    pass('radancy.fetch() sets redirect:"error" on every HTML ?p=N request');
+  } else {
+    fail(`radancy.fetch() HTML redirect option: ${JSON.stringify(redirectCallsHtml)}`);
+  }
+
+  // max_jobs must be clamped the same way max_pages already is — a garbage
+  // config value shouldn't be trusted just because it's a positive integer.
+  // The clamp lands at MAX_PAGES * 100 (the JSON transport's true ceiling,
+  // the more generous of the two transports), which happens to be
+  // unobservable through fetch() itself (max_pages already produces the same
+  // practical bound), so this is exercised directly.
+  const { resolveMaxJobs } = radancyModule;
+  if (resolveMaxJobs({ max_jobs: 999999999 }) === 20000) {
+    pass('radancy.resolveMaxJobs() clamps an absurd max_jobs to the true JSON-transport ceiling');
+  } else {
+    fail(`radancy.resolveMaxJobs() did not clamp: ${resolveMaxJobs({ max_jobs: 999999999 })}`);
+  }
+  if (resolveMaxJobs({}) === 2000) {
+    pass('radancy.resolveMaxJobs() defaults to 2000 when max_jobs is unset');
+  } else {
+    fail(`radancy.resolveMaxJobs() default wrong: ${resolveMaxJobs({})}`);
+  }
+
+  // The cache-buster must vary per call — a caching layer keying on the URL
+  // still produces a stable, wrong result if the extra parameter is itself
+  // deterministic (e.g. derived from `page`, which repeats across fetch()
+  // calls for the same page number).
+  const cbUrl1 = new URL(buildFragmentUrl('https://x.example/search-jobs', 1));
+  const cbUrl2 = new URL(buildFragmentUrl('https://x.example/search-jobs', 1));
+  if (cbUrl1.searchParams.get('_') && cbUrl1.searchParams.get('_') !== cbUrl2.searchParams.get('_')) {
+    pass('radancy.buildFragmentUrl() appends a per-call random cache-buster');
+  } else {
+    fail(`radancy.buildFragmentUrl() cache-buster missing or not unique: ${cbUrl1.searchParams.get('_')} / ${cbUrl2.searchParams.get('_')}`);
+  }
+
+  // A source total overstating what pagination actually serves is routine
+  // (verified live on 4 of 9 tenants) and must never fire the "raise
+  // max_pages" warning — that advice cannot fix a source-side count, and
+  // firing it here would be noise on a majority of real tenants.
+  const overstateWarnings = [];
+  const overstateCtx = {
+    sleep: async () => {},
+    fetchJson: async () => ({
+      results: `<section data-total-results="10" data-total-pages="1">${rowFor('501')}</section>`,
+      hasJobs: true,
+    }),
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => overstateWarnings.push(String(m));
+  let overstateJobs;
+  try {
+    overstateJobs = await radancy.fetch({ name: 'Understated', careers_url: 'https://y.example/search-jobs' }, overstateCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  if (overstateJobs.length === 1 && overstateWarnings.length === 0) {
+    pass('radancy.fetch() does not warn when a natural page-1 end falls short of an inflated totalResults');
+  } else {
+    fail(`radancy.fetch() overstated-total handling: ${overstateJobs?.length} jobs, warnings=${JSON.stringify(overstateWarnings)}`);
+  }
+
+  // max_pages capping the walk short of the source's own LARGER totalPages IS
+  // worth a warning — this is the one case where "raise max_pages" is
+  // actually actionable.
+  let capPage = 0;
+  const capWarnings = [];
+  const genuineCapCtx = {
+    sleep: async () => {},
+    fetchJson: async () => {
+      capPage++;
+      return {
+        results: `<section data-total-results="500" data-total-pages="5">${rowFor(capPage * 10 + 1)}${rowFor(capPage * 10 + 2)}</section>`,
+        hasJobs: true,
+      };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => capWarnings.push(String(m));
+  let genuineCapJobs;
+  try {
+    genuineCapJobs = await radancy.fetch({ name: 'CappedShort', careers_url: 'https://z.example/search-jobs', max_pages: 2 }, genuineCapCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  const genuineCapWarned = capWarnings.some((m) => /raise max_jobs\/max_pages/.test(m));
+  if (genuineCapJobs.length === 4 && capPage === 2 && genuineCapWarned) {
+    pass('radancy.fetch() warns when max_pages caps the walk short of a larger source-reported totalPages');
+  } else {
+    fail(`radancy.fetch() genuine cap handling: jobs=${genuineCapJobs?.length} pages=${capPage} warned=${genuineCapWarned}`);
+  }
+
+  // A mid-walk JSON fetch error must keep earlier pages and log why
+  // pagination stopped, distinct from — and without — cap advice. Page 2
+  // fails on EVERY attempt (retries included, via fetchJsonWithRetry) — a
+  // one-shot-then-recovers mock would silently "fix itself" on retry and
+  // prove nothing about the error path.
+  const errWarnings = [];
+  const jsonErrorCtx = {
+    sleep: async () => {},
+    fetchJson: async (u) => {
+      const page = Number(new URL(u).searchParams.get('CurrentPage'));
+      if (page === 2) {
+        const err = new Error('503 on page 2');
+        err.status = 503;
+        throw err;
+      }
+      return {
+        results: `<section data-total-results="500" data-total-pages="5">${rowFor(page * 10 + 1)}</section>`,
+        hasJobs: true,
+      };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => errWarnings.push(String(m));
+  let jsonErrorJobs;
+  try {
+    jsonErrorJobs = await radancy.fetch({ name: 'MidWalkError', careers_url: 'https://w.example/search-jobs' }, jsonErrorCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  const errLogged = errWarnings.some((m) => m.includes('503 on page 2'));
+  const noCapAdvice = !errWarnings.some((m) => /raise max_jobs\/max_pages/.test(m));
+  if (jsonErrorJobs.length === 1 && errLogged && noCapAdvice) {
+    pass('radancy.fetch() keeps earlier pages and logs the fetch error on a mid-walk JSON failure, without cap advice');
+  } else {
+    fail(`radancy.fetch() mid-walk JSON error handling: jobs=${jsonErrorJobs?.length} warnings=${JSON.stringify(errWarnings)}`);
+  }
+
+  // The actual point of routing through fetchJsonWithRetry: a page that
+  // fails once transiently (429/5xx/network) then succeeds must recover
+  // silently — no lost page, no error logged — where the old bare
+  // ctx.fetchJson call would have permanently truncated the walk from
+  // there on a single blip.
+  let attemptsOnPage2 = 0;
+  const transientWarnings = [];
+  const transientCtx = {
+    sleep: async () => {},
+    fetchJson: async (u) => {
+      const page = Number(new URL(u).searchParams.get('CurrentPage'));
+      if (page === 2) {
+        attemptsOnPage2++;
+        if (attemptsOnPage2 === 1) {
+          const err = new Error('503 Service Unavailable');
+          err.status = 503;
+          throw err;
+        }
+      }
+      return {
+        results: `<section data-total-results="500" data-total-pages="3">${rowFor(page * 10 + 1)}</section>`,
+        hasJobs: true,
+      };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => transientWarnings.push(String(m));
+  let transientJobs;
+  try {
+    transientJobs = await radancy.fetch({ name: 'TransientBlip', careers_url: 'https://v.example/search-jobs' }, transientCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  if (transientJobs.length === 3 && attemptsOnPage2 === 2 && transientWarnings.length === 0) {
+    pass('radancy.fetch() recovers a page that fails once transiently, via fetchJsonWithRetry, with no data lost and no warning');
+  } else {
+    fail(`radancy.fetch() transient-recovery handling: jobs=${transientJobs?.length} attempts=${attemptsOnPage2} warnings=${JSON.stringify(transientWarnings)}`);
   }
 } catch (e) {
   fail(`radancy provider tests crashed: ${e.message}`);


### PR DESCRIPTION
## Summary

Live-audited every Radancy (TalentBrew) tenant reachable from this session's `portals.yml` entry plus several found via web search, and found three independent, unrelated problems behind `radancy.mjs`'s `⚠️ truncated ... raise max_jobs/max_pages` warning: one tenant loses real postings to a caching bug, several tenants have a `totalResults` banner that simply overstates what their own search index serves on both transports, and one very large tenant hits a hard pagination-window ceiling at its backend. None of the three is fixed by raising `max_pages`/`max_jobs`, which is exactly the advice the current warning gives every time.

## Problem 1 — a caching bug drops and duplicates postings on Munich Re Group

Walking `careers.munichre.com`'s JSON fragment endpoint end-to-end and recording every `(page, id, title, location, url)` tuple showed the same posting reappearing on a second, distant page with byte-identical content, while a different posting never appeared on any page at all. Reproduced on 9 consecutive full walks with the same pages and the same magnitude every time (not random drift): 5 duplicated ids, always on the same page pairs.

Isolated the cause by testing two independent changes against the same tenant: `Cache-Control: no-cache` + `Pragma: no-cache` request headers made no difference (9/9 runs still broken), but a random per-request query parameter — forcing a cache-key miss — made it 0/9 broken. Re-running the same walk through the `?p=N` HTML transport (the same underlying data, a different route) never showed the problem at all, which further narrows it to a caching layer in front of the JSON route specifically, not the tenant's own data.

## Problem 2 — `totalResults` overstates reality on several tenants, and that's normal for this platform

Separately, four of nine fully-audited tenants (from a small board to Radancy's own corporate careers site) collected 10-56% fewer unique postings than their `data-total-results` banner claims, with zero duplicate rows anywhere. Re-walking two of them through the `?p=N` HTML transport reproduced the identical shortfall to the exact posting count, proving it isn't a transport bug — the tenant's own search index simply doesn't contain as many retrievable postings as its own counter claims. Cache-busting (the Problem 1 fix) made no difference to this shortfall on any of the affected tenants, confirming it's a separate issue.

`data-total-pages`, unlike `data-total-results`, matched the walk's own natural end (a short or empty final page) in every one of the 9 tenants checked, so it stays a valid bound for the walk itself — only the results counter is untrustworthy.

## Problem 3 — Walgreens hits a hard pagination-window ceiling at exactly 10,000

Walgreens (22,813 claimed postings, the largest tenant checked) was excluded from the count above and audited separately: a full 229-page walk shows pages 1-100 each returning a full 100 rows (10,000 total, no duplicates anywhere), then every page from 101 through 229 returning a clean, structured "no jobs" response (`hasJobs: false`, an empty results fragment) rather than an error or a short page. The cutoff lands exactly at offset 10,000 — 100 pages of 100 — the textbook default `max_result_window` ceiling on an Elasticsearch/Solr-style backend (one tenant observed so far, not established across the platform the way `workday.mjs`'s analogous `WORKDAY_OFFSET_CEILING` is). This isn't a caching artifact (a 130-page gap of identical empty responses isn't a stale cache hit) and it isn't recoverable by pagination cleverness on our side, unlike workday's clamp: TalentBrew's JSON fragment API exposes no documented facet-style split to route around it, so the backend simply refuses to serve past that offset no matter how the walk asks.

This surfaced a real gap while testing the fix live: with the *default* `max_jobs` (2,000), the walk correctly stops there first — page 20, well before the backend's own 10,000 ceiling — and now correctly warns (`truncated at 2,000 of 22,813 jobs`, `stopReason: 'cap'`), because raising `max_jobs` genuinely would recover more, up to 10,000. Only past that point does the *other* behavior apply: with `max_jobs` raised above 10,000, the walk runs to the backend's own empty page at 101 and returns exactly 10,000 with no warning, because past there raising anything no longer helps. Verified both live.

## The fix

- `buildFragmentUrl()` now appends a random `_` query parameter to every JSON fragment request, unique per call. Verified against all 11 live tenants seen in this investigation (including the one that already fails for an unrelated reason) that this changes nothing for a tenant that didn't have the caching problem — page-1 output matched with and without it in every case.
- The walk now tracks *why* it stopped (`stopReason`, matching the `workday.mjs`/`phenom.mjs` convention already used elsewhere in this file) instead of comparing the accumulated count against `totalResults`. The `raise max_jobs/max_pages` warning now fires only when `max_pages`/`max_jobs` demonstrably cut the walk short of the source's own larger page count — never when the walk ran to the source's own natural end and merely fell short of an inflated results counter, and never on a mid-walk fetch error (which now gets its own distinct, immediate log line instead of failing silently).
- `resolveMaxJobs()` now clamps a user-supplied `max_jobs` the same way `resolveMaxPages()` already clamps `max_pages` — noticed while testing Walgreens live: `max_pages` was already defended against a garbage config value, `max_jobs` wasn't. Not a resource-safety fix (the page loop was always independently bounded by `max_pages`, so an unclamped `max_jobs` never risked an unbounded walk) — just closing a defensive-coding gap between the two, capped at the true ceiling the JSON transport can ever return (`MAX_PAGES * FRAGMENT_RECORDS_PER_PAGE`).
- All three fetch call sites (the first JSON fragment request, every subsequent JSON page, the HTML `?p=N` fallback) now set `redirect:'error'` and are routed through `fetchJsonWithRetry`/`fetchTextWithRetry` instead of calling `ctx.fetchJson`/`ctx.fetchText` directly. Neither was true before this PR: `redirect:'error'` is `_http.mjs`'s per-provider-opt-in SSRF guard (#1440) that every peer provider sets and radancy.mjs didn't (flagged in review — DNS-layer `_ip-guard.mjs` already blocked a redirect to a private IP either way, so this closes a defense-in-depth gap, not a live bypass); the retry helper means a single transient 429/5xx/network blip on any page no longer permanently truncates the walk from that page on, the same protection every other multi-page provider already has.
- Fixed a false-positive `stopReason: 'cap'` flagged in review: `jobs.length >= maxJobs` alone doesn't prove `max_jobs` cut anything short — a tenant whose real total exactly fills the page(s) already walked (a naturally-complete result that happens to land exactly on `max_jobs`) was still classified as capped and warned about, even though nothing was left unfetched. Now `jobs.length > maxJobs` (a page overshot the buffer in one jump — real fetched rows the final slice still has to drop) caps unconditionally, and an exact match only counts when page budget was still available (`page <= lastPage`) when the loop stopped — i.e. `max_jobs` itself, not a coincidence of row count, is what kept a further page from being tried.
- `fetch()` now reads `ctx.maxPages` — set only by `verify-portals.mjs`'s bounded liveness probe, never during a real scan — to cap the walk to that budget (SHOULD, reference `providers/workday.mjs`) and to propagate any `ctx.fetch*` rejection unwrapped instead of absorbing it into the normal partial-result handling (MUST, reference `providers/vdab.mjs`). Before this PR `radancy.mjs` never read `ctx.maxPages` at all, and both per-page `catch` blocks would have swallowed `verify-portals.mjs`'s budget-exhaustion sentinel (`ProbePageBudgetReached`) into a normal `stopReason: 'error'`, misreporting a healthy tenant as broken during a probe instead of "live, partial". The cap-truncation warning is also suppressed while probing — the probe's own budget isn't the tenant's real config, and "raise max_pages" is not advice a liveness check has any use for.
- A non-string `json.results` on page 2+ (flagged in review) now throws a descriptive error instead of being silently coerced to `[]` and read as a natural end. Checked live before applying it: a genuine last page is still a string (Walgreens' own past-the-end response parses to zero rows but isn't itself empty or missing), so a non-string value has never actually been the documented "no more jobs" signal — coercing it to `[]` was silently reading a malformed response as the walk being done.

## Tenants checked

Munich Re Group is the tenant the original bug report was about; the rest were found via web search specifically to check whether the bug (and, separately, the fix) generalizes past that one case, not because career-ops is known to track them. None of this PR's tests or code changes depend on any of them being wired up anywhere.

All figures below are single, self-consistent snapshots from one full walk each — every tenant's own postings count changes over real time from ordinary hiring activity (confirmed separately: the same tenant's `totalResults` moved between checks made minutes apart), so figures taken at different points in this investigation are not expected to match each other and aren't compared across rows.

Table A — the caching bug (fixed by this PR), one before/after pair from two full walks:

| Company | URL | Before this fix | After this fix |
|---|---|---|---|
| Munich Re Group | https://careers.munichre.com/en/search-jobs | 1,572 collected of 1,579 claimed — 5 duplicated postings, always the same page pairs, reproduced on 9/9 consecutive full walks | 1,577 collected of 1,577 claimed — 0 duplicates, reproduced on 4/4 consecutive full walks |

Table B — `totalResults` overstates reality (unaffected by the caching fix; no longer produces a false "raise your limits" warning), one full walk each:

| Company | URL | totalResults | Actually collected (both transports agree) | Shortfall |
|---|---|---|---|---|
| Wegmans | https://jobs.wegmans.com/en | 554 | 442 | 20% |
| Baxter International | https://jobs.baxter.com/en | 610 | 549 | 10% |
| Club Med | https://www.clubmedjobs.com/en | 468 | 345 | 26% |
| Radancy (the vendor's own careers site) | https://jobs.radancy.com/en/search-jobs | 66 | 29 | 56% |

Table C — a hard backend pagination-window ceiling, distinct mechanism from Table B (confirmed via the exact page boundary, not inferred from the shortfall alone):

| Company | URL | totalResults | Actually collected | Where it stops |
|---|---|---|---|---|
| Walgreens | https://jobs.walgreens.com | 22,813 | 2,000 with the default `max_jobs`; 10,000 with `max_jobs` raised past the backend ceiling (e.g. 15,000) | Pages 1-100 full, page 101 onward a clean empty response (`hasJobs: false`) — the boundary sits exactly at offset 10,000, the standard search-backend `max_result_window` default |

Table D — confirmed clean, no bug of any kind (`totalResults` = postings actually collected, no duplicates), one full walk each:

| Company | URL | Postings |
|---|---|---|
| UnitedHealth Group (Optum) | https://careers.unitedhealthgroup.com/search-jobs | 5,593 |
| Kaiser Permanente | https://www.kaiserpermanentejobs.org/search-jobs | 2,961 |
| Cargill | https://careers.cargill.com | 1,407 |
| Comcast | https://jobs.comcast.com | 689 |

Table E — an unrelated finding from the same search, kept only because it's an instructive edge case; not a radancy.mjs bug and not fixed by this PR:

| Company | URL | Issue |
|---|---|---|
| AT&T | https://www.att.jobs/ | `radancy.mjs` makes no preliminary request — the JSON fragment fetch (`buildFragmentUrl`, the exact URL it calls first) is itself the one that fails. Its `Content-Security-Policy` and `Feature-Policy` response headers are each ~10.6 KB, past the ~16 KB total-header limit Node enforces by default — `fetch` (and the raw `https` module, confirmed with the same error) both refuse the response with `HeadersOverflowError`/`Parse Error: Header overflow` before any provider code runs, on that exact fragment URL, not just the surrounding HTML page (checked both directly). This is process-wide, not fetch- or undici-specific, and it's an environment setting, not a code bug: `NODE_OPTIONS=--max-http-header-size=65536` (or the equivalent `--max-http-header-size` CLI flag) resolves it — verified live. Confirmed the failure as-is is caught cleanly by `radancy.mjs`'s existing `try/catch` and does not crash the process; the provider correctly falls through and ultimately reports the board unreachable rather than silently empty. Not touched in this PR since it isn't a radancy-specific fix — a global launch-time setting belongs with however career-ops's entrypoints get invoked, not inside one provider. |

## Verification

- `node test-all.mjs --only providers/` — 2,114 passed, 0 failed. Added 10 new assertions: the cache-buster is present and unique per call, no warning fires when a natural page-1 end falls short of an inflated `totalResults`, a genuine `max_pages` cap (source reports more pages than our ceiling) still warns, an exact `max_jobs` match on a naturally-complete result does not false-positive into a cap warning, a mid-walk JSON fetch error keeps earlier pages and logs its own message without cap advice, `redirect:'error'` is set on every JSON and every HTML request, a page that fails once transiently recovers via retry with no data lost and no warning, and `resolveMaxJobs()` clamps an absurd value and still defaults correctly.
- Re-ran the fixed provider live against Munich Re Group 4 times: 1,577 jobs, 1,577 unique URLs, no warning, every time.
- Re-ran it live against Wegmans: 442 jobs, no warning (previously would have logged a "raise max_jobs/max_pages" warning that could not have fixed anything).
- Re-ran it live against Walgreens (Table C) twice: with the default `max_jobs`, 2,000 jobs and a correct, actionable `⚠️` cap warning (`stopReason: 'cap'` — `max_jobs` genuinely is what's limiting it, up to the backend's own 10,000); with `max_jobs: 15000`, exactly 10,000 jobs and no warning — the walk reaches the backend's own empty page at 101 and correctly reads that as a natural stop, not a local cap.

## Not in this PR

- AT&T's header-overflow fetch failure (Table E) — resolvable with a Node process launch setting (`--max-http-header-size`/`NODE_OPTIONS`), not a pagination/caching fix, so it doesn't belong inside `radancy.mjs`.
- Walgreens' 10,000-result backend ceiling (Table C) isn't something career-ops can work around from the client side — the source itself won't serve more no matter how it's asked. Nothing to fix beyond correctly not blaming a local limit for it, which this PR already does.
- The `?p=N` HTML fallback loop has no equivalent `max_pages` cap warning at all today (it silently stops at the ceiling). Out of scope here since it wasn't part of what this investigation verified live; worth a follow-up.
- A host allowlist for `resolveListUrl()` was suggested in review (CodeRabbit) but declined: unlike `greenhouse.mjs`/`workday.mjs`, radancy has no fixed vendor domain to match against — it's designed for arbitrary customer-branded hosts, wired explicitly per entry (`provider: radancy`, no `detect()`). `phenom.mjs`, the same explicit-wiring/branded-host architecture, has the identical shape (`u.protocol !== 'https:' && u.protocol !== 'http:'`, no allowlist) — this repo's actual SSRF protection for that architecture is the central DNS/IP-layer guard (`_ip-guard.mjs`, #3096), already applied to every fetch regardless. Matches the code-owner review's own earlier assessment on this PR.
