### PR TITLE
fix(verify-cv-facts): tell a disabled fact gate apart from one that ran clean

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -325,6 +325,11 @@ Usage:
     // validator before importing Playwright or writing a PDF so a failed gate
     // cannot leave behind a misleading artifact.
     const factCheck = assertFacts(html, { label: "cover letter" });
+    // Ahead of the verdict, because it qualifies it: with no config the phrase
+    // lists are empty, so a silent gate here covers metrics and facts only.
+    if (factCheck.configMissing) {
+      console.error("No config/cv-facts.json — forbidden/advisory phrase checks did not run.");
+    }
     if (factCheck.verdict === "warn") {
       console.error(`CV fact check warning: cover letter`);
       for (const phrase of factCheck.warnings) {

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -1354,6 +1354,11 @@ async function generatePDF() {
     // fails, which is the correct direction to fail for a fact gate.
     const { assertFacts } = await import('./verify-cv-facts.mjs');
     const factCheck = assertFacts(html, { label: basename(inputPath) });
+    // Ahead of the verdict, because it qualifies it: with no config the phrase
+    // lists are empty, so a "passed" below covers metrics and facts only.
+    if (factCheck.configMissing) {
+      console.warn('⚠️  No config/cv-facts.json — forbidden/advisory phrase checks did not run.');
+    }
     if (factCheck.verdict === 'warn') {
       console.warn(`⚠️  CV fact check warning: ${basename(inputPath)}`);
       for (const phrase of factCheck.warnings) console.warn(`  - advisory phrase: ${phrase}`);

--- a/tests/fact-gate-missing-config.test.mjs
+++ b/tests/fact-gate-missing-config.test.mjs
@@ -1,0 +1,142 @@
+// tests/fact-gate-missing-config.test.mjs — a fact gate with no config loaded
+// must not look like a fact gate that ran and found nothing.
+//
+// config/cv-facts.json is optional and absent from a fresh clone, and its
+// forbidden_phrases/warn_phrases are the only phrase-level guard the module
+// has. loadConfig() returned the empty shape for a missing file, so the two
+// states produced a byte-identical clean result and every render reported the
+// gate as passing — including the renders of a claim that had been
+// deliberately quarantined (#3894).
+//
+// Deliberately a warning, never a failure: a user who never wrote a
+// cv-facts.json is in a normal state. The assertions below pin the
+// distinction, not a verdict change.
+//
+// Run:  node test-all.mjs --only fact-gate-missing-config
+
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+// Namespace import on purpose: a named import of a not-yet-existing export is a
+// SyntaxError at link time, which kills the whole suite before a single
+// assertion runs and reports one opaque failure instead of the real set.
+import * as factGate from '../verify-cv-facts.mjs';
+
+const { loadFactConfig, verifyFacts } = factGate;
+
+console.log('\nFact gate: missing config is a distinguishable state (#3894)');
+
+const tmp = mkdtempSync(join(tmpdir(), 'career-ops-facts-missing-config-'));
+try {
+  const source = join(tmp, 'cv.md');
+  const presentConfig = join(tmp, 'cv-facts.json');
+  const missingConfig = join(tmp, 'no-such-cv-facts.json');
+  const target = join(tmp, 'cv.html');
+  writeFileSync(source, 'Improved reliability for 25 users.');
+  writeFileSync(presentConfig, JSON.stringify({ allow_metrics: [], allow_facts: [], forbidden_phrases: [], warn_phrases: [] }));
+  writeFileSync(target, '<html><body><p>Improved reliability for 25 users.</p></body></html>');
+
+  // 1. loadFactConfig reports existence separately from content.
+  if (typeof loadFactConfig !== 'function') {
+    fail('loadFactConfig is not exported — callers have no way to tell a disabled gate from a clean one');
+  } else {
+    const absent = loadFactConfig(missingConfig);
+    if (absent.missing === true && Array.isArray(absent.config?.forbidden_phrases)) {
+      pass('loadFactConfig reports missing:true and still returns a usable empty config');
+    } else {
+      fail(`loadFactConfig did not flag an absent config: ${JSON.stringify(absent)}`);
+    }
+
+    const present = loadFactConfig(presentConfig);
+    if (present.missing === false && Array.isArray(present.config?.forbidden_phrases)) {
+      pass('loadFactConfig reports missing:false for a config that exists');
+    } else {
+      fail(`loadFactConfig mis-reported an existing config: ${JSON.stringify(present)}`);
+    }
+
+    // Validation must survive the shape change — a malformed config is still an error.
+    const malformed = join(tmp, 'malformed.json');
+    writeFileSync(malformed, JSON.stringify({ forbidden_phrases: 'not-an-array' }));
+    try {
+      loadFactConfig(malformed);
+      fail('loadFactConfig accepted a non-array forbidden_phrases');
+    } catch (err) {
+      if (/forbidden_phrases must be an array/.test(err.message)) {
+        pass('loadFactConfig still rejects a non-array key');
+      } else {
+        fail(`loadFactConfig threw the wrong error for a malformed config: ${err.message}`);
+      }
+    }
+  }
+
+  // 2. The distinction the issue is about: disabled vs ran-clean must not be
+  //    the same result object.
+  const ranClean = verifyFacts('Improved reliability for 25 users.', { sourcePaths: [source], configPath: presentConfig });
+  const disabled = verifyFacts('Improved reliability for 25 users.', { sourcePaths: [source], configPath: missingConfig });
+  if (JSON.stringify(ranClean) === JSON.stringify(disabled)) {
+    fail('a disabled fact gate and a gate that ran clean returned identical results');
+  } else {
+    pass('a disabled fact gate and a gate that ran clean return distinguishable results');
+  }
+  if (disabled.configMissing === true && ranClean.configMissing === false) {
+    pass('verifyFacts surfaces configMissing on both sides');
+  } else {
+    fail(`verifyFacts did not surface configMissing (disabled=${JSON.stringify(disabled.configMissing)}, ran-clean=${JSON.stringify(ranClean.configMissing)})`);
+  }
+
+  // 3. A warning, not a failure: the verdict is untouched.
+  if (disabled.verdict === 'pass') {
+    pass('a missing config stays a warning — the verdict is not downgraded');
+  } else {
+    fail(`a missing config changed the verdict to ${disabled.verdict} — it must stay advisory`);
+  }
+
+  // 4. The CLI render path says so out loud, and still exits 0.
+  const cli = (configPath) => spawnSync(NODE, [
+    join(ROOT, 'verify-cv-facts.mjs'), target, '--source', source, '--config', configPath,
+  ], { cwd: tmp, encoding: 'utf-8', timeout: 30_000 });
+
+  const cliMissing = cli(missingConfig);
+  const missingOutput = `${cliMissing.stdout}${cliMissing.stderr}`;
+  const cliPresent = cli(presentConfig);
+  const presentOutput = `${cliPresent.stdout}${cliPresent.stderr}`;
+  if (missingOutput === presentOutput) {
+    fail('the CLI printed the same output with and without a fact-gate config');
+  } else if (/cv-facts|fact-gate config/i.test(missingOutput.replace(presentOutput, ''))) {
+    pass('the CLI names the missing fact-gate config');
+  } else {
+    fail(`the CLI output differed but never named the missing config: ${JSON.stringify(missingOutput)}`);
+  }
+  if (cliMissing.status === 0) {
+    pass('the CLI still exits 0 with no config — a warning, not a gate failure');
+  } else {
+    fail(`the CLI exited ${cliMissing.status} with no config — a missing config must not fail the run`);
+  }
+
+  const cliJson = spawnSync(NODE, [
+    join(ROOT, 'verify-cv-facts.mjs'), target, '--source', source, '--config', missingConfig, '--json',
+  ], { cwd: tmp, encoding: 'utf-8', timeout: 30_000 });
+  let parsed = null;
+  try { parsed = JSON.parse(cliJson.stdout); } catch { /* reported below */ }
+  if (parsed?.configMissing === true) {
+    pass('--json carries configMissing so a machine caller can see the gate was not loaded');
+  } else {
+    fail(`--json did not carry configMissing:true (stdout: ${JSON.stringify(cliJson.stdout)})`);
+  }
+
+  // 5. The two document render paths surface it too. Asserted at source level:
+  //    both gate calls sit behind a Playwright import, so exercising them here
+  //    would mean rendering a real PDF to test one console line.
+  for (const script of ['generate-pdf.mjs', 'generate-cover-letter.mjs']) {
+    const src = readFileSync(join(ROOT, script), 'utf-8');
+    if (/configMissing[\s\S]{0,200}?console\.(warn|error)/.test(src)) {
+      pass(`${script} warns when the fact-gate config is missing`);
+    } else {
+      fail(`${script} never surfaces configMissing — its renders still report a disabled gate as clean`);
+    }
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -718,15 +718,32 @@ export function auditClaims(targetText, sourceText, config = {}) {
   return { invented, forbidden };
 }
 
-/** Load and validate the optional fact-gate configuration file. */
-function loadConfig(path) {
-  if (!existsSync(path)) return { allow_metrics: [], allow_facts: [], forbidden_phrases: [], warn_phrases: [] };
+/**
+ * Load and validate the optional fact-gate configuration file.
+ *
+ * The empty config is a fine default and a terrible silent one: forbidden_phrases
+ * and warn_phrases are the only phrase-level guard this module has, so with no
+ * file loaded the phrase check cannot fail — and a gate that is DISABLED then
+ * reads exactly like a gate that RAN AND FOUND NOTHING. `missing` is the one bit
+ * that tells them apart; callers surface it (#3894).
+ *
+ * Nothing here turns a missing config into an error. A user who has never
+ * written a cv-facts.json is in a normal state; they just should not be left
+ * believing a gate is protecting them when none is loaded.
+ *
+ * @param {string} path absolute path to the configuration file
+ * @returns {{missing: boolean, config: {allow_metrics: string[], allow_facts: string[], forbidden_phrases: string[], warn_phrases: string[]}}}
+ * @throws when the file exists but is unparseable or has a non-array key
+ */
+export function loadFactConfig(path) {
+  const keys = ['allow_metrics', 'allow_facts', 'forbidden_phrases', 'warn_phrases'];
+  if (!existsSync(path)) return { missing: true, config: Object.fromEntries(keys.map(key => [key, []])) };
   const config = JSON.parse(readFileSync(path, 'utf-8'));
-  for (const key of ['allow_metrics', 'allow_facts', 'forbidden_phrases', 'warn_phrases']) {
+  for (const key of keys) {
     if (config[key] == null) config[key] = [];
     else if (!Array.isArray(config[key])) throw new Error(`${key} must be an array in ${path}`);
   }
-  return config;
+  return { missing: false, config };
 }
 
 /** Resolve a CLI or configuration path relative to the selected working directory. */
@@ -754,7 +771,7 @@ export function verifyFacts(targetText, {
   cwd = process.cwd(),
 } = {}) {
   const sourceText = sourcePaths.map(path => readIfExists(resolveInputPath(path, cwd))).join('\n');
-  const config = loadConfig(resolveInputPath(configPath, cwd));
+  const { missing: configMissing, config } = loadFactConfig(resolveInputPath(configPath, cwd));
   const allowed = allowedMetricSet(sourceText, config.allow_metrics);
   const targetClaims = metricClaims(targetText);
   const invented = [...targetClaims].filter(claim => !allowed.has(claim));
@@ -781,6 +798,10 @@ export function verifyFacts(targetText, {
     forbidden,
     warnings,
     coverage,
+    // Deliberately outside the verdict: no config is a normal state, not a
+    // finding. It rides along so a caller can say the phrase lists were never
+    // loaded instead of printing a clean result the reader takes for "checked".
+    configMissing,
   };
 }
 
@@ -1188,6 +1209,12 @@ export function runCli(args = process.argv.slice(2)) {
       sourcePaths: parsed.sourcePaths.length ? parsed.sourcePaths : DEFAULT_SOURCES,
       configPath: parsed.configPath,
     });
+    // On stderr, before any verdict line and regardless of it: with no config
+    // the phrase lists are empty, so "passed" below means the phrase check never
+    // ran. stdout stays clean so --json remains parseable.
+    if (result.configMissing) {
+      console.error(`⚠️  fact-gate config not found: ${parsed.configPath} — forbidden/advisory phrase checks did not run.`);
+    }
     if (parsed.json) {
       console.log(JSON.stringify(result));
       return result.verdict === 'block' ? 1 : 0;


### PR DESCRIPTION
## What does this PR do?

`loadConfig()` returned the empty shape when `config/cv-facts.json` was absent, and `forbidden_phrases`/`warn_phrases` are the only phrase-level guard the module has — so a **disabled** gate printed exactly what a gate that **ran and found nothing** prints. `loadFactConfig()` now returns `{missing, config}`, `verifyFacts()` carries `configMissing` through to callers, and the three render paths (the CLI, `generate-pdf.mjs`, `generate-cover-letter.mjs`) each emit one warning line when it is true. Deliberately a warning, not a hard failure: a user who has never written a `cv-facts.json` is in a normal state, so verdicts and exit codes are unchanged.

## Related issue

Closes #3894

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

### How it was verified

`tests/fact-gate-missing-config.test.mjs` asserts the distinction that did not exist before this change. On unfixed code it reports **2 passed, 7 failed** — the two greens are the "must not change" assertions (verdict stays `pass`, CLI still exits 0), which is what keeps this a warning rather than a gate failure. With the fix: **11 passed, 0 failed**.

The suite is namespace-imported on purpose: a named import of a not-yet-existing export is a link-time `SyntaxError` that kills the whole file before a single assertion runs, reporting one opaque failure instead of the real set.

Mutation-checked — each mutation applied alone, then reverted, and the file confirmed byte-identical to the fixed version afterwards:

| Mutation | Result |
|---|---|
| `loadFactConfig` returns `missing: false` for an absent file (the original silent shape) | 🔴 5 failed — `loadFactConfig did not flag an absent config`, identical-results, `configMissing` on both sides, CLI output identical, `--json` |
| `configMissing` dropped from the `verifyFacts` return | 🔴 4 failed — identical-results, `configMissing` on both sides, CLI output identical, `--json` |
| CLI warning line removed | 🔴 1 failed — `the CLI printed the same output with and without a fact-gate config` |
| `generate-pdf.mjs` warning removed | 🔴 1 failed — `generate-pdf.mjs never surfaces configMissing` |
| `generate-cover-letter.mjs` warning removed | 🔴 1 failed — `generate-cover-letter.mjs never surfaces configMissing` |
| non-array key validation removed from `loadFactConfig` | 🔴 1 failed — `loadFactConfig accepted a non-array forbidden_phrases` (proves that assertion is not vacuous across the shape change) |

No mutation left the suite green.

Full `node test-all.mjs`: **8580 passed, 0 failed, 16 warnings**. All 16 warnings are pre-existing and name none of the files touched here (`cv-sync-check.mjs` without user data, the personal-data scanner on `funding.json`/`HIRED.md`/`hired-wall-build.mjs`/`dashboard/…/stats.go`/`.codex-plugin/plugin.json` and their tests, and two live-API suites skipped behind env flags).

The two document render paths are asserted at source level rather than by rendering: both gate calls sit immediately before a Playwright import, so exercising them would mean producing a real PDF to test one console line. Both source assertions are mutation-checked above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The CV fact gate now distinguishes a missing `config/cv-facts.json` from a configured gate that finds no issues.

### User impact

When `config/cv-facts.json` is missing:

- `verifyFacts()` exposes `configMissing`.
- The CLI, PDF generator, and cover-letter generator print one warning.
- Verdicts and exit codes do not change.
- JSON output remains parseable.
- Fact checks do not run, so a clean result does not imply that the CV was checked.

Malformed configurations still fail validation.

### Files changed

- `verify-cv-facts.mjs`: Exports `loadFactConfig(path)` with `{ missing, config }`. Adds `configMissing` to verification results and CLI warnings.
- `generate-pdf.mjs`: Warns when the fact configuration is missing.
- `generate-cover-letter.mjs`: Warns when the fact configuration is missing.
- `tests/fact-gate-missing-config.test.mjs`: Adds regression coverage for loader state, verification results, CLI output, document-generation warnings, verdicts, and exit codes.

### System files

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

### Validation

The new suite reports 11 passing assertions. The full suite reports 8,580 passed and 0 failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->