### PR TITLE
chore(plugin): mirror the plugin manifest at .codex-plugin/ and pin Actions by digest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "career-ops",
+  "version": "1.32.0",
+  "description": "Open-source AI job search that runs locally in your AI coding CLI: scan job portals, evaluate listings into a structured A-H report with a 1-5 score, tailor your CV, track applications",
+  "author": {
+    "name": "santifer",
+    "url": "https://santifer.io"
+  },
+  "skills": [
+    "./.agents/skills/career-ops"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,6 +39,11 @@
           "type": "json",
           "path": ".github/plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
+      "pinDigests": true,
       "automerge": false
     },
     {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1804,21 +1804,29 @@ for (const f of skillEntrypoints) {
   }
 }
 
-// The plugin manifest ships in two locations: .claude-plugin/plugin.json is
-// canonical (Claude Code + Copilot CLI both read it), and .github/plugin/
+// The plugin manifest ships in three locations: .claude-plugin/plugin.json is
+// canonical (Claude Code + Copilot CLI both read it); .github/plugin/
 // plugin.json exists only because the awesome-copilot marketplace validator
-// accepts just three paths and the Claude-compat one is not among them. Both
-// are bumped by release-please; this assert makes any other divergence fail CI
-// loudly instead of shipping two drifting manifests.
+// accepts just three paths and the Claude-compat one is not among them; and
+// .codex-plugin/plugin.json is the path the awesome-ai-plugins catalogue
+// resolves a Codex plugin's install_url to. All are bumped by release-please;
+// this assert makes any other divergence fail CI loudly instead of shipping
+// drifting manifests.
 {
   const canonManifest = readFile('.claude-plugin/plugin.json');
-  const copilotManifest = fileExists('.github/plugin/plugin.json') ? readFile('.github/plugin/plugin.json') : null;
-  if (copilotManifest === null) {
-    fail('.github/plugin/plugin.json missing — awesome-copilot validator needs it (mirror of .claude-plugin/plugin.json)');
-  } else if (canonManifest === copilotManifest) {
-    pass('plugin.json mirror (.github/plugin/) is byte-identical to the canonical manifest');
-  } else {
-    fail('plugin.json mirror (.github/plugin/) DIVERGED from .claude-plugin/plugin.json — edit the canonical one and copy it verbatim');
+  const mirrors = [
+    ['.github/plugin/plugin.json', 'awesome-copilot validator needs it'],
+    ['.codex-plugin/plugin.json', 'awesome-ai-plugins resolves the Codex install_url to it'],
+  ];
+  for (const [mirrorPath, why] of mirrors) {
+    const mirror = fileExists(mirrorPath) ? readFile(mirrorPath) : null;
+    if (mirror === null) {
+      fail(`${mirrorPath} missing — ${why} (mirror of .claude-plugin/plugin.json)`);
+    } else if (canonManifest === mirror) {
+      pass(`plugin.json mirror (${mirrorPath}) is byte-identical to the canonical manifest`);
+    } else {
+      fail(`plugin.json mirror (${mirrorPath}) DIVERGED from .claude-plugin/plugin.json — edit the canonical one and copy it verbatim`);
+    }
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -390,6 +390,7 @@ const SYSTEM_PATHS = [
   '.opencode/skills/',
   '.opencode/commands/',
   '.claude-plugin/',
+  '.codex-plugin/',
   '.qwen/',
   '.antigravitycli/skills/',
   '.grok/skills/',


### PR DESCRIPTION
## What

- `.codex-plugin/plugin.json`: byte-identical copy of `.claude-plugin/plugin.json`. The awesome-ai-plugins catalogue resolves a Codex plugin's `install_url` to that path, so listing career-ops there needs the file to exist.
- The plugin-manifest assertion in `test-all.mjs` now checks both mirrors (`.github/plugin/`, `.codex-plugin/`) against the canonical file, so they cannot drift.
- `release-please-config.json`: the new mirror is an extra-file, so its `version` bumps with the other two on every release.
- `update-system.mjs`: `.codex-plugin/` joins `SYSTEM_PATHS`, next to `.claude-plugin/`, so installs ship it.
- `renovate.json`: `pinDigests: true` for the `github-actions` manager. Renovate will open one grouped PR pinning every third-party Action to a commit SHA (tag kept as a comment); today all of them are pinned by tag.

## Why

Two of the items the awesome-ai-plugins scanner flagged on our listing PR: no Codex manifest at the path it expects, and Actions referenced by mutable tag.

## Validation

- `node validate-system-paths-coverage.mjs` → `OK: 1369 tracked files covered by SYSTEM_PATHS or USER_PATHS`
- `node --check test-all.mjs update-system.mjs`; every JSON file parses.
- CI runs the full suite, including the mirror assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds `.codex-plugin/plugin.json` as a byte-identical mirror of `.claude-plugin/plugin.json`.

User impact:
: Codex can catalogue the `career-ops` plugin.
: Release updates keep both manifest versions synchronized (`release-please-config.json`).
: System updates include `.codex-plugin/` (`update-system.mjs`).
: Validation reports missing or divergent plugin mirrors (`test-all.mjs`).
: Renovate pins GitHub Actions to immutable digests (`renovate.json`).

System files touched:
: `update-system.mjs`
: `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->