### PR TITLE
fix: Indonesian liveness/eval-mode/model-id gaps + Kalibrr provider

### DIFF
--- a/batch-evaluate-gemini.mjs
+++ b/batch-evaluate-gemini.mjs
@@ -31,9 +31,42 @@ import { isMainModule } from './lib/is-main-module.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
+// Resolve language.modes_dir from config/profile.yml the way gemini-eval.mjs
+// does. Without this the batch evaluator always loaded the English modes/
+// files, so a profile selecting modes/id (or any other market) silently got
+// the generic rubric - the localisation was configured and never applied.
+// Measured 2026-09-04: 39 Indonesian offers all evaluated against modes/oferta.md.
+function resolveModesDir() {
+  try {
+    const ymlPath = join(DATA_ROOT, 'config', 'profile.yml');
+    if (!existsSync(ymlPath)) return join(ROOT, 'modes');
+    const m = readFileSync(ymlPath, 'utf-8').match(/^[ 	]*modes_dir[ 	]*:[ 	]*(.+)$/m);
+    if (!m) return join(ROOT, 'modes');
+    const rel = m[1].trim().replace(/^["']|["']$/g, '');
+    const candidate = join(ROOT, rel);
+    // Never let a profile value escape the project root.
+    if (!candidate.startsWith(ROOT)) return join(ROOT, 'modes');
+    return existsSync(candidate) ? candidate : join(ROOT, 'modes');
+  } catch { return join(ROOT, 'modes'); }
+}
+
+const MODES_DIR = resolveModesDir();
+// Fall back per file: a market dir may localise only some of the modes.
+const modeFile = (name) =>
+  existsSync(join(MODES_DIR, name)) ? join(MODES_DIR, name) : join(ROOT, 'modes', name);
+
+// The evaluation mode is named per market - oferta.md in Spanish, lowongan.md
+// in Indonesian, and so on. Same list gemini-eval.mjs resolves against; keep
+// the two in step or a market localises for one entry point and not the other.
+const EVAL_MODE_FILES = ['oferta.md', 'lowongan.md', 'angebot.md', 'offre.md', 'kyujin.md', 'is-ilani.md', 'naukri.md'];
+const evalModeFile = () => {
+  const found = EVAL_MODE_FILES.find((f) => existsSync(join(MODES_DIR, f)));
+  return found ? join(MODES_DIR, found) : join(ROOT, 'modes', 'oferta.md');
+};
+
 export const PATHS = {
-  shared:      join(ROOT, 'modes', '_shared.md'),
-  oferta:      join(ROOT, 'modes', 'oferta.md'),
+  shared:      modeFile('_shared.md'),
+  oferta:      evalModeFile(),
   cv:          join(DATA_ROOT, 'cv.md'),
   profile:     join(ROOT, 'modes', '_profile.md'),
   profileYml:  join(DATA_ROOT, 'config', 'profile.yml'),
@@ -59,13 +92,17 @@ function readSpendTier() {
   return 'standard';
 }
 
+// Model ids per spend tier. The 2.5 family this used to name was deprecated
+// (2.5-flash 2026-06-17, 2.5-flash-lite 2026-07-22) and now answers HTTP 404
+// "no longer available to new users", so every offer in a batch failed before
+// this was updated. Keep in step with the deprecation table in gemini-eval.mjs.
 function spendTierToModel(tier) {
   switch (tier) {
-    case 'economy': return 'gemini-2.5-flash-lite';
-    case 'premium': return 'gemini-2.5-pro';
+    case 'economy': return 'gemini-3.5-flash-lite';
+    case 'premium': return 'gemini-3.1-pro-preview';
     case 'standard':
     default:
-      return 'gemini-2.5-flash';
+      return 'gemini-3.5-flash';
   }
 }
 

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -111,7 +111,10 @@ if (existsSync(PATHS.profileYml)) {
         console.warn(`⚠️   modes_dir "${customModesDir}" escapes project root; using default modes/`);
       } else {
         if (existsSync(dirPath)) {
-          const candidateFiles = ['oferta.md', 'angebot.md', 'offre.md', 'kyujin.md', 'is-ilani.md', 'naukri.md'];
+          // modes/id names its evaluation mode lowongan.md, so it was missing from
+          // this list and every Indonesian profile silently fell back to the English
+          // modes/oferta.md - the localisation shipped but could never be selected.
+          const candidateFiles = ['oferta.md', 'lowongan.md', 'angebot.md', 'offre.md', 'kyujin.md', 'is-ilani.md', 'naukri.md'];
           const found = candidateFiles.find((file) => existsSync(join(dirPath, file)));
           if (found) {
             modesDir = customModesDir;

--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -26,6 +26,9 @@ const HARD_EXPIRED_PATTERNS = [
   // lookahead). Both guards avoid the worse error: reading a LIVE posting whose
   // copy says "once the application form has been filled…" as expired.
   /\b(?:job|jobs|position|role|posting|opening|vacancy|requisition|req|listing)\b[\s\S]{0,60}?(?<!\b(?:application|form)\s)has been filled\b(?!\s+out)/i,
+  // Jobstreet Indonesia (SEEK) serves a removed posting as HTTP 200 with this
+  // banner and no apply control — measured 2026-09-04 on two July postings.
+  /lowongan kerja ini tidak lagi diiklankan/i,
   /this job has expired/i,
   /job posting has expired/i,
   /no longer accepting applications/i,
@@ -94,6 +97,15 @@ const APPLY_PATTERNS = [
   // Chinese MokaHR and Feishu Jobs detail pages use these exact control texts.
   // Keep them narrow: bare “申请” appears in descriptive prose, while longer
   // labels containing “投递” can be status/history controls rather than Apply.
+  // Jobstreet Indonesia / Glints control labels. Measured 2026-09-04, a live
+  // Jobstreet posting exposes "Lamaran Cepat Kirim lamaran sebagai <role> di
+  // <company>" while a removed one exposes only "Cari lowongan kerja lain" —
+  // so these stay narrow phrases rather than a bare /lamar/, which would also
+  // fire on the "Lamaran kerja" footer link present on both.
+  /lamaran cepat/i,
+  /kirim lamaran/i,
+  /lamar sekarang/i,
+  /^lamar$/i,
   /^申请职位$/,
   /^投递$/,
 ];

--- a/providers/kalibrr.mjs
+++ b/providers/kalibrr.mjs
@@ -1,0 +1,206 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Kalibrr provider — hits the public, no-auth job-board search API used by
+// kalibrr.com's own front end.
+//
+// Kalibrr is one of the largest job boards in Indonesia and the Philippines.
+// Postings resolve to identifiable employers and are free for the candidate,
+// so the source clears the Source Indexing Policy.
+//
+// This provider is designed for explicit `provider: kalibrr` in portals.yml.
+// Auto-detection from careers_url is not supported: Kalibrr is an aggregator,
+// not a single company's ATS.
+//
+// Portal entry fields (all optional except `provider`):
+//   api             — search endpoint (default: https://www.kalibrr.com/kjs/job_board/search)
+//   searchKeywords  — free-text query, mapped to the `text` param (default: "")
+//   country         — country filter (default: "Indonesia")
+//   pageSize        — results per request, mapped to `limit` (default: 30)
+//   maxPages        — maximum requests (default: 3)
+//
+// Deliberately NOT sent: the API also accepts a `location` param, but measured
+// 2026-09-06 it does not filter — passing `location=Karawang` returned 1169
+// results across Riau, Banten and Jakarta and additionally cancelled the `text`
+// filter (18 results became 1169). Region narrowing belongs to portals.yml's
+// `location_filter`, which reads the structured location this provider emits.
+
+const DEFAULT_API = 'https://www.kalibrr.com/kjs/job_board/search';
+const DEFAULT_COUNTRY = 'Indonesia';
+const DEFAULT_PAGE_SIZE = 30;
+const DEFAULT_MAX_PAGES = 3;
+const SITE_ORIGIN = 'https://www.kalibrr.com';
+
+const ALLOWED_KALIBRR_HOSTS = new Set([
+  'www.kalibrr.com',
+  'kalibrr.com',
+  'www.kalibrr.id',
+  'kalibrr.id',
+]);
+
+/** @param {string} url */
+function assertKalibrrUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`kalibrr: invalid api URL "${url}"`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`kalibrr: api URL must be https — got "${url}"`);
+  }
+  if (!ALLOWED_KALIBRR_HOSTS.has(parsed.hostname)) {
+    throw new Error(`kalibrr: host "${parsed.hostname}" is not a Kalibrr host`);
+  }
+  return parsed;
+}
+
+/**
+ * Strip HTML to readable text. Kalibrr returns `description` and
+ * `qualifications` as HTML fragments in the list payload, so the scanner gets
+ * the description for free — no extra request per job.
+ *
+ * @param {unknown} html
+ * @returns {string}
+ */
+function stripHtml(html) {
+  if (typeof html !== 'string' || !html) return '';
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|h[1-6])>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '• ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&rsquo;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+/**
+ * Build the candidate-facing posting URL.
+ * Measured shape: https://www.kalibrr.com/c/{company-code}/jobs/{id}/{slug}
+ *
+ * @param {any} item
+ * @returns {string|null}
+ */
+function buildJobUrl(item) {
+  const code = item?.company?.code || item?.company_info?.code;
+  const id = item?.id;
+  const slug = item?.slug;
+  if (!code || !id || !slug) return null;
+  return `${SITE_ORIGIN}/c/${encodeURIComponent(code)}/jobs/${encodeURIComponent(String(id))}/${encodeURIComponent(slug)}`;
+}
+
+/**
+ * Kalibrr nests the location under google_location.address_components.
+ * Emit "City, Region" so portals.yml `location_filter` has something to match.
+ *
+ * @param {any} item
+ * @returns {string}
+ */
+function buildLocation(item) {
+  if (item?.is_work_from_home) return 'Remote';
+  const a = item?.google_location?.address_components;
+  if (!a) return '';
+  return [a.city, a.region].filter(Boolean).join(', ');
+}
+
+/**
+ * @param {any} item
+ * @returns {import('./_types.js').Job|null}
+ */
+function parseKalibrrItem(item) {
+  const title = String(item?.name || '').trim();
+  const url = buildJobUrl(item);
+  if (!title || !url) return null;
+
+  // A posting past its application_end_date is closed. Dropping it here keeps
+  // a dead listing out of the pipeline before it costs a liveness check.
+  const endRaw = item?.application_end_date;
+  if (endRaw) {
+    const end = Date.parse(endRaw);
+    if (Number.isFinite(end) && end < Date.now()) return null;
+  }
+
+  const description = [stripHtml(item?.description), stripHtml(item?.qualifications)]
+    .filter(Boolean)
+    .join('\n\n');
+
+  /** @type {import('./_types.js').Job} */
+  const job = {
+    title,
+    url,
+    company: String(item?.company_name || item?.company?.name || '').trim(),
+    location: buildLocation(item),
+  };
+
+  if (description) job.description = description;
+
+  const posted = Date.parse(item?.activation_date || item?.created_at || '');
+  if (Number.isFinite(posted)) job.postedAt = posted;
+
+  return job;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'kalibrr',
+
+  detect(_entry) {
+    // Aggregator, not a company ATS — require an explicit provider: kalibrr.
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const apiUrl = entry.api || DEFAULT_API;
+    assertKalibrrUrl(apiUrl);
+
+    const keywords = entry.searchKeywords || '';
+    const country = entry.country || DEFAULT_COUNTRY;
+    const pageSize = Number(entry.pageSize) || DEFAULT_PAGE_SIZE;
+    const maxPages = Number(entry.maxPages) || DEFAULT_MAX_PAGES;
+
+    /** @type {import('./_types.js').Job[]} */
+    const allJobs = [];
+    const seen = new Set();
+
+    for (let page = 0; page < maxPages; page++) {
+      const search = new URL(apiUrl);
+      search.searchParams.set('limit', String(pageSize));
+      search.searchParams.set('offset', String(page * pageSize));
+      if (country) search.searchParams.set('country', country);
+      if (keywords) search.searchParams.set('text', keywords);
+
+      let json;
+      try {
+        json = /** @type {any} */ (await ctx.fetchJson(search.toString(), { redirect: 'error' }));
+      } catch (err) {
+        // Page 0 failing is a real error; a later page failing is not — return
+        // what was collected rather than losing the whole run.
+        if (page === 0) throw err;
+        console.error(`kalibrr: page ${page} fetch failed — ${err.message}`);
+        break;
+      }
+
+      const items = Array.isArray(json?.jobs) ? json.jobs : [];
+      if (items.length === 0) break;
+
+      for (const item of items) {
+        const job = parseKalibrrItem(item);
+        if (!job || seen.has(job.url)) continue;
+        seen.add(job.url);
+        allJobs.push(job);
+      }
+
+      if (items.length < pageSize) break;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    return allJobs;
+  },
+};

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -72,6 +72,19 @@ const METRIC_NOUNS = [
   'graduates', 'alumni', 'teachers', 'instructors', 'educators', 'faculty',
   'schools', 'districts', 'campuses', 'classrooms', 'programs', 'programmes',
   'workshops', 'assessments', 'exams',
+  // Indonesian. An Indonesian-language CV names none of the nouns above, so
+  // every count in it fell out of the extractor and the checker reported "no
+  // count in this document was checked" — a silent hole exactly where an
+  // inflated number would sit. Measured 2026-09-04 on an admin/procurement CV.
+  // Ordered as the list above: people, then documents and records, then
+  // physical/organisational units, then time.
+  'karyawan', 'pegawai', 'staf', 'anggota', 'peserta', 'pelamar', 'kandidat',
+  'mahasiswa', 'siswa', 'pelanggan', 'klien', 'vendor', 'pemasok', 'mitra',
+  'dokumen', 'berkas', 'arsip', 'laporan', 'transaksi', 'pesanan', 'faktur',
+  'invoice', 'data', 'formulir',
+  'barang', 'item', 'unit', 'gudang', 'cabang', 'kantor', 'proyek', 'kegiatan',
+  'acara', 'divisi', 'tim', 'perusahaan',
+  'jam', 'hari', 'minggu', 'bulan', 'tahun',
 ];
 // How many words may sit between a number and the noun it counts. The same
 // regex parses the generated CV and the sources, so the window is symmetric by
@@ -527,8 +540,10 @@ export function diagnoseCoverage(targetText) {
   return {
     reason: 'no-count-claims-recognized',
     message:
-      `${spans.length} count-like claims are present but none matched the metric extractor, whose noun ` +
-      'list is English-only — so no count in this document was checked against your sources. ' +
+      `${spans.length} count-like claims are present but none matched the metric extractor, so no ` +
+      'count in this document was checked against your sources. This is expected when the numbers ' +
+      'are identifiers rather than counts (a GPA, a test score, a school number), and it also ' +
+      'happens when the CV is in a language whose counted nouns are missing from METRIC_NOUNS. ' +
       'Percentages, currency and multipliers were still checked. Verify the counts by hand, or add ' +
       'them to allow_metrics in config/cv-facts.json once confirmed.',
     spans,


### PR DESCRIPTION
## Summary

Four fixes found while running a 39-offer Indonesian batch through this system. Each one failed *silently* rather than erroring, so they're grouped by that shared symptom rather than by file.

## 1. Indonesian apply-control patterns (`liveness-core.mjs`)

`APPLY_PATTERNS` had entries for English, Spanish, German, French, Polish and Chinese, but no Indonesian. A live Jobstreet Indonesia posting's apply control reads `"Lamaran Cepat Kirim lamaran sebagai <role> di <company>"`, which matched nothing — so `check-liveness.mjs` classified every live Indonesian posting as `no_apply_control` and dropped it. Measured 2026-09-04: **40 of 40** verified offers were dropped in one scan, 0 survived.

Worse, that verdict is written to `data/scan-history.tsv` as `skipped_no_apply_control`, which dedup-blocks the URL from every later scan — so the false negative was also permanent.

Verified on two real pages before patching:
- live posting (`id.jobstreet.com/id/job/94396926`) → HTTP 200, control `"Lamaran Cepat Kirim lamaran sebagai…"`, body 4120 chars
- removed posting (`id.jobstreet.com/id/job/93338944`) → HTTP 200, controls only `"Cari lowongan kerja lain"`, body carries `"Lowongan kerja ini tidak lagi diiklankan"`

Added `/lamaran cepat/i`, `/kirim lamaran/i`, `/lamar sekarang/i`, `/^lamar$/i` to `APPLY_PATTERNS` (narrow phrases, not a bare `/lamar/`, which also fires on the `"Lamaran kerja"` footer link present on both live and dead pages), and `/lowongan kerja ini tidak lagi diiklankan/i` to `HARD_EXPIRED_PATTERNS` so a removed posting resolves as `expired` instead of falling through to `uncertain`.

## 2. `modes/id` was unreachable (`gemini-eval.mjs`, `batch-evaluate-gemini.mjs`)

`modes/id` ships its evaluation mode as `lowongan.md`, but `gemini-eval.mjs` resolves `language.modes_dir` against a `candidateFiles` list containing `oferta.md`, `angebot.md`, `offre.md`, `kyujin.md`, `is-ilani.md`, `naukri.md` — not `lowongan.md`. So an Indonesian profile always hit the "No matching evaluation file found" fallback and evaluated against the English rubric. Added `lowongan.md` to the list.

`batch-evaluate-gemini.mjs` had the same gap and no warning at all: it hardcoded `modes/_shared.md` and `modes/oferta.md` and never read `language.modes_dir`. All 39 offers in the batch that surfaced this were evaluated against the wrong mode files. It now resolves the directory the same way `gemini-eval.mjs` does, refuses a value that would escape the project root, falls back per-file (a market directory may localise only some modes), and shares the same evaluation-filename list so the two entry points can't drift apart again.

## 3. Gemini model ids were dead (`batch-evaluate-gemini.mjs`)

The spend-tier → model map still named the 2.5 family: `gemini-2.5-flash` (deprecated 2026-06-17) and `gemini-2.5-flash-lite` (deprecated 2026-07-22). Both now answer `404 … no longer available to new users`, so every offer in a batch failed. Updated the map to `gemini-3.5-flash-lite` / `gemini-3.5-flash` / `gemini-3.1-pro-preview`.

## 4. Fact-check gate was English-only (`verify-cv-facts.mjs`)

`METRIC_NOUNS` had no Indonesian entries, so no count in an Indonesian-language CV was ever extracted, and the fact-check gate reported "not checked" for every quantified claim instead of actually verifying them. Confirmed on a real CV before and after: `"Mengelola 5000 dokumen arsip dan 250 vendor"` passed silently before this change and is now correctly flagged as an unverified metric claim. Added the Indonesian nouns an admin/procurement/logistics CV typically counts (`dokumen`, `pegawai`, `vendor`, `unit`, `cabang`, etc.), and corrected the advisory message, which attributed every "not checked" case to the English-only noun list even when the actual cause was an identifier (a GPA, a test score) rather than a missing translation.

## 5. New provider: Kalibrr (`providers/kalibrr.mjs`)

Not a fix — Indonesian coverage in `providers/` was a single source (`jobstreet.mjs`), which is thin for a market this size. Kalibrr is one of the largest job boards in Indonesia and the Philippines; its public job-board search API needs no auth and returns `description`/`qualifications` inline, so the scan stays zero-token (no per-job request needed for `content_filter`). Postings resolve to identifiable employers and are free for the candidate, so the source clears the Source Indexing Policy.

Measured 2026-09-06: `GET /kjs/job_board/search?limit=30&offset=0&country=Indonesia&text=admin` returns HTTP 200 with 18 matching jobs out of 1057 Indonesian postings; job URLs build as `/c/{company-code}/jobs/{id}/{slug}` and all were well-formed, one confirmed live by `check-liveness.mjs`.

One thing deliberately **not** used: the API also accepts a `location` param, but it doesn't filter — `location=Karawang` returned 1169 results spread across Riau, Banten and Jakarta and *also cancelled the `text` filter* (18 results became 1169). Region narrowing is left to `portals.yml`'s existing `location_filter`, which reads the `"City, Region"` string this provider emits from `google_location.address_components`. Postings past `application_end_date` are dropped at parse time so a closed listing never reaches the pipeline.

## Testing

`node --test tests/liveness-core.test.mjs tests/fact-gate-language-coverage.test.mjs tests/nonmetric-fact-gate.test.mjs tests/cover-fact-gate.test.mjs` → 10/10 pass.

`node validate-portals.mjs` and `node verify-pipeline.mjs` → 0 errors on a live installation running this branch since 2026-09-04, with all five fixes exercised against real Jobstreet/Kalibrr traffic (not just the unit tests above).

## Notes for reviewers

- No config files, secrets, or personal data in this diff — checked before pushing.
- Happy to split into separate PRs per fix if that's easier to review; grouped them here because they were all found in the same debugging session and share the "silent failure" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This change improves Indonesian job processing and adds Kalibrr support.

### User impact

- Indonesian Jobstreet postings now detect active apply controls and expired listings: `liveness-core.mjs:29-31`, `liveness-core.mjs:100-102`.
- Indonesian Gemini evaluations can load `modes/id/lowongan.md`: `gemini-eval.mjs:106-135`.
- Batch evaluation resolves market mode files from `modes_dir` and applies safe fallbacks: `batch-evaluate-gemini.mjs:34-67`.
- Gemini uses current model IDs: `batch-evaluate-gemini.mjs:98-105`.
- CV verification recognizes Indonesian count nouns and gives clearer coverage guidance: `verify-cv-facts.mjs:41-138`, `verify-cv-facts.mjs:546`.
- Users can configure Kalibrr searches for Indonesian and Philippine listings: `providers/kalibrr.mjs:151-194`.
- Kalibrr filters expired or malformed postings and suppresses duplicates. Auto-detection remains disabled.

### System files touched

- `modes/`: Indonesian evaluation mode resolution uses `modes/id/lowongan.md`: `gemini-eval.mjs:106-135`.
- `providers/`: Adds `providers/kalibrr.mjs`.
- `AGENTS.md`: Documents `language.modes_dir`, but no change is shown.
- `update-system.mjs`, `DATA_CONTRACT.md`, and `.github/`: No change is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->