### PR TITLE
refactor(eval): single-source the tracker-addition helpers, and fix the fifth site no copy-scan could find (#3796)

### DIFF
--- a/batch-evaluate-gemini.mjs
+++ b/batch-evaluate-gemini.mjs
@@ -21,6 +21,9 @@ import { promisify } from 'util';
 import { rejectPrivateOrInvalid } from './liveness-browser.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { TSV_ADDITION_HEADER } from './tracker-parse.mjs';
+import {
+  normalizedTrackerScore, slugifyCompany, tsvSafe,
+} from './lib/tracker-addition.mjs';
 const execFileAsync = promisify(execFile);
 try {
   const { config } = await import('dotenv');
@@ -99,39 +102,6 @@ function readFile(path, label) {
 async function nextReportNumber() { // outdate-bot
   const { stdout } = await execFileAsync(process.execPath, [join(ROOT, 'reserve-report-num.mjs')], { encoding: 'utf-8' });
   return stdout.trim();
-}
-
-function slugifyCompany(value) {
-  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'unknown';
-}
-
-function tsvSafe(value) {
-  return String(value ?? '').replace(/[\t\r\n]+/g, ' ').trim();
-}
-
-function normalizedTrackerScore(value) {
-  const clean = tsvSafe(value);
-  // Parse, do not pattern-match the string. Two bugs lived in the old guard:
-  // `/n\/?a/i` was unanchored with an optional slash, so bare `na` matched and a
-  // real score with trailing prose -- `4.2 (final)`, `4.2 (internal)`,
-  // `4.5 - strong signal` -- was recorded as `N/A`; and the `/5` early return kept
-  // the whole string, so `4.2/10` became `4.2/5` and merged as a genuine score.
-  // Trailing prose is tolerated because models produce it; a denominator that is
-  // not 5, or a value outside 0..5, is refused rather than reinterpreted.
-  const parsed = clean.match(/^(\d+(?:\.\d+)?)/);
-  if (!parsed) return 'N/A';
-  const score = parseFloat(parsed[1]);
-  // The denominator is load-bearing wherever it sits. Requiring it immediately
-  // after the number read `4.2 (strong fit)/10` -- a ten-point score with an
-  // annotation -- as a bare 4.2 and wrote `4.2/5`, the same wrong number
-  // `8/10` used to produce. The first denominator in the cell is taken and must
-  // be 5; absent one, the scale is the contract's. A cell that puts an unrelated
-  // fraction first (`4.2 (fit 3/4 axes)`) is refused rather than guessed at --
-  // N/A is recoverable, a wrong score is not.
-  const denominator = clean.match(/\/\s*(\d+(?:\.\d+)?)/);
-  const scale = denominator ? parseFloat(denominator[1]) : 5;
-  if (!Number.isFinite(score) || scale !== 5 || score < 0 || score > 5) return 'N/A';
-  return `${score}/5`;
 }
 
 let systemPromptTemplate;

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -46,6 +46,9 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname, resolve, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { TokenAccumulator, formatBreakdown } from './utils/token-tracker.mjs';
+import {
+  isPostingUrl, normalizedTrackerScore, slugifyCompany, tsvSafe,
+} from './lib/tracker-addition.mjs';
 
 const tracker = new TokenAccumulator();
 tracker.recordZeroToken('scan');
@@ -284,66 +287,6 @@ function validateEvaluationShape(text) {
   if (issues.length > 0) {
     throw new Error(`Gemini returned an invalid career-ops report: ${issues.join('; ')}`);
   }
-}
-
-function slugifyCompany(value) {
-  return String(value || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '') || 'unknown';
-}
-
-/**
- * Whether a value is a complete http(s) URL, and so can become a dedup key.
- * @param {string} value - Candidate posting URL.
- * @returns {boolean} True only for a parseable http/https URL with a host.
- */
-function isPostingUrl(value) {
-  try {
-    const parsed = new URL(value);
-    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.hostname !== '';
-  } catch {
-    return false;
-  }
-}
-
-function tsvSafe(value) {
-  return String(value ?? '').replace(/[\t\r\n]+/g, ' ').trim();
-}
-
-/**
- * Normalize a model-reported score into the tracker's score cell.
- *
- * `extract('SCORE')` returns the whole rest of the SCORE line, while
- * `validateEvaluationShape` only checks its numeric prefix -- so
- * `SCORE: 4.2 (strong fit)` passes validation and arrives here intact.
- *
- * @param {string} value - Score as extracted from the model's summary block.
- * @returns {string} `X.X/5`, or the documented `N/A` sentinel (#1799).
- */
-function normalizedTrackerScore(value) {
-  const clean = tsvSafe(value);
-  // Parse, do not pattern-match the string. Two bugs lived in the old guard:
-  // `/n\/?a/i` was unanchored with an optional slash, so bare `na` matched and a
-  // real score with trailing prose -- `4.2 (final)`, `4.2 (internal)`,
-  // `4.5 - strong signal` -- was recorded as `N/A`; and the `/5` early return kept
-  // the whole string, so `4.2/10` became `4.2/5` and merged as a genuine score.
-  // Trailing prose is tolerated because models produce it; a denominator that is
-  // not 5, or a value outside 0..5, is refused rather than reinterpreted.
-  const parsed = clean.match(/^(\d+(?:\.\d+)?)/);
-  if (!parsed) return 'N/A';
-  const score = parseFloat(parsed[1]);
-  // The denominator is load-bearing wherever it sits. Requiring it immediately
-  // after the number read `4.2 (strong fit)/10` -- a ten-point score with an
-  // annotation -- as a bare 4.2 and wrote `4.2/5`, the same wrong number
-  // `8/10` used to produce. The first denominator in the cell is taken and must
-  // be 5; absent one, the scale is the contract's. A cell that puts an unrelated
-  // fraction first (`4.2 (fit 3/4 axes)`) is refused rather than guessed at --
-  // N/A is recoverable, a wrong score is not.
-  const denominator = clean.match(/\/\s*(\d+(?:\.\d+)?)/);
-  const scale = denominator ? parseFloat(denominator[1]) : 5;
-  if (!Number.isFinite(score) || scale !== 5 || score < 0 || score > 5) return 'N/A';
-  return `${score}/5`;
 }
 
 // Lazy import — only used when saving

--- a/lib/tracker-addition.mjs
+++ b/lib/tracker-addition.mjs
@@ -1,0 +1,101 @@
+/**
+ * lib/tracker-addition.mjs — the helpers every headless evaluator needs to emit
+ * a tracker-addition row, in one place.
+ *
+ * Four evaluators grew private copies of `tsvSafe` / `normalizedTrackerScore`
+ * (three of them also `slugifyCompany`), and the copies drifted
+ * (career-ops-hq/career-ops#3796). `gemini-eval.mjs`'s version concatenated
+ * rather than parsed, so a model answering `SCORE: 4.2 (strong fit)` wrote
+ * `4.2 (strong fit)/5` — neither a score nor a sentinel, which is the
+ * undecidable cell `merge-tracker.mjs` refuses outright. The evaluation was
+ * skipped, loudly but wholly, while the sibling copy had been immune the whole
+ * time for the same input. Neither file recorded that the other existed.
+ *
+ * A helper whose entire job is keeping one column parseable must not exist
+ * four times: the failure mode is silent divergence, and each copy has to be
+ * found before it can be fixed. Consolidating also makes the guard in
+ * `tests/evaluator-score-cell.test.mjs` an assertion of single-sourcing rather
+ * than a sweep for copies.
+ *
+ * Lives in lib/ rather than in `tracker-utils.mjs`, which pulls in js-yaml and
+ * the writer-lock machinery — a dependency the evaluators otherwise do not
+ * need. Like lib/placeholder-cell.mjs and lib/local-today.mjs, this file
+ * imports nothing.
+ */
+
+/**
+ * Flatten a value into something safe to place in a tab-separated cell.
+ *
+ * A raw tab or newline inside a field silently shifts every field after it into
+ * the wrong column, so they collapse to a single space rather than being
+ * escaped.
+ *
+ * @param {unknown} value - Raw field value.
+ * @returns {string} The value with tabs/newlines collapsed to spaces, trimmed.
+ */
+export function tsvSafe(value) {
+  return String(value ?? '').replace(/[\t\r\n]+/g, ' ').trim();
+}
+
+/**
+ * Slugify a company name for report and addition filenames.
+ *
+ * @param {unknown} value - Raw company name.
+ * @returns {string} Lowercase dash slug, or "unknown" when nothing survives.
+ */
+export function slugifyCompany(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'unknown';
+}
+
+/**
+ * Whether a value is a complete http(s) URL, and so can become a dedup key.
+ *
+ * @param {unknown} value - Candidate posting URL.
+ * @returns {boolean} True only for a parseable http/https URL with a host.
+ */
+export function isPostingUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.hostname !== '';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a model-reported score into the tracker's score cell.
+ *
+ * Evaluators extract the whole rest of the `SCORE:` line and validate only its
+ * numeric prefix, so `SCORE: 4.2 (strong fit)` passes validation and arrives
+ * here intact.
+ *
+ * @param {unknown} value - Score as extracted from the model's summary block.
+ * @returns {string} `X.X/5`, or the documented `N/A` sentinel (#1799).
+ */
+export function normalizedTrackerScore(value) {
+  const clean = tsvSafe(value);
+  // Parse, do not pattern-match the string. Two bugs lived in the old guard:
+  // `/n\/?a/i` was unanchored with an optional slash, so bare `na` matched and a
+  // real score with trailing prose -- `4.2 (final)`, `4.2 (internal)`,
+  // `4.5 - strong signal` -- was recorded as `N/A`; and the `/5` early return kept
+  // the whole string, so `4.2/10` became `4.2/5` and merged as a genuine score.
+  // Trailing prose is tolerated because models produce it; a denominator that is
+  // not 5, or a value outside 0..5, is refused rather than reinterpreted.
+  const parsed = clean.match(/^(\d+(?:\.\d+)?)/);
+  if (!parsed) return 'N/A';
+  const score = parseFloat(parsed[1]);
+  // The denominator is load-bearing wherever it sits. Requiring it immediately
+  // after the number read `4.2 (strong fit)/10` -- a ten-point score with an
+  // annotation -- as a bare 4.2 and wrote `4.2/5`, the same wrong number
+  // `8/10` used to produce. The first denominator in the cell is taken and must
+  // be 5; absent one, the scale is the contract's. A cell that puts an unrelated
+  // fraction first (`4.2 (fit 3/4 axes)`) is refused rather than guessed at --
+  // N/A is recoverable, a wrong score is not.
+  const denominator = clean.match(/\/\s*(\d+(?:\.\d+)?)/);
+  const scale = denominator ? parseFloat(denominator[1]) : 5;
+  if (!Number.isFinite(score) || scale !== 5 || score < 0 || score > 5) return 'N/A';
+  return `${score}/5`;
+}

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -722,7 +722,16 @@ async function cmdEvaluate(input, ctx) {
     // satisfies SCORE_CELL_RE, so it merged as a genuine score and fed
     // stats.mjs's averages. normalizedTrackerScore refuses a denominator that
     // is not 5, but only if it is handed one (#3796).
-    const scoreMatch  = result.match(/(?:score|puntuaci[oó]n)[^\d]*(\d+(?:\.\d+)?(?:\s*\/\s*\d+(?:\.\d+)?)?)/i);
+    //
+    // The capture runs to END OF LINE rather than stopping at a denominator
+    // adjacent to the number. Requiring adjacency read `Score: 4.2 (strong
+    // fit)/10` -- a ten-point score with an annotation -- as a bare 4.2 and
+    // wrote `4.2/5`, the same wrong number the numeric prefix used to produce.
+    // The cost is that an unrelated fraction later in the line (`Score: 4.2 --
+    // matched 3/4 axes`) is refused as N/A rather than guessed at. That is the
+    // trade the shared helper already documents and the gemini path already
+    // pins: N/A is recoverable, a wrong score is not.
+    const scoreMatch  = result.match(/(?:score|puntuaci[oó]n)[^\d]*(\d+(?:\.\d+)?[^\r\n]*)/i);
     // An unparseable score used to become the EMPTY string, and merge-tracker
     // refuses a blank required cell ("use the documented sentinel rather than a
     // blank cell") -- so the evaluation was skipped whole, the same loss #3796

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -25,6 +25,7 @@ import readline from 'node:readline';
 import * as yaml from 'js-yaml';
 import { outputLanguageInstruction, parseOutputLanguage } from './profile-language.mjs';
 import { TSV_ADDITION_HEADER } from './tracker-parse.mjs';
+import { normalizedTrackerScore } from './lib/tracker-addition.mjs';
 import {
   formatReportNumber, releaseReportNumbers, reserveReportNumbers,
 } from './reserve-report-num.mjs';
@@ -715,9 +716,19 @@ async function cmdEvaluate(input, ctx) {
     const legitLine  = legitMatch ? `**Legitimacy:** ${legitMatch[1].trim()}` : '**Legitimacy:** unconfirmed';
     writeFile(relPath, `**URL:** ${input || '(pasted)'}\n${legitLine}\n\n${result}`);
 
-    const scoreMatch  = result.match(/(?:score|puntuaci[oó]n)[^\d]*(\d+\.?\d*)/i);
-    const scoreValue  = scoreMatch ? parseFloat(scoreMatch[1]) : NaN;
-    const scoreStr    = isFinite(scoreValue) ? `${scoreValue.toFixed(1)}/5` : '';
+    // Capture the DENOMINATOR when the model writes one. The old pattern took
+    // only the numeric prefix, so `Score: 8/10` yielded `8` and the cell became
+    // `8.0/5` -- a ten-point score reinterpreted as a five-point one. That
+    // satisfies SCORE_CELL_RE, so it merged as a genuine score and fed
+    // stats.mjs's averages. normalizedTrackerScore refuses a denominator that
+    // is not 5, but only if it is handed one (#3796).
+    const scoreMatch  = result.match(/(?:score|puntuaci[oó]n)[^\d]*(\d+(?:\.\d+)?(?:\s*\/\s*\d+(?:\.\d+)?)?)/i);
+    // An unparseable score used to become the EMPTY string, and merge-tracker
+    // refuses a blank required cell ("use the documented sentinel rather than a
+    // blank cell") -- so the evaluation was skipped whole, the same loss #3796
+    // documents for the drifted copies. The shared helper returns the `N/A`
+    // sentinel (#1799), which merges as an unscored row instead of as nothing.
+    const scoreStr    = normalizedTrackerScore(scoreMatch ? scoreMatch[1] : '');
     const companyName = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
     const reportLink  = `[${numStr}](reports/${numStr}-${slug}-${today}.md)`;
     const tsvLine     = `${num}\t${today}\t${companyName}\t(see report)\tEvaluated\t${scoreStr}\t❌\t${reportLink}\t\n`;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9827,6 +9827,39 @@ try {
     pass('every headless evaluator outside the #3797 exemption writes **URL:** and takes a posting URL');
   }
 
+  // Same family, third contract (#3796): the tracker-addition helpers are
+  // imported, never redefined. Four evaluators carried private copies of
+  // `tsvSafe` / `normalizedTrackerScore` and they drifted -- gemini-eval.mjs's
+  // concatenated instead of parsing, so `SCORE: 4.2 (strong fit)` produced
+  // `4.2 (strong fit)/5`, which is neither a score nor a sentinel and is the
+  // undecidable cell merge-tracker.mjs refuses outright. The evaluation was
+  // skipped wholly while the sibling copy had been immune all along.
+  //
+  // tests/evaluator-score-cell.test.mjs asserts the helpers exist exactly once;
+  // this asserts the family reaches that one definition, which is the half a
+  // fifth evaluator can fail without redefining anything -- by hand-rolling a
+  // score cell inline instead, which is exactly what openrouter-runner.mjs did:
+  // it never held a copy, so a copy-scan never saw it, while it wrote
+  // `${value.toFixed(1)}/5` from a numeric prefix that discarded the
+  // denominator, and the empty string when nothing parsed.
+  const ADDITION_HELPERS = './lib/tracker-addition.mjs';
+  const helperImportRe = /from\s+'\.\/lib\/tracker-addition\.mjs'/;
+  // openai-eval.mjs and ollama-eval.mjs gain the import when #3797 lands and
+  // their copies are consolidated with the rest.
+  const pendingHelperImport = ['openai-eval.mjs', 'ollama-eval.mjs'];
+  const missingHelperImport = evaluatorSources
+    .filter(([, source]) => !helperImportRe.test(source))
+    .map(([name]) => name);
+  const staleHelperExemptions = pendingHelperImport.filter(name => !missingHelperImport.includes(name));
+  const unexemptedHelperGaps  = missingHelperImport.filter(name => !pendingHelperImport.includes(name));
+  if (unexemptedHelperGaps.length > 0) {
+    fail(`headless evaluators build their tracker-addition cells without ${ADDITION_HELPERS}, the drift #3796 consolidated: ${unexemptedHelperGaps.join(', ')}`);
+  } else if (staleHelperExemptions.length > 0) {
+    fail(`stale #3796 exemption — these now import ${ADDITION_HELPERS}, remove them from pendingHelperImport: ${staleHelperExemptions.join(', ')}`);
+  } else {
+    pass(`every headless evaluator outside the #3796 exemption imports the shared tracker-addition helpers`);
+  }
+
   // --count N: contiguous range from an empty dir.
   const rangeTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-range-'));
   const range = reserveRun(['--count', '3'], rangeTmp);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9842,22 +9842,29 @@ try {
   // it never held a copy, so a copy-scan never saw it, while it wrote
   // `${value.toFixed(1)}/5` from a numeric prefix that discarded the
   // denominator, and the empty string when nothing parsed.
+  //
+  // USE, not merely import: an evaluator can import an unrelated helper from the
+  // module and still build its score cell by hand, which would pass an
+  // import-only check while the behaviour this contract exists to protect had
+  // drifted again. Both halves are required -- the import proves it reaches the
+  // shared definition, the call proves it is the definition actually used.
   const ADDITION_HELPERS = './lib/tracker-addition.mjs';
   const helperImportRe = /from\s+'\.\/lib\/tracker-addition\.mjs'/;
+  const helperUseRe    = /\bnormalizedTrackerScore\s*\(/;
   // openai-eval.mjs and ollama-eval.mjs gain the import when #3797 lands and
   // their copies are consolidated with the rest.
   const pendingHelperImport = ['openai-eval.mjs', 'ollama-eval.mjs'];
   const missingHelperImport = evaluatorSources
-    .filter(([, source]) => !helperImportRe.test(source))
+    .filter(([, source]) => !helperImportRe.test(source) || !helperUseRe.test(source))
     .map(([name]) => name);
   const staleHelperExemptions = pendingHelperImport.filter(name => !missingHelperImport.includes(name));
   const unexemptedHelperGaps  = missingHelperImport.filter(name => !pendingHelperImport.includes(name));
   if (unexemptedHelperGaps.length > 0) {
-    fail(`headless evaluators build their tracker-addition cells without ${ADDITION_HELPERS}, the drift #3796 consolidated: ${unexemptedHelperGaps.join(', ')}`);
+    fail(`headless evaluators build their tracker-addition cells without importing AND calling ${ADDITION_HELPERS}'s normalizedTrackerScore, the drift #3796 consolidated: ${unexemptedHelperGaps.join(', ')}`);
   } else if (staleHelperExemptions.length > 0) {
     fail(`stale #3796 exemption — these now import ${ADDITION_HELPERS}, remove them from pendingHelperImport: ${staleHelperExemptions.join(', ')}`);
   } else {
-    pass(`every headless evaluator outside the #3796 exemption imports the shared tracker-addition helpers`);
+    pass(`every headless evaluator outside the #3796 exemption imports AND calls the shared tracker-addition helpers`);
   }
 
   // --count N: contiguous range from an empty dir.

--- a/tests/evaluator-score-cell.test.mjs
+++ b/tests/evaluator-score-cell.test.mjs
@@ -1,28 +1,27 @@
-// tests/evaluator-score-cell.test.mjs — every evaluator's normalizedTrackerScore
-// must parse the score and emit a cell the tracker's readers accept.
+// tests/evaluator-score-cell.test.mjs — normalizedTrackerScore parses the score
+// and emits a cell the tracker's readers accept, and it exists exactly once.
 //
-// The evaluators run on import (arg parse + network), so the helper cannot be
-// imported for a unit test. Each copy is lifted out of its source and evaluated
-// standalone instead. Discovery is by definition, not by a filename list: any
-// root-level script that grows its own normalizedTrackerScore is covered the day
-// it lands, which is the only way this stays honest while four copies exist
-// (career-ops-hq/career-ops#3796).
+// This suite used to lift each evaluator's private copy out of its source and
+// evaluate it standalone, because four copies existed and the evaluators run on
+// import (arg parse + network) so the helper could not be imported. The copies
+// have since been consolidated into lib/tracker-addition.mjs
+// (career-ops-hq/career-ops#3796), so the behaviour half is a plain import.
+//
+// The discovery half stays, inverted: rather than sweeping for copies to test,
+// it now asserts there are none. A fifth evaluator that grows its own
+// normalizedTrackerScore is caught the day it lands, which is what kept
+// `gemini-eval.mjs`'s concatenating version alive next to a sibling that had
+// been immune to the same input the whole time.
 import { readdirSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { pass, fail } from './helpers.mjs';
 import { looksLikeScoreCell } from '../tracker-parse.mjs';
+import { normalizedTrackerScore } from '../lib/tracker-addition.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 console.log('\nevaluators — normalizedTrackerScore emits a parseable score cell');
-
-const helperRe = (name) => new RegExp(`^function ${name}\\([\\s\\S]*?\\n\\}`, 'm');
-
-const copies = readdirSync(ROOT)
-  .filter(name => name.endsWith('.mjs'))
-  .map(name => [name, readFileSync(join(ROOT, name), 'utf-8')])
-  .filter(([, src]) => helperRe('normalizedTrackerScore').test(src));
 
 // The inputs that separate a parsing implementation from a concatenating one.
 // `4.2 (final)`, `4.2 (internal)` and `4.5 - strong signal` all contain the bare
@@ -61,33 +60,45 @@ const cases = [
 ];
 
 const problems = [];
-for (const [name, src] of copies) {
-  const tsv  = src.match(helperRe('tsvSafe'));
-  const norm = src.match(helperRe('normalizedTrackerScore'));
-  if (!tsv || !norm) { problems.push(`${name}: could not lift the helpers out of the source`); continue; }
-  let fn;
-  try {
-    fn = new Function(`${tsv[0]}\n${norm[0]}\nreturn normalizedTrackerScore;`)();
-  } catch (err) {
-    problems.push(`${name}: helpers do not evaluate standalone (${err.message})`);
-    continue;
+for (const [input, expected] of cases) {
+  const got = normalizedTrackerScore(input);
+  if (got !== expected) {
+    problems.push(`${JSON.stringify(input)} -> ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
   }
-  for (const [input, expected] of cases) {
-    const got = fn(input);
-    if (got !== expected) {
-      problems.push(`${name}: ${JSON.stringify(input)} -> ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
-    }
-    // Whatever a copy decides to return, the tracker's readers have to accept it.
-    if (!looksLikeScoreCell(got)) {
-      problems.push(`${name}: ${JSON.stringify(input)} -> ${JSON.stringify(got)}, which looksLikeScoreCell rejects`);
-    }
+  // Whatever the helper decides to return, the tracker's readers have to accept it.
+  if (!looksLikeScoreCell(got)) {
+    problems.push(`${JSON.stringify(input)} -> ${JSON.stringify(got)}, which looksLikeScoreCell rejects`);
   }
 }
 
-if (copies.length < 2) {
-  fail(`expected the helper in at least two evaluators, found ${copies.length} (${copies.map(([n]) => n).join(', ') || 'none'}) — the helper moved, so this suite is no longer guarding anything`);
-} else if (problems.length === 0) {
-  pass(`all ${copies.length} normalizedTrackerScore copies (${copies.map(([n]) => n).join(', ')}) parse the score and emit a cell every reader accepts`);
+if (problems.length === 0) {
+  pass(`normalizedTrackerScore parses the score and emits a cell every reader accepts (${cases.length} cases)`);
 } else {
   fail(`score-cell normalization broken: ${problems.join('; ')}`);
+}
+
+// ── Single-sourcing (#3796) ────────────────────────────────────────────────
+// Discovery by definition, as before, but the answer must now be zero. Scanning
+// root and lib/ covers where an evaluator or a helper module would put one.
+const HOME = 'lib/tracker-addition.mjs';
+const SHARED = ['tsvSafe', 'slugifyCompany', 'isPostingUrl', 'normalizedTrackerScore'];
+const defRe = (name) => new RegExp(`^(?:export\\s+)?function\\s+${name}\\s*\\(`, 'm');
+
+const scanned = [
+  ...readdirSync(ROOT).filter(n => n.endsWith('.mjs')),
+  ...readdirSync(join(ROOT, 'lib')).filter(n => n.endsWith('.mjs')).map(n => `lib/${n}`),
+].filter(rel => rel !== HOME);
+
+const rogue = [];
+for (const rel of scanned) {
+  const src = readFileSync(join(ROOT, rel), 'utf-8');
+  for (const name of SHARED) {
+    if (defRe(name).test(src)) rogue.push(`${rel} defines ${name}`);
+  }
+}
+
+if (rogue.length === 0) {
+  pass(`the tracker-addition helpers are defined once, in ${HOME} (${scanned.length} files scanned)`);
+} else {
+  fail(`private copies of the tracker-addition helpers are back — import them from ${HOME} instead: ${rogue.join('; ')}`);
 }

--- a/tests/evaluator-score-cell.test.mjs
+++ b/tests/evaluator-score-cell.test.mjs
@@ -82,7 +82,15 @@ if (problems.length === 0) {
 // root and lib/ covers where an evaluator or a helper module would put one.
 const HOME = 'lib/tracker-addition.mjs';
 const SHARED = ['tsvSafe', 'slugifyCompany', 'isPostingUrl', 'normalizedTrackerScore'];
-const defRe = (name) => new RegExp(`^(?:export\\s+)?function\\s+${name}\\s*\\(`, 'm');
+// Declarations AND function-valued bindings. Matching only `function NAME(`
+// missed the shape a re-added copy is most likely to take today --
+// `const normalizedTrackerScore = (value) => ...` -- which would sail past a
+// guard whose whole job is to notice a second definition.
+const defRe = (name) => new RegExp(
+  `^(?:export\\s+)?(?:function\\s+${name}\\s*\\(`
+  + `|(?:const|let|var)\\s+${name}\\s*=\\s*(?:async\\s+)?(?:function\\b|\\(|[A-Za-z_$][\\w$]*\\s*=>))`,
+  'm',
+);
 
 const scanned = [
   ...readdirSync(ROOT).filter(n => n.endsWith('.mjs')),

--- a/tests/openrouter-tracker-tsv.test.mjs
+++ b/tests/openrouter-tracker-tsv.test.mjs
@@ -178,6 +178,14 @@ try {
       // The two defects this block exists for.
       ['**Score:** 8/10',             'N/A'],
       ['Score: 4.2 / 10',             'N/A'],
+      // A denominator separated from the number by an annotation. Stopping the
+      // capture at an ADJACENT denominator read this as a bare 4.2 and wrote
+      // `4.2/5` -- a ten-point score recorded as a five-point one.
+      ['**Score:** 4.2 (strong fit)/10', 'N/A'],
+      // The documented cost of running the capture to end of line: an unrelated
+      // fraction later in the line is refused rather than guessed at. Pinned so
+      // nobody quietly relaxes it back into producing a wrong score.
+      ['Score: 4.2 — matched 3/4 axes',  'N/A'],
       ['Score: 7',                    'N/A'],
       ['Puntuación: 8/10',            'N/A'],
       ['no score anywhere in here',   'N/A'],
@@ -205,12 +213,23 @@ try {
 
   // And the inline formatter is gone for good: the cell must come from the
   // shared helper, not from a local toFixed with a hardcoded `/5`.
+  //
+  // The argument is pinned too, not just the call. The block above lifts the
+  // regex and composes it with the helper ITSELF, which proves the pattern and
+  // the helper agree -- but not that the runner hands the helper that same
+  // capture. A runner that stripped the denominator before calling
+  // (`scoreMatch[1].split('/')[0]`) would keep every case above green while
+  // writing the wrong score, so the call site must pass the capture unmodified.
+  // Running the runner itself against a fixture would prove more, but it needs
+  // an API key and a network round trip; pinning the expression is the bounded
+  // check that closes this specific gap.
   const usesHelper = /const\s+scoreStr\s*=\s*normalizedTrackerScore\(/.test(src);
+  const passesRawCapture = /normalizedTrackerScore\(\s*scoreMatch\s*\?\s*scoreMatch\[1\]\s*:\s*''\s*\)/.test(src);
   const inlineFormat = /toFixed\(1\)\}\/5`\s*:\s*''/.test(src);
-  if (usesHelper && !inlineFormat) {
-    pass('openrouter-runner.mjs builds its score cell with normalizedTrackerScore, with no blank-string fallback');
+  if (usesHelper && passesRawCapture && !inlineFormat) {
+    pass('openrouter-runner.mjs passes the unmodified capture to normalizedTrackerScore, with no blank-string fallback');
   } else {
-    fail(`openrouter-runner.mjs must build the score cell from the shared helper (usesHelper=${usesHelper}, inlineFormat still present=${inlineFormat})`);
+    fail(`openrouter-runner.mjs must hand the shared helper its raw capture (usesHelper=${usesHelper}, passesRawCapture=${passesRawCapture}, inlineFormat still present=${inlineFormat})`);
   }
 } finally {
   try { rmSync(work, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/tests/openrouter-tracker-tsv.test.mjs
+++ b/tests/openrouter-tracker-tsv.test.mjs
@@ -20,6 +20,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { looksLikeScoreCell } from '../tracker-parse.mjs';
+import { normalizedTrackerScore } from '../lib/tracker-addition.mjs';
 
 console.log('\nopenrouter-runner.mjs — tracker-addition TSV merges (headed and headerless)');
 
@@ -147,6 +149,68 @@ try {
     pass('openrouter-runner.mjs writes the shared header row above the data line');
   } else {
     fail(`openrouter-runner.mjs must write TSV_ADDITION_HEADER above the data row (imports=${importsHeader}, writes=${writesHeader})`);
+  }
+
+  // ── Score cell (#3796) ───────────────────────────────────────────────────
+  // openrouter-runner never held a copy of normalizedTrackerScore, so the
+  // copy-scan in tests/evaluator-score-cell.test.mjs never covered it, and it
+  // built its cell inline instead: a numeric prefix that DISCARDED the
+  // denominator, formatted as `X.X/5`, or the empty string when nothing parsed.
+  // Both ends were wrong. `Score: 8/10` became `8.0/5`, which satisfies
+  // SCORE_CELL_RE and so merged as a genuine score into stats.mjs's averages;
+  // an unparseable score became a blank required cell, which merge-tracker
+  // refuses outright, skipping the whole evaluation.
+  //
+  // The regex is inline and unexported, so it is LIFTED FROM THE SOURCE and
+  // composed with the real helper. Asserting on a restatement of the pattern
+  // would pass no matter what the file actually does.
+  const scoreRe = src.match(/result\.match\((\/\(\?:score\|puntuaci\[o[^\]]*\]n\)[^\n]*?)\/i\)/);
+  if (!scoreRe) {
+    fail('could not lift the score-extraction regex out of openrouter-runner.mjs — this guard is no longer testing the real pattern');
+  } else {
+    const extract = new RegExp(`${scoreRe[1].slice(1)}`, 'i');
+    // Report-shaped inputs: what the model actually writes into the markdown.
+    const scoreCases = [
+      ['**Score:** 4.2/5',            '4.2/5'],
+      ['**Score:** 4.2',              '4.2/5'],
+      ['Score: 5/5',                  '5/5'],
+      ['Score: 4.0 (strong fit)',     '4/5'],
+      // The two defects this block exists for.
+      ['**Score:** 8/10',             'N/A'],
+      ['Score: 4.2 / 10',             'N/A'],
+      ['Score: 7',                    'N/A'],
+      ['Puntuación: 8/10',            'N/A'],
+      ['no score anywhere in here',   'N/A'],
+      ['Score: not applicable',       'N/A'],
+    ];
+    const scoreProblems = [];
+    for (const [report, expected] of scoreCases) {
+      const m = report.match(extract);
+      const got = normalizedTrackerScore(m ? m[1] : '');
+      if (got !== expected) {
+        scoreProblems.push(`${JSON.stringify(report)} -> ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
+      }
+      // Whatever it returns, merge-tracker has to accept it. The empty string
+      // this used to emit is precisely what fails here.
+      if (!looksLikeScoreCell(got)) {
+        scoreProblems.push(`${JSON.stringify(report)} -> ${JSON.stringify(got)}, which looksLikeScoreCell rejects`);
+      }
+    }
+    if (scoreProblems.length === 0) {
+      pass(`openrouter-runner's score extraction feeds the shared helper a denominator and never emits a blank cell (${scoreCases.length} cases)`);
+    } else {
+      fail(`openrouter score cell: ${scoreProblems.join('; ')}`);
+    }
+  }
+
+  // And the inline formatter is gone for good: the cell must come from the
+  // shared helper, not from a local toFixed with a hardcoded `/5`.
+  const usesHelper = /const\s+scoreStr\s*=\s*normalizedTrackerScore\(/.test(src);
+  const inlineFormat = /toFixed\(1\)\}\/5`\s*:\s*''/.test(src);
+  if (usesHelper && !inlineFormat) {
+    pass('openrouter-runner.mjs builds its score cell with normalizedTrackerScore, with no blank-string fallback');
+  } else {
+    fail(`openrouter-runner.mjs must build the score cell from the shared helper (usesHelper=${usesHelper}, inlineFormat still present=${inlineFormat})`);
   }
 } finally {
   try { rmSync(work, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -233,6 +233,7 @@ const SYSTEM_PATHS = [
   'lib/gemini-node-floor.mjs',
   'lib/local-today.mjs',
   'lib/placeholder-cell.mjs',
+  'lib/tracker-addition.mjs',
   'lib/scan-summary-marker.mjs',
   'lib/is-main-module.mjs',
   'lib/mjs-files.mjs',


### PR DESCRIPTION
## What does this PR do?

Lifts the tracker-addition helpers (`tsvSafe`, `slugifyCompany`, `isPostingUrl`, `normalizedTrackerScore`) into one `lib/tracker-addition.mjs` and deletes the private copies, then fixes a fifth site — `openrouter-runner.mjs` — that had the same bug in a shape no copy-scan could find.

## Related issue

Closes #3796

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## Notes for the reviewer

### The issue is partly stale, and the difference matters

Checked against `main` at `afc5275`:

- **The behavioural drift is already gone.** #3799 merged, and the two live copies are now byte-for-byte identical (diffed the function bodies). The `4.2 (strong fit)/5` bug the issue leads with is fixed.
- **Only 2 copies exist on main**, not 4. The other two arrive with #3797.
- **The consolidation is genuinely undone**, which is what this PR does.

### Where the helper lives

`lib/tracker-addition.mjs`, not `tracker-utils.mjs` — which pulls in js-yaml and the writer-lock machinery, a dependency these evaluators otherwise don't need. Like `lib/placeholder-cell.mjs` and `lib/local-today.mjs`, it imports nothing. One line added to `SYSTEM_PATHS`; `validate-system-paths-coverage.mjs` is clean.

### The guard test is inverted, not deleted

`tests/evaluator-score-cell.test.mjs` used to sweep root-level scripts for copies and `fail` if it found fewer than two — so consolidating broke it by design. It now imports the single implementation for the 24-case table, and the discovery half asserts the answer is **zero**: any file under root or `lib/` redefining one of the four helpers is caught the day it lands.

`test-all.mjs` gains the complementary family contract (every headless evaluator reaches that one definition). That catches the half a copy-scan cannot — an evaluator that hand-rolls a score cell inline **without redefining anything**.

### Which is exactly what `openrouter-runner.mjs` was doing

It's in the evaluator family but never held a copy, so the copy-scan never covered it:

```js
const scoreStr = isFinite(scoreValue) ? `${scoreValue.toFixed(1)}/5` : '';
```

Two defects:

1. **Unparseable score → empty cell.** Verified against `merge-tracker.mjs` with a fixture: `⚠️ Skipping 001-blankco.tsv: required cell(s) present but empty: score — use the documented sentinel (— / N/A) rather than a blank cell`. Evaluation skipped wholly, the same loss #3796 documents.
2. **Denominator discarded before the guard could see it.** The old regex captured only the numeric prefix, so wiring in the helper alone would have changed nothing — `8` from `Score: 8/10` is indistinguishable from a genuine 8. The capture now takes an optional trailing `/N`.

**One correction to my own finding on the issue:** I first cited `8/10 → 8.0/5` as the live defect. It isn't — the 0..5 range guard already rejected it. The case that actually got through is **`4.2/10`**, which is in range and merged as a genuine `4.2/5` into `stats.mjs`'s averages. That's the case now pinned.

Minor behaviour change: `Score: 4.0` now yields `4/5` rather than `4.0/5` (`toFixed(1)` is gone). Both satisfy `SCORE_CELL_RE`, and it's consistent with the other evaluators.

### The new test can't pass vacuously

openrouter's regex is inline and unexported, so the test **lifts it from the source** and composes it with the real imported helper — asserting on a restatement of the pattern would pass regardless of what the file does. It fails loudly if the lift stops matching.

Mutation-verified: reverting the source to its pre-fix form makes the guard fail on `4.2 / 10` and on the inline formatter.

### Sequencing caveat

#3796 and @santifer both suggested sequencing this after #3797 lands, so it consolidates the final form. This is against `main` instead. **When #3797 merges it re-adds two copies, and `tests/evaluator-score-cell.test.mjs` will fail loudly** rather than regressing silently — that's the intended behaviour, but it does mean a rebase-and-delete pass is needed at that point. `openai-eval.mjs` and `ollama-eval.mjs` are named exemptions in the `test-all.mjs` contract, with the list asserted to be *exactly* the files still outside, so the exemption cannot outlive its reason.

### Verification

`node test-all.mjs` → **8573 passed, 0 failed, 16 warnings**. All 16 warnings are pre-existing and unrelated (personal-data scan on `funding.json`/`HIRED.md`, CV section order, tracker fixtures) — identical set before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Centralize tracker helpers in `lib/tracker-addition.mjs:36-89`.

`gemini-eval.mjs:50` and `batch-evaluate-gemini.mjs:25` now use the shared helpers. `openrouter-runner.mjs:740` passes captured scores to `normalizedTrackerScore`.

Invalid scores and wrong denominators now produce `N/A`. Values such as `4.2/10` no longer become `4.2/5` or blank cells.

## User impact

Tracker additions remain parseable. Invalid model scores no longer corrupt tracker merges or score statistics.

## System files touched

`update-system.mjs:236`: ships `lib/tracker-addition.mjs`.

No changes affect `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

Validation: `8573 passed, 0 failed, 16 warnings`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->