### PR TITLE
feat(templates): let a template pack declare the sections it owns (#3852)

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -24,6 +24,13 @@
 //   entry-level field names (COMPANY, PERIOD, ROLE, etc.). When no partial file
 //   is found the built-in fallback builder is used, preserving full backward
 //   compatibility.
+//
+// Section completeness (#3852):
+//   A template's manifest may declare the sections it owns (`sections: all`,
+//   or a list — see lib/template-manifest.mjs). A declared section
+//   never falls back: a missing, malformed, or empty partial fails the render
+//   with the file named. Templates that declare nothing keep the silent
+//   fallback above.
 
 import { readFile, writeFile, stat, mkdir } from 'fs/promises';
 import { existsSync, readFileSync } from 'fs';
@@ -33,6 +40,7 @@ import { tmpdir } from 'os';
 import { stripEmptySections } from './cv-sections-core.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { hasRequiredFields, validatePayload } from './lib/cv-payload-schema.mjs';
+import { PARTIAL_SECTIONS, declaredSections, parseMeta } from './lib/template-manifest.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
@@ -302,25 +310,61 @@ function fillEntry(entryTemplate, blocks, fields, blockValues) {
 
 // Load section partials from the sections/ directory co-located with the
 // template. Returns a Map<sectionName, { entryTemplate, blocks }> for each
-// partial file found. Sections with no partial file are absent from the map
-// and fall back to the built-in builders.
+// partial file found.
+//
+// Two contracts, chosen by the template's manifest (#3852):
+//
+//   - A section the manifest declares (`sections: all`, or a list) is owned by
+//     the template. Its partial must exist, parse, and carry a non-empty ENTRY
+//     zone, or this throws and the render fails. Falling back would emit the
+//     built-in DOM the pack exists to replace, with nothing in the output
+//     saying so: a typo in experience.html produced a CV that rendered,
+//     validated, and passed the placeholder check with the two-column markup
+//     the pack was written to avoid.
+//   - A section the manifest does not declare keeps the original contract:
+//     absent from the map when there is no partial or the partial is
+//     malformed, so the built-in builder renders it.
+//
+// Every problem is collected before throwing so one run names them all.
 function loadSectionPartials(templatePath) {
   const sectionsDir = join(dirname(templatePath), 'sections');
+  let declared;
+  try {
+    declared = declaredSections(parseMeta(templatePath));
+  } catch (err) {
+    throw new Error(`Template ${templatePath}: ${err.message}`);
+  }
+  const owned = declared || new Set();
   const partials = new Map();
-  if (!existsSync(sectionsDir)) return partials;
+  const problems = [];
 
-  const sectionNames = [
-    'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills',
-  ];
-  for (const name of sectionNames) {
+  for (const name of PARTIAL_SECTIONS) {
     const partialPath = join(sectionsDir, `${name}.html`);
-    if (!existsSync(partialPath)) continue;
-    try {
-      const source = readFileSync(partialPath, 'utf-8');
-      partials.set(name, parsePartial(source));
-    } catch {
-      // Silently skip malformed partial files — fall back to built-in builder.
+    const rel = `sections/${name}.html`;
+    if (!existsSync(partialPath)) {
+      if (owned.has(name)) problems.push(`${rel} is declared but does not exist`);
+      continue;
     }
+    let parsed;
+    try {
+      parsed = parsePartial(readFileSync(partialPath, 'utf-8'));
+    } catch (err) {
+      if (owned.has(name)) problems.push(`${rel} is declared but malformed: ${err.message}`);
+      continue; // undeclared: fall back to the built-in builder, as before
+    }
+    if (owned.has(name) && !parsed.entryTemplate) {
+      problems.push(`${rel} is declared but its ENTRY zone is empty`);
+      continue;
+    }
+    partials.set(name, parsed);
+  }
+
+  if (problems.length) {
+    throw new Error(
+      `Template ${templatePath} declares sections it cannot render:\n`
+        + problems.map((p) => `  - ${p}`).join('\n')
+        + '\nA declared section must ship a partial that parses — fix the file, or drop it from the manifest\'s "sections" list.'
+    );
   }
   return partials;
 }
@@ -744,7 +788,11 @@ async function main() {
     console.error('  the builder loads per-section HTML partial files from it');
     console.error('  (e.g. sections/experience.html). Partials control the DOM');
     console.error('  structure, tag names, and class names for each section.');
-    console.error('  When no partial file is found the built-in builder is used.');
+    console.error('  When no partial file is found the built-in builder is used —');
+    console.error('  unless the template manifest declares the section (#3852):');
+    console.error('  `sections: all` or `sections: experience, education` in the');
+    console.error('  <!-- career-ops-template --> block makes a missing or malformed');
+    console.error('  partial fail the build instead of falling back.');
     process.exit(args.includes('--help') ? 0 : 1);
   }
 

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -9,6 +9,15 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { isMainModule } from './lib/is-main-module.mjs';
+import {
+  parseMeta, PARTIAL_SECTIONS, declaredSections, checkDeclaredSections,
+} from './lib/template-manifest.mjs';
+
+// The manifest block and the section vocabulary live in lib/template-manifest.mjs
+// so build-cv-html.mjs can share them without importing this module (and the
+// js-yaml it pulls in for profile defaults). Re-exported here because this is
+// where callers have always found parseMeta.
+export { parseMeta, PARTIAL_SECTIONS, declaredSections, checkDeclaredSections };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_TEMPLATES_DIR = resolve(__dirname, 'templates');
@@ -60,23 +69,6 @@ function parseFilename(prefix, file) {
   const m = file.match(new RegExp(`^${prefix}(?:\\.([a-z0-9-]+))?\\.(html|tex)$`));
   if (!m) return null;
   return { name: m[1] || 'standard', format: m[2] };
-}
-
-export function parseMeta(path) {
-  let text;
-  try {
-    text = readFileSync(path, 'utf-8');
-  } catch {
-    return {};
-  }
-  const block = text.match(/<!--\s*career-ops-template\s*([\s\S]*?)-->/);
-  if (!block) return {};
-  const meta = {};
-  for (const line of block[1].split(/\r?\n/)) {
-    const kv = line.match(/^\s*([a-zA-Z_]+)\s*:\s*(.+?)\s*$/);
-    if (kv) meta[kv[1].toLowerCase()] = kv[2];
-  }
-  return meta;
 }
 
 // Build the entry a discovered template file contributes.
@@ -264,13 +256,30 @@ export function resolveTemplate(kind, name, opts = {}) {
   }
   const path = entry.path;
   if (format === 'html') {
+    // Name the file that is actually short, not the flat filename it would
+    // have had. For a pack these differ, and the flat name points at nothing.
+    const where = entry.pack ? `${entry.pack}/${fileFor(chosen)}` : fileFor(chosen);
     const v = validateTemplate(path, kind);
     if (!v.ok) {
-      // Name the file that is actually short, not the flat filename it would
-      // have had. For a pack these differ, and the flat name points at nothing.
-      const where = entry.pack ? `${entry.pack}/${fileFor(chosen)}` : fileFor(chosen);
       throw new Error(
         `Template ${where} missing required placeholders: ${v.missing.map((m) => `{{${m}}}`).join(', ')}`
+      );
+    }
+    // A template that declares its sections must ship them (#3852). Checked
+    // at resolve for the same reason the placeholders are: every by-name
+    // caller lands here, and a name that resolves and then fails to render is
+    // the failure that passes review because the demo path works.
+    let sections;
+    try {
+      sections = checkDeclaredSections(path);
+    } catch (err) {
+      throw new Error(`Template ${where}: ${err.message}`);
+    }
+    if (sections.missing.length) {
+      throw new Error(
+        `Template ${where} declares sections it does not ship: `
+          + sections.missing.map((n) => `sections/${n}.html`).join(', ')
+          + '. A declared section must have a partial — add the file, or drop it from the manifest\'s "sections" list.'
       );
     }
   }

--- a/lib/template-manifest.mjs
+++ b/lib/template-manifest.mjs
@@ -20,7 +20,14 @@ export function parseMeta(path) {
   if (!block) return {};
   const meta = {};
   for (const line of block[1].split(/\r?\n/)) {
-    const kv = line.match(/^\s*([a-zA-Z_]+)\s*:\s*(.+?)\s*$/);
+    // `(.*?)`, not `(.+?)`: a key written with a blank value is a key the
+    // author typed, and it is recorded as ''. Dropping it would put the empty
+    // declaration out of reach of every check downstream — a bare `sections:`
+    // would parse as no key at all and fall silently back to the built-in
+    // builders, which is the exact silence the sections key exists to remove.
+    // Harmless for the other keys: `name` is read through `meta.name || ...`,
+    // so an empty value still falls back to the prettified filename.
+    const kv = line.match(/^\s*([a-zA-Z_]+)\s*:\s*(.*?)\s*$/);
     if (kv) meta[kv[1].toLowerCase()] = kv[2];
   }
   return meta;
@@ -59,6 +66,9 @@ export const PARTIAL_SECTIONS = Object.freeze([
 // is the silence this key exists to remove.
 export function declaredSections(meta) {
   const raw = meta?.sections;
+  // Only an absent key declares nothing. A present-but-blank one (`sections:`
+  // with nothing after it) reaches the empty-declaration error below, which is
+  // why parseMeta records a blank value instead of dropping the line.
   if (raw === undefined || raw === null) return null;
   const value = String(raw).trim();
   if (value.toLowerCase() === 'all') return new Set(PARTIAL_SECTIONS);

--- a/lib/template-manifest.mjs
+++ b/lib/template-manifest.mjs
@@ -1,0 +1,91 @@
+// lib/template-manifest.mjs — the <!-- career-ops-template --> manifest block
+// a CV or cover-letter template carries, and the section vocabulary its
+// `sections:` key is checked against (#3852).
+//
+// Shared by cv-templates.mjs (resolve-time completeness check) and
+// build-cv-html.mjs (render-time parse check). Kept dependency-free on
+// purpose: the builder imports it, and the builder has never needed js-yaml.
+
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+export function parseMeta(path) {
+  let text;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return {};
+  }
+  const block = text.match(/<!--\s*career-ops-template\s*([\s\S]*?)-->/);
+  if (!block) return {};
+  const meta = {};
+  for (const line of block[1].split(/\r?\n/)) {
+    const kv = line.match(/^\s*([a-zA-Z_]+)\s*:\s*(.+?)\s*$/);
+    if (kv) meta[kv[1].toLowerCase()] = kv[2];
+  }
+  return meta;
+}
+
+// ── Section completeness (#3852) ─────────────────────────────────────────────
+//
+// The CV sections build-cv-html.mjs renders from a `sections/<name>.html`
+// partial when the template ships one. The manifest key below is checked
+// against this list, and the builder imports it rather than keeping a second
+// copy, so the check and the render can never disagree about which sections
+// exist.
+export const PARTIAL_SECTIONS = Object.freeze([
+  'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills',
+]);
+
+// The sections a template's manifest claims to own:
+//
+//   <!-- career-ops-template
+//   name: ATS Friendly
+//   sections: all                      every name in PARTIAL_SECTIONS
+//   sections: experience, education    an explicit subset
+//   -->
+//
+// Before this key existed a pack could only hope it was complete. A section
+// with no partial — or a partial with a typo in it — rendered through the
+// built-in builder, which emits exactly the DOM the pack was written to avoid,
+// and nothing in the output said so. A declared section is a checkable claim
+// instead: its partial must exist (checked here, at resolve) and parse
+// (checked by the builder, which owns the partial format), or the render fails.
+//
+// Returns null when the manifest is silent, which keeps every pack written
+// before this key on its old contract: silent fallback to the built-in
+// builder. Throws on an empty declaration or a name outside the vocabulary —
+// both mean the author meant to claim something, and a claim quietly ignored
+// is the silence this key exists to remove.
+export function declaredSections(meta) {
+  const raw = meta?.sections;
+  if (raw === undefined || raw === null) return null;
+  const value = String(raw).trim();
+  if (value.toLowerCase() === 'all') return new Set(PARTIAL_SECTIONS);
+  const names = value.split(/[\s,]+/).filter(Boolean).map((n) => n.toLowerCase());
+  if (names.length === 0) {
+    throw new Error('manifest key "sections" is empty — write "all" or a list of section names');
+  }
+  const unknown = names.filter((n) => !PARTIAL_SECTIONS.includes(n));
+  if (unknown.length) {
+    throw new Error(
+      `manifest key "sections" names unknown section${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')} `
+        + `(known: ${PARTIAL_SECTIONS.join(', ')}, or "all")`
+    );
+  }
+  return new Set(names);
+}
+
+// For a template file on disk: what its manifest declares, and which declared
+// sections have no partial beside it. `declared` is null for a silent manifest.
+// Existence only — whether a partial parses is the renderer's call.
+export function checkDeclaredSections(templatePath) {
+  const declared = declaredSections(parseMeta(templatePath));
+  if (!declared) return { declared: null, missing: [] };
+  const sectionsDir = resolve(dirname(templatePath), 'sections');
+  const missing = PARTIAL_SECTIONS.filter(
+    (name) => declared.has(name) && !existsSync(resolve(sectionsDir, `${name}.html`))
+  );
+  return { declared, missing };
+}
+

--- a/templates/README.md
+++ b/templates/README.md
@@ -63,6 +63,23 @@ node cv-templates.mjs resolve cv modern  # absolute path to fill
 
 **Single column, always.** All colour in these variants is decoration over a strictly top-to-bottom text flow, so PDF extraction order is unaffected. Multi-column page layouts are the classic ATS parse failure and none of these use one.
 
+### Template packs
+
+A template that needs its own **DOM**, not just its own CSS, ships as a pack: a subdirectory of `templates/` holding `cv-template.<name>.html` next to its own `sections/`. `build-cv-html.mjs` resolves section partials relative to the template file, so a pack gets its own markup without touching the `templates/sections/` every flat template shares. The name still comes from the filename, never the directory, and a name claimed by both a flat file and a pack is an error at discovery (`cv-templates.mjs`).
+
+The one shipped so far is `templates/ats/` (`cv-template.ats.html`, name `ats`): single-column, no flex or grid anywhere, every section one block element per line, for ATS parsers that walk the DOM rather than the page.
+
+**Declare the sections a pack owns.** Partials cover seven sections — `competencies`, `experience`, `projects`, `education`, `certifications`, `awards`, `skills` — and any section a pack does not ship a partial for renders through the built-in builder, which emits the DOM the pack exists to replace. A malformed partial falls back the same way. Neither says anything in the output, so a pack's manifest can make ownership an explicit, checked claim:
+
+```html
+<!-- career-ops-template
+name: ATS Friendly
+sections: all
+-->
+```
+
+`sections: all` claims every section; `sections: experience, education` claims a subset. A declared section must exist (checked when the template resolves by name) and must parse with a non-empty `<!--ENTRY-->` zone (checked when the CV renders), or the build fails naming the file — it never falls back. Undeclared sections keep the silent fallback, so a pack written before this key exists behaves exactly as it did; a pack that declares nothing is simply a pack that has not made the claim. Prefer `sections: all` for a pack whose point is its DOM, as the ATS pack does: the alternative is being correct by a coincidence the pack never stated, which the next change to a built-in builder can end without any test noticing.
+
 ### resume-template.html
 
 Resume-branded variant of `cv-template.html` for US/industry job applications. Key differences from the CV template:

--- a/templates/ats/cv-template.ats.html
+++ b/templates/ats/cv-template.ats.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <!-- career-ops-template
 name: ATS Friendly
-version: 1.0.0
+version: 1.1.0
+sections: all
 -->
 <html lang="{{LANG}}">
 <head>

--- a/templates/ats/sections/awards.html
+++ b/templates/ats/sections/awards.html
@@ -1,0 +1,26 @@
+<!--
+  awards.html — ATS section partial for Awards & Honors.
+
+  Field placeholders filled per entry:
+    TITLE      — award name
+    ORG_BLOCK  — conditional: award-org span with the issuing body when present;
+                 falls back to an empty award-org span (ORG_EMPTY) so every row has the same cells
+    YEAR_BLOCK — conditional: award-year span with year text when present;
+                 falls back to an empty award-year span (YEAR_EMPTY) for the same reason
+
+  Mirrors certifications.html: one row per award, inline-block cells, no table
+  and no flex.
+
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
+-->
+<!--ENTRY-->
+<div class="award-item">
+  <span class="award-title">{{TITLE}}</span>
+  {{ORG_BLOCK}}
+  {{YEAR_BLOCK}}
+</div>
+<!--ORG_BLOCK--><span class="award-org">{{ORG}}</span><!--/ORG_BLOCK-->
+<!--ORG_EMPTY--><span class="award-org"></span><!--/ORG_EMPTY-->
+<!--YEAR_BLOCK--><span class="award-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
+<!--YEAR_EMPTY--><span class="award-year"></span><!--/YEAR_EMPTY-->
+<!--/ENTRY-->

--- a/templates/ats/sections/certifications.html
+++ b/templates/ats/sections/certifications.html
@@ -1,0 +1,26 @@
+<!--
+  certifications.html — ATS section partial for Certifications.
+
+  Field placeholders filled per entry:
+    TITLE      — certification name
+    ORG_BLOCK  — conditional: cert-org span with org text when present;
+                 falls back to an empty cert-org span (ORG_EMPTY) so every row has the same cells
+    YEAR_BLOCK — conditional: cert-year span with year text when present;
+                 falls back to an empty cert-year span (YEAR_EMPTY) for the same reason
+
+  One row per certification, inline-block cells, no table and no flex — the
+  cells read left to right as one line of text.
+
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
+-->
+<!--ENTRY-->
+<div class="cert-item">
+  <span class="cert-title">{{TITLE}}</span>
+  {{ORG_BLOCK}}
+  {{YEAR_BLOCK}}
+</div>
+<!--ORG_BLOCK--><span class="cert-org">{{ORG}}</span><!--/ORG_BLOCK-->
+<!--ORG_EMPTY--><span class="cert-org"></span><!--/ORG_EMPTY-->
+<!--YEAR_BLOCK--><span class="cert-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
+<!--YEAR_EMPTY--><span class="cert-year"></span><!--/YEAR_EMPTY-->
+<!--/ENTRY-->

--- a/templates/ats/sections/projects.html
+++ b/templates/ats/sections/projects.html
@@ -1,0 +1,24 @@
+<!--
+  projects.html — ATS section partial for Projects.
+
+  Field placeholders filled per entry:
+    NAME         — project name (already wrapped in <a> when the entry has a url)
+    BADGE_BLOCK  — conditional: badge span when badge is present; omitted otherwise
+    DESC_BLOCK   — conditional: description div when description is present; omitted otherwise
+    TECH_BLOCK   — conditional: tech div when tech is present; omitted otherwise
+
+  Stacked block elements only — every line is its own div, so a parser walking
+  the DOM reads title, description, and stack in order with nothing side by side.
+
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
+-->
+<!--ENTRY-->
+<div class="project">
+  <div class="project-title">{{NAME}}{{BADGE_BLOCK}}</div>
+  {{DESC_BLOCK}}
+  {{TECH_BLOCK}}
+</div>
+<!--BADGE_BLOCK--><span class="project-badge">{{BADGE}}</span><!--/BADGE_BLOCK-->
+<!--DESC_BLOCK--><div class="project-desc">{{DESC}}</div><!--/DESC_BLOCK-->
+<!--TECH_BLOCK--><div class="project-tech">{{TECH}}</div><!--/TECH_BLOCK-->
+<!--/ENTRY-->

--- a/templates/ats/sections/skills.html
+++ b/templates/ats/sections/skills.html
@@ -1,0 +1,17 @@
+<!--
+  skills.html — ATS section partial for Skills.
+
+  Field placeholders filled per skill category:
+    CATEGORY_BLOCK — conditional: category label span when category is present; omitted otherwise
+    ITEMS_TEXT     — comma-joined items string
+
+  One block-level line per category. The builder wraps every entry in a
+  <div class="skills-grid"> it emits itself; this template leaves that class
+  unstyled on purpose, so the wrapper is a plain block and the lines stack.
+
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
+-->
+<!--ENTRY-->
+<div class="skill-item">{{CATEGORY_BLOCK}}{{ITEMS_TEXT}}</div>
+<!--CATEGORY_BLOCK--><span class="skill-category">{{CATEGORY}}: </span><!--/CATEGORY_BLOCK-->
+<!--/ENTRY-->

--- a/tests/template-pack-sections.test.mjs
+++ b/tests/template-pack-sections.test.mjs
@@ -1,0 +1,310 @@
+// tests/template-pack-sections.test.mjs — a template pack can declare the
+// sections it owns, and a declared section never falls back silently (#3852).
+//
+// build-cv-html.mjs walks seven section names and renders each from the
+// pack's sections/<name>.html when one exists, otherwise from its built-in
+// builder. Before the manifest key pinned here, that fallback was the only
+// contract: a pack that shipped three partials got the other four from the
+// builders — the DOM it was written to avoid — and a typo in a partial it did
+// ship degraded the same way, with nothing in the output saying so.
+//
+// `sections: all` (or a list) in the <!-- career-ops-template --> block turns
+// ownership into a checkable claim. A declared section must exist at resolve
+// (cv-templates.mjs) and parse at render (build-cv-html.mjs); a pack that
+// declares nothing keeps the old behaviour, which is what keeps every pack
+// written before the key on its existing contract.
+//
+// Lives in tests/ because only tests/**/*.test.mjs is discovered by
+// test-all.mjs.
+
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, run, NODE, ROOT, lastRunFailure } from './helpers.mjs';
+import {
+  PARTIAL_SECTIONS, declaredSections, checkDeclaredSections, listTemplates, resolveTemplate,
+} from '../cv-templates.mjs';
+
+console.log('\nCV template packs — declared sections and completeness (#3852)');
+
+const fixtures = [];
+process.on('exit', () => {
+  for (const dir of fixtures) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // A fixture that cannot be removed must not change the suite's verdict.
+    }
+  }
+});
+
+const VALID_ENTRY = '<!--ENTRY--><div class="pack-job">{{ROLE}} at {{COMPANY}}</div><!--/ENTRY-->';
+const MALFORMED_ENTRY = '<div class="pack-job">{{ROLE}}</div>'; // no ENTRY zone
+const EMPTY_ENTRY = '<!--ENTRY-->   <!--/ENTRY-->';
+
+/** A templates/ dir holding the base template plus one pack, "mine". */
+function fixture({ manifest = '', sections = {} } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'pack-sections-'));
+  fixtures.push(dir);
+  const body = `<!DOCTYPE html>\n<!-- career-ops-template\nname: Mine\n${manifest}\n-->\n`
+    + '<html><body>{{NAME}}{{EXPERIENCE}}{{EDUCATION}}</body></html>\n';
+  writeFileSync(join(dir, 'cv-template.html'), '{{NAME}}{{EXPERIENCE}}{{EDUCATION}}');
+  const packDir = join(dir, 'mine');
+  mkdirSync(join(packDir, 'sections'), { recursive: true });
+  writeFileSync(join(packDir, 'cv-template.mine.html'), body);
+  for (const [name, html] of Object.entries(sections)) {
+    writeFileSync(join(packDir, 'sections', `${name}.html`), html);
+  }
+  return { dir, template: join(packDir, 'cv-template.mine.html') };
+}
+
+/** Assert `fn` throws with a message matching every pattern. */
+function throws(label, fn, ...patterns) {
+  let err = null;
+  try {
+    fn();
+  } catch (e) {
+    err = e;
+  }
+  if (!err) return fail(`${label}: expected a throw, got none`);
+  const missed = patterns.filter((p) => !p.test(err.message));
+  if (missed.length) return fail(`${label}: message missed ${missed.join(', ')} — got "${err.message}"`);
+  pass(label);
+}
+
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Pack Tester', email: 'pack@example.com' },
+  summary: 'Summary.',
+  experience: [{ company: 'Corp', role: 'Engineer', dates: '2024 - Present', bullets: ['Did a thing'] }],
+  education: [{ title: 'BSc', org: 'University', year: '2020' }],
+};
+
+/**
+ * Run build-cv-html.mjs against a template path. Returns { html } on a zero
+ * exit or { stderr, status } on a non-zero one, so each check can assert the
+ * outcome it expects instead of treating a crash as a suite abort.
+ */
+function build(dir, template) {
+  const input = join(dir, 'payload.json');
+  const output = join(dir, 'out.html');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+  if (run(NODE, [join(ROOT, 'build-cv-html.mjs'), input, output, template]) === null) {
+    const f = lastRunFailure();
+    return { status: f?.status ?? null, stderr: f?.stderr || '' };
+  }
+  if (!existsSync(output)) return { status: 0, stderr: 'exited 0 but wrote no output file' };
+  return { status: 0, html: readFileSync(output, 'utf-8') };
+}
+
+// ── declaredSections: the manifest vocabulary ───────────────────────────────
+
+{
+  if (declaredSections({}) === null && declaredSections({ name: 'X' }) === null) {
+    pass('a manifest with no "sections" key declares nothing (null)');
+  } else {
+    fail('a silent manifest must return null, not an empty set');
+  }
+
+  const all = declaredSections({ sections: 'all' });
+  if (all instanceof Set && all.size === PARTIAL_SECTIONS.length && PARTIAL_SECTIONS.every((n) => all.has(n))) {
+    pass('"sections: all" declares every section in PARTIAL_SECTIONS');
+  } else {
+    fail(`"all" declared ${[...(all || [])].join(', ')}`);
+  }
+
+  const some = declaredSections({ sections: 'Experience, education skills' });
+  if (some?.size === 3 && some.has('experience') && some.has('education') && some.has('skills')) {
+    pass('a list splits on commas and whitespace, case-insensitively');
+  } else {
+    fail(`list declared ${[...(some || [])].join(', ')}`);
+  }
+
+  throws(
+    'an unknown section name is an error naming it and the vocabulary',
+    () => declaredSections({ sections: 'experience, references' }),
+    /unknown section/, /references/, /competencies/
+  );
+  throws('an empty declaration is an error', () => declaredSections({ sections: ' , ' }), /empty/);
+}
+
+// ── Resolution: a declared section must exist ───────────────────────────────
+
+{
+  const { dir } = fixture({ manifest: 'sections: all', sections: { experience: VALID_ENTRY } });
+  const listed = listTemplates('cv', { dir }).map((t) => t.name);
+  if (listed.includes('mine')) pass('an incomplete pack still lists — listing is not the gate');
+  else fail(`incomplete pack vanished from the listing: ${listed.join(', ')}`);
+
+  throws(
+    'resolving a pack that declares "all" but ships one partial names every missing file',
+    () => resolveTemplate('cv', 'mine', { dir }),
+    /mine[/\\]cv-template\.mine\.html/,
+    /declares sections it does not ship/,
+    /sections\/education\.html/, /sections\/skills\.html/
+  );
+  const { missing } = checkDeclaredSections(join(dir, 'mine', 'cv-template.mine.html'));
+  if (missing.length === PARTIAL_SECTIONS.length - 1 && !missing.includes('experience')) {
+    pass('checkDeclaredSections reports exactly the declared sections with no partial');
+  } else {
+    fail(`checkDeclaredSections reported ${missing.join(', ')}`);
+  }
+}
+
+{
+  const { dir, template } = fixture({
+    manifest: 'sections: experience, education',
+    sections: { experience: VALID_ENTRY, education: '<!--ENTRY--><div class="pack-edu">{{TITLE}}</div><!--/ENTRY-->' },
+  });
+  let resolved;
+  try {
+    resolved = resolveTemplate('cv', 'mine', { dir });
+  } catch (e) {
+    resolved = `threw: ${e.message}`;
+  }
+  if (resolved === template) pass('a pack that ships every section it declares resolves by name');
+  else fail(`complete pack did not resolve: ${resolved}`);
+}
+
+{
+  const { dir } = fixture({ manifest: 'sections: experience, references', sections: { experience: VALID_ENTRY } });
+  throws(
+    'a manifest naming an unknown section fails at resolve, naming the pack',
+    () => resolveTemplate('cv', 'mine', { dir }),
+    /mine[/\\]cv-template\.mine\.html/, /unknown section/, /references/
+  );
+}
+
+{
+  // The pre-#3852 contract, unchanged: no key, no check.
+  const { dir, template } = fixture({ sections: { experience: MALFORMED_ENTRY } });
+  let resolved;
+  try {
+    resolved = resolveTemplate('cv', 'mine', { dir });
+  } catch (e) {
+    resolved = `threw: ${e.message}`;
+  }
+  if (resolved === template) pass('a pack that declares nothing resolves with a malformed partial, as before');
+  else fail(`silent pack no longer resolves: ${resolved}`);
+}
+
+// ── Rendering: a declared section must parse, and never falls back ──────────
+//
+// build-cv-html.mjs accepts a template path directly, so the render is a
+// second gate rather than a redundant one: a caller can bypass resolveTemplate
+// entirely, and parse errors are only detectable here anyway.
+
+{
+  const { dir, template } = fixture({ manifest: 'sections: experience', sections: { experience: MALFORMED_ENTRY } });
+  const r = build(dir, template);
+  if (r.status !== 0 && /sections\/experience\.html/.test(r.stderr) && /malformed/.test(r.stderr)) {
+    pass('a declared partial that does not parse fails the build, naming the file');
+  } else {
+    fail(`malformed declared partial: exit ${r.status}, stderr "${(r.stderr || '').trim()}"`);
+  }
+}
+
+{
+  const { dir, template } = fixture({ manifest: 'sections: experience', sections: { experience: EMPTY_ENTRY } });
+  const r = build(dir, template);
+  if (r.status !== 0 && /sections\/experience\.html/.test(r.stderr) && /ENTRY zone is empty/.test(r.stderr)) {
+    pass('a declared partial with an empty ENTRY zone fails the build — an empty section is not ownership');
+  } else {
+    fail(`empty declared partial: exit ${r.status}, stderr "${(r.stderr || '').trim()}"`);
+  }
+}
+
+{
+  const { dir, template } = fixture({ manifest: 'sections: all', sections: { experience: VALID_ENTRY } });
+  const r = build(dir, template);
+  const named = ['education', 'skills', 'awards'].every((n) => new RegExp(`sections/${n}\\.html`).test(r.stderr || ''));
+  if (r.status !== 0 && named && !/sections\/experience\.html/.test(r.stderr)) {
+    pass('rendering an incomplete pack by path fails and lists every missing partial in one run');
+  } else {
+    fail(`incomplete pack by path: exit ${r.status}, stderr "${(r.stderr || '').trim()}"`);
+  }
+}
+
+{
+  const { dir, template } = fixture({ manifest: 'sections: experience', sections: { experience: VALID_ENTRY } });
+  const r = build(dir, template);
+  if (r.status === 0 && r.html.includes('class="pack-job"') && !r.html.includes('class="job-header"')) {
+    pass('a declared partial that parses renders the pack DOM, not the built-in one');
+  } else {
+    fail(`valid declared partial: exit ${r.status}, ${r.html ? 'built-in DOM leaked' : (r.stderr || '').trim()}`);
+  }
+}
+
+{
+  // Same broken file, no declaration: today's silent fallback survives intact.
+  const { dir, template } = fixture({ sections: { experience: MALFORMED_ENTRY } });
+  const r = build(dir, template);
+  if (r.status === 0 && r.html.includes('class="job-header"')) {
+    pass('an undeclared malformed partial still falls back to the built-in builder');
+  } else {
+    fail(`undeclared malformed partial: exit ${r.status}, ${(r.stderr || '').trim()}`);
+  }
+}
+
+{
+  // Declaring one section must not make the others strict.
+  const { dir, template } = fixture({
+    manifest: 'sections: experience',
+    sections: { experience: VALID_ENTRY, education: MALFORMED_ENTRY },
+  });
+  const r = build(dir, template);
+  if (r.status === 0 && r.html.includes('class="pack-job"') && r.html.includes('class="edu-item"')) {
+    pass('an undeclared section keeps its fallback even when a sibling is declared');
+  } else {
+    fail(`mixed pack: exit ${r.status}, ${(r.stderr || '').trim()}`);
+  }
+}
+
+// ── The shipped packs ───────────────────────────────────────────────────────
+//
+// The ATS pack is the case the issue was filed over: it shipped three partials
+// and inherited four sections from the built-in builders, which was fine only
+// because none of the inherited wrapper classes happened to be styled in its
+// CSS. It now declares all seven and ships all seven, so that coincidence is a
+// checked claim — and every pack that declares anything must be complete.
+
+{
+  const shipped = listTemplates('cv').filter((t) => t.pack);
+  const ats = shipped.find((t) => t.name === 'ats');
+  if (!ats) {
+    fail('the shipped ATS pack (templates/ats/) is missing');
+  } else {
+    const declared = declaredSections(ats.meta);
+    if (declared && declared.size === PARTIAL_SECTIONS.length) pass('the ATS pack declares every section');
+    else fail(`the ATS pack declares ${declared ? [...declared].join(', ') : 'nothing'} — it must own its whole DOM`);
+  }
+
+  for (const t of shipped) {
+    let report;
+    try {
+      report = checkDeclaredSections(t.path);
+    } catch (e) {
+      fail(`shipped pack ${t.pack}/ has a bad manifest: ${e.message}`);
+      continue;
+    }
+    if (report.declared === null) {
+      pass(`shipped pack ${t.pack}/ declares no sections (silent fallback, by choice)`);
+    } else if (report.missing.length === 0) {
+      pass(`shipped pack ${t.pack}/ ships every section it declares`);
+    } else {
+      fail(`shipped pack ${t.pack}/ declares sections it does not ship: ${report.missing.join(', ')}`);
+    }
+  }
+
+  if (ats) {
+    const dir = mkdtempSync(join(tmpdir(), 'pack-sections-ats-'));
+    fixtures.push(dir);
+    const r = build(dir, ats.path);
+    if (r.status === 0 && !r.html.includes('class="job-header"')) {
+      pass('the ATS pack renders through its own partials with no built-in experience DOM');
+    } else {
+      fail(`ATS pack render: exit ${r.status}, ${r.html ? 'built-in job-header leaked' : (r.stderr || '').trim()}`);
+    }
+  }
+}

--- a/tests/template-pack-sections.test.mjs
+++ b/tests/template-pack-sections.test.mjs
@@ -22,7 +22,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { pass, fail, run, NODE, ROOT, lastRunFailure } from './helpers.mjs';
 import {
-  PARTIAL_SECTIONS, declaredSections, checkDeclaredSections, listTemplates, resolveTemplate,
+  PARTIAL_SECTIONS, parseMeta, declaredSections, checkDeclaredSections, listTemplates, resolveTemplate,
 } from '../cv-templates.mjs';
 
 console.log('\nCV template packs — declared sections and completeness (#3852)');
@@ -127,6 +127,51 @@ function build(dir, template) {
     /unknown section/, /references/, /competencies/
   );
   throws('an empty declaration is an error', () => declaredSections({ sections: ' , ' }), /empty/);
+  throws('a blank string declaration is an error', () => declaredSections({ sections: '' }), /empty/);
+}
+
+// ── A bare `sections:` reaches the empty-declaration error ──────────────────
+//
+// parseMeta records a key written with a blank value as '' rather than
+// dropping the line. It matched `(.+?)` once, so `sections:` parsed as no key
+// at all, declaredSections returned null, and the template fell silently back
+// to the built-in builders — the exact silence this key exists to remove, and
+// reachable by the most natural way to write an empty declaration.
+
+{
+  const { dir, template } = fixture({ manifest: 'sections:', sections: { experience: VALID_ENTRY } });
+
+  const meta = parseMeta(template);
+  if (meta.sections === '') pass('parseMeta records a bare `sections:` as an empty value, not an absent key');
+  else fail(`parseMeta read sections as ${JSON.stringify(meta.sections)} — a typed key must not vanish`);
+
+  throws('a bare `sections:` is an empty declaration, not a silent fallback', () => declaredSections(meta), /empty/);
+  throws(
+    'and it fails at resolve, naming the pack',
+    () => resolveTemplate('cv', 'mine', { dir }),
+    /mine[/\\]cv-template\.mine\.html/, /empty/
+  );
+
+  const r = build(dir, template);
+  if (r.status !== 0 && /empty/.test(r.stderr)) {
+    pass('and it fails the render rather than falling back to the built-in builders');
+  } else {
+    fail(`bare "sections:" rendered: exit ${r.status}, ${(r.stderr || '').trim()}`);
+  }
+}
+
+{
+  // The regex is shared by every manifest key, so the widening must not change
+  // what a blank `name:` means: displayName reads it through `meta.name || …`,
+  // and an empty value still falls back to the prettified filename.
+  const { dir, template } = fixture({ manifest: 'name:\nsections: experience', sections: { experience: VALID_ENTRY } });
+  if (parseMeta(template).name === '') {
+    const entry = listTemplates('cv', { dir }).find((t) => t.name === 'mine');
+    if (entry?.displayName === 'Mine') pass('a blank `name:` still falls back to the prettified filename');
+    else fail(`blank name: produced displayName ${JSON.stringify(entry?.displayName)}`);
+  } else {
+    fail('blank `name:` was dropped by parseMeta — the widening is not applied uniformly');
+  }
 }
 
 // ── Resolution: a declared section must exist ───────────────────────────────

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -240,6 +240,7 @@ const SYSTEM_PATHS = [
   'lib/outcome-types.mjs',
   'lib/latex-escape.mjs',
   'lib/cv-payload-schema.mjs',
+  'lib/template-manifest.mjs',
   'scan-hn.mjs',
   'scripts/check-syntax.mjs',
   'scripts/export-ats-text.mjs',


### PR DESCRIPTION
## What does this PR do?

Adds a `sections:` key to the template manifest block so a template pack can declare the sections it owns. A declared section with no partial fails at resolve; a declared partial that does not parse (or has an empty ENTRY zone) fails at render, with every offending file named. Packs that declare nothing keep today's silent fallback. The shipped ATS pack now declares `sections: all` and ships the four partials it used to inherit from the built-in builders.

## Related issue

Closes #3852. Shape per @santifer's comment there: declare completeness in the manifest, a declared section never falls back, silent manifests keep the old behaviour.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## What changed

- **`lib/template-manifest.mjs`** (new): `parseMeta` moves here from `cv-templates.mjs`, alongside `PARTIAL_SECTIONS` (the seven partial names), `declaredSections(meta)` and `checkDeclaredSections(templatePath)`. Dependency-free on purpose so the builder can import it without pulling in js-yaml. `cv-templates.mjs` re-exports all four, so existing importers are untouched.
- **`cv-templates.mjs`**: `resolveTemplate` fails when a declared section has no partial file, naming the pack path and every missing file. Listing is not the gate, only resolving is, matching how placeholder validation already works.
- **`build-cv-html.mjs`**: `loadSectionPartials` reads the manifest. Declared sections are strict; undeclared sections keep the fallback, including when a sibling is declared. This is a second gate rather than a redundant one: the builder accepts a template path directly, and parse errors are only detectable at render.
- **`templates/ats/`**: manifest declares `sections: all` (version 1.1.0) and ships `projects`, `certifications`, `awards`, `skills` partials. Their DOM matches what the builders emitted, so the ATS render is unchanged apart from indentation and whitespace placement inside the skills category span.
- **`templates/README.md`**: new "Template packs" section documenting the layout and the key.
- **`tests/template-pack-sections.test.mjs`** (new, 21 checks): the vocabulary, resolve-time and render-time failures, the preserved fallback for undeclared sections, and a guard that every shipped pack ships what it declares.
- **`update-system.mjs`**: registers `lib/template-manifest.mjs` in SYSTEM_PATHS so the updater ships it alongside the two files that import it.

## Reviewer notes

- Option (c) from the issue (a CSS lint for inherited unstyled wrapper classes) is not included. With the ATS pack declaring `all`, the coincidence it would have guarded no longer exists for the shipped pack.
- `buildSkills` still emits its `skills-grid` wrapper around partial output for every template. Changing that touches all seven flat templates and is out of scope here.
- Full `node test-all.mjs`: **8590 passed, 0 failed, 16 warnings**. All 16 warnings are pre-existing (the author's name in project metadata, expected fixture warnings) and unrelated to this change. `npm run lint` passes.
- The full run caught one gap this PR then fixed: `lib/template-manifest.mjs` was unregistered in `update-system.mjs` SYSTEM_PATHS, so an update would have shipped `cv-templates.mjs` and `build-cv-html.mjs` importing a module that never arrived. Registered in the second commit.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Template packs can now declare section ownership with `sections: all` or an explicit list.

From the user's perspective:

: Declared sections must have matching partial files. Missing files fail during template resolution.
: Declared partials must parse and contain a non-empty `ENTRY` zone. Invalid partials fail during rendering.
: A bare `sections:` declaration reaches validation errors instead of enabling silent fallback.
: Packs without `sections:` retain the existing fallback behavior.
: The ATS pack now owns all seven sections and includes its four previously inherited partials.
: Manifest parsing and validation are centralized in `lib/template-manifest.mjs:1`. Existing exports remain available through `cv-templates.mjs:1`.
: Documentation and 21 tests cover declarations, validation, rendering failures, and fallback behavior.

Key locations: `lib/template-manifest.mjs:1`, `build-cv-html.mjs:307`, `cv-templates.mjs:1`, `templates/README.md:1`, `templates/ats/cv-template.ats.html:1`, `tests/template-pack-sections.test.mjs:1`.

## System files

`update-system.mjs:1` is updated. `lib/template-manifest.mjs` is now included in `SYSTEM_PATHS` for updater-managed installations.

The change does not touch `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
