### PR TITLE
feat(update-system): resolve to the latest release tag by default, not main

### DIFF
--- a/tests/updater-channel-resolution.test.mjs
+++ b/tests/updater-channel-resolution.test.mjs
@@ -183,3 +183,22 @@ console.log('\n🧪 Testing updater channel resolution (release tag vs. main)...
     fail(`expected the guard to pass a career-ops-v* tag through, got '${ref}'`);
   }
 }
+
+// ── 10. A right-prefix, malformed-version tag is rejected too ──────────────
+// The prefix check alone would let 'career-ops-vnot-a-version' through —
+// same prefix, no real version. SEMVER_RE (shared with the VERSION/tag
+// parsing elsewhere in this file) is the same bar a genuine tag must clear.
+{
+  const fakeCurlGet = async () => JSON.stringify({ tag_name: 'career-ops-vnot-a-version' });
+  let threw = null;
+  try {
+    await resolveTargetRef([], {}, { curlGet: fakeCurlGet });
+  } catch (err) {
+    threw = err;
+  }
+  if (threw && /career-ops-vnot-a-version/.test(threw.message) && /--channel main/.test(threw.message)) {
+    pass('a right-prefix but non-semver tag is rejected, not silently fetched');
+  } else {
+    fail(threw ? `threw, but without naming the rejected tag: ${threw.message}` : 'a malformed tag resolved instead of throwing');
+  }
+}

--- a/tests/updater-channel-resolution.test.mjs
+++ b/tests/updater-channel-resolution.test.mjs
@@ -1,0 +1,185 @@
+/**
+ * updater-channel-resolution.test.mjs — apply() must fetch a reproducible
+ * release, not whatever main happens to be at the moment it runs.
+ *
+ * The regression: apply()'s only fetch call was hardcoded to CANONICAL_REPO's
+ * `main`. release-please can bump VERSION on main hours before the matching
+ * tag lands (and, rarely, before a fix for a bug introduced in that window
+ * lands too), so a same-moment `main` fetch can install an untagged
+ * intermediate commit — reproducing a real support case where a user's
+ * VERSION file said v1.30.0 but their code was not the v1.30.0 release.
+ *
+ * resolveTargetRef() is the fix: the default ('release') channel resolves to
+ * the newest published release tag via RELEASES_API; `--channel main` (flag
+ * or, for the re-exec'd child, CAREER_OPS_UPDATE_CHANNEL=main) opts back into
+ * tracking main, with no network call at all. A failed release lookup on the
+ * default channel throws — silently falling back to main would reintroduce
+ * the exact bug this closes, on exactly the network blip that makes it matter.
+ *
+ * One more failure mode this pins: this is a manifest-mode monorepo that also
+ * releases a sibling `web` component (`web-vX.Y.Z`), and RELEASES_API's
+ * `/releases/latest` returns correctly ONLY because release.yml's "Keep the
+ * career-ops release marked as Latest" step re-asserts it on every push. If
+ * that step ever silently stopped doing its job, `/releases/latest` would
+ * hand back a `web-*` tag and, without a guard, apply() would fetch and
+ * install it without complaint. resolveTargetRef() rejects any tag not
+ * prefixed `career-ops-v` for exactly this reason.
+ *
+ * These tests drive the real export against an injected ctx.curlGet, the
+ * same seam production uses (ctx.git elsewhere in this suite) — no real
+ * network, no git fixture needed, since resolveTargetRef never touches git.
+ */
+
+import { pass, fail } from './helpers.mjs';
+import { resolveTargetRef } from '../update-system.mjs';
+
+console.log('\n🧪 Testing updater channel resolution (release tag vs. main)...');
+
+// ── 1. Default channel resolves to the latest release tag ──────────────────
+{
+  let calls = 0;
+  const fakeCurlGet = async (url) => {
+    calls++;
+    if (!url.includes('/releases/latest')) return null;
+    return JSON.stringify({ tag_name: 'career-ops-v1.32.0' });
+  };
+
+  const ref = await resolveTargetRef([], {}, { curlGet: fakeCurlGet });
+  if (ref === 'career-ops-v1.32.0') {
+    pass('default channel resolves to the release tag verbatim');
+  } else {
+    fail(`default channel resolved to '${ref}', expected the release tag`);
+  }
+  if (calls === 1) {
+    pass('default channel calls the release lookup exactly once');
+  } else {
+    fail(`default channel called curlGet ${calls} time(s), expected 1`);
+  }
+}
+
+// ── 2. --channel main resolves to 'main' WITHOUT any network call ──────────
+{
+  let calls = 0;
+  const fakeCurlGet = async () => { calls++; return JSON.stringify({ tag_name: 'career-ops-v9.9.9' }); };
+
+  const ref = await resolveTargetRef(['apply', '--channel', 'main', '--confirm'], {}, { curlGet: fakeCurlGet });
+  if (ref === 'main') {
+    pass("--channel main resolves to 'main'");
+  } else {
+    fail(`--channel main resolved to '${ref}', expected 'main'`);
+  }
+  if (calls === 0) {
+    pass('--channel main never calls curlGet');
+  } else {
+    fail(`--channel main called curlGet ${calls} time(s), expected 0`);
+  }
+}
+
+// ── 3. CAREER_OPS_UPDATE_CHANNEL=main (the re-exec'd child's path) ─────────
+// The child reads its channel from env, not argv — its own argv is just
+// `apply --confirm` (see the reexec spawn in apply()). Same no-network
+// contract applies.
+{
+  let calls = 0;
+  const fakeCurlGet = async () => { calls++; return JSON.stringify({ tag_name: 'career-ops-v9.9.9' }); };
+
+  const ref = await resolveTargetRef(['apply', '--confirm'], { CAREER_OPS_UPDATE_CHANNEL: 'main' }, { curlGet: fakeCurlGet });
+  if (ref === 'main' && calls === 0) {
+    pass('CAREER_OPS_UPDATE_CHANNEL=main resolves to main with no network call');
+  } else {
+    fail(`env channel=main gave ref='${ref}', curlGet calls=${calls}`);
+  }
+}
+
+// ── 4. argv --channel wins over env CAREER_OPS_UPDATE_CHANNEL ──────────────
+{
+  const fakeCurlGet = async () => JSON.stringify({ tag_name: 'career-ops-v1.32.0' });
+  const ref = await resolveTargetRef(['apply', '--channel', 'main'], { CAREER_OPS_UPDATE_CHANNEL: 'release' }, { curlGet: fakeCurlGet });
+  if (ref === 'main') {
+    pass('an explicit --channel flag overrides the inherited env channel');
+  } else {
+    fail(`expected argv to win over env, got ref='${ref}'`);
+  }
+}
+
+// ── 5. A failed release lookup on the default channel THROWS ───────────────
+// No silent fallback to main — that would defeat the entire point on exactly
+// the network blip that makes it matter most.
+{
+  const fakeCurlGet = async () => null; // curlGet's own null-on-failure contract
+  let threw = null;
+  try {
+    await resolveTargetRef([], {}, { curlGet: fakeCurlGet });
+  } catch (err) {
+    threw = err;
+  }
+  if (threw && /--channel main/.test(threw.message)) {
+    pass('a failed release lookup throws and names the --channel main escape hatch');
+  } else {
+    fail(threw ? `threw but without the expected guidance: ${threw.message}` : 'a failed release lookup silently resolved instead of throwing');
+  }
+}
+
+// ── 6. A release with no usable tag_name also throws, not falls back ───────
+{
+  const fakeCurlGet = async () => JSON.stringify({ tag_name: '' });
+  let threw = null;
+  try {
+    await resolveTargetRef([], {}, { curlGet: fakeCurlGet });
+  } catch (err) {
+    threw = err;
+  }
+  if (threw) {
+    pass('an empty tag_name throws instead of silently falling back');
+  } else {
+    fail('an empty tag_name resolved instead of throwing');
+  }
+}
+
+// ── 7. An unknown --channel value throws before any network call ──────────
+{
+  let calls = 0;
+  const fakeCurlGet = async () => { calls++; return JSON.stringify({ tag_name: 'career-ops-v1.32.0' }); };
+  let threw = null;
+  try {
+    await resolveTargetRef(['apply', '--channel', 'nightly'], {}, { curlGet: fakeCurlGet });
+  } catch (err) {
+    threw = err;
+  }
+  if (threw && /nightly/.test(threw.message) && calls === 0) {
+    pass('an unknown channel throws without ever calling curlGet');
+  } else {
+    fail(threw ? `threw, but curlGet was called ${calls} time(s)` : 'an unknown channel silently resolved');
+  }
+}
+
+// ── 8. A tag from the sibling `web` component is rejected, not installed ───
+// Reproduces release.yml's "Keep the career-ops release marked as Latest"
+// step silently not running: /releases/latest hands back web's tag instead.
+{
+  const fakeCurlGet = async () => JSON.stringify({ tag_name: 'web-v0.10.0' });
+  let threw = null;
+  try {
+    await resolveTargetRef([], {}, { curlGet: fakeCurlGet });
+  } catch (err) {
+    threw = err;
+  }
+  if (threw && /web-v0\.10\.0/.test(threw.message) && /--channel main/.test(threw.message)) {
+    pass("a 'web' component tag is rejected by name, not silently fetched");
+  } else {
+    fail(threw ? `threw, but without naming the rejected tag: ${threw.message}` : "a 'web' tag resolved instead of throwing");
+  }
+}
+
+// ── 9. A correctly-prefixed tag still resolves normally ─────────────────────
+// Pins the guard to the sibling-component case specifically, not to every
+// tag shape — a real career-ops-v* release must not start tripping this.
+{
+  const fakeCurlGet = async () => JSON.stringify({ tag_name: 'career-ops-v1.32.0' });
+  const ref = await resolveTargetRef([], {}, { curlGet: fakeCurlGet });
+  if (ref === 'career-ops-v1.32.0') {
+    pass('a correctly-prefixed career-ops tag passes the guard');
+  } else {
+    fail(`expected the guard to pass a career-ops-v* tag through, got '${ref}'`);
+  }
+}

--- a/tests/updater-reexec-bypass.test.mjs
+++ b/tests/updater-reexec-bypass.test.mjs
@@ -9,130 +9,101 @@
  * targetRef ternary trusted that alone to skip resolveTargetRef() entirely
  * and fall through to CAREER_OPS_UPDATE_TARGET_REF ?? 'main' — silently
  * reverting to the exact unpinned-main behavior this PR exists to close,
- * with nothing but one stray env var and no --channel flag. Manually
- * reproduced against the pre-fix code before writing this test: the process
- * actually fetched real upstream `main` and updated a throwaway install,
- * with no network call to RELEASES_API at all.
+ * with nothing but one stray env var and no --channel flag.
  *
- * The fix gates the targetRef fallback on (authenticatedReexec ||
- * legacyReexec) instead of the broader isReexec, so only a cryptographically
- * authenticated reexec (consumeReexecMarker()) or the more heavily guarded
- * legacy path (isLegacyReexec(): a real lock file + a really-existing,
- * correctly-named backup branch) may skip resolveTargetRef().
+ * The fix extracts the gate as its own pure function, trustsEnvTargetRef()
+ * (true only for an authenticated marker or the more heavily guarded legacy
+ * path — never the bare third disjunct alone), and apply()'s targetRef
+ * ternary calls it instead of the broader isReexec.
  *
- * apply() isn't structured for the ctx-injection seam used elsewhere in this
- * suite (it reads process.argv/process.env directly and has real git/network
- * side effects), so this drives the real CLI entrypoint as a subprocess
- * against a disposable git fixture — the smallest faithful way to observe
- * its behavior. A stub `curl` shadowing the real one on PATH makes the
- * release lookup fail deterministically (no real network needed, no
- * dependency on live connectivity in CI): if resolveTargetRef() runs, it
- * fails loudly naming RELEASES_API and --channel main, BEFORE apply() ever
- * reaches its git fetch step. If resolveTargetRef() is skipped instead, the
- * process moves on to `git fetch` — a materially different outcome, easy to
- * tell apart from the assertions below.
+ * ── Why this file no longer drives apply() as a subprocess ──────────────
  *
- * Scoped to exactly this bypass, per the CodeRabbit finding. The companion
- * property — a GENUINE authenticated reexec still correctly honors
- * CAREER_OPS_UPDATE_TARGET_REF without calling resolveTargetRef() at all —
- * was verified manually (a real marker via createReexecMarker(), a real git
- * fetch of the env-supplied ref, zero curl invocations) but isn't encoded
- * here: proving it end-to-end needs a local CANONICAL_REPO mirror
- * (upgrade-tests.mjs's insteadOf trick) to avoid a live-network dependency,
- * which is more machinery than this specific regression calls for.
+ * The first version of this test spawned the real `apply()` CLI against a
+ * disposable git fixture, shadowing `curl` on PATH with a stub that always
+ * failed, to observe from the outside whether resolveTargetRef() actually
+ * ran. That approach reached Windows CI and failed all 3 of its assertions:
+ * the stub was a POSIX-shebang script with a POSIX exec bit, neither of
+ * which Windows' PATHEXT-based executable resolution recognizes, so Windows
+ * silently fell through to the REAL curl and ran a REAL update against the
+ * real upstream repo instead of hitting the intended blocked failure.
+ *
+ * The next idea — reliably block curl by removing every PATH entry that
+ * contains a curl-named binary, instead of shadowing it with a stub file —
+ * was verified BEFORE being adopted, not assumed safe, and it also failed:
+ * on this very development machine, `which git` and `which curl` both
+ * resolve to /usr/bin, so removing curl's directory removes git's too.
+ * That's not a POSIX-vs-Windows split; it's a per-machine/packaging fact
+ * that can differ across POSIX systems as well, which makes any PATH-surgery
+ * approach fundamentally unsound as a portable test mechanism, not merely
+ * one bug away from working.
+ *
+ * resolveTargetRef() already has a real, proven-portable seam for exactly
+ * this — ctx.curlGet dependency injection, used throughout
+ * updater-channel-resolution.test.mjs with zero subprocess, zero PATH, zero
+ * filesystem executable concerns. trustsEnvTargetRef() is even simpler: a
+ * pure two-argument boolean function needing no injection seam at all. This
+ * file now tests that function directly, plus a cheap source-pattern check
+ * that apply() still actually calls it — so the property that mattered
+ * (a bare CAREER_OPS_UPDATE_REEXEC=1 cannot skip resolveTargetRef()) is
+ * pinned with no OS-specific surface left to get wrong.
  */
 
-import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, copyFileSync } from 'fs';
-import { tmpdir } from 'os';
+import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { pass, fail, rmSync } from './helpers.mjs';
+import { pass, fail } from './helpers.mjs';
+import { trustsEnvTargetRef } from '../update-system.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const UPDATE_SYSTEM_SRC = join(__dirname, '..', 'update-system.mjs');
-
-/** A disposable git repo containing its own copy of update-system.mjs —
- *  apply()'s ROOT is the script's own directory, so this IS the install. */
-function makeFixtureInstall() {
-  const dir = mkdtempSync(join(tmpdir(), 'co-reexec-bypass-'));
-  const g = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
-  g('init', '-q', '-b', 'main', '.');
-  g('config', 'user.email', 'test@example.com');
-  g('config', 'user.name', 'Test');
-  g('config', 'commit.gpgsign', 'false');
-  copyFileSync(UPDATE_SYSTEM_SRC, join(dir, 'update-system.mjs'));
-  writeFileSync(join(dir, 'VERSION'), '1.0.0\n');
-  g('add', '-A');
-  g('commit', '-qm', 'base');
-  return dir;
-}
-
-/** A `curl` that always fails, shadowing the real one so resolveTargetRef()'s
- *  release lookup fails deterministically — no live network dependency. */
-function makeCurlStubBin() {
-  const dir = mkdtempSync(join(tmpdir(), 'co-reexec-bypass-bin-'));
-  const stub = join(dir, 'curl');
-  writeFileSync(stub, '#!/bin/sh\nexit 7\n');
-  chmodSync(stub, 0o755);
-  return dir;
-}
-
-/** Run `apply --confirm` in the fixture with the given extra env, stubbed
- *  curl shadowing the real one. Returns {status, stdout, stderr} either way
- *  — apply() is expected to exit non-zero here, which execFileSync throws on. */
-function runApply(dir, stubBin, extraEnv) {
-  try {
-    const stdout = execFileSync(process.execPath, ['update-system.mjs', 'apply', '--confirm'], {
-      cwd: dir,
-      encoding: 'utf-8',
-      timeout: 30000,
-      env: { ...process.env, PATH: `${stubBin}:${process.env.PATH}`, ...extraEnv },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    return { status: 0, stdout, stderr: '' };
-  } catch (err) {
-    return { status: err.status ?? null, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
-  }
-}
+const UPDATE_SYSTEM_SRC = readFileSync(join(__dirname, '..', 'update-system.mjs'), 'utf-8');
 
 console.log('\n🧪 Testing that CAREER_OPS_UPDATE_REEXEC=1 alone cannot bypass channel resolution...');
 
-const install = makeFixtureInstall();
-const stubBin = makeCurlStubBin();
-try {
-  // ── Control: a normal (non-reexec) invocation must call resolveTargetRef()
-  // and fail loudly when the release lookup is blocked — this proves the
-  // fixture and curl stub are actually exercising the code path in question,
-  // not passing for an unrelated reason.
-  const control = runApply(install, stubBin, {});
-  const controlCallsResolve = control.status !== 0 &&
-    /releases\/latest/.test(control.stderr) &&
-    /--channel main/.test(control.stderr);
-  if (controlCallsResolve) {
-    pass('control: a normal invocation calls resolveTargetRef() and fails loudly when it cannot reach GitHub');
+// ── The exact bypass scenario: neither an authenticated marker nor the
+// guarded legacy path — i.e. isReexec's bare third disjunct alone — must
+// NOT trust an env-supplied target ref.
+{
+  const trusted = trustsEnvTargetRef(false, false);
+  if (trusted === false) {
+    pass('neither authenticated nor legacy reexec proven -> does NOT trust the env target ref (resolveTargetRef() runs instead)');
   } else {
-    fail(`control: expected a resolveTargetRef failure naming RELEASES_API and --channel main; got status=${control.status} stderr=${control.stderr.slice(0, 300)}`);
+    fail(`trustsEnvTargetRef(false, false) = ${trusted}, expected false — the bypass would be open again`);
   }
+}
 
-  // ── The actual regression: CAREER_OPS_UPDATE_REEXEC=1 alone, --confirm,
-  // clean state (no lock file, no marker, no backup branch) must behave
-  // IDENTICALLY to the control above — not silently skip to a bare `main`
-  // fetch.
-  const bypassAttempt = runApply(install, stubBin, { CAREER_OPS_UPDATE_REEXEC: '1' });
-  const stillCallsResolve = bypassAttempt.status !== 0 &&
-    /releases\/latest/.test(bypassAttempt.stderr) &&
-    /--channel main/.test(bypassAttempt.stderr);
-  const neverReachedFetch = !/Fetching .* from upstream/.test(bypassAttempt.stdout);
-  if (stillCallsResolve && neverReachedFetch) {
-    pass('CAREER_OPS_UPDATE_REEXEC=1 alone does NOT skip resolveTargetRef() or silently resolve to main');
+// ── A genuine authenticated reexec (consumeReexecMarker() validated the
+// marker) legitimately inherits the parent's resolved ref.
+{
+  const trusted = trustsEnvTargetRef(true, false);
+  if (trusted === true) {
+    pass('authenticated reexec (consumeReexecMarker) -> trusts the env target ref');
   } else {
-    fail(
-      `bare CAREER_OPS_UPDATE_REEXEC=1 changed apply()'s behavior — status=${bypassAttempt.status}, ` +
-      `stdout=${bypassAttempt.stdout.slice(0, 300)}, stderr=${bypassAttempt.stderr.slice(0, 300)}`,
-    );
+    fail(`trustsEnvTargetRef(true, false) = ${trusted}, expected true`);
   }
-} finally {
-  rmSync(install, { recursive: true, force: true });
-  rmSync(stubBin, { recursive: true, force: true });
+}
+
+// ── The more heavily guarded legacy path (isLegacyReexec(): a real lock
+// file + a really-existing, correctly-named backup branch) also legitimately
+// inherits it, for a pre-dating-this-env-var parent.
+{
+  const trusted = trustsEnvTargetRef(false, true);
+  if (trusted === true) {
+    pass('legacy reexec (isLegacyReexec) -> trusts the env target ref');
+  } else {
+    fail(`trustsEnvTargetRef(false, true) = ${trusted}, expected true`);
+  }
+}
+
+// ── Wiring: apply()'s targetRef ternary must actually call this function
+// with these two inputs, or the unit tests above pin a function nothing
+// calls. A source-pattern check, not a behavioral one — matches this repo's
+// own convention (see e.g. the batch-runner curl-prefetch tests) for pinning
+// that a specific call site exists without re-running apply() itself.
+{
+  const wired = /trustsEnvTargetRef\(authenticatedReexec,\s*legacyReexec\)/.test(UPDATE_SYSTEM_SRC);
+  if (wired) {
+    pass("apply()'s targetRef ternary calls trustsEnvTargetRef(authenticatedReexec, legacyReexec)");
+  } else {
+    fail("apply() no longer calls trustsEnvTargetRef(authenticatedReexec, legacyReexec) — the unit tests above are pinning a function nothing uses");
+  }
 }

--- a/tests/updater-reexec-bypass.test.mjs
+++ b/tests/updater-reexec-bypass.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * updater-reexec-bypass.test.mjs — a bare CAREER_OPS_UPDATE_REEXEC=1 must not
+ * let apply() skip channel resolution.
+ *
+ * The regression (CodeRabbit review on the release-channel PR): isReexec's
+ * third disjunct — `--confirm` in argv plus a bare CAREER_OPS_UPDATE_REEXEC=1
+ * in env — proves nothing (no lock file, no authenticated marker, no backup
+ * branch) and is satisfiable from a clean state. Before the fix, apply()'s
+ * targetRef ternary trusted that alone to skip resolveTargetRef() entirely
+ * and fall through to CAREER_OPS_UPDATE_TARGET_REF ?? 'main' — silently
+ * reverting to the exact unpinned-main behavior this PR exists to close,
+ * with nothing but one stray env var and no --channel flag. Manually
+ * reproduced against the pre-fix code before writing this test: the process
+ * actually fetched real upstream `main` and updated a throwaway install,
+ * with no network call to RELEASES_API at all.
+ *
+ * The fix gates the targetRef fallback on (authenticatedReexec ||
+ * legacyReexec) instead of the broader isReexec, so only a cryptographically
+ * authenticated reexec (consumeReexecMarker()) or the more heavily guarded
+ * legacy path (isLegacyReexec(): a real lock file + a really-existing,
+ * correctly-named backup branch) may skip resolveTargetRef().
+ *
+ * apply() isn't structured for the ctx-injection seam used elsewhere in this
+ * suite (it reads process.argv/process.env directly and has real git/network
+ * side effects), so this drives the real CLI entrypoint as a subprocess
+ * against a disposable git fixture — the smallest faithful way to observe
+ * its behavior. A stub `curl` shadowing the real one on PATH makes the
+ * release lookup fail deterministically (no real network needed, no
+ * dependency on live connectivity in CI): if resolveTargetRef() runs, it
+ * fails loudly naming RELEASES_API and --channel main, BEFORE apply() ever
+ * reaches its git fetch step. If resolveTargetRef() is skipped instead, the
+ * process moves on to `git fetch` — a materially different outcome, easy to
+ * tell apart from the assertions below.
+ *
+ * Scoped to exactly this bypass, per the CodeRabbit finding. The companion
+ * property — a GENUINE authenticated reexec still correctly honors
+ * CAREER_OPS_UPDATE_TARGET_REF without calling resolveTargetRef() at all —
+ * was verified manually (a real marker via createReexecMarker(), a real git
+ * fetch of the env-supplied ref, zero curl invocations) but isn't encoded
+ * here: proving it end-to-end needs a local CANONICAL_REPO mirror
+ * (upgrade-tests.mjs's insteadOf trick) to avoid a live-network dependency,
+ * which is more machinery than this specific regression calls for.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, copyFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { pass, fail, rmSync } from './helpers.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const UPDATE_SYSTEM_SRC = join(__dirname, '..', 'update-system.mjs');
+
+/** A disposable git repo containing its own copy of update-system.mjs —
+ *  apply()'s ROOT is the script's own directory, so this IS the install. */
+function makeFixtureInstall() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-reexec-bypass-'));
+  const g = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  g('config', 'commit.gpgsign', 'false');
+  copyFileSync(UPDATE_SYSTEM_SRC, join(dir, 'update-system.mjs'));
+  writeFileSync(join(dir, 'VERSION'), '1.0.0\n');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+  return dir;
+}
+
+/** A `curl` that always fails, shadowing the real one so resolveTargetRef()'s
+ *  release lookup fails deterministically — no live network dependency. */
+function makeCurlStubBin() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-reexec-bypass-bin-'));
+  const stub = join(dir, 'curl');
+  writeFileSync(stub, '#!/bin/sh\nexit 7\n');
+  chmodSync(stub, 0o755);
+  return dir;
+}
+
+/** Run `apply --confirm` in the fixture with the given extra env, stubbed
+ *  curl shadowing the real one. Returns {status, stdout, stderr} either way
+ *  — apply() is expected to exit non-zero here, which execFileSync throws on. */
+function runApply(dir, stubBin, extraEnv) {
+  try {
+    const stdout = execFileSync(process.execPath, ['update-system.mjs', 'apply', '--confirm'], {
+      cwd: dir,
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, PATH: `${stubBin}:${process.env.PATH}`, ...extraEnv },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status ?? null, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+console.log('\n🧪 Testing that CAREER_OPS_UPDATE_REEXEC=1 alone cannot bypass channel resolution...');
+
+const install = makeFixtureInstall();
+const stubBin = makeCurlStubBin();
+try {
+  // ── Control: a normal (non-reexec) invocation must call resolveTargetRef()
+  // and fail loudly when the release lookup is blocked — this proves the
+  // fixture and curl stub are actually exercising the code path in question,
+  // not passing for an unrelated reason.
+  const control = runApply(install, stubBin, {});
+  const controlCallsResolve = control.status !== 0 &&
+    /releases\/latest/.test(control.stderr) &&
+    /--channel main/.test(control.stderr);
+  if (controlCallsResolve) {
+    pass('control: a normal invocation calls resolveTargetRef() and fails loudly when it cannot reach GitHub');
+  } else {
+    fail(`control: expected a resolveTargetRef failure naming RELEASES_API and --channel main; got status=${control.status} stderr=${control.stderr.slice(0, 300)}`);
+  }
+
+  // ── The actual regression: CAREER_OPS_UPDATE_REEXEC=1 alone, --confirm,
+  // clean state (no lock file, no marker, no backup branch) must behave
+  // IDENTICALLY to the control above — not silently skip to a bare `main`
+  // fetch.
+  const bypassAttempt = runApply(install, stubBin, { CAREER_OPS_UPDATE_REEXEC: '1' });
+  const stillCallsResolve = bypassAttempt.status !== 0 &&
+    /releases\/latest/.test(bypassAttempt.stderr) &&
+    /--channel main/.test(bypassAttempt.stderr);
+  const neverReachedFetch = !/Fetching .* from upstream/.test(bypassAttempt.stdout);
+  if (stillCallsResolve && neverReachedFetch) {
+    pass('CAREER_OPS_UPDATE_REEXEC=1 alone does NOT skip resolveTargetRef() or silently resolve to main');
+  } else {
+    fail(
+      `bare CAREER_OPS_UPDATE_REEXEC=1 changed apply()'s behavior — status=${bypassAttempt.status}, ` +
+      `stdout=${bypassAttempt.stdout.slice(0, 300)}, stderr=${bypassAttempt.stderr.slice(0, 300)}`,
+    );
+  }
+} finally {
+  rmSync(install, { recursive: true, force: true });
+  rmSync(stubBin, { recursive: true, force: true });
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2078,6 +2078,37 @@ export function reconcileGitignore(localText, upstreamText) {
 
 // ── APPLY ───────────────────────────────────────────────────────
 
+/**
+ * Whether apply() should trust CAREER_OPS_UPDATE_TARGET_REF from the
+ * environment for this invocation, rather than resolving a fresh ref via
+ * resolveTargetRef(). True only when reexec status was actually PROVEN: a
+ * cryptographically authenticated marker (consumeReexecMarker()) or the more
+ * heavily guarded legacy path (isLegacyReexec(): a real lock file plus a
+ * really-existing, correctly-named backup branch).
+ *
+ * Deliberately narrower than isReexec as a whole: isReexec's own third,
+ * unauthenticated disjunct (`--confirm` in argv plus a bare
+ * CAREER_OPS_UPDATE_REEXEC=1 in env — no marker, no lock, no backup branch)
+ * proves nothing and is satisfiable from a clean state with one stray env
+ * var. Letting THAT alone reach this fallback would skip resolveTargetRef()
+ * entirely on what looks like a fresh invocation, silently reverting to
+ * 'main' regardless of channel — the exact bug this file exists to close.
+ *
+ * Extracted as its own function (rather than inlined in apply()'s targetRef
+ * ternary) so the decision is unit-testable without spawning apply() itself:
+ * apply() has real git/network side effects and no ctx-injection seam, so a
+ * subprocess-level test needing this gate's THREE inputs to differ (marker,
+ * lock file, backup branch) is disproportionately heavy machinery for what
+ * is, underneath, one boolean expression.
+ *
+ * @param {boolean} authenticatedReexec - consumeReexecMarker()'s result.
+ * @param {boolean} legacyReexec - isLegacyReexec()'s result.
+ * @returns {boolean}
+ */
+export function trustsEnvTargetRef(authenticatedReexec, legacyReexec) {
+  return authenticatedReexec || legacyReexec;
+}
+
 async function apply() {
   assertOwnGitToplevel();
   const local = localVersion();
@@ -2111,15 +2142,8 @@ async function apply() {
   // land on the exact same content; resolving independently in each process
   // would leave a window where a new release lands between the two fetches.
   //
-  // Deliberately gated on (authenticatedReexec || legacyReexec), NOT the
-  // broader isReexec: isReexec's third disjunct (`--confirm` + a bare
-  // CAREER_OPS_UPDATE_REEXEC=1, no marker, no lock, no backup branch) proves
-  // nothing — it's satisfiable from a clean state with one stray env var,
-  // which would otherwise let a non-reexec invocation skip resolveTargetRef()
-  // and silently fetch 'main' regardless of channel. Only a cryptographically
-  // authenticated reexec or the more-guarded legacy path (lock file + a real,
-  // correctly-named backup branch, see isLegacyReexec()) may inherit a target
-  // ref from the environment at all.
+  // See trustsEnvTargetRef()'s doc comment for why this is gated on that
+  // function rather than the broader isReexec.
   //
   // A legacy parent (pre-dating this env var) leaves it unset — falling back
   // to 'main' there matches what that parent itself did, since it never
@@ -2127,7 +2151,7 @@ async function apply() {
   // shouldn't happen in practice (this process always sets it when it spawns
   // one), but the same fallback covers it as a safety net rather than crashing
   // mid-update.
-  const targetRef = (authenticatedReexec || legacyReexec)
+  const targetRef = trustsEnvTargetRef(authenticatedReexec, legacyReexec)
     ? (process.env.CAREER_OPS_UPDATE_TARGET_REF || 'main')
     : await resolveTargetRef(process.argv, process.env);
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -9,11 +9,17 @@
  * Usage:
  *   node update-system.mjs check      # Check if update available
  *   node update-system.mjs apply --confirm
- *                                     # Apply update after explicit confirmation
+ *                                     # Apply update after explicit confirmation.
+ *                                     # Default channel: the newest published
+ *                                     # release tag, not main's current tip.
  *   node update-system.mjs apply --force --confirm
  *                                     # …and overwrite system files this
  *                                     # install edited locally (#2337). Without
  *                                     # it those files are kept and listed.
+ *   node update-system.mjs apply --channel main --confirm
+ *                                     # …track main instead: every merge,
+ *                                     # including whatever's mid-flight
+ *                                     # between a bad one and its fix.
  *   node update-system.mjs rollback   # Rollback last update
  *   node update-system.mjs dismiss    # Dismiss update check
  *
@@ -1680,6 +1686,105 @@ function curlGet(url, extraArgs = []) {
   });
 }
 
+// ── CHANNEL RESOLUTION ──────────────────────────────────────────
+
+/**
+ * Which channel apply() should fetch from: the `--channel` flag wins over
+ * CAREER_OPS_UPDATE_CHANNEL (the re-exec'd child's copy of the parent's
+ * resolved choice — see resolveTargetRef()'s callers). Unset means the
+ * default, 'release'. Anything else is a typo, not a third channel, so it
+ * throws before any lock or network call rather than silently doing
+ * something the caller didn't ask for.
+ *
+ * @param {string[]} argv - process.argv (or a test double).
+ * @param {NodeJS.ProcessEnv} env - process.env (or a test double).
+ * @returns {'release'|'main'}
+ */
+function resolveChannel(argv, env) {
+  const idx = argv.indexOf('--channel');
+  const requested = idx !== -1 ? argv[idx + 1] : env.CAREER_OPS_UPDATE_CHANNEL;
+  if (requested === undefined || requested === 'release') return 'release';
+  if (requested === 'main') return 'main';
+  throw new Error(`Unknown --channel '${requested}'. Supported channels: release (default), main.`);
+}
+
+// release-please-config.json also releases a sibling `web` component, tagged
+// `web-vX.Y.Z` — see resolveTargetRef()'s doc comment for why this matters.
+const RELEASE_TAG_PREFIX = 'career-ops-v';
+
+/**
+ * Resolve the git ref apply() should fetch from CANONICAL_REPO.
+ *
+ * Default channel ('release'): the newest published career-ops release tag,
+ * read from RELEASES_API. main's tip is not a safe default — release-please
+ * can bump VERSION on main hours before the matching tag lands, so a
+ * same-moment `main` checkout can carry a version string with none of that
+ * release's guarantees (an intermediate commit, not a reproducible one).
+ * `--channel main` opts back into the old behavior: every merge, including
+ * whatever's mid-flight between a bad one and its fix.
+ *
+ * Fails loudly on the default channel instead of falling back to 'main' —
+ * a silent fallback would reintroduce the exact bug this exists to close,
+ * and on exactly the network blip that makes it matter most. This includes
+ * a tag returned by GitHub that isn't ours: this is a manifest-mode
+ * monorepo (release-please-config.json also releases a `web` component,
+ * tagged `web-vX.Y.Z`), and RELEASES_API's `/releases/latest` returns
+ * whichever release was created most recently across BOTH components —
+ * correct only because release.yml's "Keep the career-ops release marked
+ * as Latest" step re-asserts it on every push. If that step ever silently
+ * stopped running, this would otherwise fetch and install a `web` tag
+ * without complaint; TAG_PREFIX makes that fail loudly and diagnosably
+ * instead, naming the unexpected tag rather than silently installing it.
+ *
+ * @param {string[]} argv - process.argv (or a test double).
+ * @param {NodeJS.ProcessEnv} env - process.env (or a test double).
+ * @param {{curlGet?: typeof curlGet}} [ctx] - injection seam for tests.
+ * @returns {Promise<string>} A ref fetchable from CANONICAL_REPO: a release
+ *   tag verbatim (e.g. `career-ops-v1.32.0`) or the literal `main`.
+ */
+export async function resolveTargetRef(argv, env, ctx = {}) {
+  const runCurlGet = ctx.curlGet || curlGet;
+  if (resolveChannel(argv, env) === 'main') {
+    return 'main';
+  }
+
+  const releaseRaw = await runCurlGet(RELEASES_API, [
+    '--header', 'Accept: application/vnd.github.v3+json',
+    '--header', 'User-Agent: career-ops-update-checker',
+  ]);
+  if (releaseRaw === null) {
+    throw new Error(
+      `Could not reach ${RELEASES_API} to resolve the latest career-ops release. ` +
+      'Retry, or run with --channel main to update from the latest commit on main instead.',
+    );
+  }
+
+  let tagName = '';
+  try {
+    tagName = String(JSON.parse(releaseRaw)?.tag_name || '').trim();
+  } catch {
+    // Unparseable body; tagName stays empty and falls through to the throw below.
+  }
+  if (!tagName) {
+    throw new Error(
+      `GitHub returned no usable release tag from ${RELEASES_API}. ` +
+      'Retry, or run with --channel main to update from the latest commit on main instead.',
+    );
+  }
+  if (!tagName.startsWith(RELEASE_TAG_PREFIX)) {
+    // Almost certainly the sibling `web` component's tag surfacing because
+    // release.yml's Latest-reassignment step didn't run — see the doc
+    // comment above. Fetching it anyway would silently install an unrelated
+    // release; naming it here turns that into an actionable report instead.
+    throw new Error(
+      `${RELEASES_API} returned '${tagName}', which is not a ${RELEASE_TAG_PREFIX}* tag — ` +
+      `likely the sibling 'web' component's release surfacing instead of career-ops's. ` +
+      'Retry, or run with --channel main to update from the latest commit on main instead.',
+    );
+  }
+  return tagName;
+}
+
 async function check() {
   // Respect dismiss flag
   if (existsSync(join(ROOT, '.update-dismissed'))) {
@@ -1993,6 +2098,18 @@ async function apply() {
     );
   }
 
+  // Which ref to fetch from CANONICAL_REPO. Resolved once — a real network
+  // call on the default channel — and threaded to the re-exec'd child via
+  // CAREER_OPS_UPDATE_TARGET_REF below, so both fetches in a self-reexec pair
+  // land on the exact same content; resolving independently in each process
+  // would leave a window where a new release lands between the two fetches.
+  // A legacy parent (pre-dating this env var, see isLegacyReexec()) leaves it
+  // unset — falling back to 'main' there matches what that parent itself did,
+  // since it never resolved a channel either.
+  const targetRef = isReexec
+    ? (process.env.CAREER_OPS_UPDATE_TARGET_REF || 'main')
+    : await resolveTargetRef(process.argv, process.env);
+
   // Check for lock
   const lockFile = join(ROOT, '.update-lock');
   if (existsSync(lockFile) && !isReexec) {
@@ -2027,8 +2144,8 @@ async function apply() {
     }
 
     // 2. Fetch from canonical repo
-    console.log('Fetching latest from upstream...');
-    git('fetch', CANONICAL_REPO, 'main');
+    console.log(`Fetching ${targetRef} from upstream...`);
+    git('fetch', CANONICAL_REPO, targetRef);
 
     if (!isReexec) {
       const timeout = reexecTimeoutMs();
@@ -2071,6 +2188,7 @@ async function apply() {
             // marker was introduced; only the authenticated child receives it.
             CAREER_OPS_UPDATE_REEXEC: '1',
             CAREER_OPS_UPDATE_BACKUP_BRANCH: backupBranch,
+            CAREER_OPS_UPDATE_TARGET_REF: targetRef,
             ...(updateForce ? { CAREER_OPS_UPDATE_FORCE: '1' } : {}),
             // Keep the legacy confirmation channel for older target updaters;
             // this process still requires the authenticated marker above.
@@ -2680,7 +2798,7 @@ if (isCli) {
       case 'rollback': rollback(); break;
       case 'dismiss': dismiss(); break;
       default:
-        console.log('Usage: node update-system.mjs [check|apply --confirm [--force]|rollback|dismiss]');
+        console.log('Usage: node update-system.mjs [check|apply --confirm [--force] [--channel main]|rollback|dismiss]');
         process.exit(1);
     }
   } catch (err) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1733,8 +1733,9 @@ const RELEASE_TAG_PREFIX = 'career-ops-v';
  * correct only because release.yml's "Keep the career-ops release marked
  * as Latest" step re-asserts it on every push. If that step ever silently
  * stopped running, this would otherwise fetch and install a `web` tag
- * without complaint; TAG_PREFIX makes that fail loudly and diagnosably
- * instead, naming the unexpected tag rather than silently installing it.
+ * without complaint; the RELEASE_TAG_PREFIX + SEMVER_RE check makes that
+ * fail loudly and diagnosably instead, naming the unexpected tag rather
+ * than silently installing it or fetching a ref that doesn't exist.
  *
  * @param {string[]} argv - process.argv (or a test double).
  * @param {NodeJS.ProcessEnv} env - process.env (or a test double).
@@ -1771,14 +1772,19 @@ export async function resolveTargetRef(argv, env, ctx = {}) {
       'Retry, or run with --channel main to update from the latest commit on main instead.',
     );
   }
-  if (!tagName.startsWith(RELEASE_TAG_PREFIX)) {
+  // Prefix AND shape: 'career-ops-vnot-a-version' passes a prefix-only check
+  // but isn't a real release tag either — SEMVER_RE (shared with the VERSION
+  // and release-tag parsing above) is the same bar a genuine tag must clear.
+  if (!tagName.startsWith(RELEASE_TAG_PREFIX) || !SEMVER_RE.test(tagName)) {
     // Almost certainly the sibling `web` component's tag surfacing because
-    // release.yml's Latest-reassignment step didn't run — see the doc
-    // comment above. Fetching it anyway would silently install an unrelated
-    // release; naming it here turns that into an actionable report instead.
+    // release.yml's Latest-reassignment step didn't run (wrong prefix) — see
+    // the doc comment above — or a malformed tag (right prefix, no valid
+    // version). Fetching either anyway would silently install the wrong
+    // content or crash on a nonexistent ref; naming it here turns that into
+    // an actionable report instead.
     throw new Error(
-      `${RELEASES_API} returned '${tagName}', which is not a ${RELEASE_TAG_PREFIX}* tag — ` +
-      `likely the sibling 'web' component's release surfacing instead of career-ops's. ` +
+      `${RELEASES_API} returned '${tagName}', which is not a valid ${RELEASE_TAG_PREFIX}X.Y.Z release tag — ` +
+      `likely the sibling 'web' component's release surfacing instead of career-ops's, or a malformed tag. ` +
       'Retry, or run with --channel main to update from the latest commit on main instead.',
     );
   }
@@ -2077,8 +2083,9 @@ async function apply() {
   const local = localVersion();
   // Environment variables are a private one-use channel for the self-reexec;
   // they must not authorize the initial invocation (#2866).
+  const authenticatedReexec = consumeReexecMarker();
   const legacyReexec = isLegacyReexec();
-  const isReexec = consumeReexecMarker() || legacyReexec ||
+  const isReexec = authenticatedReexec || legacyReexec ||
     (process.argv.includes('--confirm') && process.env.CAREER_OPS_UPDATE_REEXEC === '1');
   const updateForce = process.argv.includes('--force') ||
     (isReexec && process.env.CAREER_OPS_UPDATE_FORCE === '1');
@@ -2103,10 +2110,24 @@ async function apply() {
   // CAREER_OPS_UPDATE_TARGET_REF below, so both fetches in a self-reexec pair
   // land on the exact same content; resolving independently in each process
   // would leave a window where a new release lands between the two fetches.
-  // A legacy parent (pre-dating this env var, see isLegacyReexec()) leaves it
-  // unset — falling back to 'main' there matches what that parent itself did,
-  // since it never resolved a channel either.
-  const targetRef = isReexec
+  //
+  // Deliberately gated on (authenticatedReexec || legacyReexec), NOT the
+  // broader isReexec: isReexec's third disjunct (`--confirm` + a bare
+  // CAREER_OPS_UPDATE_REEXEC=1, no marker, no lock, no backup branch) proves
+  // nothing — it's satisfiable from a clean state with one stray env var,
+  // which would otherwise let a non-reexec invocation skip resolveTargetRef()
+  // and silently fetch 'main' regardless of channel. Only a cryptographically
+  // authenticated reexec or the more-guarded legacy path (lock file + a real,
+  // correctly-named backup branch, see isLegacyReexec()) may inherit a target
+  // ref from the environment at all.
+  //
+  // A legacy parent (pre-dating this env var) leaves it unset — falling back
+  // to 'main' there matches what that parent itself did, since it never
+  // resolved a channel either. An authenticated reexec missing the env var
+  // shouldn't happen in practice (this process always sets it when it spawns
+  // one), but the same fallback covers it as a safety net rather than crashing
+  // mid-update.
+  const targetRef = (authenticatedReexec || legacyReexec)
     ? (process.env.CAREER_OPS_UPDATE_TARGET_REF || 'main')
     : await resolveTargetRef(process.argv, process.env);
 


### PR DESCRIPTION
## What does this PR do?


update-system.mjs's apply() fetched whatever main's tip happened to be at the moment it ran, not the latest published release, because its only fetch call was hardcoded to main. That has a real cost: a user reported a crash "on v1.30.0," and their VERSION file did say v1.30.0, but their code was an untagged intermediate main state carrying a bug that lived for about 9 hours between two releases (root-caused in #3412). "What version are you on?" had no reliable answer, which made support triage effectively blind.

This PR makes the updater follow the latest release by default. resolveTargetRef() resolves the newest career-ops-v* tag via RELEASES_API, and apply() fetches that ref instead of main. --channel main is added as an explicit opt-in for the old behavior (every merge, including whatever's mid-flight between a bad one and its fix). A failed release lookup on the default channel fails loudly instead of silently falling back to main, since a silent fallback would reintroduce the exact bug this closes, on exactly the network blip that makes it matter most. This is a manifest-mode monorepo that also releases a sibling web component, so resolveTargetRef() also rejects any resolved tag that isn't prefixed career-ops-v. That way, if release.yml's "keep career-ops marked Latest" step ever silently stopped running, a web-* tag surfacing from /releases/latest fails loudly instead of being installed without complaint.

Out of scope, deliberately: check() still has two hardcoded main references (its drift-fetch and its remote-commit lookup). Left untouched here to keep this PR bounded to apply()'s fetch target. On the default channel this means check() can end up reporting system-files-changed after a channel="release" update, since main is expected to diverge from the tag it was released from. Flagging this as a known gap and a likely fast-follow. 

## Related issue

Closes #3583

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `update-system.mjs:1692-1782` resolves the newest valid `career-ops-v*` release by default.
- `update-system.mjs:2801` documents `--channel main`.
- `update-system.mjs:2102-2111` preserves the target ref during self-reexecution.
- `tests/updater-channel-resolution.test.mjs` covers channel selection and release lookup failures.
- `tests/updater-reexec-bypass.test.mjs` covers reexecution trust behavior.

## User impact

- Default updates install a numbered release tag.
- Use `--channel main` to install every merge, including intermediate states.
- If release lookup fails or returns an invalid tag, the update stops. It does not fall back to `main`.

## Files

Touched: `update-system.mjs`, `tests/updater-channel-resolution.test.mjs`, `tests/updater-reexec-bypass.test.mjs`.

Not touched: `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->