### PR TITLE
Fix/sync pdf flags prune 3893

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -24,6 +24,7 @@ All scripts live in the project root as `.mjs` modules. Most are exposed via
 | `npm run update:check` | `update-system.mjs check` | Check for upstream updates |
 | `npm run update` | `update-system.mjs apply --confirm` | Apply upstream update |
 | `npm run rollback` | `update-system.mjs rollback` | Rollback last update |
+| `node update-system.mjs status` | `update-system.mjs status` | Print installed version + short SHA |
 | `npm run liveness` | `check-liveness.mjs` | Test if job URLs are still active |
 | `npm run extract` | `browser-extract.mjs` | Headless read-only page extractor (opt-in `scan.extractor: cli`) — compact JSON for scan/JD; Greenhouse, Lever, Ashby and Workday postings are read from their public JSON endpoints instead of the client-rendered page, and an empty jd extraction exits 1 with `code: empty_text` |
 | `node fetch-jd.mjs <url>` | `fetch-jd.mjs` | JD text on stdout from a known ATS API (Greenhouse/Lever/Ashby/Workday) — exit 1 with empty stdout when the host has no JD-bearing API, so a caller falls back to its browser/WebFetch path |
@@ -556,6 +557,32 @@ Possible JSON responses:
 | `update-available` | Newer version exists (includes `local`, `remote`, `changelog`) |
 | `dismissed` | User dismissed the update prompt |
 | `offline` | Could not reach GitHub |
+
+The `local` field in the JSON output is the formatted installed version, including the short commit SHA when the install is a git checkout — for example `"1.32.0 (ae919b6f)"`. For tarball installs without git metadata it is just the version string (`"1.32.0"`). This lets a bug report identify the exact tree under test, not just the release name (two installs pulled days apart can share a version string while running different code — see #3203).
+
+**Exit codes:** `0` always.
+
+---
+
+## status
+
+Prints the installed version to stdout — a quick human-readable alternative to parsing `check` JSON.
+
+```bash
+node update-system.mjs status
+```
+
+Example output:
+
+```
+career-ops v1.32.0 (ae919b6f)
+```
+
+On a tarball install with no git metadata the short SHA is omitted:
+
+```
+career-ops v1.32.0
+```
 
 **Exit codes:** `0` always.
 

--- a/sync-pdf-flags.mjs
+++ b/sync-pdf-flags.mjs
@@ -9,14 +9,21 @@
  *
  * Runs under the shared tracker lock and replaces the file atomically.
  *
+ * Prune mode (--prune) drops manifest rows whose PDF file is no longer on disk.
+ * A deleted artifact otherwise keeps the manifest row alive, which causes the next
+ * normal sync to re-assert ✅ on the tracker even though no file backs it. Prune
+ * is kind-agnostic: it drops any row (CV or cover letter) whose pdf column points
+ * at a missing file. It is a dry run by default — add --write to commit changes.
+ *
  * Usage:
  *   node sync-pdf-flags.mjs [--dry-run] [--json]
+ *   node sync-pdf-flags.mjs --prune [--write] [--json]
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve, dirname } from 'path';
 import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
-import { rebuildRow, resolveTrackerPath, resolvePdfIndexPath, openTrackerTransaction } from './tracker-utils.mjs';
+import { rebuildRow, resolveTrackerPath, resolvePdfIndexPath, openTrackerTransaction, writeFileAtomic, resolveWorkspaceRoot, pathIsInsideCanonical } from './tracker-utils.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 
 const DATA_ROOT = getCareerOpsRoot();
@@ -25,18 +32,30 @@ const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 // CAREER_OPS_TRACKER moves the whole workspace together (#2471).
 const PDF_MANIFEST = resolvePdfIndexPath(APPS_FILE);
 
-const flags = { dryRun: false, json: false };
+const flags = { dryRun: false, json: false, prune: false, write: false };
 const unknownOptions = [];
 for (const arg of process.argv.slice(2)) {
   if (arg === '--dry-run') flags.dryRun = true;
   else if (arg === '--json') flags.json = true;
+  else if (arg === '--prune') flags.prune = true;
+  else if (arg === '--write') flags.write = true;
   else unknownOptions.push(arg);
+}
+
+// --dry-run must win over --write
+if (flags.dryRun) flags.write = false;
+
+// --prune is dry-run by default; --write opts in to committing changes.
+// Outside prune mode, --write has no meaning — surface it as an unknown option
+// to avoid silent surprises.
+if (!flags.prune && flags.write) {
+  unknownOptions.push('--write');
 }
 
 if (unknownOptions.length > 0) {
   const error = `unknown option(s): ${unknownOptions.join(', ')}`;
   if (flags.json) console.error(JSON.stringify({ error, code: 'unknown-option' }));
-  else console.error(`Error: ${error}\nUsage: node sync-pdf-flags.mjs [--dry-run] [--json]`);
+  else console.error(`Error: ${error}\nUsage: node sync-pdf-flags.mjs [--dry-run] [--json]\n       node sync-pdf-flags.mjs --prune [--write] [--json]`);
   process.exit(1);
 }
 
@@ -45,6 +64,114 @@ if (!existsSync(APPS_FILE)) {
   else console.error(`❌ No tracker found at ${APPS_FILE}`);
   process.exit(2);
 }
+
+// ---------------------------------------------------------------------------
+// Prune mode: drop manifest rows whose PDF is gone from disk.
+// Kind-agnostic — a cover letter whose file was deleted is just as stale as a
+// CV's. Flag-clearing (resetting ✅ on the tracker) is the follow-on half once
+// #3887 introduces kind-awareness; this half is scoped to the manifest only.
+// ---------------------------------------------------------------------------
+if (flags.prune) {
+  if (!existsSync(PDF_MANIFEST)) {
+    const result = { pruned: 0, kept: 0, dryRun: !flags.write };
+    if (flags.json) console.log(JSON.stringify(result));
+    else console.log('\n📊 Summary: manifest does not exist — nothing to prune');
+    process.exit(0);
+  }
+
+  let rawContent;
+  try {
+    rawContent = readFileSync(PDF_MANIFEST, 'utf-8');
+  } catch (err) {
+    if (flags.json) {
+      console.log(JSON.stringify({ error: `Cannot read PDF manifest: ${err.message}`, code: 'manifest-read-error' }));
+    } else {
+      console.error(`❌ Cannot read PDF manifest: ${err.message}`);
+    }
+    process.exit(2);
+  }
+
+  // The workspace root is needed to resolve the workspace-relative pdf paths
+  // stored in the manifest (e.g. "output/042-acme-cv.pdf").
+  const workspaceRoot = resolveWorkspaceRoot(APPS_FILE);
+
+  const inputLines = rawContent.split('\n');
+  const keptLines = [];
+  const prunedRows = [];
+
+  for (const line of inputLines) {
+    // Preserve comment lines and blank lines verbatim.
+    if (!line.trim() || line.startsWith('#')) {
+      keptLines.push(line);
+      continue;
+    }
+
+    const parts = line.split('\t');
+    const relPdf = parts[1]?.trim();
+
+    if (!relPdf) {
+      // Malformed row (no pdf column) — keep it; not our business to remove it.
+      keptLines.push(line);
+      continue;
+    }
+
+    const absPath = resolve(workspaceRoot, relPdf);
+    if (!pathIsInsideCanonical(absPath, workspaceRoot)) {
+      prunedRows.push({ line, relPdf, report: parts[0]?.trim() || '' });
+      if (!flags.json) {
+        const marker = flags.write ? '🗑️ ' : '🔎';
+        const action = flags.write ? 'pruned' : 'would prune';
+        console.log(`${marker} ${action}: ${relPdf} (report ${parts[0]?.trim() || '?'}) — outside workspace`);
+      }
+      continue;
+    }
+
+    if (existsSync(absPath)) {
+      keptLines.push(line);
+    } else {
+      prunedRows.push({ line, relPdf, report: parts[0]?.trim() || '' });
+      if (!flags.json) {
+        const marker = flags.write ? '🗑️ ' : '🔎';
+        const action = flags.write ? 'pruned' : 'would prune';
+        console.log(`${marker} ${action}: ${relPdf} (report ${parts[0]?.trim() || '?'}) — file not found`);
+      }
+    }
+  }
+
+  const pruned = prunedRows.length;
+  const kept = inputLines.filter(l => l.trim() && !l.startsWith('#')).length - pruned;
+
+  if (pruned > 0 && flags.write) {
+    // Trim trailing blank lines added during the split, then restore exactly one.
+    const content = keptLines.join('\n').replace(/\n+$/, '') + '\n';
+    try {
+      writeFileAtomic(PDF_MANIFEST, content);
+    } catch (err) {
+      if (flags.json) {
+        console.log(JSON.stringify({ error: `Cannot write manifest: ${err.message}`, code: 'write-failure' }));
+      } else {
+        console.error(`❌ Cannot write manifest: ${err.message}`);
+      }
+      process.exit(1);
+    }
+  }
+
+  const result = { pruned, kept, dryRun: !flags.write };
+  if (flags.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    const verb = flags.write ? 'pruned' : 'would prune (dry run — pass --write to commit)';
+    console.log(`\n📊 Summary: ${pruned} row(s) ${verb}, ${kept} kept`);
+    if (pruned > 0 && !flags.write) {
+      console.log('ℹ️  Re-run with --write to remove stale rows, then run sync-pdf-flags.mjs to reconcile tracker flags.');
+    }
+  }
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Normal sync mode: set tracker PDF cell to ✅ for rows present in the manifest.
+// ---------------------------------------------------------------------------
 
 const manifestReports = new Set();
 if (existsSync(PDF_MANIFEST)) {

--- a/tests/sync-pdf-flags.test.mjs
+++ b/tests/sync-pdf-flags.test.mjs
@@ -136,3 +136,305 @@ try {
     rmSync(work, { recursive: true, force: true });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Prune mode tests (#3893)
+// ---------------------------------------------------------------------------
+
+{
+  // A manifest with one row whose PDF exists and one whose PDF is deleted.
+  // --prune dry run (default): manifest unchanged, output names the missing file.
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-dryrun-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    const outputDir = join(work, 'output');
+    mkdirSync(outputDir, { recursive: true });
+
+    // Only report 1's PDF is present on disk; report 2's is not.
+    writeFileSync(join(outputDir, '1-acme-cv.pdf'), 'pdf-content');
+
+    const manifest = [
+      '# report\tpdf\thtml\tformat\tdate',
+      '1\toutput/1-acme-cv.pdf\toutput/1-acme.html\ta4\t2026-01-01',
+      '2\toutput/2-gone-cv.pdf\toutput/2-gone.html\ta4\t2026-01-02',
+      '',
+    ].join('\n');
+
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, manifest);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--prune', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    const manifestAfter = readFileSync(pdfIndex, 'utf-8');
+    const json = (() => { try { return JSON.parse(result.stdout); } catch { return null; } })();
+
+    if (result.status === 0 && json && json.pruned === 1 && json.kept === 1 && json.dryRun === true) {
+      pass('sync-pdf-flags --prune reports one stale row in dry-run JSON');
+    } else {
+      fail(`--prune dry-run JSON wrong: status=${result.status}, stdout=${result.stdout.trim()}`);
+    }
+
+    if (manifestAfter === manifest) {
+      pass('sync-pdf-flags --prune dry run does not write the manifest');
+    } else {
+      fail('--prune dry run mutated the manifest without --write');
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+{
+  // --prune --write removes the stale row and keeps the live one.
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-write-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    const outputDir = join(work, 'output');
+    mkdirSync(outputDir, { recursive: true });
+
+    writeFileSync(join(outputDir, '1-acme-cv.pdf'), 'pdf-content');
+
+    const manifest = [
+      '# report\tpdf\thtml\tformat\tdate',
+      '1\toutput/1-acme-cv.pdf\toutput/1-acme.html\ta4\t2026-01-01',
+      '2\toutput/2-gone-cv.pdf\toutput/2-gone.html\ta4\t2026-01-02',
+      '',
+    ].join('\n');
+
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, manifest);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--prune', '--write', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    const manifestAfter = readFileSync(pdfIndex, 'utf-8');
+    const json = (() => { try { return JSON.parse(result.stdout); } catch { return null; } })();
+
+    if (result.status === 0 && json && json.pruned === 1 && json.kept === 1 && json.dryRun === false) {
+      pass('sync-pdf-flags --prune --write reports correct counts and dryRun:false');
+    } else {
+      fail(`--prune --write JSON wrong: status=${result.status}, stdout=${result.stdout.trim()}`);
+    }
+
+    if (!manifestAfter.includes('2-gone-cv.pdf') && manifestAfter.includes('1-acme-cv.pdf')) {
+      pass('sync-pdf-flags --prune --write removes the stale row and keeps the live row');
+    } else {
+      fail(`--prune --write manifest content wrong:\n${manifestAfter}`);
+    }
+
+    // The comment header must be preserved.
+    if (manifestAfter.startsWith('#')) {
+      pass('sync-pdf-flags --prune --write preserves the manifest comment header');
+    } else {
+      fail('--prune --write dropped the manifest comment header');
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+{
+  // --prune with all PDFs present: manifest unchanged, pruned:0.
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-noop-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    const outputDir = join(work, 'output');
+    mkdirSync(outputDir, { recursive: true });
+
+    writeFileSync(join(outputDir, '1-acme-cv.pdf'), 'pdf-content');
+    writeFileSync(join(outputDir, '2-globex-cv.pdf'), 'pdf-content');
+
+    const manifest = [
+      '# report\tpdf\thtml\tformat\tdate',
+      '1\toutput/1-acme-cv.pdf\toutput/1-acme.html\ta4\t2026-01-01',
+      '2\toutput/2-globex-cv.pdf\toutput/2-globex.html\ta4\t2026-01-02',
+      '',
+    ].join('\n');
+
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, manifest);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--prune', '--write', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    const manifestAfter = readFileSync(pdfIndex, 'utf-8');
+    const json = (() => { try { return JSON.parse(result.stdout); } catch { return null; } })();
+
+    if (result.status === 0 && json && json.pruned === 0 && json.kept === 2) {
+      pass('sync-pdf-flags --prune is a no-op when all PDFs are on disk');
+    } else {
+      fail(`--prune all-live JSON wrong: status=${result.status}, stdout=${result.stdout.trim()}`);
+    }
+
+    if (manifestAfter === manifest) {
+      pass('sync-pdf-flags --prune does not rewrite manifest when nothing is pruned');
+    } else {
+      fail('--prune rewrote an already-clean manifest');
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+{
+  // --write without --prune is an unknown option.
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-write-only-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, PDF_MANIFEST);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--write', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    if (result.status === 1 && /unknown option.*--write/i.test(result.stderr)) {
+      pass('sync-pdf-flags rejects --write outside of --prune mode');
+    } else {
+      fail(`--write without --prune should fail: status=${result.status}, stderr=${result.stderr.trim()}`);
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+{
+  // --prune with no manifest file is a silent no-op (exit 0, pruned:0).
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-no-manifest-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv'); // does not exist
+
+    writeFileSync(tracker, TRACKER_HEADER);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--prune', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    const json = (() => { try { return JSON.parse(result.stdout); } catch { return null; } })();
+
+    if (result.status === 0 && json && json.pruned === 0) {
+      pass('sync-pdf-flags --prune is a no-op when no manifest exists');
+    } else {
+      fail(`--prune no-manifest wrong: status=${result.status}, stdout=${result.stdout.trim()}`);
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+{
+  // --dry-run combined with --write ignores --write (dry-run wins).
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-dryrun-write-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    const outputDir = join(work, 'output');
+    mkdirSync(outputDir, { recursive: true });
+
+    writeFileSync(join(outputDir, '1-acme-cv.pdf'), 'pdf-content');
+
+    const manifest = [
+      '# report\tpdf\thtml\tformat\tdate',
+      '1\toutput/1-acme-cv.pdf\toutput/1-acme.html\ta4\t2026-01-01',
+      '2\toutput/2-gone-cv.pdf\toutput/2-gone.html\ta4\t2026-01-02',
+      '',
+    ].join('\n');
+
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, manifest);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--prune', '--dry-run', '--write', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    const manifestAfter = readFileSync(pdfIndex, 'utf-8');
+    const json = (() => { try { return JSON.parse(result.stdout); } catch { return null; } })();
+
+    if (result.status === 0 && json && json.pruned === 1 && json.kept === 1 && json.dryRun === true) {
+      pass('sync-pdf-flags --dry-run --write forces dry-run behavior');
+    } else {
+      fail(`--dry-run --write JSON wrong: status=${result.status}, stdout=${result.stdout.trim()}`);
+    }
+
+    if (manifestAfter === manifest) {
+      pass('sync-pdf-flags --dry-run --write does not mutate manifest');
+    } else {
+      fail('--dry-run --write mutated the manifest');
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+{
+  // Path traversal guard: absolute paths or ../ paths outside the workspace are pruned.
+  const work = mkdtempSync(join(tmpdir(), 'cops-prune-traversal-'));
+  const outOfBounds = mkdtempSync(join(tmpdir(), 'cops-prune-outofbounds-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    const outputDir = join(work, 'output');
+    mkdirSync(outputDir, { recursive: true });
+
+    // The files exist, but one is outside the workspace.
+    writeFileSync(join(outputDir, '1-acme-cv.pdf'), 'pdf-content');
+    const externalPdf = join(outOfBounds, 'outside.pdf');
+    writeFileSync(externalPdf, 'pdf-content');
+
+    const manifest = [
+      '# report\tpdf\thtml\tformat\tdate',
+      '1\toutput/1-acme-cv.pdf\toutput/1-acme.html\ta4\t2026-01-01',
+      `2\t${externalPdf.replace(/\\/g, '/')}\toutput/2-gone.html\ta4\t2026-01-02`,
+      '3\toutput/../../outside.pdf\toutput/3-gone.html\ta4\t2026-01-02',
+      '',
+    ].join('\n');
+
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, manifest);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--prune', '--write', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+
+    const manifestAfter = readFileSync(pdfIndex, 'utf-8');
+    const json = (() => { try { return JSON.parse(result.stdout); } catch { return null; } })();
+
+    if (result.status === 0 && json && json.pruned === 2 && json.kept === 1) {
+      pass('sync-pdf-flags --prune prunes paths outside the workspace');
+    } else {
+      fail(`path traversal JSON wrong: status=${result.status}, stdout=${result.stdout.trim()}`);
+    }
+
+    if (!manifestAfter.includes('outside.pdf') && manifestAfter.includes('1-acme-cv.pdf')) {
+      pass('sync-pdf-flags --prune removes out-of-bounds files from manifest');
+    } else {
+      fail(`path traversal manifest content wrong:\n${manifestAfter}`);
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+    rmSync(outOfBounds, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
### Summary
Fixes #3893 by adding a `--prune` mode to `sync-pdf-flags.mjs` to reconcile `data/pdf-index.tsv` against the filesystem.

- **Reconciles missing files**: Drops manifest rows pointing to PDFs that no longer exist on disk in `output/`.
- **Dry-run by default**: `node sync-pdf-flags.mjs --prune` previews stale rows; `--prune --write` updates `data/pdf-index.tsv`.
- **Kind-agnostic**: Works across all PDF entry types as scoped in #3893.
- **Unit tests**: Added test suite covering `--prune` and `--prune --write` modes.

### Testing
- `node sync-pdf-flags.mjs --prune` → Previews removed stale rows without writing.
- `node sync-pdf-flags.mjs --prune --write` → Safely updates manifest file.
- `node --test tests/sync-pdf-flags.test.mjs` (16/16 Passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `--prune` to `sync-pdf-flags.mjs`: reports manifest rows for missing or out-of-workspace PDFs without changing files by default.
- Use `--prune --write` to remove stale rows. `--dry-run` takes precedence over `--write`.
- Added validation for absolute paths and `..` traversal.
- Added `update-system.mjs status` to report the installed version and short Git SHA.
- Documented the new command in `docs/SCRIPTS.md`.
- Added regression tests for prune behavior and nested Git installations.

System files touched: `update-system.mjs`. `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/` were not changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->