### PR TITLE
fix(gemini-eval): write `**URL:**` in the report header so its rows reach the URL dedup key (#3795)

### DIFF
--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -20,6 +20,7 @@ if (process.platform === 'win32') {
  * Usage:
  *   node gemini-eval.mjs "Paste full JD text here"
  *   node gemini-eval.mjs --file ./jds/my-job.txt
+ *   node gemini-eval.mjs --posting-url https://acme.com/jobs/42 --file ./jds/my-job.txt
  *
  * Requires:
  *   GEMINI_API_KEY in .env (or environment variable)
@@ -154,6 +155,8 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
   OPTIONS
     --file <path>    Read JD from a file instead of inline text
     --model <name>   Gemini model to use (default: gemini-3.6-flash)
+    --posting-url <url>  Posting URL, recorded in the report header and
+                     used as the tracker's dedup key
     --no-save        Do not save report to reports/ directory
     --no-compress    Skip token budget compression (full context injection)
     --help           Show this help
@@ -166,12 +169,14 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
   EXAMPLES
     node gemini-eval.mjs "We are looking for a Senior AI Engineer..."
     node gemini-eval.mjs --file ./jds/openai-swe.txt
+    node gemini-eval.mjs --posting-url https://acme.com/jobs/42 --file ./jds/openai-swe.txt
 `);
   process.exit(0);
 }
 
 // Parse flags
 let jdText = '';
+let postingUrl = '';
 let modelName = process.env.GEMINI_MODEL || 'gemini-3.6-flash';
 let saveReport = true;
 let noCompress = false;
@@ -186,6 +191,8 @@ for (let i = 0; i < args.length; i++) {
     jdText = stripBom(readFileSync(filePath, 'utf-8')).trim();
   } else if (args[i] === '--model' && args[i + 1]) {
     modelName = args[++i];
+  } else if (args[i] === '--posting-url' && args[i + 1]) {
+    postingUrl = args[++i];
   } else if (args[i] === '--no-save') {
     saveReport = false;
   } else if (args[i] === '--no-compress') {
@@ -197,6 +204,18 @@ for (let i = 0; i < args.length; i++) {
 
 if (!jdText) {
   console.error('❌  No Job Description provided. Run with --help for usage.');
+  process.exit(1);
+}
+
+// A posting URL is the tracker's deterministic dedup key, so it is taken only in
+// a form that can actually become one. Parsed, not prefix-matched: `https://`
+// satisfies a prefix test and would then sit in the URL column looking like a
+// key while normalizeUrl derives nothing from it, deduping nothing. A
+// placeholder written there would be worse still, handing every such row the
+// same key -- which is why an absent URL yields `(pasted)` in the report header
+// and no url cell at all, rather than a stand-in.
+if (postingUrl && !isPostingUrl(postingUrl)) {
+  console.error(`❌  --posting-url must be a complete http(s) URL: "${postingUrl}"`);
   process.exit(1);
 }
 
@@ -272,6 +291,20 @@ function slugifyCompany(value) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '') || 'unknown';
+}
+
+/**
+ * Whether a value is a complete http(s) URL, and so can become a dedup key.
+ * @param {string} value - Candidate posting URL.
+ * @returns {boolean} True only for a parseable http/https URL with a host.
+ */
+function isPostingUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.hostname !== '';
+  } catch {
+    return false;
+  }
 }
 
 function tsvSafe(value) {
@@ -509,6 +542,7 @@ if (saveReport) {
 **Date:** ${today}
 **Archetype:** ${archetype}
 **Score:** ${score}/5
+**URL:** ${postingUrl || '(pasted)'}
 **Legitimacy:** ${legitimacy}
 **PDF:** pending
 **Tool:** Gemini (${modelName})
@@ -531,9 +565,19 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
         `[${num}](reports/${filename})`,
         'Gemini evaluation',
       ];
+      // Optional `url` column, appended only when there is a real URL to put in
+      // it. merge-tracker.mjs matches on the URL FIRST -- the one tier that can
+      // prove two same-title rows are different openings -- so writing it here
+      // puts the row on that tier at merge time instead of leaving it to a
+      // later `--backfill-urls`. Label and value are appended together: the
+      // headed path resolves cells by NAME, so a value without its label would
+      // be dropped, and a label without its value would leave the url cell
+      // absent (#3517).
+      const trackerHeader = postingUrl ? `${TSV_ADDITION_HEADER}\turl` : TSV_ADDITION_HEADER;
+      if (postingUrl) trackerFields.push(tsvSafe(postingUrl));
       // Header row first: merge-tracker resolves the fields by name, so this
       // row cannot be ingested into the wrong columns (#3517).
-      writeFileSync(trackerPath, `${TSV_ADDITION_HEADER}\n${trackerFields.join('\t')}\n`, 'utf-8');
+      writeFileSync(trackerPath, `${trackerHeader}\n${trackerFields.join('\t')}\n`, 'utf-8');
       console.log(`\n✅  Report saved: reports/${filename}`);
       console.log(`📊  Tracker addition saved: batch/tracker-additions/${num}-${companySlug}.tsv`);
       reportSaved = true;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9785,6 +9785,40 @@ try {
     fail(`headless evaluators still carry private max+1 allocators: ${unmigratedEvaluators.join(', ')}`);
   }
 
+  // Same family, second contract (#3795): every headless evaluator writes
+  // `**URL:**` into its report header, per AGENTS.md Pipeline Integrity rule 3.
+  // The report is where the posting URL survives the posting, and it is the only
+  // place merge-tracker.mjs's resolveReportUrl() looks -- a report without the
+  // line yields `no-url`, so the row can never be backfilled and stays outside
+  // the deterministic URL dedup key, the tier merge-tracker tries FIRST and the
+  // one that can prove two same-title rows are different openings.
+  //
+  // Two halves, because the line is worthless without a value to put in it:
+  // the header must be written, AND the evaluator must have somewhere to
+  // receive a posting URL from. Absent one, `(pasted)` is the honest value and
+  // keeps the field present; normalizeUrl derives no key from it, so it cannot
+  // hand every pasted row the same key.
+  const urlHeaderRe  = /\*\*URL:\*\*/;
+  const urlSourceRe  = /--posting-url|\bpostingUrl\b|\$\{input \|\| '\(pasted\)'\}/;
+  // openai-eval.mjs and ollama-eval.mjs gain the same header in #3797, which
+  // owns those two files. Named rather than skipped, and the list is asserted
+  // to be EXACTLY the files still missing the header: once #3797 lands this
+  // fails until the names are removed, so the exemption cannot outlive its
+  // reason and quietly become permanent coverage loss.
+  const pendingUrlHeader = ['openai-eval.mjs', 'ollama-eval.mjs'];
+  const missingUrlHeader = evaluatorSources
+    .filter(([, source]) => !urlHeaderRe.test(source) || !urlSourceRe.test(source))
+    .map(([name]) => name);
+  const staleExemptions = pendingUrlHeader.filter(name => !missingUrlHeader.includes(name));
+  const unexemptedGaps  = missingUrlHeader.filter(name => !pendingUrlHeader.includes(name));
+  if (unexemptedGaps.length > 0) {
+    fail(`headless evaluators write a report with no **URL:** header, so their rows can never reach the URL dedup key: ${unexemptedGaps.join(', ')}`);
+  } else if (staleExemptions.length > 0) {
+    fail(`stale #3797 exemption — these now carry the **URL:** header, remove them from pendingUrlHeader: ${staleExemptions.join(', ')}`);
+  } else {
+    pass('every headless evaluator outside the #3797 exemption writes **URL:** and takes a posting URL');
+  }
+
   // --count N: contiguous range from an empty dir.
   const rangeTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-range-'));
   const range = reserveRun(['--count', '3'], rangeTmp);


### PR DESCRIPTION
## What does this PR do?

`gemini-eval.mjs` now writes `**URL:**` into its report header, as AGENTS.md Pipeline Integrity rule 3 requires, and gains a `--posting-url` flag to have something to put there. A real URL also becomes an optional `url` column on the tracker addition, so the row reaches the deterministic dedup key at merge time.

## Related issue

Fixes #3795.

Scoped to this one file on purpose: `openai-eval.mjs` and `ollama-eval.mjs` get the same treatment in #3797, and this copies that PR's shape (`--posting-url`, the `isPostingUrl` parser, `**URL:** ${postingUrl || '(pasted)'}`).

## Why a missing line is a permanently lost row

The report is where the posting URL survives the posting, and it is the only place `resolveReportUrl()` (`merge-tracker.mjs:233`) looks. No line → `reason: 'no-url'` → the row can never be backfilled and stays outside the URL dedup key: the tier `merge-tracker` tries **first**, and the only one that can prove two same-title rows are different openings.

Reproduced against the parent commit, in a temp workspace with two genuinely different Acme "Staff Engineer" postings:

```
🔽 Update: #42 Acme — Staff Engineer (4.2→4) — DOWNGRADE, re-eval scored lower
✅ Backfill URLs: 0 filled, … 1 report has no **URL:**.
```

The second posting overwrote the first — report 042's row is gone — and `--backfill-urls` cannot rescue it, ever. With this change both merge as distinct rows, each carrying its own URL.

## What changed

**`--posting-url <url>`.** None of the three evaluators in #3795 *had* a URL to write; they accept JD text or `--file` and nothing else. Validated by parsing, not prefix-matching: `https://` satisfies a prefix test, but `normalizeUrl` derives no key from it, so it would sit in the URL column looking like a key while deduping nothing.

**`**URL:** ${postingUrl || '(pasted)'}`** between Score and PDF. Where the JD really was pasted, `(pasted)` is the honest value and keeps the field present — and it cannot poison the column, since `normalizeUrl` yields no key for it and `resolveReportUrl` reports `no-url` rather than handing every pasted row the same key.

**The optional `url` column.** Unlike the two files in #3797, this evaluator writes the **headed** TSV, so the label is appended alongside the value rather than the value alone — the headed path resolves cells by name (#3517), and a value without its label is dropped.

## Tests

The issue's item 3: the family contract, added next to the allocator one in the same block. It checks both halves, because the line is worthless without a value to fill it — the header must be written, **and** the evaluator must have somewhere to receive a posting URL from.

`openai-eval.mjs` / `ollama-eval.mjs` are named in a `pendingUrlHeader` list asserted to be **exactly** the files still missing the header. When #3797 lands this fails with "stale exemption — remove them" rather than quietly becoming permanent coverage loss. Both branches verified by hand: the gap branch fails against `HEAD:gemini-eval.mjs`, and the stale branch fires when the header is temporarily added to `openai-eval.mjs`.

Rebased onto `main` (`a61c976`) before opening — 5 of the intervening commits touch these two files, including #3799 in the same `gemini-eval.mjs` block — and re-run after the rebase, not just before it.

`node test-all.mjs`: **8402 passed, 0 failed**, 15 warnings (all pre-existing personal-data scan hits on `funding.json` / `HIRED.md`). `npm run lint` clean.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## Two notes for review

**A merge-order conflict with #3797.** That PR's write-sink regex pins `writeFileSync(trackerPath, \`${trackerFields.join('\t')}…` for `gemini-eval.mjs`. It does not match today's `${TSV_ADDITION_HEADER}\n…` even before this change, and this change puts `${trackerHeader}` in front of it. Whichever of the two merges second needs that regex updated.

**`verify-pipeline.mjs` is deliberately untouched.** The issue notes that nothing flags a missing header today, but that is an observation rather than one of its three suggested fixes, and turning the check on would flag the entire legacy report backlog at once. That is a separate call about how to handle the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can pass a validated posting URL to `gemini-eval.mjs` with `--posting-url <url>`.

The evaluator now:

- Writes `**URL:** <url>` between Score and PDF in reports.
- Uses `(pasted)` when no posting URL is provided.
- Adds the URL to tracker TSV output for URL-based deduplication.
- Rejects invalid non-HTTP(S) URLs.

`test-all.mjs` adds evaluator-family checks for the URL header and posting URL input. OpenAI and Ollama remain temporarily exempt.

## Files changed

- `gemini-eval.mjs`: Adds posting URL handling and tracker output.
- `test-all.mjs`: Adds validation checks.

The requested system files were not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->