### PR TITLE
docs(providers): browser-based scanners are accepted as standalone scripts, under three conditions

### DIFF
--- a/providers/ADDING_A_PROVIDER.md
+++ b/providers/ADDING_A_PROVIDER.md
@@ -354,6 +354,16 @@ A provider reads only open APIs/feeds with no login. Sending the user's data
 (CV, pipeline) to an external service is out of core (see
 [`../CONTRIBUTING.md`](../CONTRIBUTING.md), "What we do NOT accept").
 
+### Browser-based scanners (standalone scripts only)
+
+Some sources have no reachable API and render their listings in the browser (`scan-interamt.mjs` is the precedent; Dayforce career sites are the same shape). A scanner that drives a real browser (Playwright) is accepted as its own top-level script, never as a `providers/*.mjs` module, and under three conditions:
+
+1. **Standalone.** It ships as `scan-<source>.mjs` with its own npm script, tests, `SUPPORTED_JOB_BOARDS.md` row, `portals.example.yml` stanza and `SYSTEM_PATHS` entry. `providers/` stays fetch-only.
+2. **Public pages only.** It reads what any visitor sees: no login, no session or cookies of a real user, no authenticated area.
+3. **No bypass.** It never solves or relays a CAPTCHA, and never spoofs another client's cookies, tokens or headers. If a source puts an interactive challenge in front of its public listings, the scanner reports that as a named error and stops; it does not work around it.
+
+A browser scanner is slower and more fragile than a provider (markup changes break it), so say in the PR what was measured live: which pages, how many listings, and what the source answers to a bare `fetch`, so the reviewer can see why a provider was not enough.
+
 ## 3. Tests
 
 One file: `tests/providers/{name}.test.mjs`. Auto-discovered


### PR DESCRIPTION
Writes down the line that scan-interamt.mjs set and that #3734 (a Dayforce scanner) is asking about: a Playwright scanner ships as its own top-level script (never a providers/ module), reads public pages only, and never solves a CAPTCHA or spoofs another client's cookies, tokens or headers. Also asks the PR to say what was measured live, so a reviewer can see why a provider was not enough.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Documents the policy for browser-based scanners in `providers/ADDING_A_PROVIDER.md:1`.

## User impact

Contributors can add browser-based scanners as standalone `scan-<source>.mjs` scripts with dedicated wiring, tests, documentation, and system-path configuration.

Scanners must read public pages only. They must stop with a named error when they encounter CAPTCHAs or interactive challenges. They must not bypass challenges or spoof cookies, tokens, or headers.

Pull requests must include live measurements and explain why an existing provider is insufficient.

This documentation-only change does not modify runtime behavior.

## Files changed

: `providers/ADDING_A_PROVIDER.md`

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->