### PR TITLE
fix(followup-cadence): accept --json, the flag both web follow-up routes pass

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -986,12 +986,20 @@ function printSummary(result) {
 
 // ── CLI flags + help ────────────────────────────────────────────────
 
-const KNOWN_FLAGS = ['--summary', '--overdue-only', '--applied-days', '--help', '-h'];
+// --json is the DEFAULT output form, not a mode switch: it names what the
+// script already does with no flag at all. It is listed here because callers
+// pass it explicitly — web/src/app/api/followups/route.ts and
+// web/src/app/api/followups/cadence/route.ts both spawn `[script, '--json']`
+// — and validateFlags() rejects any flag not on this list, so omitting it
+// made both routes exit 1 and read as "no follow-ups" (#3196 added the
+// validation without the flag the web already passed).
+const KNOWN_FLAGS = ['--summary', '--json', '--overdue-only', '--applied-days', '--help', '-h'];
 const VALUE_FLAGS = ['--applied-days'];
 
 const USAGE = `Usage:
   node followup-cadence.mjs                    # full JSON analysis to stdout
-  node followup-cadence.mjs --summary          # human-readable dashboard
+  node followup-cadence.mjs --json             # same as above, JSON is the default
+  node followup-cadence.mjs --summary          # human-readable dashboard (wins over --json)
   node followup-cadence.mjs --overdue-only     # only show overdue/urgent entries
   node followup-cadence.mjs --applied-days 10  # override applied_first cadence (days)
   node followup-cadence.mjs --help|-h          # print this usage block and exit`;
@@ -1016,6 +1024,8 @@ if (isMainModule(import.meta.url)) {
 
   const result = analyze();
 
+  // --summary wins when both are given: it is the flag that asks for something
+  // other than the default, so it is the one carrying an intention.
   if (summaryMode) {
     printSummary(result);
   } else {

--- a/tests/web-core-argv-contract.test.mjs
+++ b/tests/web-core-argv-contract.test.mjs
@@ -1,0 +1,188 @@
+// tests/web-core-argv-contract.test.mjs — the web app spawns core scripts with
+// a fixed argv, and the core validates its own flags. Nothing linked the two.
+//
+// followup-cadence.mjs gained validateFlags() without `--json` on its
+// KNOWN_FLAGS list, while both web follow-up routes had been spawning
+// `[script, '--json']` all along. The script started exiting 1 with
+// "unrecognized flag(s): --json"; both routes discard the error and resolve to
+// "", so the UI rendered an empty follow-up list and told the user they were
+// caught up. No test could see it: the suite exercised the cadence analysis
+// in-process and never spawned the CLI with the web's argv.
+//
+// This file is that missing link. Every web call site that spawns a root
+// script is listed below with the argv it passes, and the argv is put to the
+// real script.
+import { pass, fail, ROOT, NODE, rmSync, walkFiles } from './helpers.mjs';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, relative, sep } from 'path';
+
+console.log('\nweb → core argv contract');
+
+// Probe kinds:
+//   'run'        — spawn the exact argv the web passes and require exit 0.
+//   'flags-only' — the real run would sweep live job boards, so append --help
+//                  instead. validateFlags() checks unrecognized flags BEFORE
+//                  --help, so an argv the script rejects still exits 1 naming
+//                  the flag, and exit 0 with usage means every flag was
+//                  accepted. Same verdict on the flags, no network.
+//   'none'       — the call site spawns node with an inline module rather than
+//                  a root script with flags; listed so the enumeration at the
+//                  bottom stays complete.
+const CALL_SITES = [
+  {
+    source: 'web/src/app/api/followups/route.ts',
+    script: 'followup-cadence.mjs',
+    args: ['--json'],
+    probe: 'run',
+  },
+  {
+    source: 'web/src/app/api/followups/cadence/route.ts',
+    script: 'followup-cadence.mjs',
+    args: ['--json'],
+    probe: 'run',
+  },
+  {
+    source: 'web/src/app/api/doctor/route.ts',
+    script: 'doctor.mjs',
+    args: ['--json'],
+    probe: 'run',
+  },
+  {
+    source: 'web/src/app/api/status/route.ts',
+    script: 'set-status.mjs',
+    // The route builds ['--row', row, canon, '--source', 'web', '--json'];
+    // row 1 and Responded are the fixture tracker's row and a canonical state.
+    args: ['--row', '1', 'Responded', '--source', 'web', '--json'],
+    probe: 'run',
+  },
+  {
+    source: 'web/src/app/api/portals/verify/route.ts',
+    script: 'verify-portals.mjs',
+    args: [],
+    probe: 'run',
+  },
+  {
+    source: 'web/src/app/api/tracker/delete/route.ts',
+    script: 'tracker.mjs',
+    // --dry-run is conditional in the route (added when the caller asks for a
+    // preview); passing it keeps the probe off the fixture tracker.
+    args: ['delete', '--num', '1', '--dry-run'],
+    probe: 'run',
+  },
+  {
+    source: 'web/src/lib/core/scan.ts',
+    script: 'scan-ats-full.mjs',
+    // The values are the route's own defaults; only the flag names matter here.
+    args: ['--dry-run', '--since', '7', '--ats', 'greenhouse', '--limit', '150', '--json'],
+    probe: 'flags-only',
+  },
+  {
+    source: 'web/src/lib/core/pipeline.ts',
+    script: null,
+    args: [],
+    probe: 'none',
+  },
+];
+
+const sandbox = mkdtempSync(join(tmpdir(), 'co-web-argv-'));
+try {
+  // A minimal data root: one Applied row, enough for every script here to have
+  // something to report on. Fictional company and role.
+  const tracker = join(sandbox, 'data', 'applications.md');
+  mkdirSync(join(sandbox, 'data'), { recursive: true });
+  writeFileSync(
+    tracker,
+    '# Applications Tracker\n\n' +
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+    '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+    '| 1 | 2026-01-05 | Northwind Robotics | Backend Engineer | 4.2/5 | Applied | ✅ | [1](reports/001-northwind-robotics-2026-01-05.md) | fixture |\n',
+    'utf-8',
+  );
+
+  const env = {
+    ...process.env,
+    CAREER_OPS_ROOT: sandbox,
+    CAREER_OPS_DATA_DIR: '',
+    // set-status.mjs resolves its root from the codebase, not from
+    // CAREER_OPS_ROOT, so without this the probe would read and write the
+    // developer's own tracker.
+    CAREER_OPS_TRACKER: tracker,
+    // verify-portals.mjs reads portals.yml relative to the codebase root, and
+    // a real one would put this probe on the network. Point it at a path that
+    // does not exist: the script's documented no-op for a fresh setup.
+    CAREER_OPS_PORTALS: join(sandbox, 'no-portals.yml'),
+  };
+
+  for (const site of CALL_SITES) {
+    if (site.probe === 'none') continue;
+    const argv = site.probe === 'flags-only' ? [...site.args, '--help'] : site.args;
+    const label = `${site.script} ${argv.join(' ')}`.trim();
+    const result = spawnSync(NODE, [join(ROOT, site.script), ...argv], {
+      cwd: ROOT, encoding: 'utf-8', timeout: 60_000, env,
+    });
+
+    if (result.error || result.signal) {
+      fail(`${label} — did not run (${result.error?.message || `killed by ${result.signal}`})`);
+      continue;
+    }
+    if (result.status !== 0) {
+      // The flag rejection is the failure this file exists to catch, so name it.
+      const why = /unrecognized flag/.test(result.stderr || '')
+        ? `${site.script} rejects a flag ${site.source} passes — ${result.stderr.trim()}`
+        : `exit ${result.status}: ${(result.stderr || result.stdout || '').trim().split('\n').slice(0, 3).join(' | ')}`;
+      fail(`${label} — ${why}`);
+      continue;
+    }
+    if (site.probe === 'run' && argv.includes('--json')) {
+      try {
+        JSON.parse(result.stdout);
+        pass(`${label} — exit 0, stdout parses as JSON (${site.source})`);
+      } catch (e) {
+        fail(`${label} — exit 0 but stdout is not JSON: ${e.message}`);
+      }
+    } else {
+      pass(`${label} — exit 0 (${site.source})`);
+    }
+  }
+
+  // --- static half ---------------------------------------------------------
+  // The probes above test the argv as transcribed into this file. These two
+  // checks tie that transcription back to the sources, so a flag added to a
+  // web route — or a whole new route that spawns a script — cannot land
+  // without going through a probe.
+
+  // Every `"--flag"` literal in a listed source must appear in its argv here.
+  // This covers the argv literals the routes write inline; it does NOT cover a
+  // flag assembled at runtime from a variable or a template string.
+  const flagDrift = [];
+  for (const site of CALL_SITES) {
+    const src = readFileSync(join(ROOT, site.source), 'utf-8');
+    const literals = [...new Set([...src.matchAll(/"(--[a-z][a-z0-9-]*)"/g)].map((m) => m[1]))];
+    for (const flag of literals) {
+      if (!site.args.includes(flag)) flagDrift.push(`${site.source} passes ${flag}, which no probe above covers`);
+    }
+  }
+  if (flagDrift.length === 0) pass('every --flag literal in the listed web sources is covered by a probe');
+  else for (const d of flagDrift) fail(d);
+
+  // Every web source that spawns a core script must be listed. A new route is
+  // a new argv nobody has put to the script.
+  const spawners = walkFiles(join(ROOT, 'web', 'src'), /\.(ts|tsx|mjs)$/)
+    .map((f) => relative(ROOT, f).split(sep).join('/'))
+    .filter((rel) => {
+      const src = readFileSync(join(ROOT, rel), 'utf-8');
+      return /\brootScript\(/.test(src) && /\b(execFile|spawn)\(/.test(src);
+    });
+  const listed = new Set(CALL_SITES.map((s) => s.source));
+  const unlisted = spawners.filter((f) => !listed.has(f));
+  if (unlisted.length === 0) pass(`all ${spawners.length} web sources that spawn a core script are listed here`);
+  else fail(`web sources spawning a core script with no argv probe: ${unlisted.join(', ')}`);
+
+  const stale = [...listed].filter((f) => !spawners.includes(f));
+  if (stale.length === 0) pass('no stale entries — every listed source still spawns a core script');
+  else fail(`listed sources that no longer spawn a core script: ${stale.join(', ')}`);
+} finally {
+  rmSync(sandbox, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What does this PR do?

`followup-cadence.mjs` rejects `--json`, the exact flag both web follow-up routes pass it, so both features have been returning nothing since the flag validation landed. This adds `--json` to the script's `KNOWN_FLAGS` (JSON stays the default output, behaviour is unchanged) and adds a contract test that puts every argv the web spawns to the core script it spawns.

## Related issue

None. Bug fix, sent straight in per CONTRIBUTING.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## How it works

`ec800a2c` (#3196) moved `followup-cadence.mjs` onto the shared `validateFlags()` helper, which rejects any flag not on the script's own list. The list it introduced (`followup-cadence.mjs:989` before this change) is `['--summary', '--overdue-only', '--applied-days', '--help', '-h']`. `--json` is missing from it, and `--json` is what the web passes:

- `web/src/app/api/followups/route.ts:19`, `execFile("node", [script, "--json"], …)`, which resolves `""` on error
- `web/src/app/api/followups/cadence/route.ts:42`, `execFile("node", [script, "--json"], …)`, which ignores the error argument entirely

Measured on `main` (fad070fe):

```
$ node followup-cadence.mjs --json
Error: unrecognized flag(s): --json. Valid flags: --summary, --overdue-only, --applied-days, --help, -h
exit 1
```

Both routes discard that failure and hand the UI an empty answer, so `today-dashboard.tsx` renders "You're all caught up" from a script that never ran. The flag is not a mode switch (with no flag at all the script already prints JSON), so accepting it is a one-line list change with no behaviour change.

Two smaller things in the same file:

- `USAGE` now names `--json` as the default output form, so `--help` no longer implies the flag is invalid.
- `--summary` plus `--json` together: `--summary` wins, which is what the existing code already does, since `summaryMode` is checked first. Now written down in `USAGE` and in a comment rather than left to be rediscovered.

**Sibling scripts.** Since this is a class of bug and not a one-off, I enumerated the closed set: every `execFile`/`spawn` of a root script under `web/src`, and the flags each one passes, checked against that script's own accepted flags.

| Web call site | argv | Script accepts it? |
|---|---|---|
| `web/src/app/api/followups/route.ts:19` | `followup-cadence.mjs --json` | **no, fixed here** |
| `web/src/app/api/followups/cadence/route.ts:42` | `followup-cadence.mjs --json` | **no, fixed here** |
| `web/src/app/api/doctor/route.ts:18` | `doctor.mjs --json` | yes (`doctor.mjs:33`) |
| `web/src/app/api/status/route.ts:160` | `set-status.mjs --row N <State> --source web --json` | yes (`set-status.mjs:138`, `:173`) |
| `web/src/app/api/portals/verify/route.ts:32` | `verify-portals.mjs` (no flags) | yes |
| `web/src/app/api/tracker/delete/route.ts:58` | `tracker.mjs delete --num N [--dry-run]` | yes (`tracker.mjs:562`, `:571`) |
| `web/src/lib/core/scan.ts:88` | `scan-ats-full.mjs --dry-run --since N --ats X --limit N [--json]` | yes (`scan-ats-full.mjs:255`) |
| `web/src/lib/core/pipeline.ts:68` | `node --input-type=module -e <code>`, no root script in argv | n/a |

`followup-cadence.mjs` was the only mismatch, so this PR is a one-line fix plus the test that keeps it one.

## Tests

New file `tests/web-core-argv-contract.test.mjs` (188 lines, `pass`/`fail` from `tests/helpers.mjs`). It holds the table above and puts each argv to the real script, in a hermetic temp data root (`CAREER_OPS_ROOT` plus a one-row fixture tracker with a fictional company), no network:

- 7 argv probes. Six run the exact web argv and require exit 0, with `JSON.parse(stdout)` where the argv carries `--json`. `scan-ats-full.mjs` would sweep live job boards, so its probe appends `--help` instead: `validateFlags()` checks unrecognized flags *before* `--help`, so a rejected flag still exits 1 naming the flag, and exit 0 with usage means every flag was accepted. `verify-portals.mjs` and `set-status.mjs` are pointed at the sandbox with `CAREER_OPS_PORTALS` and `CAREER_OPS_TRACKER`, because both resolve from the codebase root rather than from `CAREER_OPS_ROOT`.
- 1 static check that every `"--flag"` literal in a listed web source is covered by a probe. Best effort by design: it sees the argv literals the routes write inline, not a flag assembled at runtime from a variable or a template string.
- 2 static checks that the table and the sources cannot drift apart: every `web/src` file that both calls `rootScript()` and spawns must be listed, and every listed source must still spawn.

Results on this branch:

```
$ node test-all.mjs --only web-core-argv
web → core argv contract
  ✅ followup-cadence.mjs --json — exit 0, stdout parses as JSON (web/src/app/api/followups/route.ts)
  ✅ followup-cadence.mjs --json — exit 0, stdout parses as JSON (web/src/app/api/followups/cadence/route.ts)
  ✅ doctor.mjs --json — exit 0, stdout parses as JSON (web/src/app/api/doctor/route.ts)
  ✅ set-status.mjs --row 1 Responded --source web --json — exit 0, stdout parses as JSON (…/status/route.ts)
  ✅ verify-portals.mjs — exit 0 (web/src/app/api/portals/verify/route.ts)
  ✅ tracker.mjs delete --num 1 --dry-run — exit 0 (web/src/app/api/tracker/delete/route.ts)
  ✅ scan-ats-full.mjs --dry-run --since 7 --ats greenhouse --limit 150 --json --help — exit 0 (web/src/lib/core/scan.ts)
  ✅ every --flag literal in the listed web sources is covered by a probe
  ✅ all 8 web sources that spawn a core script are listed here
  ✅ no stale entries — every listed source still spawns a core script
📊 Results: 10 passed, 0 failed, 0 warnings
```

`node test-all.mjs --quick` gives **8104 passed, 0 failed, 13 warnings** (exit 0), against **8093 passed, 0 failed, 13 warnings** measured on `main`: the 10 new assertions plus one more from the syntax section, which prints a line per `.mjs` file and so counts the new file. The 13 warnings are pre-existing and unrelated to this change. `npm run lint` passes on 655 files.

**Mutant checks** (both restored afterwards; in each case the file kept parsing and only the named assertions went red):

1. Removed `--json` from `KNOWN_FLAGS`. The two `followup-cadence.mjs --json` probes went red naming the rejection (`8 passed, 2 failed`), everything else stayed green. That is the bug reproduced through the test.
2. Added `"--verbose"` to the doctor route's argv literal. The static half went red with `web/src/app/api/doctor/route.ts passes --verbose, which no probe above covers` (`9 passed, 1 failed`). That half is not dead code.

The existing `test-all.mjs:15573` assertion titled "followup-cadence --json emits…" could not catch this: it calls `analyzeFromContent()` in-process and never spawns the CLI, so the flag list is never consulted.

## Out of scope

- **The routes' error handling.** `followups/route.ts` resolves `""` on error and `followups/cadence/route.ts` ignores the error argument entirely, which is why a script exiting 1 reads as "no follow-ups" instead of as a failure. That is a separate class of fix and there is already work in flight on it.
- **Any other `--json` semantics.** `--json` stays a no-op alias for the default output; this PR does not make it suppress anything or change an exit code.
- **`set-status.mjs` and `verify-portals.mjs` resolving paths from the codebase root rather than from `CAREER_OPS_ROOT`.** The new test works around it with the env overrides those scripts already support; whether that resolution is right is a separate question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can now pass `--json` to `followup-cadence.mjs` without an argument error. JSON remains the default output. If users pass both `--json` and `--summary`, `--summary` takes precedence.

The usage documentation now describes these options: `followup-cadence.mjs`.

A new contract test checks that web routes pass valid arguments to core scripts: `tests/web-core-argv-contract.test.mjs`. It also detects uncovered flags and stale route entries.

## System files touched

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->