### PR TITLE
refactor(lock): clamp the retry backoff inside the policy that owns it

### DIFF
--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -326,10 +326,12 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
   // from the definition: waiters woke in lockstep and re-raced, and a caller
   // waiting on a healthy lock being handed round briskly was killed anyway.
   //
-  // There is no separate maxWaitMs knob here, so the ceiling is the same
-  // multiple of timeoutMs the definition defaults to.
+  // There is no separate maxWaitMs knob here, so no hardDeadline is passed and
+  // the policy applies its own ceiling. Writing one out here would put a fourth
+  // copy of that bound in the tree, and a copy that drifts changes retry timing
+  // silently — nothing fails, so nothing reports it (#3895).
   const { backoffMs, holderStillWedged, noteWaiting, ceilingReached } = createLockWaitPolicy(lockDir, {
-    timeoutMs, retryMs, deadline: Date.now() + timeoutMs, hardDeadline: Date.now() + timeoutMs * 10,
+    timeoutMs, retryMs, deadline: Date.now() + timeoutMs,
   });
   for (;;) {
     if (holderStillWedged() || ceilingReached()) break;

--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -246,21 +246,43 @@ export function lockRecoveryVerdict(lockDir, staleMs) {
  * previous fingerprint and a re-armable window.
  *
  * @param {string} lockDir - The lock directory this caller is waiting on.
- * @param {{timeoutMs: number, retryMs: number, deadline: number, hardDeadline: number}} timing
+ * @param {{timeoutMs: number, retryMs: number, deadline: number, hardDeadline?: number}} timing
+ *   `hardDeadline` is OPTIONAL: omit it and the policy applies its own default
+ *   ceiling, DEFAULT_MAX_WAIT_FACTOR x timeoutMs from now. Pass one only when
+ *   the caller has a real knob of its own (acquirePipelineLock's `maxWaitMs`).
  * @returns {{backoffMs: () => number, holderStillWedged: () => boolean}}
  */
 export function createLockWaitPolicy(lockDir, { timeoutMs, retryMs, deadline, hardDeadline }) {
   let perHolderDeadline = deadline;
   let lastFingerprint;
 
+  // The ceiling is the policy's, not each caller's (#3895). Three lock modules
+  // used to write `Date.now() + timeoutMs * 10` at their own call sites, so the
+  // bound the clamp below applies existed in four places. Copies of an
+  // invariant stay correct only until one is edited, and a wrong ceiling fails
+  // silently — it changes retry timing, which nothing asserts and nobody
+  // reports. Deriving it here leaves one copy for them all.
+  const ceiling = hardDeadline ?? Date.now() + timeoutMs * DEFAULT_MAX_WAIT_FACTOR;
+  // A ceiling that is not a number is not a ceiling, and it fails INVISIBLY:
+  // Math.min(x, NaN) is NaN, Math.max(0, NaN) is NaN, and setTimeout(NaN) fires
+  // immediately — so a caller that got this wrong would spin hot through the
+  // retry loop rather than raise anything. Infinity is a deliberate, legible
+  // "no ceiling" (acquirePipelineLock passes it for maxWaitMs: Infinity) and is
+  // kept; NaN and non-numbers are mistakes and are refused where they are made.
+  if (typeof ceiling !== 'number' || Number.isNaN(ceiling)) {
+    throw new TypeError(
+      `createLockWaitPolicy: hardDeadline must be a number or omitted, got ${String(hardDeadline)}`,
+    );
+  }
+
   // Jittered backoff, never sleeping past the ceiling. An uncapped sleep can
-  // cross hardDeadline and let the NEXT mkdir succeed, returning a lock after
+  // cross the ceiling and let the NEXT mkdir succeed, returning a lock after
   // the documented absolute limit — an overshoot of up to 1.5x retryMs. Waking
   // exactly at the ceiling means the check at the top of the loop is what
   // decides, rather than whichever of the two happened to be later.
   const backoffMs = () => Math.max(0, Math.min(
     retryMs * (0.5 + Math.random()),
-    hardDeadline - Date.now(),
+    ceiling - Date.now(),
   ));
 
   // The per-holder deadline, evaluated the SAME way everywhere: an expired
@@ -300,7 +322,7 @@ export function createLockWaitPolicy(lockDir, { timeoutMs, retryMs, deadline, ha
   // this at the top of its loop; the three copies had no ceiling at all before
   // they adopted the progress rule, and adopting it without this would trade a
   // premature timeout for an unbounded wait.
-  const ceilingReached = () => Date.now() > hardDeadline;
+  const ceilingReached = () => Date.now() > ceiling;
 
   return { backoffMs, holderStillWedged, noteWaiting, ceilingReached };
 }

--- a/portal-health-lock.mjs
+++ b/portal-health-lock.mjs
@@ -121,10 +121,12 @@ export async function acquirePortalHealthLock(filePath, options = {}) {
   // from the definition: waiters woke in lockstep and re-raced, and a caller
   // waiting on a healthy lock being handed round briskly was killed anyway.
   //
-  // maxWaitMs has no separate knob here, so the ceiling is the same multiple
-  // of timeoutMs the definition defaults to.
+  // maxWaitMs has no separate knob here, so no hardDeadline is passed and the
+  // policy applies its own ceiling. Writing one out here would put a fourth
+  // copy of that bound in the tree, and a copy that drifts changes retry timing
+  // silently — nothing fails, so nothing reports it (#3895).
   const { backoffMs, holderStillWedged, noteWaiting, ceilingReached } = createLockWaitPolicy(lockDir, {
-    timeoutMs, retryMs, deadline, hardDeadline: Date.now() + timeoutMs * 10,
+    timeoutMs, retryMs, deadline,
   });
 
   // A fresh install may not have data/ yet, and appendPortalHealth() creates

--- a/tests/pipeline-lock.test.mjs
+++ b/tests/pipeline-lock.test.mjs
@@ -22,12 +22,17 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   acquirePipelineLock, LockTimeoutError, OWNERLESS_GRACE_MS,
   lockRecoveryVerdict, RECOVER_STALE, RECOVER_VANISHED, RECOVER_LIVE,
+  createLockWaitPolicy,
 } from '../pipeline-lock.mjs';
+import { collectMjsFiles } from '../lib/mjs-files.mjs';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const SELF = fileURLToPath(import.meta.url);
+const REPO_ROOT = dirname(dirname(SELF));
 
 // Occupies `lockDir` continuously while handing it to a fresh owner every
 // `everyMs`, the way a queue of short writers does. The swap runs inside one
@@ -596,4 +601,125 @@ test('release(): a holder whose lock was reclaimed by another process must not d
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// The wait ceiling belongs to the policy, not to each caller (#3895)
+// ---------------------------------------------------------------------------
+//
+// createLockWaitPolicy clamps the jittered retry against a ceiling, but the
+// ceiling itself used to arrive from outside: three lock modules each wrote
+// `hardDeadline: Date.now() + timeoutMs * 10` at their own call site. Copies of
+// an invariant stay correct only until one is edited, and NOTHING FAILED when
+// they diverged — a wrong ceiling changes retry timing, which no test asserted
+// and no user reports. These are the assertions that make that divergence
+// detectable, so moving the clamp inside the policy is a fix rather than a
+// relocation of a silent invariant.
+
+test('createLockWaitPolicy: the wait ceiling is the policy\'s own, so a caller need not supply one (#3895)', () => {
+  const root = fixtureRoot();
+  try {
+    const lockDir = join(root, 'data', 'pipeline.md.lock');
+    // retryMs far above the ceiling, so the jittered retry never wins the
+    // Math.min and backoffMs() reports the remaining ceiling itself.
+    const policy = createLockWaitPolicy(lockDir, {
+      timeoutMs: 200, retryMs: 1_000_000, deadline: Date.now() + 200,
+    });
+
+    const remaining = policy.backoffMs();
+    assert.ok(
+      Number.isFinite(remaining),
+      `backoffMs() returned ${remaining}: with no ceiling the clamp is Math.min(x, NaN) === NaN, `
+      + 'and setTimeout(NaN) fires immediately — the retry loop spins hot instead of waiting',
+    );
+    // 2000ms is the 10x multiple of timeoutMs each of the three lock modules
+    // used to write out for itself. A literal on purpose: a test that reads the
+    // constant back out of the module cannot notice that constant moving.
+    assert.ok(
+      Math.abs(remaining - 2_000) <= 100,
+      `default ceiling is ~${remaining}ms away, expected ~2000ms (10 x timeoutMs)`,
+    );
+    assert.equal(policy.ceilingReached(), false, 'the ceiling cannot already be reached at t=0');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('createLockWaitPolicy: the policy-supplied ceiling actually expires, so waiting stays bounded (#3895)', async () => {
+  const root = fixtureRoot();
+  try {
+    const lockDir = join(root, 'data', 'pipeline.md.lock');
+    const policy = createLockWaitPolicy(lockDir, {
+      timeoutMs: 5, retryMs: 1, deadline: Date.now() + 5,
+    });
+
+    await sleep(120); // well past 10 x 5ms, so this is not a race against the clock
+
+    assert.equal(
+      policy.ceilingReached(), true,
+      'ceilingReached() never fires without a ceiling (Date.now() > undefined is always false), '
+      + 'so a caller waits unboundedly on a lock that never frees',
+    );
+    assert.equal(policy.backoffMs(), 0, 'past the ceiling there is nothing left to sleep');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('createLockWaitPolicy: a hardDeadline that is not a number is refused, not silently turned into NaN (#3895)', () => {
+  const root = fixtureRoot();
+  try {
+    const lockDir = join(root, 'data', 'pipeline.md.lock');
+    const timing = { timeoutMs: 100, retryMs: 10, deadline: Date.now() + 100 };
+
+    for (const bad of ['in a bit', NaN, {}]) {
+      assert.throws(
+        () => createLockWaitPolicy(lockDir, { ...timing, hardDeadline: bad }),
+        /hardDeadline/,
+        `hardDeadline: ${String(bad)} must be refused — as a ceiling it silently becomes NaN, `
+        + 'and a NaN backoff is a hot spin rather than an error anyone can see',
+      );
+    }
+
+    // null is "nothing supplied", the same as omitting the key, so it takes the
+    // policy default rather than throwing. Pinned because `??` is what draws
+    // that line, and a later switch to `||` or a truthiness test would move it.
+    const viaNull = createLockWaitPolicy(lockDir, { ...timing, hardDeadline: null });
+    assert.ok(Number.isFinite(viaNull.backoffMs()), 'a null ceiling means "use the default", not NaN');
+
+    // Infinity is a legitimate, explicit "no ceiling": acquirePipelineLock
+    // passes it for maxWaitMs: Infinity. The check must not swallow it.
+    const unbounded = createLockWaitPolicy(lockDir, { ...timing, hardDeadline: Infinity });
+    assert.ok(unbounded.backoffMs() > 0, 'an unbounded ceiling still yields a real jittered retry');
+    assert.equal(unbounded.ceilingReached(), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('no lock module re-derives the wait ceiling — the policy holds the only copy (#3895)', () => {
+  const policyModule = join(REPO_ROOT, 'pipeline-lock.mjs');
+  const sources = collectMjsFiles(REPO_ROOT).filter((f) => f !== SELF && f !== policyModule);
+
+  // A guard that cannot look must never pass: an empty or tiny scan means the
+  // walk failed, not that the repository is clean.
+  assert.ok(
+    sources.length > 100,
+    `only ${sources.length} .mjs files scanned — this guard could not inspect the tree`,
+  );
+
+  // Comments are stripped first: naming the parameter while explaining why it
+  // is NOT passed is exactly what the three call sites now do, and a guard that
+  // fires on prose gets silenced rather than obeyed.
+  const withoutComments = (src) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+  const offenders = sources
+    .filter((f) => withoutComments(readFileSync(f, 'utf-8')).includes('hardDeadline'))
+    .map((f) => f.slice(REPO_ROOT.length + 1).replace(/\\/g, '/'));
+
+  assert.deepEqual(
+    offenders, [],
+    'these modules name hardDeadline themselves, which means they are bounding the wait '
+    + 'instead of letting createLockWaitPolicy do it — the duplicated invariant #3895 removed. '
+    + 'A ceiling belongs to the policy; a copy of it stays correct only until someone edits one side',
+  );
 });

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -349,10 +349,12 @@ export async function acquireTrackerLock(lockDir, options = {}) {
   // from the definition: waiters woke in lockstep and re-raced, and a caller
   // waiting on a healthy lock being handed round briskly was killed anyway.
   //
-  // There is no separate maxWaitMs knob here, so the ceiling is the same
-  // multiple of timeoutMs the definition defaults to.
+  // There is no separate maxWaitMs knob here, so no hardDeadline is passed and
+  // the policy applies its own ceiling. Writing one out here would put a fourth
+  // copy of that bound in the tree, and a copy that drifts changes retry timing
+  // silently — nothing fails, so nothing reports it (#3895).
   const { backoffMs, holderStillWedged, noteWaiting, ceilingReached } = createLockWaitPolicy(lockDir, {
-    timeoutMs, retryMs, deadline: Date.now() + timeoutMs, hardDeadline: Date.now() + timeoutMs * 10,
+    timeoutMs, retryMs, deadline: Date.now() + timeoutMs,
   });
   for (;;) {
     if (holderStillWedged() || ceilingReached()) break;


### PR DESCRIPTION
## What does this PR do?

Moves the lock retry backoff's clamp inside `createLockWaitPolicy`, so callers receive an already-valid interval instead of each deriving the bound themselves. `hardDeadline` becomes optional: omit it and the policy applies its own `DEFAULT_MAX_WAIT_FACTOR x timeoutMs` ceiling. Three callers stop bounding, and two assertions are added that make a future divergence fail loudly.

## Related issue

Closes #3895

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

---

### Which three callers

The issue names `tracker-utils.mjs`, `pipeline-lock.mjs` and `followup-seed.mjs`. On `main` the modules that actually re-derive the bound are:

| Module | Line on `main` |
|---|---|
| `tracker-utils.mjs` | `hardDeadline: Date.now() + timeoutMs * 10` |
| `followup-seed.mjs` | `hardDeadline: Date.now() + timeoutMs * 10` |
| `portal-health-lock.mjs` | `hardDeadline: Date.now() + timeoutMs * 10` |

`portal-health-lock.mjs` adopted the shared policy in `39f87cd7` ("share the waiting half of the protocol with the three lock copies") and carries the same copy — it is the third of the "three lock copies" that commit names, so it is included here. Leaving it out would have left exactly one copy of the bound alive, which is the fourth-call-site outcome the issue was filed to prevent.

`acquirePipelineLock` still passes an explicit `hardDeadline`, and deliberately so: it has a real `maxWaitMs` option whose `0` ("never wait past now") and `Infinity` ("no ceiling") readings are load-bearing, and its factor constant already lives in the same module as the policy. It is a caller with a knob, not a copy of the default.

### Why a refactor alone would not have been a fix

The issue's own framing is the important half: **nothing currently fails when the copies diverge.** A wrong ceiling only changes retry timing, which no test asserts and no user reports, so the drift is silent and permanent.

That is not a claim I took on trust. On this branch, drifting one caller's copy from `timeoutMs * 10` to `timeoutMs * 2` leaves the entire 27-case `tracker-writer-lock-tests.mjs` suite green — 27 passed, 0 failed. Moving the clamp without adding an assertion would have relocated a silent invariant rather than removed one.

Two assertions close it:

1. **The policy refuses a ceiling that is not a number.** This failure mode is invisible by construction: `Math.min(x, NaN)` is `NaN`, `Math.max(0, NaN)` is `NaN`, and `setTimeout(NaN)` fires immediately — so a caller that got the ceiling wrong would spin hot through the retry loop instead of raising anything. `Infinity` is explicitly kept, because it is a deliberate "no ceiling" that `acquirePipelineLock` relies on; `NaN` and non-numbers are mistakes and are refused where they are made. `null` is treated as "not supplied" and takes the default, pinned by a test because `??` is what draws that line.

2. **A guard fails if any module other than the policy names `hardDeadline`.** That is precisely the shape a fourth call site copying the pattern would take. Comments are stripped before the check, so a module may explain why it does *not* pass one — a guard that fires on prose gets silenced rather than obeyed. The scan refuses to pass on an empty or implausibly small file list, so it cannot report success when it failed to look.

### Test evidence

`tests/pipeline-lock.test.mjs` — 4 new cases, 25 passing in that file.

Written test-first, and every assertion mutation-checked:

| Mutation | Result |
|---|---|
| Remove the default derivation (`ceiling = hardDeadline`) | RED — 3 of the 4 new cases; `backoffMs()` returns `NaN` and `ceilingReached()` never fires |
| Drift the factor to `timeoutMs * 5` | RED — the ceiling-value case (~1000ms observed, ~2000ms expected) |
| Disable the type guard | RED — the refusal case |
| Tighten the guard to `Number.isFinite`, rejecting `Infinity` | RED — the refusal case. Worth noting: the pre-existing `maxWaitMs` cases all stayed green, so nothing else covered that path |
| Re-add `hardDeadline: Date.now() + timeoutMs * 10` at a caller | RED — the drift guard only; `tracker-writer-lock-tests.mjs` stayed 27/27 green |
| Diverge a caller's copy to `timeoutMs * 2` | RED — the drift guard only; `tracker-writer-lock-tests.mjs` stayed 27/27 green |

The last two are the point of the PR: the existing suite cannot tell a diverged copy from a correct one, and now something can.

The ceiling value is asserted as a literal `2000ms` rather than by importing the constant — a test that reads the constant back out of the module it is testing cannot notice that constant moving.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — 8568 passed, 0 failed, 16 warnings, none of which name any file this PR touches (they are the pre-existing template/fixture and font-probe warnings on `main`)
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Centralizes lock retry backoff limits in `createLockWaitPolicy`.

### User impact

- Lock callers no longer calculate their own retry ceiling.
- The policy derives the default ceiling from `DEFAULT_MAX_WAIT_FACTOR × timeoutMs`.
- `acquirePipelineLock` keeps explicit `maxWaitMs` behavior, including `0` and `Infinity`.
- Invalid non-number or `NaN` ceilings now raise `TypeError`.
- No user-facing behavior changes are expected beyond consistent retry timing.

### Files changed

- `pipeline-lock.mjs`: Adds optional `hardDeadline` handling and validation.
- `followup-seed.mjs`: Removes local ceiling calculation.
- `portal-health-lock.mjs`: Removes local ceiling calculation.
- `tracker-utils.mjs`: Removes local ceiling calculation.
- `tests/pipeline-lock.test.mjs`: Adds coverage for default ceilings, expiration, invalid values, and duplicated call-site calculations.

The requested system files were not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

### Verification

- `tests/pipeline-lock.test.mjs`: 25 tests pass.
- Full test suite: 8,568 tests pass with no failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->