### PR TITLE
docs(budget): document the per-session evaluation cap (~10 roles)

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -315,6 +315,15 @@ To prevent unnecessary API costs or hitting rate limits, implement the following
    npm run scan -- --verify
    ```
 
+
+### Cap interactive sessions (~10 roles)
+
+Evaluating many roles in one interactive session degrades the output well before the quota runs out. At 40+ evaluations in a single session, reports started mixing job titles and dates, and CV PDFs came out wrong. Cap an interactive session at about ten role evaluations, then `/clear` or start a fresh session.
+
+The real limit is tokens of accumulated job text, not a hard role count. When descriptions are long, cut the batch roughly in half.
+
+To evaluate more than that in one go, use `batch/batch-runner.sh`. It reuses one worker instead of letting context pile up across interactive turns. Source: [discussion #1089](https://github.com/career-ops-hq/career-ops/discussions/1089).
+
 ---
 
 ## 7. Worked Example: Running the Pipeline Cheaply


### PR DESCRIPTION
## Summary
- Adds a short subsection under Token-Saving Best Practices in `docs/RUNNING_ON_A_BUDGET.md` capping interactive sessions at about ten role evaluations (then `/clear` or a new session).
- Notes that long JDs mean a smaller batch, and points heavier runs at `batch/batch-runner.sh` (reuses one worker instead of accumulating context).
- Cites [discussion #1089](https://github.com/career-ops-hq/career-ops/discussions/1089). Pure markdown; advice appears once.

Closes #3881

## Test plan
- [x] Docs-only change (markdown subsection next to existing batch advice)
- [ ] `node test-all.mjs --quick` — not run in this environment (deps install succeeded, harness execution was blocked); docs-only should be fine
- [ ] Skim `RUNNING_ON_A_BUDGET.md` §6 → new subsection → §7 to confirm the session-cap guidance is not duplicated elsewhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can limit interactive sessions to about ten role evaluations. For long job descriptions, users can reduce the batch size because the cap depends on accumulated tokens. For larger runs, users can use `batch/batch-runner.sh`, which reuses one worker without accumulating context.

The guidance cites discussion `#1089` and appears in `docs/RUNNING_ON_A_BUDGET.md` near the existing batch advice.

## Files changed

`docs/RUNNING_ON_A_BUDGET.md`: documentation only.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->