### PR TITLE
fix(updater): strip preserve exclusions before staging, not just at commit

### DIFF
--- a/tests/updater-add-paths.test.mjs
+++ b/tests/updater-add-paths.test.mjs
@@ -1,9 +1,9 @@
 /**
  * updater-add-paths.test.mjs — BEHAVIORAL staging tests for apply()'s commit step.
  *
- * apply() stages its checked-out system paths and commits them. Two ways that
- * `git add` call could fail leave the update half-done — files on disk, nothing
- * committed — and the user is told to finish it by hand:
+ * apply() stages its checked-out system paths and commits them. Three ways
+ * that `git add` call could fail leave the update half-done — files on disk,
+ * nothing committed — and the user is told to finish it by hand:
  *
  *   1. A tracked system file shadowed by a local DIRECTORY-level ignore rule.
  *      `git add` refuses explicitly-named ignored paths (exit 1). .gitignore is
@@ -16,6 +16,14 @@
  *      never in the index, so staging it after deletion is a fatal unmatched
  *      pathspec (exit 128) that -f does NOT rescue. Reproduces in a stock
  *      checkout with no customization: dismiss an update, then apply one.
+ *   3. A preserve exclusion in the staging list. `addPaths` always runs under
+ *      --literal-pathspecs, so a `:(exclude)<path>` entry is taken as a literal
+ *      (nonexistent) filename and fails the WHOLE batch with "pathspec did not
+ *      match any files" (exit 128) -- with ANY local system-file edit still
+ *      present, on EVERY future update, since `preservedPaths` is never empty
+ *      until the edit either reverts or matches upstream. `expandedPathsToStage`
+ *      keeps exclusions (test 6c) for the scoped commit that reads it after
+ *      staging; addPaths must never see them.
  *
  * Follows updater-rollback-behavior.test.mjs: drive the real exports against a
  * throwaway repo through the git-runner seam, so the property is verified rather
@@ -381,6 +389,67 @@ console.log('\n🧪 Testing updater staging behavior (ignored + never-tracked pa
     pass('scoped commit honors the preserve exclusion');
   } else {
     fail(`preserve exclusion failed: committed=${committed.join(', ')} status=${status}`);
+  }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 6d. addPaths must never see the exclusion 6c just proved the commit needs ──
+//    Reproduces the production crash directly: apply() hands addPaths the same
+//    `expandedPathsToStage` that 6c fed to the scoped commit, exclusions
+//    included, whenever locallyModifiedSystemFiles() finds even one preserved
+//    file. --literal-pathspecs takes `:(exclude)modes/update.md` as a literal
+//    filename that doesn't exist, and the whole batch -- every real file in
+//    it, AGENTS.md here, entirely unrelated to the preserved file -- fails to
+//    stage alongside it. Fixture deliberately mirrors the real SYSTEM_PATHS
+//    shape: the preserved file (modes/update.md) is a standalone file-level
+//    manifest entry, never a member of some OTHER directory entry that's also
+//    being expanded -- unlike 6c's docs/, where docs/KEEP.md is independently
+//    reachable via `docs/`'s own expansion. That would need addPaths to catch
+//    a plain-filename duplicate of a preserved path, a different, currently
+//    unreachable failure mode this fix does not attempt to cover.
+{
+  const { dir, g, ctx } = makeRepo();
+  mkdirSync(join(dir, 'modes'));
+  writeFileSync(join(dir, 'AGENTS.md'), 'v1');
+  writeFileSync(join(dir, 'modes/update.md'), 'v1');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+
+  writeFileSync(join(dir, 'AGENTS.md'), 'updated by this release');
+  writeFileSync(join(dir, 'modes/update.md'), 'the user\'s preserved local edit');
+  const expanded = expandToShippedFiles(['AGENTS.md', ':(exclude)modes/update.md'], 'HEAD', ctx);
+
+  let rawThrew = null;
+  try {
+    addPaths(expanded, ctx);
+  } catch (err) {
+    rawThrew = err;
+  }
+  if (rawThrew && /pathspec.*did not match/i.test(rawThrew.message)) {
+    pass('addPaths on the unfiltered list reproduces the production crash');
+  } else if (!rawThrew) {
+    fail('addPaths accepted an exclusion pathspec -- the underlying git behavior changed, revisit the fix');
+  } else {
+    fail(`addPaths threw for an unexpected reason: ${rawThrew.message.split('\n')[0]}`);
+  }
+  if (stagedPaths(g).size === 0) {
+    pass('the failed batch left nothing staged, matching the "half-done update" it produces live');
+  } else {
+    fail(`unexpected partial staging after the failed batch: ${[...stagedPaths(g)].join(', ')}`);
+  }
+
+  const filtered = expanded.filter((spec) => !spec.startsWith(':(exclude)'));
+  let filteredThrew = null;
+  try {
+    addPaths(filtered, ctx);
+  } catch (err) {
+    filteredThrew = err;
+  }
+  const staged = stagedPaths(g);
+  if (!filteredThrew && staged.has('AGENTS.md') && !staged.has('modes/update.md')) {
+    pass('stripping exclusions before addPaths stages the real file and leaves the preserved one alone');
+  } else {
+    fail(`filtered staging failed: threw=${filteredThrew?.message.split('\n')[0] ?? 'no'} staged=${[...staged].join(', ')}`);
   }
   rmSync(dir, { recursive: true, force: true });
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2426,8 +2426,15 @@ async function apply() {
       prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);
       // Stage per filename, never per directory. pathsToStage is the manifest,
       // so it carries directory entries, and `-f` on one of those sweeps every
-      // ignored file underneath into the commit.
-      addPaths(expandedPathsToStage);
+      // ignored file underneath into the commit. addPaths' own contract is
+      // "callers must pass files, not directory pathspecs" — it runs every
+      // entry through `git --literal-pathspecs add -f`, which takes an
+      // `:(exclude)` entry as a literal (nonexistent) filename and fails the
+      // whole batch with "pathspec did not match any files". Exclusions are
+      // meaningful to the scoped commit below, never to staging: omitting a
+      // path from the add list IS excluding it, so strip them here rather
+      // than teach addPaths a second pathspec dialect.
+      addPaths(expandedPathsToStage.filter((spec) => !spec.startsWith(EXCLUDE_PATHSPEC_PREFIX)));
       // Scope the commit to only the staged update paths (#915 bug 2).
       // A bare `git commit` would sweep any unrelated pre-staged files into
       // the update commit. Passing the explicit pathspec list constrains the


### PR DESCRIPTION
## What

`apply()`'s commit step calls `addPaths(expandedPathsToStage)` with a list that can carry `:(exclude)<path>` entries for locally-preserved system files (`#2337`). `addPaths()` always runs under `--literal-pathspecs`, so an exclude entry is taken as a literal, nonexistent filename, and the whole batch — every real file alongside it — fails to stage.

## Repro

Have any single locally-modified system file (the updater correctly detects it and preserves it rather than overwriting), then run `apply --confirm`:

```
fatal: pathspec ':(exclude)modes/update.md' did not match any files
Update commit failed (files may be staged but not committed).
```

Hit this today on a real install, v1.31.0 → v1.32.0, with one locally patched `modes/update.md` (from #3774, still under review). The recovery is a manual `git commit` with the same pathspec list — a *plain* `git commit` isn't run under `--literal-pathspecs`, so the exclude syntax works there, which is why the tool's own printed recovery command succeeds. Staging is the only place this breaks.

This isn't specific to which file is preserved or what it contains — any locally-modified system file triggers it, on every update, for as long as the file stays diverged from upstream.

## Why

The commit-scoping guard a few lines later already filters these out for exactly this reason:

```js
const ownedPaths = pathsToStage.filter((spec) => !spec.startsWith(EXCLUDE_PATHSPEC_PREFIX));
```

The staging call above it never got the same treatment. Exclusions are meaningful to the scoped commit (which needs pathspec magic to keep a preserved file out of the diff); they're meaningless to staging — omitting a path from the add list already excludes it, so `addPaths` never needed to understand a second pathspec dialect.

## Fix

One line: filter exclusions immediately before the `addPaths()` call, mirroring the existing pattern.

## Tests

Added a regression case to `tests/updater-add-paths.test.mjs` (which already documents two other staging failure modes) that drives the real exports against a throwaway repo:
- confirms `addPaths` on the unfiltered list reproduces the exact production error string
- confirms the failed batch leaves nothing staged (matches the "half-done update" it produces live)
- confirms the fix stages the real file and leaves the preserved one untouched

The fixture deliberately mirrors the real `SYSTEM_PATHS` shape — a standalone file-level preserved entry, not one nested inside a directory-level entry that's also being expanded (unlike an earlier test in the same file, where the preserved file happens to be reachable a second way via directory expansion). Noted in the test's comment as a different, currently-unreachable failure mode this fix doesn't attempt to cover.

`node tests/updater-add-paths.test.mjs`: 41/41 pass (40/40 before this change — additions only, nothing regressed).
`node tests/updater-local-system-edits.test.mjs`: 20/20 pass, unaffected.

I didn't run the full `test-all.mjs` suite locally (it's a multi-minute CI-scale run); happy to if reviewers want that confirmed before merge, or CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015d3wzPAaxLVcFnuiiLbBqJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

When you update locally preserved system files, the updater now stages the intended files without treating `:(exclude)<path>` entries as literal filenames. See `update-system.mjs:2429-2437`.

The preserved file remains unchanged. Failed staging no longer leaves a partial index. The regression coverage is in `tests/updater-add-paths.test.mjs:396-450`.

The system-file scope includes `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`. Only `update-system.mjs` and its regression test changed.

Validation passed: 41/41 and 20/20 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->