### PR TITLE
feat: add control to ollama ctx size and implement streaming from olla…

### DIFF
--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -104,6 +104,10 @@ let baseUrl   = (process.env.OLLAMA_BASE_URL || 'http://localhost:11434').replac
 // 32768, so behaviour is unchanged unless OLLAMA_NUM_CTX is set. Raise it for a model with a
 // bigger window; `ollama show` reports each model's ceiling (qwen2.5 caps at 32768).
 const numCtx = parseInt(process.env.OLLAMA_NUM_CTX || '32768', 10);
+if (Number.isNaN(numCtx) || numCtx <= 0) {
+  console.error(`❌  Invalid OLLAMA_NUM_CTX: "${process.env.OLLAMA_NUM_CTX}" — must be a positive integer (tokens).`);
+  process.exit(1);
+}
 let saveReport = true;
 
 for (let i = 0; i < args.length; i++) {
@@ -339,6 +343,10 @@ try {
   if (tail) {
     try {
       const obj = JSON.parse(tail);
+      if (obj.error) {
+        console.error(`❌  Ollama error: ${obj.error}`);
+        process.exit(1);
+      }
       if (obj.message?.content) acc += obj.message.content;
       if (obj.done) {
         promptCount = obj.prompt_eval_count ?? promptCount;

--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -100,6 +100,10 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
 let jdText    = '';
 let modelName = process.env.OLLAMA_MODEL || 'llama3.3';
 let baseUrl   = (process.env.OLLAMA_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
+// Context window for the request AND the prompt budget. Defaults to the previous hardcoded
+// 32768, so behaviour is unchanged unless OLLAMA_NUM_CTX is set. Raise it for a model with a
+// bigger window; `ollama show` reports each model's ceiling (qwen2.5 caps at 32768).
+const numCtx = parseInt(process.env.OLLAMA_NUM_CTX || '32768', 10);
 let saveReport = true;
 
 for (let i = 0; i < args.length; i++) {
@@ -217,7 +221,7 @@ const { contextBody, budgetReport } = buildBudgetedPrompt({
   profileYml,
   profileContent,
   jdText,
-  maxTokens: 32_768, // matches options.num_ctx below
+  maxTokens: numCtx, // matches options.num_ctx below
 });
 
 if (budgetReport.compressed) {
@@ -282,14 +286,18 @@ try {
         { role: 'system', content: systemPrompt },
         { role: 'user',   content: `JOB DESCRIPTION TO EVALUATE:\n\n${jdText}` },
       ],
-      stream: false,
+      // stream:true so response headers arrive with the FIRST token. With stream:false
+      // Ollama sends nothing until the whole report is generated, and Node's undici client
+      // gives up at its own 300s headersTimeout — a deadline neither OLLAMA_TIMEOUT_MS nor
+      // AbortSignal.timeout controls, which surfaced as a bare "fetch failed" at 5:01.
+      stream: true,
       // Ollama's native /api/chat reads generation params from `options` only.
       // This call targets that endpoint (NOT the OpenAI-compatible /v1 route,
       // which ignores `options` and has no num_ctx equivalent), so both the
       // deterministic temperature and the enlarged context window actually take
       // effect. Without num_ctx here Ollama defaults to a 2048-token context and
       // silently truncates the prompt; without temperature it runs at 0.8.
-      options: { temperature: 0.4, num_ctx: 32768 },
+      options: { temperature: 0.4, num_ctx: numCtx },
     }),
     signal: AbortSignal.timeout(timeoutMs),
   });
@@ -301,14 +309,50 @@ try {
     process.exit(1);
   }
 
-  const data = await res.json();
-  evaluationText = data.message?.content?.trim();
+  // Streamed /api/chat is newline-delimited JSON: one object per token, the last carrying
+  // done:true and the token counts.
+  let acc = '', buf = '', promptCount = 0, evalCount = 0;
+  const decoder = new TextDecoder();
+  for await (const chunk of res.body) {
+    buf += decoder.decode(chunk, { stream: true });
+    let nl;
+    while ((nl = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      let obj;
+      try { obj = JSON.parse(line); } catch { continue; }
+      if (obj.error) {
+        console.error(`❌  Ollama error: ${obj.error}`);
+        process.exit(1);
+      }
+      if (obj.message?.content) acc += obj.message.content;
+      if (obj.done) {
+        promptCount = obj.prompt_eval_count ?? 0;
+        evalCount = obj.eval_count ?? 0;
+      }
+    }
+  }
+  // Flush a final line that arrived without a trailing newline. Ollama terminates every
+  // chunk with one, but a body that ends mid-line would otherwise be dropped silently.
+  const tail = buf.trim();
+  if (tail) {
+    try {
+      const obj = JSON.parse(tail);
+      if (obj.message?.content) acc += obj.message.content;
+      if (obj.done) {
+        promptCount = obj.prompt_eval_count ?? promptCount;
+        evalCount = obj.eval_count ?? evalCount;
+      }
+    } catch { /* a truncated final line is not recoverable; the empty-response check below reports it */ }
+  }
+  evaluationText = acc.trim();
   // Native /api/chat reports tokens as prompt_eval_count / eval_count, not an
   // OpenAI-shaped `usage` object; map them through the shared normalizer.
   const usage = normalizeOpenAIUsage({
-    prompt_tokens: data.prompt_eval_count,
-    completion_tokens: data.eval_count,
-    total_tokens: (data.prompt_eval_count ?? 0) + (data.eval_count ?? 0),
+    prompt_tokens: promptCount,
+    completion_tokens: evalCount,
+    total_tokens: promptCount + evalCount,
   });
   tracker.record('evaluation', usage);
   if (!evaluationText) {

--- a/tests/ollama-eval-endpoint.test.mjs
+++ b/tests/ollama-eval-endpoint.test.mjs
@@ -3,7 +3,7 @@
 //
 // The request was POSTed to the OpenAI-compatible /v1/chat/completions route,
 // which ignores the `options` object and has no num_ctx equivalent, so NEITHER
-// temperature: 0.4 NOR num_ctx: 32768 reached the model — every eval ran at the
+// temperature: 0.4 NOR num_ctx reached the model — every eval ran at the
 // server default temperature and a 2048-token context that silently truncated
 // the prompt. This drives the real CLI against a mock Ollama that captures the
 // request, asserting the endpoint and the params, and that the native response
@@ -22,15 +22,13 @@ const server = createServer((req, res) => {
   req.on('end', () => {
     captured.path = req.url;
     try { captured.body = JSON.parse(raw); } catch { captured.body = null; }
-    // Native /api/chat shape (NOT OpenAI choices[]).
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({
-      model: 'test',
-      message: { role: 'assistant', content: 'Evaluation.\nVERDICT: 4/5 — solid fit' },
-      done: true,
-      prompt_eval_count: 1234,
-      eval_count: 56,
-    }));
+    // Native /api/chat shape (NOT OpenAI choices[]). Since #3921 the request sets
+    // stream:true, so the reply is newline-delimited JSON rather than one body.
+    res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+    res.end([
+      { model: 'test', message: { role: 'assistant', content: 'Evaluation.\nVERDICT: 4/5 — solid fit' }, done: false },
+      { model: 'test', message: { role: 'assistant', content: '' }, done: true, prompt_eval_count: 1234, eval_count: 56 },
+    ].map((c) => JSON.stringify(c)).join('\n') + '\n');
   });
 });
 
@@ -41,7 +39,9 @@ const done = new Promise((resolve) => {
   execFile(
     NODE,
     [join(ROOT, 'ollama-eval.mjs'), '--url', `http://127.0.0.1:${port}`, '--no-save', 'Some job description text.'],
-    { timeout: 30000 },
+    // num_ctx follows OLLAMA_NUM_CTX since #3920. Pin it so this assertion tests the
+    // request plumbing rather than whatever the developer's .env happens to set.
+    { timeout: 30000, env: { ...process.env, OLLAMA_NUM_CTX: '32768' } },
     (err, stdout, stderr) => resolve({ err, stdout, stderr }),
   );
 });

--- a/tests/ollama-eval-streaming-context.test.mjs
+++ b/tests/ollama-eval-streaming-context.test.mjs
@@ -1,0 +1,123 @@
+// tests/ollama-eval-streaming-context.test.mjs — the context window follows OLLAMA_NUM_CTX,
+// and the response is read as a stream.
+//
+// Two defects this locks down:
+//
+//   #3920  num_ctx and the prompt budget were hardcoded to 32768, so a model with a bigger
+//          window could not use it. The A-G prompt overshot the resulting budget on every
+//          real JD and left under 4k tokens to generate a report that runs 10-12k.
+//
+//   #3921  stream:false meant Ollama sent no response headers until generation finished, and
+//          undici aborts at its own 300s headersTimeout — a deadline OLLAMA_TIMEOUT_MS does
+//          not control. Any run over five minutes died as a bare "fetch failed".
+//
+// Each case drives the real CLI against a mock Ollama that captures the request and replies
+// with newline-delimited JSON, the shape the native /api/chat streaming endpoint produces.
+import { createServer } from 'http';
+import { execFile } from 'child_process';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, rmSync, NODE, ROOT } from './helpers.mjs';
+
+console.log('\nollama-eval.mjs — OLLAMA_NUM_CTX drives the window, and the response streams');
+
+/**
+ * Run ollama-eval against a mock Ollama and return the captured request.
+ *
+ * @param {object}   opts
+ * @param {object}   opts.env       - Extra environment for the child process.
+ * @param {boolean} [opts.trailingNewline=true] - End the NDJSON body with a newline.
+ * @param {boolean} [opts.cleanCwd=false] - Run from a temp dir so the repo's .env is not read.
+ * @returns {Promise<{body: object|null, stdout: string, stderr: string}>}
+ */
+async function run({ env = {}, trailingNewline = true, cleanCwd = false }) {
+  const captured = { body: null };
+  const server = createServer((req, res) => {
+    let raw = '';
+    req.on('data', (c) => (raw += c));
+    req.on('end', () => {
+      try { captured.body = JSON.parse(raw); } catch { captured.body = null; }
+      // Native /api/chat with stream:true emits one JSON object per line: content chunks
+      // with done:false, then a final done:true carrying the token counts.
+      const chunks = [
+        { model: 'test', message: { role: 'assistant', content: 'Evaluation.\n' }, done: false },
+        { model: 'test', message: { role: 'assistant', content: 'VERDICT: 4/5 ' }, done: false },
+        { model: 'test', message: { role: 'assistant', content: '— solid fit' }, done: false },
+        {
+          model: 'test', message: { role: 'assistant', content: '' }, done: true,
+          done_reason: 'stop', prompt_eval_count: 1234, eval_count: 56,
+        },
+      ];
+      res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+      const body = chunks.map((c) => JSON.stringify(c)).join('\n');
+      res.end(trailingNewline ? `${body}\n` : body);
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+
+  // dotenv reads .env from the child's cwd and does not override values already in the
+  // environment. A temp cwd is therefore the only way to observe the unset default on a
+  // machine whose repo .env sets OLLAMA_NUM_CTX. The script resolves its own modes/ and
+  // cv.md from its file location, so it runs correctly from anywhere.
+  const cwd = cleanCwd ? mkdtempSync(join(tmpdir(), 'ollama-eval-test-')) : ROOT;
+  const childEnv = { ...process.env, ...env };
+  if (env.OLLAMA_NUM_CTX === undefined) delete childEnv.OLLAMA_NUM_CTX;
+
+  try {
+    const { stdout, stderr } = await new Promise((resolve) => {
+      execFile(
+        NODE,
+        [join(ROOT, 'ollama-eval.mjs'), '--url', `http://127.0.0.1:${port}`, '--no-save',
+         'Some job description text.'],
+        { timeout: 30000, cwd, env: childEnv },
+        (err, out, errOut) => resolve({ stdout: out ?? '', stderr: errOut ?? '' }),
+      );
+    });
+    return { body: captured.body, stdout, stderr };
+  } finally {
+    server.close();
+    if (cleanCwd) rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+// --- #3921: the request streams -------------------------------------------------------
+const streamed = await run({ env: { OLLAMA_NUM_CTX: '65536' } });
+
+if (streamed.body?.stream === true) pass('sends stream: true, so headers arrive with the first token');
+else fail(`expected stream: true, got ${JSON.stringify(streamed.body?.stream)}`);
+
+const all = streamed.stdout + streamed.stderr;
+if (/Evaluation\.[\s\S]*VERDICT:\s*4\/5\s*—\s*solid fit/.test(all)) {
+  pass('accumulates every NDJSON content chunk in order');
+} else {
+  fail(`streamed chunks not reassembled. tail: ${all.trim().split('\n').slice(-2).join(' | ')}`);
+}
+
+// prompt_eval_count / eval_count arrive on the done:true chunk, not on a single JSON body.
+// Had they not been read, the accumulator would still hold 0 and the footer would print
+// "(zero-token by design)" for this step instead of the counts.
+if (/evaluation:\s+1\.2k prompt \/ 0\.1k completion/.test(all)) {
+  pass('reads prompt_eval_count / eval_count off the done:true chunk');
+} else {
+  fail(`token counts missing from the footer. tail: ${all.trim().split('\n').slice(-4).join(' | ')}`);
+}
+
+// --- #3920: the window follows the environment ----------------------------------------
+if (streamed.body?.options?.num_ctx === 65536) pass('OLLAMA_NUM_CTX=65536 reaches options.num_ctx');
+else fail(`expected num_ctx 65536, got ${JSON.stringify(streamed.body?.options)}`);
+
+const dflt = await run({ env: {}, cleanCwd: true });
+if (dflt.body?.options?.num_ctx === 32768) pass('unset OLLAMA_NUM_CTX keeps the 32768 default');
+else fail(`expected the 32768 default, got ${JSON.stringify(dflt.body?.options)}`);
+
+// --- regression: a final line with no trailing newline --------------------------------
+// The first cut of the streaming parser only flushed on '\n', so a body ending mid-line was
+// dropped and the run failed with "Ollama returned an empty response". Ollama terminates
+// every chunk with a newline, which is exactly why live runs never surfaced it.
+const noNewline = await run({ env: { OLLAMA_NUM_CTX: '32768' }, trailingNewline: false });
+const tailAll = noNewline.stdout + noNewline.stderr;
+if (/VERDICT:\s*4\/5/.test(tailAll)) pass('flushes a final chunk that has no trailing newline');
+else fail(`unterminated final line dropped. tail: ${tailAll.trim().split('\n').slice(-2).join(' | ')}`);

--- a/tests/ollama-eval.test.mjs
+++ b/tests/ollama-eval.test.mjs
@@ -1,5 +1,5 @@
-// tests/ollama-eval-streaming-context.test.mjs — the context window follows OLLAMA_NUM_CTX,
-// and the response is read as a stream.
+// tests/ollama-eval.test.mjs — the context window follows OLLAMA_NUM_CTX, and the response
+// is read as a stream.
 //
 // Two defects this locks down:
 //


### PR DESCRIPTION
## What does this PR do?

Makes `ollama-eval`'s context window configurable via `OLLAMA_NUM_CTX` (defaulting to today's
32768, so it is a no-op unless set) and switches the chat request to `stream: true`. Together
these are what a local model needs to finish a full A-G report: the window fix stops the prompt
overflowing its budget, and streaming stops undici's 300s `headersTimeout` killing every run
that generates for more than five minutes.

### 1. Context window follows the model — #3920

`num_ctx` and the prompt budget were hardcoded to 32768 in two places. Both now read one value:

```js
const numCtx = parseInt(process.env.OLLAMA_NUM_CTX || '32768', 10);
```

The cap contradicted the script's own recommended-model list at `:21` — three of those four
models ship 128k windows — and `docs/RUNNING_ON_A_BUDGET.md` §5, which tells local users to run
a 32B+/70B+ model for reliable scoring. On every real JD the prompt overshot the resulting
24576-token budget (32768 minus the 8192 safety margin): three context sections were dropped,
the prompt was still ~4.8k over, and under 4k tokens remained to write a report that runs 10–12k.

```
📊  Token budget: 31540 → 29378 tokens (saved 2162)
    Trimmed sections: Sources of Truth (EXCLUSIVE), Spend Tier (Model Routing),
                      Company Type and Compensation Reliability
    ⚠️  Still 4802 tokens over budget after compression
```

With `OLLAMA_NUM_CTX=65536` on a 256k model: no warning, no sections trimmed, 31.2k prompt with
~35k of headroom.

### 2. The response streams — #3921

`stream: false` meant Ollama sent no response headers until generation finished, and Node's
undici client aborts at its own 300s `headersTimeout` — a deadline neither `OLLAMA_TIMEOUT_MS`
nor `AbortSignal.timeout` controls. Long runs died as a bare `fetch failed`, taking the generic
error branch while the purpose-built `TimeoutError` branch at `:319` never fired, so the symptom
pointed at Ollama rather than at the client.

`await res.json()` cannot read an NDJSON stream, so the body is accumulated line by line.
`prompt_eval_count` / `eval_count` arrive on the `done: true` chunk and feed
`normalizeOpenAIUsage` as before; nothing downstream changes.

Measured on one machine, same rubric, same JD shapes:

| run | model | streams? | window | duration | outcome |
|---|---|---|---|---|---|
| A (cold) | qwen2.5:32b | no | 32768 | **5:01.19** | `fetch failed` |
| A (warm) | qwen2.5:32b | no | 32768 | **4:54.56** | succeeded |
| B | gemma4:31b | no | 32768 | **5:01.16** | `fetch failed` |
| A | gemma4:31b | yes | 65536 | 11:44.62 | succeeded |
| C | gemma4:31b | yes | 65536 | 11:05.46 | succeeded |
| B | gemma4:31b | yes | 65536 | 11:32.32 | succeeded |

The 4:54 row is the load-bearing one: same model and prompt as the 5:01 failure above it,
surviving only because the model was already resident. The boundary is 5:00, not the model.

### Tests

New `tests/ollama-eval-streaming-context.test.mjs` (own file per CONTRIBUTING, auto-discovered)
drives the real CLI against a mock Ollama and asserts: `stream: true` is sent, NDJSON chunks
reassemble in order, the token counts are read off the `done:true` chunk, `OLLAMA_NUM_CTX=65536`
reaches `options.num_ctx`, an unset value keeps the 32768 default, and a final chunk with no
trailing newline is still flushed.

That last case is a regression test for a bug the existing suite caught during development: the
first cut of the parser only flushed on `\n`, so a body ending mid-line was silently dropped.
Ollama terminates every chunk with a newline, which is why six live runs never surfaced it.

`tests/ollama-eval-endpoint.test.mjs` is updated in the same commit-range, for two reasons that
follow from the change: its mock now speaks NDJSON, and it pins `OLLAMA_NUM_CTX` explicitly so
the assertion tests the request plumbing rather than whatever the contributor's `.env` happens
to set. Without that pin the test fails on any machine where that variable is exported.

## Related issue

Closes #3920
Closes #3921

## Type of change

- [x] Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can configure the Ollama context window with `OLLAMA_NUM_CTX`. The default remains `32768`. The value controls prompt budgeting and `options.num_ctx` in `ollama-eval.mjs`.

Ollama responses now stream as NDJSON. The evaluator preserves content order, token counts, streamed errors, and final response lines without trailing newlines. Long generations can now run under `OLLAMA_TIMEOUT_MS` instead of undici’s 300-second headers timeout.

Tests cover streaming, chunk ordering, token counts, context configuration, defaults, endpoint behavior, and unterminated final lines.

## Files changed

- `ollama-eval.mjs`: Adds context configuration and streamed response handling.
- `tests/ollama-eval-endpoint.test.mjs`: Updates endpoint mocks for NDJSON streaming.
- `tests/ollama-eval.test.mjs`: Adds integration coverage for the new behavior.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->