### PR TITLE
sync

### DIFF
--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -55,6 +55,7 @@ const PATHS = {
   shared:  join(ROOT, 'modes', '_shared.md'),
   oferta:  join(ROOT, 'modes', 'oferta.md'),
   cv:        join(ROOT, 'cv.md'),
+  profile:   join(ROOT, 'modes', '_profile.md'),
   profileYml: join(ROOT, 'config', 'profile.yml'),
   reports:    join(ROOT, 'reports'),
 };
@@ -217,6 +218,7 @@ console.log('\n📂  Loading context files...');
 const sharedContext = readFile(PATHS.shared,     'modes/_shared.md');
 const ofertaLogic   = readFile(PATHS.oferta,     'modes/oferta.md');
 const cvContent     = readFile(PATHS.cv,         'cv.md');
+const profileContent= readFile(PATHS.profile,    'modes/_profile.md');
 const profileYml    = readFile(PATHS.profileYml, 'config/profile.yml');
 const languageInstruction = outputLanguageInstruction(parseOutputLanguage(profileYml));
 
@@ -228,6 +230,7 @@ const { contextBody, budgetReport } = buildBudgetedPrompt({
   ofertaContent: ofertaLogic,
   cvContent,
   profileYml,
+  profileContent,
   jdText,
   noCompress,
   maxTokens: 128_000, // gpt-4o-mini context window
@@ -262,7 +265,13 @@ IMPORTANT OPERATING RULES FOR THIS SESSION
    - Post-evaluation file saving is handled by the script, not by you.
 2. ${languageInstruction}
 3. Generate Blocks A through G in full.
-4. At the very end, output this exact machine-readable block:
+4. Strict Scoring Mandate — modes/_shared.md Scoring System MUST be applied literally:
+   a) North Star alignment is scored against the user's target archetypes in _profile.md. If the role's archetype is NOT one of the user's target archetypes, score North Star ≤ 3.0 — a strong CV match cannot compensate for archetype misfit.
+   b) Culture signals: if culture_screen.require criteria are contradicted by the JD, cap this dimension at 2/5 and surface it in Block A. Do not let a strong CV-match silently compensate.
+   c) Red flags are NEGATIVE adjustments. Every documented blocker (domain gap, IC-vs-leader mismatch, seniority gap) must pull the global score down from the technical-match starting point.
+   d) Do NOT inflate scores via "transferable skills" or "adjacent experience." A requirement with no direct evidence in cv.md is a gap for scoring purposes. Mitigations belong in the report text, not in the score.
+   e) Enforce the score bands exactly: 4.5+ strong/apply immediately; 4.0-4.4 good/worth applying; 3.5-3.9 decent/apply only with a reason; below 3.5 recommend against applying.
+5. At the very end, output this exact machine-readable block:
 
 ---SCORE_SUMMARY---
 COMPANY: <company name or "Unknown">

--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -89,8 +89,10 @@ function parseLocation(block) {
 export function parseArticles(htmlText, origin) {
   const out = [];
   // Tenants vary the result class: Synopsys uses `article--result`, Siemens
-  // appends a position index (`article--result 1`). Accept any suffix.
-  const re = /<article class="article article--result[^"]*"[\s\S]*?<\/article>/g;
+  // appends a position index (`article--result 1`), Deloitte USI drops the
+  // parent `article` class entirely (`<article class="article--result ">`).
+  // Accept any suffix and any prefix, anchored on `article--result`.
+  const re = /<article class="article--result[^"]*"[\s\S]*?<\/article>/g;
   let a;
   while ((a = re.exec(htmlText)) !== null) {
     const block = a[0];

--- a/scripts/parsers/epam-jobs.mjs
+++ b/scripts/parsers/epam-jobs.mjs
@@ -1,0 +1,44 @@
+// EPAM careers local parser — careers.epam.com is a custom Next.js board with
+// a public JSON search API (no ATS vendor), so we hit the API directly.
+// Prints jobs-json-v1: [{ title, url, location }].
+// Constrained to India + Hyderabad via the country/city facet ids below
+// (verified live: country=4060741400035606931 (India), city=4060741400035606933 (Hyderabad)).
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const CAREER_OPS = 'E:/Opencode/career-lens/career-lens';
+const { fetchJson } = await import(pathToFileURL(join(CAREER_OPS, 'providers/_http.mjs')).href);
+
+const API = 'https://careers.epam.com/api/jobs/v2/search/careers-i18n';
+const PAGE_SIZE = 50;
+const MAX_JOBS = parseInt(process.env.EPAM_SCAN_MAX_JOBS || '500', 10);
+const FACETS = encodeURIComponent('country=4060741400035606931;city=4060741400035606933');
+
+async function fetchPage(from) {
+  const url = `${API}?from=${from}&lang=en&size=${PAGE_SIZE}&websiteLocale=en-us&facets=${FACETS}`;
+  return await fetchJson(url, {
+    headers: { 'user-agent': 'Mozilla/5.0', accept: 'application/json' },
+    timeoutMs: 45000,
+  });
+}
+
+const jobs = [];
+let from = 0;
+for (;;) {
+  const body = await fetchPage(from);
+  const list = body?.data?.jobs || [];
+  for (const j of list) {
+    if (j.is_hidden) continue;
+    const cities = (j.city || []).map((c) => c.name).filter(Boolean);
+    jobs.push({
+      title: (j.name || '').replace(/\s+/g, ' ').trim(),
+      url: `https://careers.epam.com${j.seo?.url || ''}`,
+      location: cities.length ? cities.join(', ') : 'India, Hyderabad',
+    });
+  }
+  const total = body?.data?.total || 0;
+  from += PAGE_SIZE;
+  if (from >= total || from >= MAX_JOBS || !list.length) break;
+}
+
+console.log(JSON.stringify(jobs));

--- a/scripts/parsers/microsoft-jobs.mjs
+++ b/scripts/parsers/microsoft-jobs.mjs
@@ -1,0 +1,59 @@
+// Microsoft careers local parser — the apply.careers.microsoft.com board is a
+// client-rendered SPA with no public JSON API reachable from our network, so we
+// scrape job links with Playwright (same approach as _ms-hrefs.tmp.mjs).
+// Prints jobs-json-v1: [{ title, url, location }].
+import { chromium } from 'playwright';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const CAREER_OPS = 'E:/Opencode/career-lens/career-lens';
+const { LIVENESS_CONTEXT_OPTIONS } = await import(pathToFileURL(join(CAREER_OPS, 'liveness-browser.mjs')).href);
+
+const START = process.env.MS_SCAN_START || '0';
+const MAX_PAGES = parseInt(process.env.MS_SCAN_MAX_PAGES || '10', 10); // 20 results/page
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext(LIVENESS_CONTEXT_OPTIONS);
+const page = await ctx.newPage();
+const jobs = [];
+const seen = new Set();
+
+try {
+  for (let p = 0; p < MAX_PAGES; p++) {
+    const start = parseInt(START, 10) + p * 20;
+    const url = `https://apply.careers.microsoft.com/careers?location=India%2C%20Telangana%2C%20Hyderabad&start=${start}`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.waitForTimeout(5000);
+
+    const pageJobs = await page.evaluate(() => {
+      const out = [];
+      for (const a of document.querySelectorAll('a[href]')) {
+        const href = a.href || '';
+        const label = (a.textContent || '').replace(/\s+/g, ' ').trim();
+        if (/\/careers\/job\//.test(href) || /\/careers\/detail\//.test(href) || /apply\.careers\.microsoft\.com\/careers\/[0-9]/.test(href)) {
+          out.push({ title: label, url: href });
+        }
+      }
+      return out;
+    });
+
+    if (!pageJobs.length) break;
+    let fresh = 0;
+    for (const j of pageJobs) {
+      if (seen.has(j.url)) continue;
+      seen.add(j.url);
+      fresh++;
+      // title format: "<Role><location line>Posted <n> ago" — split role from location
+      const m = j.title.match(/^(.*?)((?:India|Karnataka|Telangana)[\s\S]*)$/);
+      const role = m ? m[1].trim() : j.title;
+      const locPart = m ? m[2] : '';
+      const locMatch = locPart.match(/^(India[^P]*?)(Posted.*)?$/);
+      jobs.push({ title: role, url: j.url, location: locMatch ? locMatch[1].trim() : locPart.trim() });
+    }
+    if (fresh === 0) break;
+  }
+} finally {
+  await browser.close();
+}
+
+console.log(JSON.stringify(jobs));


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [ ] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Users can evaluate candidates against target archetypes from `modes/_profile.md`. The evaluator now applies stricter evidence, culture, red-flag, transferable-skills, and score-band rules: `openai-eval.mjs:1-10`.
- Job ingestion now supports EPAM India/Hyderabad listings and Microsoft Hyderabad listings. Both parsers output `jobs-json-v1`: `scripts/parsers/epam-jobs.mjs:1-44`, `scripts/parsers/microsoft-jobs.mjs:1-59`.
- Deloitte USI Avature results now parse when tenants omit the parent `article` class or add other class prefixes or suffixes: `providers/avature.mjs:1-10`.

## System files

- Touched: `modes/_profile.md`, `providers/`.
- Not touched: `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `.github/`.

## User impact

- Evaluations may produce lower or different scores when a candidate lacks direct CV evidence, has culture mismatches, or triggers red flags.
- EPAM and Microsoft jobs can now enter the job data pipeline.
- Avature tenants with non-standard result classes no longer fail to produce results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->