### PR TITLE
fix(workday): tag a split whose chosen facet under-covers the board

### DIFF
--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -555,6 +555,37 @@ export default {
         const facet = chooseSplitFacet(result.facets, { exclude: excluded });
         if (!facet) { splitIncomplete = true; return; }
 
+        // The clamp is detected against the LARGEST facet sum, but the split
+        // runs on whichever facet partitions most finely. Postings outside the
+        // chosen facet's values are never requested by any slice, so a facet
+        // that covers materially less than the board can finish every slice
+        // cleanly and still leave the board short — reported recovered, which
+        // is the failure this path exists to avoid.
+        //
+        // Materiality matters here, and the bar comes from the response. Real
+        // facets disagree by a point or two (a posting missing a facet value is
+        // absent from that facet's counts), so the chosen facet sits just under
+        // the max on essentially every board — DSG: trueTotal 8367, chosen
+        // jobFamily 8366. A bare `chosen < trueTotal` would tag every one of
+        // them, the tag-that-says-nothing case 'cap' already had to avoid above.
+        // The spread across the OTHER counted facets measures that ordinary
+        // disagreement (77 on DSG, 2 on cvshealth); a gap wider than it is real
+        // undercoverage. The chosen facet is excluded from the spread because a
+        // badly under-covering facet is itself the minimum, and leaving it in
+        // would inflate the bar to exactly the gap it should be judged against.
+        const chosenCoverage = facet.values.reduce((sum, v) => sum + v.count, 0);
+        const trueTotal = trueTotalFromFacets(result.facets);
+        if (trueTotal !== null) {
+          const others = [];
+          for (const f of Array.isArray(result.facets) ? result.facets : []) {
+            if (f?.facetParameter === facet.facetParameter) continue;
+            const coverage = facetCoverage(f);
+            if (coverage !== null) others.push(coverage);
+          }
+          const spread = others.length > 0 ? Math.max(...others) - Math.min(...others) : 0;
+          if (trueTotal - chosenCoverage > spread) splitIncomplete = true;
+        }
+
         for (const value of facet.values) {
           if (slicesSpent >= MAX_SPLIT_SLICES) { splitIncomplete = true; break; }
           if (pagesSpent >= pageBudget) { splitIncomplete = true; break; }

--- a/tests/providers/workday-facet-split.test.mjs
+++ b/tests/providers/workday-facet-split.test.mjs
@@ -479,6 +479,71 @@ try {
     fail('a slice that stopped past the --since window is complete for the sweep and must not tag workdayTruncated');
   }
 
+
+  // ── #2: the chosen facet may not cover the whole board ─────────────
+  //
+  // The clamp is detected against the LARGEST facet sum, but the split runs on
+  // whichever facet partitions most finely. When the chosen facet covers
+  // materially less than that, the postings it does not partition are never
+  // requested by any slice — and if every slice completes, the board is
+  // reported recovered with no "(still incomplete)".
+  const coverageResponder = (rootFacets, sliceTotals) => async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const key = sliceKey(body.appliedFacets);
+    if (key === '') {
+      return { total: 2000, facets: rootFacets, jobPostings: postings('unfaceted', body.offset) };
+    }
+    if (!sliceTotals.includes(key)) throw new Error(`unexpected slice ${JSON.stringify(key)}`);
+    return { total: 20, facets: [], jobPostings: body.offset === 0 ? postings(key, 0) : [] };
+  };
+
+  // `tier` wins the split (largest slice 300 beats jobFamily's 1500) but covers
+  // 600 of a 2700 board. The 2100 postings outside it are unreachable.
+  const UNDERCOVERING = [
+    { facetParameter: 'jobFamily', values: [{ id: 'a', count: 1500 }, { id: 'b', count: 1200 }] },
+    { facetParameter: 'tier', values: [{ id: 't1', count: 300 }, { id: 't2', count: 300 }] },
+  ];
+  const { result: underJobs, errors: underErrors } = await captureConsoleErrors(() => workday.fetch(
+    ENTRY,
+    mkCtx(coverageResponder(UNDERCOVERING, ['tier=t1', 'tier=t2']), { includeUndated: true }),
+  ));
+
+  if (underJobs.workdayTruncated === true) {
+    pass('workday.fetch() tags a split whose chosen facet covers materially less than the board');
+  } else {
+    fail('a split facet covering 600 of a 2700 board leaves 2100 postings unreachable and must tag workdayTruncated');
+  }
+
+  const underLine = underErrors.find((e) => String(e).includes('offset-clamped at'));
+  if (underLine && String(underLine).includes('(still incomplete)')) {
+    pass('workday.fetch() says "(still incomplete)" when the chosen facet under-covers the board');
+  } else {
+    fail(`under-covering split printed ${JSON.stringify(underLine)}, expected "(still incomplete)"`);
+  }
+
+  // The materiality bar, and the reason it exists. Real facets disagree by a
+  // point or two because a posting missing a facet value is absent from that
+  // facet's counts, so the chosen facet is almost always just under the max —
+  // DSG's own numbers: trueTotal 8367, chosen jobFamily 8366, short by 1,
+  // against a 77-wide spread across the counted facets. A bare
+  // `chosen < trueTotal` fires here, which would tag essentially every board
+  // and make the tag mean nothing.
+  const NOISE = [
+    { facetParameter: 'jobFamily', values: [{ id: 'jf1', count: 800 }, { id: 'jf2', count: 783 }, { id: 'jf3', count: 783 }] },
+    { facetParameter: 'locType', values: [{ id: 'l1', count: 1184 }, { id: 'l2', count: 1183 }] },
+    { facetParameter: 'timeType', values: [{ id: 'tt1', count: 1200 }, { id: 'tt2', count: 1090 }] },
+  ];
+  const { result: noiseJobs } = await captureConsoleErrors(() => workday.fetch(
+    ENTRY,
+    mkCtx(coverageResponder(NOISE, ['jobFamily=jf1', 'jobFamily=jf2', 'jobFamily=jf3']), { includeUndated: true }),
+  ));
+
+  if (noiseJobs.workdayTruncated === undefined) {
+    pass('workday.fetch() ignores a chosen facet one posting under the max — inside the counted facets’ own spread');
+  } else {
+    fail('a 1-posting gap against a 77-wide facet spread is ordinary disagreement, not undercoverage, and must not tag');
+  }
+
   // The unclamped path must not pay for any of this.
   const healthyCalls = [];
   await workday.fetch(ENTRY, mkCtx(async (_url, opts) => {


### PR DESCRIPTION
This is the second half of your review on #3311 — the finding about the split keeping its own honesty promise. #3311 merged with the page-0 containment landed and this one still open, so it comes back on its own.

It also closes CodeRabbit's remaining actionable on `providers/workday.mjs`, which asked for exactly this comparison plus a regression proving an under-covering facet reports `workdayTruncated`.

## The gap

The clamp is detected against the **largest** facet sum, but the split runs on whichever facet partitions most finely. Postings outside the chosen facet's values are never requested by any slice. So a facet that covers materially less than the board can finish every slice cleanly, leave the board short, and get logged as recovered with no `(still incomplete)` — the exact failure the recovery path exists to avoid.

## Why the obvious one-liner doesn't work

The bare `chosen < trueTotal` you suggested, and my own first counter-proposal, both fail — and it's worth writing down why so it isn't re-derived later.

`trueTotalFromFacets()` returns the **maximum** facet coverage, and the chosen facet is one of the counted facets. So for chosen coverage `c`:

```
gap    = trueTotal - c = max - c
spread = max - min
c >= min                    (c is one of the counted facets)
=>  gap <= spread,  always
```

Two consequences:

- **A bare comparison fires on noise.** Real facets disagree by a point or two — a posting missing a facet value is absent from that facet's counts, which is what your own comment above `trueTotalFromFacets` predicts. The chosen facet therefore sits just under the max on essentially every tenant. `workdayTruncated` would come to mean "some facet did not sum to the maximum" rather than "coverage was lost" — the tag-that-says-nothing case `'cap'` already had to avoid.
- **A spread bar computed over *all* counted facets is unsatisfiable.** `gap > spread` can never be true. Worse, it inverts: a genuinely under-covering facet *is* the minimum, so it sets `spread = max - c`, exactly the gap it is being judged against. The rule goes quietest precisely where it should fire hardest.

## The rule that works

Compute the spread over the **other** counted facets, excluding the chosen one. The bar then measures ordinary facet disagreement — which is what it was always meant to measure — and the chosen facet is judged against it instead of contributing to it.

## Evidence

Live boards, page 0, measured 2026-08-28:

| board | trueTotal | chosen facet | gap | spread (others) | tags? |
|---|---|---|---|---|---|
| `dickssportinggoods\|wd1\|dsg` | 8367 | `jobFamily` 8366 | 1 | 77 | no — noise, correct |
| `cvshealth` | 19436 | `timeType` 19434 | 2 | 2 | no — noise, correct |
| synthetic under-coverer | 2700 | `tier` 600 | 2100 | 0 | **yes** |

Three tests: two positive assertions that an under-covering split tags `workdayTruncated` and says `(still incomplete)`, plus the discriminator — the DSG-shaped 1-posting gap that must *not* tag.

Mutation-tested against today's `main`: replacing the spread bar with the bare comparison flips **exactly one** test, the discriminator, and nothing else. That is the whole behavioural difference between the two shapes, and it lands on the flagship tenant this feature was built for.

## If you'd still rather have the bare comparison

It's one line — drop the `spread` computation and compare `trueTotal - chosenCoverage > 0`. I've built it that way and it's green too, minus the discriminator. I went with the materiality bar because I don't think a tag that fires on every healthy board is one the sweep can act on, but it's your invariant and I'll switch it on request.

## Not in this PR

`locationMainGroup` is a live 2x trap in the same function — filed as #3875 rather than bundled here, since it is latent rather than a bug today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Workday facet splitting now detects material under-coverage.

When the selected facet covers only part of the board, the provider sets `workdayTruncated` and reports “(still incomplete)”. Small facet-count differences do not trigger this result.

### Files changed

- `providers/workday.mjs: coverage validation`
- `tests/providers/workday-facet-split.test.mjs: regression tests`

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->