### PR TITLE
feat(plugins-registry): add jobspipe

### DIFF
--- a/plugins-registry/jobspipe.json
+++ b/plugins-registry/jobspipe.json
@@ -1,0 +1,14 @@
+{
+  "id": "jobspipe",
+  "name": "career-ops-plugin-jobspipe",
+  "version": "0.1.0",
+  "license": "MIT",
+  "description": "JobsPipe API provider — normalized job postings deduplicated across 30+ ATS and job-board sources, with title/skill/country/seniority/remote filters.",
+  "repo": "https://github.com/jobspipe/career-ops-plugin-jobspipe",
+  "sha": "e87ab945277e53f29e63ef079f3cbb8da71c51ba",
+  "hooks": ["provider"],
+  "requiredEnv": ["JOBSPIPE_API_KEY"],
+  "allowedHosts": ["api.jobspipe.dev"],
+  "registrationIssue": "https://github.com/career-ops-hq/career-ops/issues/3840",
+  "addedAt": "2026-09-04"
+}


### PR DESCRIPTION
Registers `career-ops-plugin-jobspipe`, pinned to an exact SHA, per the two-step flow in [docs/PLUGINS.md](https://github.com/career-ops-hq/career-ops/blob/main/docs/PLUGINS.md).

Registration issue: #3840

## What it is

A `provider` hook over the JobsPipe API — job postings deduplicated across 30+ ATS and job-board sources (Workday, Greenhouse, Lever, Ashby, Workable, SmartRecruiters, iCIMS, JazzHR, Teamtailor and others) into one schema, so a role cross-posted to four boards arrives once.

Opt-in and inert without a key, following the `theirstack` precedent for keyed providers in the plugin layer.

| | |
|---|---|
| Repo | https://github.com/jobspipe/career-ops-plugin-jobspipe |
| License | MIT |
| Hooks | `provider` |
| Keys | `JOBSPIPE_API_KEY` |
| Hosts | `api.jobspipe.dev` |

## Verified with this repo's own tooling before submitting

```
✓ plugin registry is valid      # validate-plugin-registry.mjs
✓ audit clean                   # plugin-audit.mjs
✓ smoke ok: provider            # manifest/hook contract, no network
✓ live sandbox ok               # no API key required
✓ live production ok: 10/10 mapped with links
```

`node scan.mjs --dry-run` against a real key returned 10 live roles (Roblox via Greenhouse, several Ashby boards) into the tracker.

## Disclosure

I maintain JobsPipe. It is a commercial API with a free tier (1,000 jobs/month, no card). Filing this myself rather than routing it through a user, in the spirit of #1697.

The plugin sends search filters only — job titles, skills, country codes. It never transmits CV text, pipeline state or tracker contents, and carries no telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can enable the JobsPipe provider by setting `JOBSPIPE_API_KEY`. The provider sends search filters to `api.jobspipe.dev` and returns deduplicated job postings from 30+ sources through one schema.

The registry entry pins the plugin to an exact commit SHA and restricts its API host: `plugins-registry/jobspipe.json:1-14`. The plugin remains inactive without an API key.

Only `plugins-registry/jobspipe.json` is changed. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->