### PR TITLE
test(guards): enumerate the repo-scanning guards through lib/mjs-files.mjs

### DIFF
--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -19,10 +19,112 @@
  * `test-all.mjs`: two independently maintained definitions of the same set is
  * exactly the drift that caused this, and a second copy would be free to
  * re-diverge the next time one of them learned about a directory.
+ *
+ * Two exports, answering two DIFFERENT questions — which is not the drift
+ * above, and the distinction is worth stating so nobody collapses them:
+ *
+ *   `collectMjsFiles` — every `.mjs` in the WORKING TREE, skip-list and all.
+ *                       What the syntax gates want: the file you just wrote and
+ *                       have not `git add`ed yet still has to parse.
+ *   `trackedFiles`    — every file the INDEX holds, at any depth, no skip-list.
+ *                       What the repo-scanning guards want: they grade what the
+ *                       repository ships, and git already knows which trees are
+ *                       not that. Four guards each kept their own walk with
+ *                       their own skip-list until #3890; every one of them
+ *                       carried the same silent narrowing as the gate above.
  */
 
+import { execFileSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
+
+/**
+ * Every file `root` TRACKS, as absolute paths, sorted.
+ *
+ * The enumerator for repo-scanning guards, as distinct from `collectMjsFiles`
+ * below, which walks the working tree. The two answer different questions on
+ * purpose and the difference is not drift: a syntax gate wants the file you
+ * just wrote and have not added yet, and a guard grading what the repository
+ * SHIPS wants the index — which is also the only definition that needs no
+ * skip-list. `node_modules`, `output/`, `data/`, a gitignored worktree and a
+ * half-finished scratch file are all excluded because git already knows they
+ * are not repository content, not because four separate walkers each remembered
+ * to name them (#3890).
+ *
+ * Every hand-maintained walker in this repo carried the #3419 defect in some
+ * form: it scanned directories it should not, it missed newly tracked files
+ * under a directory its skip-list excluded, and a green run looked identical
+ * either way. A skip-list narrows silently. An index does not.
+ *
+ * `filter` receives the repo-relative path with FORWARD slashes on every
+ * platform (`ls-files` emits POSIX separators), so `rel.startsWith('modes/')`
+ * is written once rather than per-OS. It is applied before the existence check
+ * so a caller scoping to a subtree does not pay a stat for the whole tree.
+ *
+ * @param {string} root - Absolute path to a git working tree.
+ * @param {(rel: string) => boolean} [filter] - Tested against the relative path.
+ * @returns {string[]} Absolute paths, lexicographically sorted.
+ */
+export function trackedFiles(root, filter = () => true) {
+  // Deliberately uncaught. A `git` that cannot run, or a `root` that is not a
+  // working tree, is a scan that did not happen — and the one thing this module
+  // exists to prevent is a scan that did not happen reading as a scan that
+  // passed. The same reasoning as the missing-root throw in collectMjsFiles.
+  const out = execFileSync('git', ['-C', root, 'ls-files', '-z'], {
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  // De-duplicated because `ls-files` prints one line PER INDEX STAGE, so a path
+  // in an unresolved merge arrives two or three times. Left alone, every hit
+  // inside a conflicted file would be reported once per stage and every
+  // "n files scanned" figure would be wrong for the duration of the merge.
+  const listed = [...new Set(out.split('\0').filter(Boolean))];
+
+  // Empty is never "nothing to check" — it means this call could not look.
+  // `ls-files` exits 0 with no output when run from an untracked directory,
+  // which is exactly how the SYSTEM_PATHS coverage guard printed
+  // "0 tracked files covered" and exited 0 for its entire life while the tree
+  // really did have an unregistered file in it. Callers filter afterwards, so
+  // this is the LISTING being empty, not the caller's slice of it.
+  if (listed.length === 0) {
+    throw new Error(
+      `git ls-files listed no tracked files under ${root} — this scan could not inspect anything. ` +
+        'An empty listing usually means the caller is running from an untracked directory ' +
+        '(a temp copy, a fixture dir), where git reports nothing and the guard is meaningless.',
+    );
+  }
+
+  const files = [];
+  const absent = [];
+  for (const rel of listed) {
+    if (!filter(rel)) continue;
+    const full = join(root, rel);
+    // Listed but not on disk. Mid-merge the index holds stages for a path the
+    // working tree may not have — a delete/modify conflict whose deletion is
+    // the resolution being accepted, still unstaged, is a `DU` path that
+    // `ls-files` names and `readFileSync` cannot open. That is an ordinary
+    // state during conflict resolution, not a corrupt repository (a submodule
+    // that was never initialised and a sparse checkout land here too), so it
+    // must not take the whole guard down with an ENOENT: a guard that crashes
+    // while you are resolving a merge is a guard people learn to skip, which
+    // costs more than the guard was worth. Skipped LOUDLY, though — a scan
+    // quietly covering less than it claims is the defect this module is named
+    // after.
+    if (existsSync(full)) files.push(full);
+    else absent.push(rel);
+  }
+
+  if (absent.length > 0) {
+    console.warn(
+      `warning: skipped ${absent.length} tracked path(s) the working tree does not have ` +
+        `(unresolved merge, uninitialised submodule, sparse checkout): ${absent.join(', ')}`,
+    );
+  }
+
+  return files.sort();
+}
 
 /**
  * Directories excluded from the walk BY NAME.

--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -35,7 +35,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, lstatSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -58,8 +58,12 @@ import { join } from 'path';
  *
  * `filter` receives the repo-relative path with FORWARD slashes on every
  * platform (`ls-files` emits POSIX separators), so `rel.startsWith('modes/')`
- * is written once rather than per-OS. It is applied before the existence check
- * so a caller scoping to a subtree does not pay a stat for the whole tree.
+ * is written once rather than per-OS. It is applied before the lstat below, so
+ * a caller scoping to a subtree does not pay a stat for the whole tree.
+ *
+ * Only regular files come back: a symlink, a submodule directory and a path the
+ * index names but the tree does not have are each skipped with a warning that
+ * says which. See the comment on the loop for why each one is not readable.
  *
  * @param {string} root - Absolute path to a git working tree.
  * @param {(rel: string) => boolean} [filter] - Tested against the relative path.
@@ -96,30 +100,54 @@ export function trackedFiles(root, filter = () => true) {
     );
   }
 
+  // Only REGULAR FILES are returned, and `lstatSync` rather than `existsSync`
+  // is what decides that. The index names three things a caller cannot simply
+  // open, and the walkers being replaced here excluded all three for free —
+  // `readdirSync` told them what each entry was:
+  //
+  //   MISSING     Mid-merge the index holds stages for a path the working tree
+  //               may not have: a delete/modify conflict whose deletion is the
+  //               resolution being accepted, still unstaged, is a `DU` path
+  //               that `ls-files` names and `readFileSync` cannot open. An
+  //               ordinary state during conflict resolution, not a corrupt
+  //               repository — a sparse checkout and an uninitialised
+  //               submodule land here too. A guard that crashes while you are
+  //               resolving a merge is a guard people learn to skip, which
+  //               costs more than the guard was worth (#3890).
+  //   SYMLINK     `ls-files` lists tracked symlinks (this repo has seven: the
+  //               per-CLI `SKILL.md` links to the canonical one), and
+  //               `existsSync`/`readFileSync` follow them. Following costs
+  //               twice: the target is usually tracked in its own right, so
+  //               one offender gets reported once per link, and a link
+  //               pointing outside the checkout puts source this repository
+  //               does not own under a guard that grades it — the #3499 hazard
+  //               `isNestedCheckout` exists for. `collectMjsFiles` below skips
+  //               them for exactly this reason; so does this.
+  //   DIRECTORY   An initialised submodule is a gitlink: one index entry, a
+  //               directory on disk. `existsSync` says yes and `readFileSync`
+  //               throws EISDIR.
+  //
+  // Skipped LOUDLY in every case, and named with its reason — a scan quietly
+  // covering less than it claims is the defect this module is named after.
   const files = [];
-  const absent = [];
+  const skipped = [];
   for (const rel of listed) {
     if (!filter(rel)) continue;
-    const full = join(root, rel);
-    // Listed but not on disk. Mid-merge the index holds stages for a path the
-    // working tree may not have — a delete/modify conflict whose deletion is
-    // the resolution being accepted, still unstaged, is a `DU` path that
-    // `ls-files` names and `readFileSync` cannot open. That is an ordinary
-    // state during conflict resolution, not a corrupt repository (a submodule
-    // that was never initialised and a sparse checkout land here too), so it
-    // must not take the whole guard down with an ENOENT: a guard that crashes
-    // while you are resolving a merge is a guard people learn to skip, which
-    // costs more than the guard was worth. Skipped LOUDLY, though — a scan
-    // quietly covering less than it claims is the defect this module is named
-    // after.
-    if (existsSync(full)) files.push(full);
-    else absent.push(rel);
+    const stat = lstatSync(join(root, rel), { throwIfNoEntry: false });
+    if (stat?.isFile()) {
+      files.push(join(root, rel));
+      continue;
+    }
+    const why = stat === undefined ? 'not in the working tree'
+      : stat.isSymbolicLink() ? 'a symlink'
+        : 'not a regular file';
+    skipped.push(`${rel} (${why})`);
   }
 
-  if (absent.length > 0) {
+  if (skipped.length > 0) {
     console.warn(
-      `warning: skipped ${absent.length} tracked path(s) the working tree does not have ` +
-        `(unresolved merge, uninitialised submodule, sparse checkout): ${absent.join(', ')}`,
+      `warning: skipped ${skipped.length} tracked path(s) that are not readable regular files ` +
+        `(unresolved merge, sparse checkout, submodule, symlink): ${skipped.join(', ')}`,
     );
   }
 

--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -56,6 +56,22 @@ import { join } from 'path';
  * under a directory its skip-list excluded, and a green run looked identical
  * either way. A skip-list narrows silently. An index does not.
  *
+ * THE INDEX, THOUGH — NOT THE COMMIT, AND NOT THE WORKING TREE. The sharp edge
+ * of grading what the repository ships is that a file you have written but not
+ * `git add`ed is not yet part of what it ships, so it does not exist to any
+ * guard built on this: the new suite that skips its own `main` guard, the new
+ * mode file carrying mojibake, the new scanner with a private walk. The guard
+ * does not fail on it and does not mention it — it reports a clean sweep of the
+ * files that WERE staged, which is the exact shape of green-that-checked-less
+ * this module was written to remove, arriving through the fix rather than the
+ * bug. It is the deliberate trade and not a defect to route around: the
+ * alternative is the skip-list, and the failure lands one `git add` later
+ * rather than never. But it means a pre-commit run and a CI run legitimately
+ * disagree, and a contributor debugging that discrepancy should find the reason
+ * written down here rather than infer it from `ls-files`. Stage first, then
+ * trust the guard. `collectMjsFiles` is the export that does not care, which is
+ * why the syntax gates use it.
+ *
  * `filter` receives the repo-relative path with FORWARD slashes on every
  * platform (`ls-files` emits POSIX separators), so `rel.startsWith('modes/')`
  * is written once rather than per-OS. It is applied before the lstat below, so

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -2,11 +2,11 @@
 // Moved verbatim from test-all.mjs (issue #1440); no framework by design:
 // the suite must run on a fresh clone with only Node.
 import { execFileSync } from 'child_process';
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync as _rmSync, symlinkSync, writeFileSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync as _rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join, dirname } from 'path';
+import { basename, join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { isNestedCheckout } from '../lib/mjs-files.mjs';
+import { trackedFiles } from '../lib/mjs-files.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const ROOT = join(__dirname, '..');   // repo root (tests/ lives one level down)
@@ -370,40 +370,41 @@ export function formatRunFailure(maxChars = 2000) {
 export function fileExists(path) { return existsSync(join(ROOT, path)); }
 
 /**
- * Recursively collect files under `dir` whose basename matches `match`.
+ * Every TRACKED file under `dir` whose basename matches `match`.
  *
- * Deterministic by construction: entries are sorted lexicographically at every
- * level, so the result is identical on every run and every OS — the same
- * property test-all.mjs's own `tests/` discovery relies on (#1440).
+ * Enumerated through lib/mjs-files.mjs (#3890), not a private walk. This used
+ * to recurse the working tree with a skip-list its one caller passed in
+ * (`node_modules`, `.next`, `.git`, `out`, `dist`, `coverage`) — the same
+ * hand-maintained shape #3419 removed from the syntax gate, and the same silent
+ * narrowing: a suite added under a directory somebody forgot to un-skip never
+ * enters the guard, and the run is exactly as green as one that read it. Git
+ * already knows which of those trees is repository content, so the skip-list
+ * parameter is gone rather than reproduced here.
+ *
+ * That also retires the `isNestedCheckout` guard this walk used to need, and
+ * retires it rather than losing it: a name-matching skip-list never fired on a
+ * linked worktree, which marks itself with a `.git` FILE, so the walk descended
+ * into a whole second checkout of this repository (#3499, #3762). Nothing in
+ * that second checkout is tracked HERE, so the index cannot name it — the
+ * hazard is gone by construction instead of by a rule each walker remembers.
+ *
+ * Deterministic by construction (sorted), which is the property test-all.mjs's
+ * own `tests/` discovery relies on (#1440).
  *
  * A missing `dir` yields `[]` rather than throwing, so the caller reports its
- * own contract failure (e.g. "discovery is empty") instead of the run dying
- * mid-traversal with an ENOENT that says nothing about what was expected.
+ * own contract failure (e.g. "discovery is empty") instead of the run dying on
+ * an ENOENT that says nothing about what was expected. A `dir` that EXISTS but
+ * that git can see nothing in is a different thing entirely — that is a scan
+ * that could not look, and trackedFiles throws rather than let it read as a
+ * clean sweep.
  *
- * @param {string} dir - Absolute directory to walk.
- * @param {RegExp} match - Tested against each entry's basename.
- * @param {Set<string>} [skipDirs] - Directory names never descended into.
- * @returns {string[]} Absolute paths, parents before children.
+ * @param {string} dir - Absolute directory inside a git working tree.
+ * @param {RegExp} match - Tested against each tracked file's basename.
+ * @returns {string[]} Absolute paths, lexicographically sorted.
  */
-export function walkFiles(dir, match, skipDirs = new Set()) {
+export function walkFiles(dir, match) {
   if (!existsSync(dir)) return [];
-  const out = [];
-  const entries = readdirSync(dir, { withFileTypes: true })
-    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-  for (const entry of entries) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      // A linked worktree carries a `.git` FILE, so a caller's `skipDirs` set —
-      // which matches by NAME — never fires on one, and the walk descends into a
-      // whole second checkout of this repository (#3499, #3762). The caller's
-      // own set stays authoritative for everything else.
-      if (isNestedCheckout(full)) continue;
-      if (!skipDirs.has(entry.name)) out.push(...walkFiles(full, match, skipDirs));
-    } else if (match.test(entry.name)) {
-      out.push(full);
-    }
-  }
-  return out;
+  return trackedFiles(dir, (rel) => match.test(basename(rel)));
 }
 
 /**

--- a/tests/local-today-gates.test.mjs
+++ b/tests/local-today-gates.test.mjs
@@ -22,11 +22,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { localToday } from '../lib/local-today.mjs';
-import { isNestedCheckout } from '../lib/mjs-files.mjs';
+import { trackedFiles } from '../lib/mjs-files.mjs';
 import { shouldDedupScanHistoryRow } from '../scan.mjs';
 import { parseScanHistory, detectReposts } from '../detect-reposts.mjs';
 
@@ -504,28 +504,23 @@ function topLevelArgs({ list, isCode }) {
   return out;
 }
 
-/** Every .mjs source file in the repo, at any depth. */
-function sourceFiles(dir, acc = []) {
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    // Vendored code, build output, and the suite's own scratch copy of the repo
-    // (test-all.mjs mkdtemps it under ROOT) would otherwise be walked.
-    if (entry.isDirectory()) {
-      if (/^(node_modules|\.git|\.next|coverage|dist|build)$/.test(entry.name)) continue;
-      if (entry.name.startsWith('.tmp-script-test-')) continue;
-      // ...and so would git's OWN scratch copy of the repo. The `\.git` above
-      // matches a directory NAME, which a linked worktree does not have — it
-      // marks itself with a `.git` file. This gate read the worktree's stale
-      // sources as repo source and failed, naming files that are correct on the
-      // branch under test (#3499). Same hazard as the line above it, different
-      // author of the second copy.
-      if (isNestedCheckout(join(dir, entry.name))) continue;
-      sourceFiles(join(dir, entry.name), acc);
-    } else if (entry.name.endsWith('.mjs') && !entry.name.endsWith('.test.mjs')) {
-      acc.push(join(dir, entry.name));
-    }
-  }
-  return acc;
-}
+/**
+ * Every tracked .mjs source file in the repo, at any depth, tests excluded.
+ *
+ * Enumerated through lib/mjs-files.mjs (#3890) rather than a private walk. The
+ * walk this replaces named `node_modules`, `.git`, `.next`, `coverage`, `dist`,
+ * `build`, `.tmp-script-test-*` and — via isNestedCheckout() — a linked
+ * worktree, whose stale sources once failed this very gate by naming files that
+ * are correct on the branch under test (#3499). Git tracks none of those, so
+ * the index excludes all of them without a list anyone has to keep current.
+ *
+ * That matters here specifically: this gate is DERIVED, not a hard-coded list
+ * of writers, so a new scan script is covered the day it lands — but only if
+ * the enumerator can see it. A skip-list that silently stops covering a
+ * directory turns a derived gate back into a hard-coded one without saying so.
+ */
+const sourceFiles = () =>
+  trackedFiles(ROOT, (rel) => rel.endsWith('.mjs') && !rel.endsWith('.test.mjs'));
 
 // The census above is only as good as its scanner, and every shape below was
 // found by review rather than by the scanner's own tests. So the scanner gets
@@ -575,7 +570,21 @@ test('every scan-history writer stamps the local day', () => {
   // `scripts/scan-foo.mjs` counts, not just a direct child of ROOT. That is the
   // shape tests/lock-rm-contention.test.mjs used to finally pin its own family
   // shut after two reintroductions.
-  const writers = sourceFiles(ROOT)
+  const sources = sourceFiles();
+
+  // The four known writers all sit at the repository ROOT, so the floor below
+  // ("at least four") stays true even when the enumeration has narrowed to the
+  // root and stopped covering `scripts/`, `providers/` and everything else —
+  // the derived gate quietly reverts to the hard-coded list it was written to
+  // replace, and reads exactly as green. That is #3419's failure shape, here.
+  // So assert the REACH separately from the count.
+  assert.ok(
+    sources.some((f) => relative(ROOT, f).split('\\').join('/').includes('/')),
+    'the enumeration stopped at the repository root — a scan-history writer added under any ' +
+      'subdirectory would silently leave this gate while it kept reporting the four it already knew',
+  );
+
+  const writers = sources
     .map((file) => ({ file, calls: scanHistoryCallArgs(readFileSync(file, 'utf-8')), src: readFileSync(file, 'utf-8') }))
     .filter((w) => w.calls.length > 0);
 

--- a/tests/main-guard-convention.test.mjs
+++ b/tests/main-guard-convention.test.mjs
@@ -24,12 +24,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { isMainModule } from '../lib/is-main-module.mjs';
-import { isNestedCheckout } from '../lib/mjs-files.mjs';
+import { trackedFiles } from '../lib/mjs-files.mjs';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -199,35 +199,20 @@ const STATIC_RELATIVE_IMPORT = new RegExp(
 // is treated as code, which can only over-report, never under-report.
 const COMMENT_LINE = /^\s*(\/\/|\*|\/\*)/;
 
-const SKIP_DIRS = new Set([
-  'node_modules', '.git',
-  // User-layer / generated trees (gitignored, may hold arbitrary user files).
-  // batch/ is deliberately NOT here: its tracked scripts (aggregate-tokens.mjs)
-  // are entrypoints like any other and stay under enforcement.
-  'output', 'data', 'reports', 'jds', 'documents', 'interview-prep',
-]);
-
-function walk(dir, out = []) {
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith('.')) continue; // .tmp-* probe dirs; no tracked dotdir ships .mjs
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      // A linked worktree is a second checkout of this repo at some other
-      // commit, and `.git` in SKIP_DIRS does not catch one — it marks itself
-      // with a `.git` FILE (#3499). The dot-prefix skip above happens to cover
-      // Claude Code's default `.claude/worktrees/`, but nothing keeps a
-      // worktree there; one at `wt/` would put a stale copy of every entrypoint
-      // under enforcement, and this gate would grade source the branch does not
-      // contain — passing or failing on the age of somebody's worktree.
-      if (isNestedCheckout(full)) continue;
-      walk(full, out);
-    } else if (entry.name.endsWith('.mjs')) {
-      out.push(full);
-    }
-  }
-  return out;
-}
+// The enforced set is what the repository TRACKS, enumerated once in
+// lib/mjs-files.mjs (#3890). This used to be a private walk with a
+// hand-maintained skip-list — `node_modules`, `.git`, `output`, `data`,
+// `reports`, `jds`, `documents`, `interview-prep`, every name starting with a
+// dot, plus an isNestedCheckout() call for the linked worktree the `.git` name
+// misses (#3499). Every one of those is a directory git already declines to
+// track, so the index answers the same question with no list to maintain and
+// nothing to forget: batch/'s tracked scripts stay under enforcement because
+// they are tracked, and a gitignored worktree drops out because it is not.
+//
+// A skip-list also narrows in silence, which is the failure #3419 is named
+// after: a newly tracked entrypoint under an excluded directory would sail past
+// this gate, and the run would look exactly as green as one that read it.
+const repoSources = () => trackedFiles(ROOT, (rel) => rel.endsWith('.mjs'));
 
 // Every exemption carries its reason; an unexplained entry is a review smell.
 const EXEMPT = new Map([
@@ -263,8 +248,14 @@ function entryRefViolations(src) {
 }
 
 test('no file outside the helper reads the process entry path', () => {
+  const files = repoSources();
+  // A gate that read nothing must never read as a gate that passed. trackedFiles
+  // already throws on an empty LISTING; this pins the enforced slice of it, so a
+  // filter typo cannot quietly take every entrypoint out of scope.
+  assert.ok(files.length > 100, `expected the tracked .mjs tree, got ${files.length} files`);
+
   const offenders = [];
-  for (const file of walk(ROOT)) {
+  for (const file of files) {
     const rel = relative(ROOT, file).split('\\').join('/');
     if (EXEMPT.has(rel)) continue;
     const hits = entryRefViolations(readFileSync(file, 'utf-8'));

--- a/tests/mjs-files.test.mjs
+++ b/tests/mjs-files.test.mjs
@@ -23,7 +23,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -303,6 +303,65 @@ test('trackedFiles skips a path the index lists but the tree does not have, and 
       'the listed-but-absent path must be skipped, and the rest of the scan must survive it');
     assert.equal(warnings.length, 1, `expected exactly one warning, got: ${JSON.stringify(warnings)}`);
     assert.match(warnings[0], /doomed\.mjs/, 'the warning must name the path that was skipped');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles skips a tracked symlink rather than following it', (t) => {
+  // `ls-files` lists symlinks, and existsSync/readFileSync follow them. This
+  // repository tracks seven (each CLI's SKILL.md links to the canonical one),
+  // so following is not hypothetical: the target is tracked in its own right,
+  // and one offender inside it would be reported once per link. A link pointing
+  // OUT of the checkout is worse — it puts source this repository does not own
+  // under a guard that grades it, the #3499 hazard in a new costume.
+  const { dir, git } = gitRepo('co-tracked-symlink-');
+  try {
+    writeFileSync(join(dir, 'real.mjs'), 'const a = 1;\n');
+    try {
+      symlinkSync(join(dir, 'real.mjs'), join(dir, 'alias.mjs'));
+    } catch (err) {
+      // Windows needs a privilege for this unless Developer Mode is on (#2828).
+      // A machine that cannot link must SKIP, not redden.
+      return t.skip(`symlinks unsupported here (${err.code || err.message})`);
+    }
+    git('add', '-A');
+    assert.match(git('ls-files', '-s'), /^120000 /m, 'the fixture did not track a symlink');
+
+    const { value: files, warnings } = capturingWarnings(() => trackedFiles(dir));
+
+    assert.deepEqual(relPaths(files, dir), ['real.mjs'],
+      'the link must be skipped and its target returned exactly once');
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /alias\.mjs \(a symlink\)/, 'the warning must name the link, and say it is one');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles skips a gitlink directory rather than throwing EISDIR', () => {
+  // An initialised submodule is one index entry (mode 160000) that is a
+  // DIRECTORY on disk. existsSync says yes and readFileSync throws EISDIR.
+  // Written straight into the index rather than by wiring up a real submodule:
+  // the entry is what the enumerator sees, and this needs no second repository,
+  // no network, and no `protocol.file.allow` config to reproduce.
+  const { dir, git } = gitRepo('co-tracked-gitlink-');
+  try {
+    writeFileSync(join(dir, 'real.mjs'), 'const a = 1;\n');
+    git('add', '-A');
+    git('commit', '-qm', 'base');
+    const sha = git('rev-parse', 'HEAD').trim();
+    git('update-index', '--add', '--cacheinfo', `160000,${sha},sub`);
+    mkdirSync(join(dir, 'sub'));
+    assert.match(git('ls-files', '-s'), /^160000 /m, 'the fixture did not create a gitlink');
+
+    const { value: files, warnings } = capturingWarnings(() => trackedFiles(dir));
+
+    for (const file of files) readFileSync(file);   // the EISDIR this prevents
+
+    assert.deepEqual(relPaths(files, dir), ['real.mjs']);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /sub \(not a regular file\)/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/mjs-files.test.mjs
+++ b/tests/mjs-files.test.mjs
@@ -23,13 +23,59 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { collectMjsFiles, isNestedCheckout, SKIP_DIRS } from '../lib/mjs-files.mjs';
+import { collectMjsFiles, isNestedCheckout, trackedFiles, SKIP_DIRS } from '../lib/mjs-files.mjs';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * A throwaway repository, and a `git` bound to it.
+ *
+ * `-C dir` rather than `cwd`, so nothing here depends on the process working
+ * directory. The three configs are not decoration: `user.*` because `commit`
+ * refuses without them on a machine that has no global identity, and
+ * `commit.gpgsign=false` because a contributor whose global config signs every
+ * commit would otherwise have these fixtures block on a passphrase prompt.
+ *
+ * @param {string} prefix - mkdtemp prefix.
+ * @returns {{dir: string, git: (...args: string[]) => string}} The repo.
+ */
+function gitRepo(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  git('init', '-q', '-b', 'trunk');
+  git('config', 'user.email', 'fixture@example.invalid');
+  git('config', 'user.name', 'Fixture');
+  git('config', 'commit.gpgsign', 'false');
+  return { dir, git };
+}
+
+/** Repo-relative POSIX paths, so an assertion reads the same on every OS. */
+const relPaths = (files, dir) => files.map((f) => f.slice(dir.length + 1).replace(/\\/g, '/'));
+
+/**
+ * Run `body` with console.warn captured.
+ *
+ * @param {() => T} body - The call under test.
+ * @returns {{value: T, warnings: string[]}} Its return value and what it warned.
+ * @template T
+ */
+function capturingWarnings(body) {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    return { value: body(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
 
 test('collectMjsFiles recurses, filters, skips and sorts', () => {
   const dir = mkdtempSync(join(tmpdir(), 'co-mjs-files-'));
@@ -160,6 +206,198 @@ test('isNestedCheckout detects the marker, of either type, and nothing else', ()
     assert.equal(isNestedCheckout(join(dir, 'does-not-exist')), false, 'a missing directory is not a checkout');
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── trackedFiles: the guards' enumerator ────────────────────────────────────
+
+test('trackedFiles lists what git tracks, and nothing else', () => {
+  const { dir, git } = gitRepo('co-tracked-');
+  try {
+    mkdirSync(join(dir, 'nested', 'deep'), { recursive: true });
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(join(dir, '.gitignore'), 'node_modules/\ngenerated.mjs\n');
+    writeFileSync(join(dir, 'zz-root.mjs'), '');
+    writeFileSync(join(dir, 'nested', 'deep', 'leaf.mjs'), '');
+    writeFileSync(join(dir, 'nested', 'notes.md'), '');
+    git('add', '-A');
+
+    // The three kinds of file a hand-maintained skip-list gets wrong, all
+    // present at once: vendored code it has to remember to exclude, generated
+    // output it has to remember to exclude, and a brand-new working file that
+    // is not part of the repository yet. The index already knows which is
+    // which, so none of them needs a rule here.
+    writeFileSync(join(dir, 'node_modules', 'dep.mjs'), '');
+    writeFileSync(join(dir, 'generated.mjs'), '');
+    writeFileSync(join(dir, 'scratch.mjs'), '');
+
+    const rel = relPaths(trackedFiles(dir), dir);
+
+    assert.deepEqual(rel, ['.gitignore', 'nested/deep/leaf.mjs', 'nested/notes.md', 'zz-root.mjs'],
+      `only tracked paths, sorted, at any depth — got: ${rel.join(', ')}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles applies the caller filter to the repo-relative path', () => {
+  const { dir, git } = gitRepo('co-tracked-filter-');
+  try {
+    mkdirSync(join(dir, 'templates'), { recursive: true });
+    writeFileSync(join(dir, 'templates', 'cv.html'), '');
+    writeFileSync(join(dir, 'root.mjs'), '');
+    writeFileSync(join(dir, 'root.test.mjs'), '');
+    git('add', '-A');
+
+    // POSIX separators in the filter argument on every platform: `ls-files`
+    // emits forward slashes even on Windows, and a caller scoping to a subtree
+    // writes `startsWith('templates/')` exactly once rather than per-OS.
+    assert.deepEqual(relPaths(trackedFiles(dir, (rel) => rel.startsWith('templates/')), dir),
+      ['templates/cv.html']);
+    assert.deepEqual(
+      relPaths(trackedFiles(dir, (rel) => rel.endsWith('.mjs') && !rel.endsWith('.test.mjs')), dir),
+      ['root.mjs'],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles skips a path the index lists but the tree does not have, and says so', () => {
+  // A REAL unresolved merge, not a simulated one. `git ls-files` reports the
+  // index, and mid-merge the index holds stages for a path the working tree may
+  // not have — here because the deletion is the resolution being accepted and
+  // has not been staged yet. That is an ordinary Tuesday, not a corrupt repo,
+  // and a guard that throws ENOENT during conflict resolution is a guard people
+  // learn to skip (#3890).
+  const { dir, git } = gitRepo('co-tracked-unmerged-');
+  try {
+    writeFileSync(join(dir, 'keep.mjs'), 'const keep = 1;\n');
+    writeFileSync(join(dir, 'doomed.mjs'), 'const a = 1;\n');
+    git('add', '-A');
+    git('commit', '-qm', 'base');
+
+    git('checkout', '-q', '-b', 'deleting');
+    git('rm', '-q', 'doomed.mjs');
+    git('commit', '-qm', 'delete it');
+
+    git('checkout', '-q', 'trunk');
+    writeFileSync(join(dir, 'doomed.mjs'), 'const a = 2;\n');
+    git('commit', '-qam', 'change it');
+
+    git('checkout', '-q', 'deleting');
+    // Exits non-zero on the conflict it is here to create.
+    assert.throws(() => git('merge', 'trunk'), /./, 'the fixture must actually conflict');
+    unlinkSync(join(dir, 'doomed.mjs'));   // accept the deletion, do not stage it
+
+    const status = git('status', '--porcelain');
+    assert.match(status, /^DU doomed\.mjs$/m, `fixture is not in the DU state: ${status}`);
+
+    const { value: files, warnings } = capturingWarnings(() => trackedFiles(dir));
+
+    // The crash this exists to prevent, asserted where it actually happened:
+    // every path handed back can be opened.
+    for (const file of files) readFileSync(file);
+
+    assert.deepEqual(relPaths(files, dir), ['keep.mjs'],
+      'the listed-but-absent path must be skipped, and the rest of the scan must survive it');
+    assert.equal(warnings.length, 1, `expected exactly one warning, got: ${JSON.stringify(warnings)}`);
+    assert.match(warnings[0], /doomed\.mjs/, 'the warning must name the path that was skipped');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles returns an unmerged path once, not once per index stage', () => {
+  // `git ls-files` prints one line per stage, so a conflicted path arrives two
+  // or three times. Left as-is, every offender inside one would be reported
+  // twice and every per-file count would be wrong for the duration of a merge.
+  const { dir, git } = gitRepo('co-tracked-stages-');
+  try {
+    writeFileSync(join(dir, 'both.mjs'), 'const a = 0;\n');
+    git('add', '-A');
+    git('commit', '-qm', 'base');
+
+    git('checkout', '-q', '-b', 'theirs');
+    writeFileSync(join(dir, 'both.mjs'), 'const a = 2;\n');
+    git('commit', '-qam', 'theirs');
+
+    git('checkout', '-q', 'trunk');
+    writeFileSync(join(dir, 'both.mjs'), 'const a = 1;\n');
+    git('commit', '-qam', 'ours');
+    assert.throws(() => git('merge', 'theirs'), /./, 'the fixture must actually conflict');
+
+    // The fixture is only meaningful while git really is listing it repeatedly.
+    const listed = git('ls-files').trim().split('\n').filter((l) => l === 'both.mjs');
+    assert.ok(listed.length > 1, `ls-files listed the unmerged path ${listed.length} time(s)`);
+
+    assert.deepEqual(relPaths(trackedFiles(dir), dir), ['both.mjs']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles throws rather than reporting an empty, passing scan', () => {
+  // Same stance as collectMjsFiles above and validate-system-paths-coverage.mjs:
+  // a guard that could not look must never read as a guard that passed. The
+  // realistic way to get here is running from a temp copy inside the repo,
+  // where `ls-files` reports nothing at all — which is how the SYSTEM_PATHS
+  // coverage guard sat green and inert in CI for its whole life.
+  const empty = gitRepo('co-tracked-empty-');
+  try {
+    writeFileSync(join(empty.dir, 'untracked.mjs'), '');
+    assert.throws(() => trackedFiles(empty.dir), /no tracked files|tracked nothing|listed no/i);
+  } finally {
+    rmSync(empty.dir, { recursive: true, force: true });
+  }
+
+  const notARepo = mkdtempSync(join(tmpdir(), 'co-tracked-norepo-'));
+  try {
+    // And a failing `git` must propagate as a failure, not as "nothing tracked".
+    assert.throws(() => trackedFiles(notARepo));
+  } finally {
+    rmSync(notARepo, { recursive: true, force: true });
+  }
+});
+
+test('trackedFiles enumerates this repository, and reaches past its root', () => {
+  const rel = relPaths(trackedFiles(ROOT, (f) => f.endsWith('.mjs')), ROOT);
+  const rootOnly = rel.filter((f) => !f.includes('/'));
+
+  assert.ok(rel.length > rootOnly.length * 2,
+    `the guards must cover far more than the root: ${rel.length} total vs ${rootOnly.length} at root`);
+  assert.ok(rel.includes('lib/mjs-files.mjs'), 'the module under test must be inside its own enumeration');
+  assert.ok(rel.some((f) => f.startsWith('tests/')), 'tests/ must be enumerated');
+  assert.ok(!rel.some((f) => f.startsWith('node_modules/')), 'vendored code is never tracked, so never enumerated');
+});
+
+test('every repo-scanning guard enumerates through the shared definition', () => {
+  // The four that did not, and carried #3419's defect the whole time: a private
+  // walk with a hand-maintained skip-list, silently narrowing whenever a file
+  // moved or a directory was forgotten (#3890).
+  //
+  // The IMPORT is the assertion, for the same reason as the predicate check
+  // below: matching `trackedFiles(` anywhere is satisfied by a local
+  // re-implementation wearing the shared name.
+  for (const caller of [
+    'tests/main-guard-convention.test.mjs',
+    'tests/local-today-gates.test.mjs',
+    'tests/mojibake-canary.test.mjs',
+    'tests/helpers.mjs',
+  ]) {
+    const src = readFileSync(join(ROOT, caller), 'utf-8');
+    assert.match(
+      src,
+      /import\s*\{[^}]*\btrackedFiles\b[^}]*\}\s*from\s*'\.{1,2}\/lib\/mjs-files\.mjs'/,
+      `${caller} must enumerate through lib/mjs-files.mjs, not its own walk (#3890)`,
+    );
+    assert.match(src, /trackedFiles\(/, `${caller} must actually call trackedFiles (#3890)`);
+
+    // ...and must not have kept a walk beside it. A readdir here is how a
+    // second definition of "every file" gets back in, which is the whole
+    // reason this module exists.
+    assert.doesNotMatch(src, /readdirSync\s*\(/,
+      `${caller} still walks a directory to build its own file list (#3890)`);
   }
 });
 

--- a/tests/mojibake-canary.test.mjs
+++ b/tests/mojibake-canary.test.mjs
@@ -9,9 +9,9 @@
 //
 // Run:  node test-all.mjs --only mojibake-canary
 
-import { readFileSync, readdirSync } from 'fs';
-import { join } from 'path';
-import { isNestedCheckout } from '../lib/mjs-files.mjs';
+import { readFileSync } from 'fs';
+import { relative } from 'path';
+import { trackedFiles } from '../lib/mjs-files.mjs';
 import { pass, fail, ROOT } from './helpers.mjs';
 
 console.log('\nmojibake-canary — double-encoded UTF-8 detection in templates/ and modes/');
@@ -187,52 +187,37 @@ if (allLatinExtendedPassed) {
 // Repo-wide scan: walk templates/ and modes/ and check every file.
 console.log('  Repo-wide scan: templates/ and modes/');
 
-const treesToScan = [
-  { path: join(ROOT, 'templates'), relativePath: 'templates' },
-  { path: join(ROOT, 'modes'), relativePath: 'modes' },
-];
+// Scoped to the two trees this canary owns, enumerated through
+// lib/mjs-files.mjs's tracked-file list rather than a private readdir walk
+// (#3890). The walk this replaces had no skip-list at all, so it read whatever
+// a given checkout happened to have dropped under templates/ or modes/ — and
+// it would have thrown ENOENT on a path git listed but the working tree did not
+// have, which is an ordinary mid-merge state. Only tracked content can ship
+// mojibake to a user, so tracked content is exactly what this scans.
+//
+// It also subsumes the isNestedCheckout guard the walk carried: a checkout
+// parked under templates/ or modes/ is another tree's content, and mojibake in
+// it is not this repository's defect to report (#3762). Its files are untracked
+// HERE, so the index never names them, and an initialised submodule arrives as
+// one gitlink the enumerator drops — no per-directory rule to remember.
+const TREES = ['templates/', 'modes/'];
 let filesScanned = 0;
 let filesWithMojibake = 0;
 
-/**
- * Recursively walk a directory and check every file for mojibake.
- * @param {string} dir - Directory to walk.
- * @param {string} relativePath - Relative path for error reporting.
- */
-function walkAndCheck(dir, relativePath = '') {
-  const entries = readdirSync(dir, { withFileTypes: true });
-  
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
-    
-    if (entry.isDirectory()) {
-      // A checkout placed under templates/ or modes/ is another tree's content,
-      // and mojibake in it is not this repository's defect to report (#3762).
-      // Unlikely there — but "unlikely" is the assumption that let a worktree
-      // under tests/ run its own suites as ours.
-      if (isNestedCheckout(fullPath)) continue;
-      walkAndCheck(fullPath, entryRelativePath);
-    } else if (entry.isFile()) {
-      filesScanned++;
-      const content = readFileSync(fullPath, 'utf-8');
-      const lines = content.split('\n');
-      
-      for (let i = 0; i < lines.length; i++) {
-        if (containsMojibake(lines[i])) {
-          filesWithMojibake++;
-          fail(`Mojibake found in ${entryRelativePath} at line ${i + 1}: "${lines[i].trim()}"`);
-          // Don't report every line in the same file — one failure per file is enough
-          // to signal the problem without spamming the log.
-          break;
-        }
-      }
+for (const file of trackedFiles(ROOT, (rel) => TREES.some((t) => rel.startsWith(t)))) {
+  const relativePath = relative(ROOT, file).split('\\').join('/');
+  filesScanned++;
+  const lines = readFileSync(file, 'utf-8').split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (containsMojibake(lines[i])) {
+      filesWithMojibake++;
+      fail(`Mojibake found in ${relativePath} at line ${i + 1}: "${lines[i].trim()}"`);
+      // Don't report every line in the same file — one failure per file is enough
+      // to signal the problem without spamming the log.
+      break;
     }
   }
-}
-
-for (const tree of treesToScan) {
-  walkAndCheck(tree.path, tree.relativePath);
 }
 
 if (filesScanned === 0) {

--- a/tests/web-test-layout.test.mjs
+++ b/tests/web-test-layout.test.mjs
@@ -149,11 +149,15 @@ if (!existsSync(WEB_PKG)) {
   // without a loader, so one would sit in the tree looking like coverage and
   // never execute.
   const TEST_FILE = /(?:\.test\.(?:mjs|js|ts|tsx)|^test-.*\.(?:mjs|js|ts|tsx))$/;
-  // node_modules matters for speed, not just noise: a populated
-  // web/node_modules is ~400 MB (see test-all.mjs's copy-exclusion note).
-  const SKIP_DIRS = new Set(['node_modules', '.next', '.git', 'out', 'dist', 'coverage']);
-
-  const found = walkFiles(WEB, TEST_FILE, SKIP_DIRS)
+  // Scoped to what web/ TRACKS (#3890): walkFiles enumerates the index now, so
+  // `node_modules`, `.next`, `out`, `dist` and `coverage` drop out because git
+  // does not track them, not because this file remembered to list them. That
+  // list was also the narrowing hazard — an unlisted generated directory put a
+  // built copy of every suite under the contract, and a suite added under a
+  // listed one silently left it. node_modules mattered for speed too: a
+  // populated web/node_modules is ~400 MB (see test-all.mjs's copy-exclusion
+  // note), and the index never walks into it at all.
+  const found = walkFiles(WEB, TEST_FILE)
     .map((p) => relative(WEB, p).split(sep).join('/'));
 
   const pkg = JSON.parse(readFileSync(WEB_PKG, 'utf8'));


### PR DESCRIPTION
## What does this PR do?

Migrates the four repo-scanning guards off their private, hand-maintained skip-list directory walks and onto a shared `git ls-files`-backed enumerator in `lib/mjs-files.mjs`. That enumerator tolerates a path the index lists but the working tree does not have — an unresolved merge — by skipping it with a warning instead of throwing ENOENT, so the tolerance is a property of the shared helper rather than something each caller re-implements.

## Related issue

Closes #3890

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

<sub>Refactor is the closest box: no user-facing behavior changes, and the scanned sets are identical on a clean checkout. It does fix a crash (the ENOENT below) and close a silent-narrowing hole, so it is not purely cosmetic.</sub>

## The problem

`lib/mjs-files.mjs` exists because the syntax gate covered 121 of ~575 `.mjs` files and narrowed further every time a file moved, never saying so (#3419). Four guards were never migrated and carried the identical defect:

| File | Its private walk |
|---|---|
| `tests/main-guard-convention.test.mjs` | 8-name `SKIP_DIRS` + a dot-prefix rule + `isNestedCheckout()` |
| `tests/local-today-gates.test.mjs` | a 6-name regex + a `.tmp-script-test-` prefix + `isNestedCheckout()` |
| `tests/mojibake-canary.test.mjs` | no skip-list at all — it read whatever a checkout happened to have |
| `tests/helpers.mjs` (`walkFiles`) | a `skipDirs` set its one caller passed in |

A skip-list narrows in silence: a newly tracked file under an excluded directory never enters the guard, and the run is exactly as green as one that read it.

The second failure, found while resolving a real merge: a file deleted on one side stayed listed by `git ls-files` while it was an unresolved `DU` path, and a scanner ENOENTed on it. That is an ordinary mid-merge state, not a corrupt repo, and a guard that crashes during conflict resolution is a guard people learn to skip.

## The shared enumerator

`trackedFiles(root, filter)` joins `collectMjsFiles`. The two answer different questions on purpose — the module docblock now states the distinction so nobody collapses them:

- `collectMjsFiles` — the **working tree**. What the syntax gates want: a file you just wrote and have not `git add`ed yet still has to parse.
- `trackedFiles` — the **index**. What the repo-scanning guards want: they grade what the repository ships, and git already knows which trees are not that. `node_modules`, `output/`, `data/`, a gitignored worktree and a scratch file drop out with no list to maintain.

Three properties live in the helper, not in each caller:

- **A listed-but-absent path is skipped, with a warning.** Mid-merge the index holds stages for a path the tree may not have — a modify/delete conflict whose deletion is the resolution being accepted, still unstaged. Uninitialised submodules and sparse checkouts land here too. Loud rather than silent: a scan quietly covering less than it claims is the failure this module is named after.
- **Unmerged paths are de-duplicated.** `ls-files` prints one line per index stage, so a conflicted path arrives two or three times; left alone, every hit inside one is reported per stage and every file count is wrong for the duration of the merge.
- **An empty listing throws.** `ls-files` exits 0 with no output from an untracked directory — how the `SYSTEM_PATHS` coverage guard printed "0 tracked files covered" and exited 0 for its whole life. Same stance as the missing-root throw beside it.

Scanned sets are unchanged on a clean checkout: 207 files across `templates/` and `modes/`, 49 web suites, 684 tracked `.mjs`.

## Tests

`tests/mjs-files.test.mjs` gains six cases. **The unresolved merge is real, not mocked**: a throwaway repo, an actual modify/delete conflict, the file removed and not staged, `git status` asserted to be `DU` before the call — and the assertion is that every path handed back can be opened. Against a naive implementation that test fails with the reported `Error: ENOENT: no such file or directory`.

The convention test that pinned three callers to `isNestedCheckout` is replaced by one pinning all four to `trackedFiles`: the import (a local re-implementation wearing the shared name is the drift), the call, and the absence of a `readdirSync` walk beside it.

### Mutation results

Eleven mutations; each reddened the assertion that names it.

| Mutation | Test that went red |
|---|---|
| drop the listed-but-absent skip | `trackedFiles skips a path the index lists…` — `ENOENT … doomed.mjs` |
| drop the warning | same test — `expected exactly one warning, got: []` |
| drop the stage dedupe | `…returns an unmerged path once` — `['both.mjs','both.mjs','both.mjs']` |
| drop the empty-listing throw | `…throws rather than reporting an empty, passing scan` |
| ignore the caller filter | `…applies the caller filter to the repo-relative path` |
| local re-implementation instead of the import | `every repo-scanning guard enumerates through the shared definition` |
| point the canary at a non-existent tree | `Repo-wide scan found 0 files` |
| narrow the main-guard filter to nothing | `expected the tracked .mjs tree, got 0 files` |
| restore the private skip-list walk in `helpers.mjs` | `must actually call trackedFiles` |
| add a second walk beside the shared call | `still walks a directory to build its own file list` |
| **narrow the local-today enumeration to the repo root** | **initially none — see below** |

That last one left the suite green, and is fixed rather than hidden. `tests/local-today-gates.test.mjs` is a *derived* gate whose floor is "at least the four known scan-history writers" — but all four sit at the repository root, so the floor stays true while the enumeration silently reverts to a root-only scan and the derived gate becomes the hard-coded list it was written to replace. That is #3419's exact shape in a second file. Reach is now asserted separately from count, and the mutation goes red.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — 8568 passed, 0 failed, 16 warnings (all pre-existing; none names a file this branch touches)
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR moves repository scanning to the shared `trackedFiles` enumerator in `lib/mjs-files.mjs:88`.

### User impact

: Guards scan Git-tracked files instead of private directory walks.
: Newly tracked files are included automatically.
: Ignored and unrelated directories are excluded without local skip lists.
: Missing, symlink, and gitlink paths are skipped with warnings.
: Merge-index stages are de-duplicated.
: Empty or invalid tracked-file listings fail clearly.
: `trackedFiles` reads the Git index, so unstaged local files are not scanned.
: `walkFiles` no longer accepts a manual skip-directory set (`tests/helpers.mjs:405`).

### Files changed

: `lib/mjs-files.mjs:88`: Adds and exports `trackedFiles`.
: `tests/helpers.mjs:9`: Uses `trackedFiles` for discovery.
: `tests/main-guard-convention.test.mjs:215`: Scans tracked `.mjs` files.
: `tests/local-today-gates.test.mjs:523`: Scans tracked source files.
: `tests/mojibake-canary.test.mjs:207`: Scans tracked files under `templates/` and `modes/`.
: `tests/web-test-layout.test.mjs:152`: Removes manual directory exclusions.
: `tests/mjs-files.test.mjs:212`: Covers filtering, merge stages, missing files, non-regular files, empty listings, and guard adoption.

### System files

No changes touch `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->