### PR TITLE
fix(invite-match): extract company names in any script, not just ASCII

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -257,11 +257,24 @@ export function companySimilarity(a, b) {
 // too much for one regex to be authoritative, so this is a best-effort
 // extraction — the fuzzy match against the tracker is what actually decides
 // the result, not this heuristic alone.
+//
+// The name class is Unicode, not `[A-Z][\w…]`: `\w` is ASCII-only in JS, so a
+// lazy `[\w…]{1,60}?` cannot cross the `é` in Nestlé and the terminator it is
+// looking for never arrives — the whole pattern fails and the invite yields no
+// company at all. `[A-Z]` refused a non-Latin first letter for the same reason,
+// so Яндекс and 株式会社 never even started matching. `\p{Lo}` covers
+// scripts with no case distinction; the body class is the one
+// normalizeCompanyName() already uses (#2517), plus the punctuation company
+// names carry, plus `_`: `\w` included it, and dropping it reproduces the
+// exact same failure mode this fix is for (a lazy class with no reachable
+// terminator fails the whole pattern, not just the one character) for any
+// ASCII company name that happens to contain an underscore. The first
+// pattern captures `(.+)` and was never script-bound.
 const COMPANY_LINE_PATTERNS = [
   /(?:^|\n)\s*company\s*[:\-]\s*(.+)/i,
-  /interview(?:ing)?\s+(?:with|at)\s+([A-Z][\w.,&' -]{1,60}?)(?:[.,\n]|\s+for\s|\s+regarding\s|$)/i,
-  /(?:phone screen|screening|interview)\s*[-–—:]\s*([A-Z][\w.,&' -]{1,60}?)(?:\s+opportunity)?(?:[.,\n]|$)/i,
-  /schedule your (?:phone screen|interview)\s*(?:[-–—:]\s*)?([A-Z][\w.,&' -]{1,60}?)\s*opportunity/i,
+  /interview(?:ing)?\s+(?:with|at)\s+([\p{Lu}\p{Lo}][\p{L}\p{M}\p{N}_.,&' -]{1,60}?)(?:[.,\n]|\s+for\s|\s+regarding\s|$)/iu,
+  /(?:phone screen|screening|interview)\s*[-–—:]\s*([\p{Lu}\p{Lo}][\p{L}\p{M}\p{N}_.,&' -]{1,60}?)(?:\s+opportunity)?(?:[.,\n]|$)/iu,
+  /schedule your (?:phone screen|interview)\s*(?:[-–—:]\s*)?([\p{Lu}\p{Lo}][\p{L}\p{M}\p{N}_.,&' -]{1,60}?)\s*opportunity/iu,
 ];
 
 /**

--- a/tests/invite-match.test.mjs
+++ b/tests/invite-match.test.mjs
@@ -15,7 +15,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
-import { matchInvite, normalizeCompanyName, extractPlatform, isAIInterviewerPlatform, classifyEmail, analyzeInvite, applyRejectionStatus, selectApplyTarget } from '../invite-match.mjs';
+import { matchInvite, normalizeCompanyName, extractCompany, extractPlatform, isAIInterviewerPlatform, classifyEmail, analyzeInvite, applyRejectionStatus, selectApplyTarget } from '../invite-match.mjs';
 import { pass, fail } from './helpers.mjs';
 
 console.log('\ninvite-match.mjs — interview invite matching');
@@ -358,6 +358,61 @@ const redundancyFullEmail = 'Hi team,\n\nWe regret to inform everyone that, foll
 const redundancyFullResult = classifyEmail(redundancyFullEmail);
 eq('unrelated company-wide redundancy announcement does not classify as rejection', redundancyFullResult.classification === 'rejection', false);
 eq('unrelated company-wide redundancy announcement does not report phraseStrength "strong"', redundancyFullResult.phraseStrength === 'strong', false);
+
+// --- extractCompany must not be ASCII-only ---
+// COMPANY_LINE_PATTERNS used `[A-Z][\w.,&' -]{1,60}?`, and `\w` is ASCII-only
+// in JS: the lazy match could not cross the `e` with an acute accent in a name
+// like Nestle, so the terminator it was waiting for never arrived and the whole
+// pattern failed. The leading `[A-Z]` refused a non-Latin first letter for the
+// same reason. normalizeCompanyName() was already script-preserving (#2517), so
+// the miss sat one function earlier: extraction returned null, matchInvite() got
+// no company, and an invite from a company sitting right there in the tracker
+// produced zero candidates.
+
+const accented = [
+  ['Your interview with <accented name>', 'Your interview with Nestl\u00e9', 'Nestl\u00e9'],
+  ['Interview at <accented name> for <role>', 'Interview at Nestl\u00e9 for Senior Engineer', 'Nestl\u00e9'],
+  ['Phone screen - <accented name>', 'Phone screen - Nestl\u00e9', 'Nestl\u00e9'],
+  ['Schedule your interview - <accented name> opportunity', 'Schedule your interview - Nestl\u00e9 opportunity', 'Nestl\u00e9'],
+  ['an umlaut mid-name does not truncate the company', 'Your interview with M\u00fcnchen Analytics', 'M\u00fcnchen Analytics'],
+  ['a Cyrillic name is extracted, not refused by the leading [A-Z]', 'Your interview with \u042f\u043d\u0434\u0435\u043a\u0441', '\u042f\u043d\u0434\u0435\u043a\u0441'],
+  ['a Japanese name is extracted (no case distinction to lead with)', 'Your interview with \u682a\u5f0f\u4f1a\u793e\u65e5\u7acb\u88fd\u4f5c\u6240', '\u682a\u5f0f\u4f1a\u793e\u65e5\u7acb\u88fd\u4f5c\u6240'],
+];
+for (const [label, text, expected] of accented) {
+  eq(`extractCompany: ${label}`, extractCompany(text), expected);
+}
+
+// The ASCII phrasings are unchanged by the Unicode classes, including the
+// known trailing-clause weakness ("on Monday" is swallowed), which this PR
+// deliberately does not touch.
+const ascii = [
+  ['Your interview with Acme', 'Acme'],
+  ['Interview at Acme for Senior Engineer', 'Acme'],
+  ['Phone screen - Acme', 'Acme'],
+  ['Schedule your interview - Acme opportunity', 'Acme'],
+  ['Company: Acme Corporation', 'Acme Corporation'],
+  ['Interview at Acme Inc on Monday', 'Acme Inc on Monday'],
+  // `\w` (ASCII-only) included `_`; the Unicode replacement class must too,
+  // or a company name with an underscore hits the exact same "no reachable
+  // terminator" failure this PR fixes for accented and non-Latin names.
+  ['Interview with Acme_Corp for Senior Engineer', 'Acme_Corp'],
+  ['Your interview with Acme_Corp', 'Acme_Corp'],
+  ['Phone screen - Acme_Corp', 'Acme_Corp'],
+  ['Nothing that looks like an invite line at all.', null],
+];
+for (const [text, expected] of ascii) {
+  eq(`extractCompany (ASCII unchanged): ${JSON.stringify(text)}`, extractCompany(text), expected);
+}
+
+// End to end: the tracker row exists, so the invite must produce a candidate.
+// This is what the user actually loses when extraction returns null.
+const accentedRows = [
+  { num: 301, company: 'Nestl\u00e9', role: 'Data Engineer', status: 'Applied', date: '2026-05-01', notes: '' },
+];
+const accentedInvite = analyzeInvite('Hi Jamie,\n\nInterview with Nestl\u00e9 for Data Engineer is confirmed.\n\nBest,\nRecruiting', accentedRows);
+eq('an accented-company invite yields the company signal', accentedInvite.signals.company, 'Nestl\u00e9');
+eq('an accented-company invite matches its tracker row', accentedInvite.candidates.length, 1);
+eq('the matched row is the right one', accentedInvite.candidates[0]?.appNumber, 301);
 
 // --- CLI flag-handling & help regression tests (#2854) ---
 


### PR DESCRIPTION
## What does this PR do?

`extractCompany()` in `invite-match.mjs` could not read a company name containing a non-ASCII letter, or one written in a script without capitals, so pasting an invite from Nestlé, München Analytics, Яндекс or 株式会社日立製作所 produced no company and therefore zero candidates against a tracker row that exists. This gives the three affected patterns Unicode character classes and the `u` flag.

## Related issue

Closes #3861

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## How it works

`COMPANY_LINE_PATTERNS` (`invite-match.mjs:260-265` on `main`) built each name as `[A-Z][\w.,&' -]{1,60}?`. Two ASCII assumptions in one class:

- **`\w` is ASCII-only in JavaScript.** The body is a *lazy* `{1,60}?`, so it expands only far enough to reach a terminator. It cannot expand across the `é` in `Nestlé`, the terminator never arrives, and the pattern fails outright rather than matching a truncated name. One accented character anywhere in the name is enough: `München Analytics` fails on the `ü`.
- **The leading `[A-Z]`** refuses any non-Latin first letter, so `Яндекс` and `株式会社日立製作所` never started matching. Names in Japanese and Chinese have no case distinction to satisfy it with.

Measured on `main` (fad070fe), each accented case beside its ASCII control:

```
null                  <- Your interview with Nestlé
"Acme"                <- Your interview with Acme
null                  <- Interview at Nestlé for Senior Engineer
"Acme"                <- Interview at Acme for Senior Engineer
null                  <- Phone screen - Nestlé
"Acme"                <- Phone screen - Acme
null                  <- Schedule your interview - Nestlé opportunity
null                  <- Your interview with München Analytics
null                  <- Your interview with Яндекс
null                  <- Your interview with 株式会社日立製作所
"Nestlé"              <- Company: Nestlé
```

The fourth pattern (`Company: X`) captures `(.+)` and was never script-bound, which is what made this easy to miss: an invite that spells out `Company:` works fine.

The fix, on the three affected patterns only:

```js
([\p{Lu}\p{Lo}][\p{L}\p{M}\p{N}_.,&' -]{1,60}?)   // + the u flag
```

`\p{Lo}` is the "other letter" category, which is where scripts without a case distinction live. The body class is the one `normalizeCompanyName()` already settled on at `invite-match.mjs:195` (`[^\p{L}\p{M}\p{N} ]/gu`, from the #2517 lineage), plus `_` (see below) and the punctuation company names carry. The terminators are untouched.

This closes the second half of #2517. That fix made `normalizeCompanyName()` script-preserving, with a comment naming this exact outcome: a non-Latin name normalized to `''`, `matchInvite()` bailed on the empty key, and the invite returned zero candidates. Extraction was left ASCII-only, so the same invite still returns zero candidates; it just fails one function earlier.

**`_` is carried over into the new class deliberately.** `[\w…]` admitted `_`; `[\p{L}\p{M}\p{N}…]` on its own does not. An earlier draft dropped it and that is a real regression, not a no-op: for a company like `Acme_Corp`, the lazy body class has no reachable terminator right after the `_` (it is not `.`, `,`, a newline, ` for `, ` regarding`, or end of string), so the whole pattern fails and returns `null` instead of extracting a truncated or full name. That is the exact same failure mode this PR fixes for `é` and non-Latin scripts, reintroduced for one ASCII character. The class here is `[\p{L}\p{M}\p{N}_.,&' -]`, keeping `_` so extraction still succeeds on an ASCII name that has one; `normalizeCompanyName()` strips it again during matching, so the final match key is unaffected either way.

**No backtracking risk.** #3463 fixed quadratic backtracking in the sibling `extractReqId`, so I measured this one: `Interview with ` + 50,000 class characters with no terminator returns in 0.1 ms, in both the Unicode and ASCII forms. The `{1,60}` cap bounds the work regardless of input length.

## Tests

20 assertions added to the existing `tests/invite-match.test.mjs`, which goes from **103 passed** to **123 passed**:

- 7 for the affected phrasings: Nestlé in all three patterns, a mid-name umlaut, a Cyrillic name, a Japanese name.
- 10 pinning the ASCII behaviour as unchanged: the pre-existing 7 (including the known trailing-clause weakness, `Interview at Acme Inc on Monday` still returns `"Acme Inc on Monday"`, so this PR is on record as not touching it), plus 3 for a company name containing `_` (`tests/invite-match.test.mjs:398-400`), pinning the fix at `invite-match.mjs:275-277` described above.
- 3 end to end through `analyzeInvite()`: the tracker holds a `Nestlé` row, and the invite must now produce exactly that one candidate. This is the assertion that describes what the user actually lost, since a missing company name is only visible to them as an empty candidate list.

All fixture data is fictional except the company names, which are public brands used as encoding samples.

```
$ node test-all.mjs --only invite-match
📊 Results: 123 passed, 0 failed, 0 warnings          # 103 on main
```

`node test-all.mjs --quick` gives **8113 passed, 0 failed, 13 warnings** (exit 0), against **8093 passed, 0 failed, 13 warnings** measured on `main` in the same worktree: exactly the 20 new assertions, no collateral. `npm run lint` passes on 654 files.

**Mutant checks** (four, each restored afterwards; in every case the file kept parsing):

1. Dropped the `u` flag from pattern 2, the mutation the fix is named for. `110 passed, 13 failed`: every new assertion that reaches that pattern went red, including the ASCII ones, since without `u` the `\p{…}` classes decay into literal characters.
2. Reverted pattern 2's body class to `[\w.,&' -]`, keeping the `u` flag. `115 passed, 8 failed`: the accented, Cyrillic and Japanese cases went red and **the ASCII cases, including the `_` ones, stayed green**. The new tests are not simply red against any change.
3. Dropped `\p{Lo}` from pattern 2's leading class. `122 passed, 1 failed`, and the one failure is `a Japanese name is extracted (no case distinction to lead with)`. Exactly the assertion that names the property, and nothing else.
4. Dropped `_` from all three body classes (the mutation named above). `120 passed, 3 failed`, and the three failures are exactly the `Acme_Corp` assertions; every other assertion, including all the other ASCII and Unicode ones, stayed green.

## Out of scope

- **The trailing-clause weakness.** `extractCompany('Interview at Acme Inc on Monday')` returns `"Acme Inc on Monday"` because `on Monday` is not one of the pattern's terminators. It behaves identically before and after this change and is now pinned by a test so a future fix has a starting point.
- **The `Interview invitation from <Company> for <Role>` phrasing**, which returns `null` for **any** company, ASCII included (`Interview invitation from Globex Corporation for Senior Engineer` → `null`). No pattern covers `invitation from`. That is a missing pattern rather than an encoding bug, and adding phrasings is a wider change than this fix.
- **The `Company: X` pattern**, which captures `(.+)` and was never script-bound. Left alone.
