### PR TITLE
fix(tracker): strip invisible control characters at the cell sanitizer

### DIFF
--- a/tests/tracker-utils.test.mjs
+++ b/tests/tracker-utils.test.mjs
@@ -37,6 +37,31 @@ test('cell neutralizes table-breaking characters without changing ordinary text'
   assert.equal(cell('Senior Engineer'), 'Senior Engineer');
 });
 
+// Asserted on the sanitizer itself, never through a writer. cell() is the one
+// chokepoint every tracker writer passes through — merge-tracker's buildRow for
+// company/role/location/notes/url (and so the web, which dictates rows through
+// the same merge path), set-status for its note. Testing a caller instead would
+// leave the guard un-asserted the moment a new writer is added; testing the
+// chokepoint means a new writer inherits it or bypasses cell() visibly.
+test('cell strips invisible control characters (#3892)', () => {
+  // The realistic path: a role title copied out of a rendered posting carries a
+  // C0 byte. It is invisible in markdown, on GitHub and in the web dashboard,
+  // and it shifts or truncates the positional `split('|')` parse downstream.
+  assert.equal(cell('Senior\x01 Engineer'), 'Senior Engineer');
+  assert.equal(cell('Head\x7f of Growth'), 'Head of Growth');
+  assert.equal(cell('Zeta\x9dCorp'), 'ZetaCorp');
+  assert.equal(cell('\x00\x1b'), '');
+
+  // Deleted, not replaced with a space: the byte renders as nothing, so a
+  // replacement would change the text a human already sees.
+  assert.equal(cell('Data\x0cEngineer'), 'DataEngineer');
+
+  // Whitespace that legitimately separates words is left alone — a tab is
+  // ordinary whitespace in a cell, and a newline still folds to one space.
+  assert.equal(cell('Staff\tEngineer'), 'Staff\tEngineer');
+  assert.equal(cell('Acme\r\nRemote'), 'Acme Remote');
+});
+
 test('normalizeCompany preserves meaningful non-Latin company names', () => {
   assert.equal(normalizeCompany('Acme, Inc. (Remote)'), 'acmeincremote');
   assert.equal(normalizeCompany('株式会社ゼータ'), '株式会社ゼータ');

--- a/tests/verify-pipeline-control-bytes.test.mjs
+++ b/tests/verify-pipeline-control-bytes.test.mjs
@@ -1,0 +1,72 @@
+// tests/verify-pipeline-control-bytes.test.mjs — Check 16 (#3892), end to end
+// through the real verify-pipeline.mjs process.
+//
+// Stripping at the cell sanitizer stops NEW control bytes entering the tracker;
+// it can do nothing about the ones already written. This is the other half:
+// the only place a byte that is invisible in every rendered view of the table
+// becomes visible again. Asserted through the process because the exit code is
+// the part CI and cron wrappers read — a finding that printed but exited 0
+// would be indistinguishable from a clean tracker.
+//
+// Only the tracker and reports dir point at a fixture, the same way
+// tests/verify-pipeline-check15.test.mjs arranges them, so no user data is read.
+import { execFileSync } from 'child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, ROOT, NODE, rmSync } from './helpers.mjs';
+
+console.log('\nverify-pipeline — Check 16 fails on a control byte already written into a tracker cell');
+
+const HEADER = '# Applications Tracker\n\n'
+  + '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n'
+  + '|---|------|---------|------|-------|--------|-----|--------|-------|\n';
+const CLEAN_ROW = '| 1 | 2026-09-05 | Acme Co | Senior Engineer | 4.5/5 | Applied | ❌ | — | seeded |\n';
+// U+0001 in the Role cell — what a title pasted out of a rendered posting looks
+// like on disk. Every markdown renderer shows "Senior Engineer".
+const DIRTY_ROW = '| 1 | 2026-09-05 | Acme Co | Senior\x01 Engineer | 4.5/5 | Applied | ❌ | — | seeded |\n';
+
+const tmp = mkdtempSync(join(tmpdir(), 'co-vp-ctrl-'));
+try {
+  const reports = join(tmp, 'reports');
+  mkdirSync(reports, { recursive: true });
+  const tracker = join(tmp, 'applications.md');
+
+  // verify-pipeline exits 1 on errors, so the output has to be read off the
+  // thrown error too — otherwise the non-zero exit hides the assertion.
+  const runVp = () => {
+    const env = { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_REPORTS: reports, CAREER_OPS_PORTALS: join(tmp, 'no-portals.yml') };
+    try {
+      const stdout = execFileSync(NODE, [join(ROOT, 'verify-pipeline.mjs')], { cwd: ROOT, env, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 60_000 });
+      return { stdout, status: 0 };
+    } catch (err) {
+      return { stdout: typeof err.stdout === 'string' ? err.stdout : '', status: err.status ?? 1 };
+    }
+  };
+
+  writeFileSync(tracker, HEADER + DIRTY_ROW, 'utf-8');
+  const dirty = runVp();
+  const flagged = /control character/i.test(dirty.stdout);
+  if (flagged && dirty.status === 1) {
+    pass('a control byte in a tracker cell is reported as an error and exits 1');
+  } else {
+    fail(`control byte not caught: flagged=${flagged} exit=${dirty.status}\n${dirty.stdout.split('\n').filter((l) => /control|Pipeline Health/i.test(l)).join('\n')}`);
+  }
+  if (/U\+0001/.test(dirty.stdout)) {
+    pass('the finding names the code point, so the byte can be found in the file');
+  } else {
+    fail('the finding did not name the offending code point');
+  }
+
+  writeFileSync(tracker, HEADER + CLEAN_ROW, 'utf-8');
+  const clean = runVp();
+  if (/No control characters in tracker cells/.test(clean.stdout) && !/control character\(s\)/.test(clean.stdout)) {
+    pass('control: the same row without the byte reports clean and raises nothing');
+  } else {
+    fail(`control drifted:\n${clean.stdout.split('\n').filter((l) => /control|Pipeline Health/i.test(l)).join('\n')}`);
+  }
+} catch (err) {
+  fail(`verify-pipeline Check 16 tests could not run: ${err.message}`);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/tests/verify-pipeline-control-bytes.test.mjs
+++ b/tests/verify-pipeline-control-bytes.test.mjs
@@ -60,10 +60,13 @@ try {
 
   writeFileSync(tracker, HEADER + CLEAN_ROW, 'utf-8');
   const clean = runVp();
-  if (/No control characters in tracker cells/.test(clean.stdout) && !/control character\(s\)/.test(clean.stdout)) {
-    pass('control: the same row without the byte reports clean and raises nothing');
+  // Exit 0 as well as the success line: the line alone would still print if the
+  // byte were reported by some other check, which is the false negative this
+  // control exists to rule out.
+  if (/No control characters in tracker cells/.test(clean.stdout) && !/control character\(s\)/.test(clean.stdout) && clean.status === 0) {
+    pass('control: the same row without the byte reports clean, raises nothing and exits 0');
   } else {
-    fail(`control drifted:\n${clean.stdout.split('\n').filter((l) => /control|Pipeline Health/i.test(l)).join('\n')}`);
+    fail(`control drifted: exit=${clean.status}\n${clean.stdout.split('\n').filter((l) => /control|Pipeline Health/i.test(l)).join('\n')}`);
   }
 } catch (err) {
   fail(`verify-pipeline Check 16 tests could not run: ${err.message}`);

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -84,8 +84,13 @@ export function normalizeCompany(name) {
  * C0 and DEL and C1, minus the three whitespace controls: `\t` is ordinary
  * whitespace inside a cell, and `\r`/`\n` are folded to a single space by
  * cell() before this runs — stripping any of the three would glue words
- * together instead of separating them. Same class the plugin token/display
- * sanitizer uses, named the same way, so the two cannot drift apart.
+ * together instead of separating them.
+ *
+ * Deliberately NOT shared with the plugin token/display sanitizer, which strips
+ * the same idea but a different range: it collapses all whitespace first and so
+ * can take `\t`/`\r`/`\n` with the rest, which here would destroy word breaks.
+ * Two ranges that must differ are two constants; only the ranges that must
+ * agree are shared, which is the single export below.
  *
  * Exported because verify-pipeline.mjs has to recognize exactly what cell()
  * removes: stripping only stops NEW bytes entering, and a second copy of this

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -79,6 +79,22 @@ export function normalizeCompany(name) {
 }
 
 /**
+ * Control characters that are invisible in every rendered view of the tracker.
+ *
+ * C0 and DEL and C1, minus the three whitespace controls: `\t` is ordinary
+ * whitespace inside a cell, and `\r`/`\n` are folded to a single space by
+ * cell() before this runs — stripping any of the three would glue words
+ * together instead of separating them. Same class the plugin token/display
+ * sanitizer uses, named the same way, so the two cannot drift apart.
+ *
+ * Exported because verify-pipeline.mjs has to recognize exactly what cell()
+ * removes: stripping only stops NEW bytes entering, and a second copy of this
+ * range would let the write path and the detector disagree about what counts.
+ */
+// eslint-disable-next-line no-control-regex
+export const CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g;
+
+/**
  * Neutralize characters that would corrupt the applications.md table.
  *
  * Tracker rows are read with a raw `line.split('|')`, so a literal pipe or a
@@ -87,11 +103,26 @@ export function normalizeCompany(name) {
  * on the inner pipe. Additive — normal cells are unchanged; only values that
  * would already break the table get sanitized.
  *
+ * Control characters (#3892) get the same treatment for the same reason, and
+ * here rather than in each writer: this is the one sanitizer every tracker
+ * writer passes through — merge-tracker's buildRow (and so the web, which
+ * dictates its rows through the same merge path), set-status's note. A guard
+ * added per writer is a guard the next writer is free to reintroduce the bug
+ * around. They are DELETED, not replaced with a space: the byte renders as
+ * nothing in markdown, on GitHub and in the dashboard, so a substitution would
+ * change text a human has already read. The asymmetry is the point — a byte
+ * that costs one regex to reject costs an unrelated arithmetic discrepancy
+ * much later to find, because every view of the table hides it.
+ *
  * @param {*} v - Free-text value headed for a table cell.
  * @returns {string} Table-safe value.
  */
 export function cell(v) {
-  return String(v ?? '').replace(/[\r\n]+/g, ' ').replace(/\s*\|\s*/g, ' / ').trim();
+  return String(v ?? '')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(CONTROL_CHARS, '')
+    .replace(/\s*\|\s*/g, ' / ')
+    .trim();
 }
 
 /**

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -16,6 +16,9 @@
  * 11. Via channel consistency (see #1596)
  * 12. No # value reused across 2+ tracker rows (error — see #1704)
  * 13. applications.md <-> active-interviews.md status sync (see #1504)
+ * 14. data/follow-ups.md table schema (see #2971)
+ * 15. portals.yml entries no provider claims (see #3251)
+ * 16. No invisible control characters in tracker cells (error — see #3892)
  *
  * Run: node career-ops/verify-pipeline.mjs
  */
@@ -28,6 +31,7 @@ import {
   looksLikeScoreCell, isSeparatorRow, isHeaderRow, resolveColumns,
   normalizeTextKey, normalizeVia,
 } from './tracker-parse.mjs';
+import { CONTROL_CHARS } from './tracker-utils.mjs';
 import { checkTrackerSync } from './tracker-sync-check.mjs';
 import { checkFollowupsSchema } from './stats.mjs';
 
@@ -566,6 +570,35 @@ if (!existsSync(PORTALS_FILE)) {
     warn(`Portal coverage check could not run: ${err.message}`);
   }
 }
+
+// --- Check 16: invisible control bytes already in tracker cells (#3892) ---
+// cell() in tracker-utils.mjs strips these on the way in, which stops new ones
+// entering but can do nothing about the ones already written. This is the only
+// place such a byte is visible at all: it shifts or truncates the positional
+// `split('|')` parse, so a row silently reads as a different row or drops out
+// of a count entirely, while every renderer of the table — markdown, GitHub,
+// the web dashboard — shows the cell as correct. The corruption surfaces much
+// later as an unrelated arithmetic discrepancy with no trail back to the cause.
+//
+// Read off the RAW lines rather than the parsed `entries`, so a byte in a
+// column this file has no field for is caught too, and reported with the file
+// line number: a shifted parse is exactly the situation where the row's own #
+// cell is the thing not to trust.
+//
+// CONTROL_CHARS is imported, never re-declared — a second copy of the range
+// would let the write path and this detector disagree about what counts.
+let controlByteRows = 0;
+for (let i = 0; i < lines.length; i++) {
+  if (!lines[i].startsWith('|')) continue;
+  // .match() with a /g regex resets lastIndex; .test() would not, and would
+  // then skip every other offending row.
+  const found = lines[i].match(CONTROL_CHARS);
+  if (!found) continue;
+  const points = [...new Set(found.map(c => `U+${c.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}`))];
+  error(`applications.md line ${i + 1}: tracker row contains invisible control character(s) ${points.join(', ')} — delete them; they render as nothing in every view but shift the positional column parse`);
+  controlByteRows++;
+}
+if (controlByteRows === 0) ok('No control characters in tracker cells');
 
 // --- Summary ---
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Strips invisible control characters at `cell()` in `tracker-utils.mjs` — the one sanitizer every tracker writer passes through — and adds `verify-pipeline.mjs` Check 16 for the bytes already sitting in a tracker file, which stripping alone cannot reach. Both halves share one exported `CONTROL_CHARS`, so the write path and the detector cannot drift apart about what counts.

## Related issue

Closes #3892

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Why the sanitizer and not each writer

`cell()` is the chokepoint: `merge-tracker.mjs`'s `buildRow` runs company, role, location, notes and url through it — and the web dictates its rows through that same merge path — while `set-status.mjs` runs its note through it. A guard added per writer is a guard the next writer is free to reintroduce the bug around, so the strip lands once, where all of them already route.

The tests assert `cell()` directly, never a caller. A writer added later either inherits the guard or bypasses `cell()` visibly; it cannot quietly opt out of a caller-shaped test that was never written about it.

## What the class covers

C0, DEL and C1, minus the three whitespace controls. `\t` is ordinary whitespace inside a cell and `\r`/`\n` are folded to a single space by the replace that already runs ahead of this one — stripping any of the three would glue words together instead of separating them. Same range, same name, as the existing display sanitizer in `plugins/h1b-sponsor/`.

They are **deleted, not replaced with a space**. The byte renders as nothing in markdown, on GitHub and in the dashboard, so substituting a space would change text a human has already read.

## Check 16

Reads the raw lines rather than the parsed entries, so a byte in a column this file has no field for is caught too, and reports the file line number — a shifted parse is exactly the case where a row's own `#` cell is the thing not to trust. It names the code point (`U+0001`) so the byte can be found, and it `error`s rather than `warn`s: the exit code is what CI and cron wrappers read, and a finding that printed while exiting 0 would be indistinguishable from a clean tracker.

Columns that do not pass through `cell()` (`num`, `date`, `score`, `status`, `pdf`, `report`) are left as they are — their own existing checks already reject a malformed value, and Check 16 backstops every column regardless of how the byte arrived.

## Verification

TDD, both halves red first on unfixed code:

- `cell('Senior\x01 Engineer')` returned `'Senior\x01 Engineer'` unchanged.
- `verify-pipeline.mjs` on a tracker whose Role cell held `U+0001` printed `0 errors, 0 warnings` and exited 0 — the silent-corruption shape the issue describes.

Mutation-checked, each one reverted after:

| Mutation | Test that went red |
|---|---|
| Drop `.replace(CONTROL_CHARS, '')` from `cell()` | `cell strips invisible control characters (#3892)` |
| Narrow the class to `\x02-\x08` (drop NUL/SOH) | same |
| Drop `\x7F-\x9F` (DEL and C1) | same |
| Drop `\x0C` (the delete-don't-substitute case) | same |
| Widen the class to `\x00-\x1F` so it swallows `\t` | same |
| Check 16 `error()` → `warn()` | `a control byte ... is reported as an error and exits 1` |
| Drop the code points from the finding | `the finding names the code point` |
| Change the clean-run success line | `control: the same row without the byte reports clean` |

`node test-all.mjs` (full, not `--quick`): **8572 passed, 0 failed, 16 warnings**. None of the 16 warnings name a file in this PR — they are the pre-existing set (maintainer name/domain matches in `funding.json`/`HIRED.md`, missing-font probes, fixture merge notices, skipped opt-in live-API tests, portal config notes).

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`tracker-utils.mjs:cell()` removes invisible C0, DEL, and C1 control characters. Tabs remain valid. Newlines keep their existing folding behavior. Pipes remain sanitized.

`verify-pipeline.mjs` adds Check 16. It scans tracker lines and reports the line number and Unicode code point for each control character. The check fails verification.

## User impact

New tracker writes cannot add these control characters through `cell()`. Existing corrupted tracker files fail verification with a precise location and code point.

Tests cover sanitization, detection, error output, and clean tracker files. Full verification passed: 8,572 tests, 0 failures, and 16 pre-existing warnings.

## Files touched

- `tracker-utils.mjs`
- `verify-pipeline.mjs`
- `tests/tracker-utils.test.mjs`
- `tests/verify-pipeline-control-bytes.test.mjs`

The requested system files were not touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->