### PR TITLE
fix(updater): do not commit the auto-update onto a non-default branch

### DIFF
--- a/modes/update.md
+++ b/modes/update.md
@@ -102,6 +102,15 @@ If yes:
 8. Show final status:
    > "✅ Updated to v{version}. Run `node doctor.mjs` anytime to verify setup, or `node verify-pipeline.mjs` to check your data."
 
+   If the updater printed `Update applied but NOT committed` (you were on a branch that is not the
+   default one — #3846), relay that block instead of the plain success line, and do not summarize the
+   three options away:
+   > "✅ Updated to v{version}, but you're on branch `{branch}`, not `{default}` — so the updater staged the
+   > refreshed files instead of committing them there. Committing a full system snapshot onto a feature
+   > branch is what turns a small PR into an unreviewable one. You can commit it here, move it to
+   > `{default}`, or undo it with `node update-system.mjs rollback` — the updater printed the exact
+   > commands. Re-run with `--commit-on-branch` if you always want it committed wherever you are."
+
    If the updater's output ended with its note about the CareerOps Manifesto, relay it once (do not drop it when summarizing):
    > "One more thing: this project ships with the CareerOps Manifesto — a new way of job searching is taking shape, and you are already practicing it. Run `npm run manifesto` to read it and sign it if you want to help. No action needed."
 
@@ -122,5 +131,8 @@ If the user says "rollback" or runs `/career-ops update rollback`:
 - Exception: `modes/_profile.md` may be edited **only** in Step 4.7, and **only** after the user explicitly confirms each individual rename/removal. Never batch-edit without per-change consent.
 - User-specific customizations (archetypes, scoring weights, narrative) belong in `modes/_profile.md` or `config/profile.yml`, never in `modes/_shared.md`
 - CLAUDE.md's local additions (everything after the two-line `@AGENTS.md` header) MUST be saved before apply and restored immediately after — on both the success AND failure path (Step 4.2, Step 4.4). `update-system.mjs apply` resets CLAUDE.md before it can fail partway through, so a failed apply still needs the restore. `apply` has no awareness of this content and will silently discard it otherwise.
+- The branch notice (`Update applied but NOT committed`) is not optional output to trim: it is the only
+  place the user learns their tree is staged-but-uncommitted, and dropping it recreates the silence #3846
+  fixed. Relay it whenever it appears, with all three options intact.
 - If anything goes wrong, tell the user to run `node update-system.mjs rollback`
 - Keep the output concise — users don't want walls of text during an update

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -21,7 +21,7 @@
 import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { pass, fail } from './helpers.mjs';
+import { pass, fail, warn } from './helpers.mjs';
 import {
   COMMIT_ON_BRANCH_FLAG,
   commitOnBranchOptIn,
@@ -36,6 +36,7 @@ import {
   updateCommitBranchDecision,
   updateCommitCommand,
   gitIn,
+  gitQuietIn,
 } from '../update-system.mjs';
 
 // A throwaway repo with one commit on `main`, no remote. Remotes are added per
@@ -416,6 +417,56 @@ function stashStagedArgs(g) {
     pass('the contributor\'s own staged work leaves the snapshot trusted');
   } else {
     fail('unrelated staged work invalidated the withheld snapshot');
+  }
+}
+
+// ── 17. The snapshot must be recordable without a git identity ─────────
+{
+  // `commit-tree` needs an author and a committer. On an install with no git
+  // identity — a container, a fresh machine, a harness that isolates the global
+  // config — it fails, recordStagedUpdate()'s catch swallows that, and the next
+  // run falls back to an older baseline and reads this update's own files as
+  // the user's edits: the second-order bug, back through a side door.
+  const { dir, g, gitAt } = repoWithWithheldUpdate();
+  g('config', '--unset', 'user.email');
+  g('config', '--unset', 'user.name');
+
+  const noConfig = join(dir, 'no-such-gitconfig');   // absent file reads as empty, on every platform
+  const restore = { global: process.env.GIT_CONFIG_GLOBAL, system: process.env.GIT_CONFIG_SYSTEM };
+  process.env.GIT_CONFIG_GLOBAL = noConfig;
+  process.env.GIT_CONFIG_SYSTEM = noConfig;
+  try {
+    // NEGATIVE CONTROL: the same call without a pinned identity is what fails.
+    let bareCommitTreeFailed = false;
+    try {
+      // gitQuietIn: this call is EXPECTED to fail, so its stderr is noise.
+      gitQuietIn(dir, 'commit-tree', gitAt('write-tree'), '-p', gitAt('rev-parse', 'HEAD'), '-m', 'probe');
+    } catch {
+      bareCommitTreeFailed = true;
+    }
+
+    recordStagedUpdate('2.0.0', { git: gitAt });
+    let recorded = false;
+    try {
+      recorded = Boolean(gitAt('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`));
+    } catch {
+      recorded = false;
+    }
+
+    if (!bareCommitTreeFailed) {
+      // This git resolved an identity anyway, so the case cannot be exercised
+      // here — say so rather than passing on a control that never fired.
+      warn('no-identity case not reachable on this git; snapshot recording untested here');
+    } else if (recorded && !atRiskIn(dir, gitAt).includes('sys.mjs')) {
+      pass('the snapshot is recorded even with no git identity configured');
+    } else {
+      fail(`no-identity: recorded=${recorded}, atRisk=${JSON.stringify(atRiskIn(dir, gitAt))}`);
+    }
+  } finally {
+    if (restore.global === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = restore.global;
+    if (restore.system === undefined) delete process.env.GIT_CONFIG_SYSTEM;
+    else process.env.GIT_CONFIG_SYSTEM = restore.system;
   }
 }
 

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -29,6 +29,7 @@ import {
   defaultBranchIn,
   STAGED_UPDATE_REF,
   locallyModifiedSystemFiles,
+  recordStagedUpdate,
   resolveUpdateCommitBranch,
   skippedBranchCommitNotice,
   updateCommitBranchDecision,
@@ -234,66 +235,132 @@ console.log('\n🧪 Testing updater branch guard (#3846)...');
   }
 }
 
-// ── 12. A withheld update must not read as a local edit next time ──────
-{
-  // NEGATIVE CONTROL FIRST. Without the recorded baseline, the second update on
-  // the same branch sees the FIRST update's own staged files, finds no updater
-  // commit to explain them, and classifies them as edits this install made — so
-  // it preserves them, writes .bak copies, and skips exactly the delta it came
-  // to install. That is the staleness failure the issue warns is worse than the
-  // bug being fixed, arriving one run later.
+// ── 12-15. The withheld snapshot as a baseline, and its lifetime ───────
+//
+// A withheld update leaves its snapshot staged and uncommitted, so there is no
+// updater commit to serve as locallyModifiedSystemFiles' baseline and the next
+// run reads the previous run's own files as edits THIS install made: preserved,
+// .bak'd, and the delta it came to install skipped. recordStagedUpdate() writes
+// the snapshot the run staged; stagedUpdateBaseline() believes it only while it
+// is still the state on disk.
+//
+// A repo in the state a withheld run leaves behind: v1 is the last committed
+// updater snapshot, v2 is staged but uncommitted, upstream has moved to v3.
+function repoWithWithheldUpdate() {
   const { dir, g } = repo();
-  const gitAt = (...args) => gitIn(dir, ...args);
-
-  // v1 is the last committed updater snapshot; v2 is the update whose commit
-  // the guard withheld (staged only); v3 is what upstream has moved on to.
   writeFileSync(join(dir, 'sys.mjs'), 'v1\n');
   g('add', 'sys.mjs');
   g('commit', '-qm', 'chore: auto-update system files to v1');
   g('checkout', '-q', '-b', 'upstream-line');
-  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');
-  g('commit', '-qam', 'upstream v2');
-  const upstreamV2 = g('rev-parse', 'HEAD');
   writeFileSync(join(dir, 'sys.mjs'), 'v3\n');
   g('commit', '-qam', 'upstream v3');
   g('tag', 'upstream');
   g('checkout', '-q', 'main');
-  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');   // what the withheld run left staged
+  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');
   g('add', 'sys.mjs');
+  return { dir, g, gitAt: (...args) => gitIn(dir, ...args) };
+}
 
-  const withoutRef = locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: gitAt, root: dir });
-  g('update-ref', STAGED_UPDATE_REF, upstreamV2);
-  const withRef = locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: gitAt, root: dir });
+const atRiskIn = (dir, gitAt) =>
+  locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: gitAt, root: dir });
 
-  if (withoutRef.includes('sys.mjs') && !withRef.includes('sys.mjs')) {
+// ── 12. NEGATIVE CONTROL + fix: pending snapshot is not a local edit ────
+{
+  const { dir, gitAt } = repoWithWithheldUpdate();
+  const withoutRecord = atRiskIn(dir, gitAt);      // no snapshot recorded: the bug
+  recordStagedUpdate('2.0.0', { git: gitAt });
+  const withRecord = atRiskIn(dir, gitAt);
+
+  if (withoutRecord.includes('sys.mjs') && !withRecord.includes('sys.mjs')) {
     pass('withheld update is not mistaken for a local edit on the next run');
   } else {
-    fail(`baseline wrong: without ref=${JSON.stringify(withoutRef)} with ref=${JSON.stringify(withRef)}`);
+    fail(`baseline wrong: unrecorded=${JSON.stringify(withoutRecord)} recorded=${JSON.stringify(withRecord)}`);
   }
 }
 
-// ── 13. A genuine local edit is still caught with the ref recorded ──────
+// ── 13. A genuine local edit is still caught while one is pending ───────
 {
-  // The recorded baseline must not become a blanket amnesty: the preservation
+  // The recorded snapshot must not become a blanket amnesty: the preservation
   // guard (#2337) exists to stop the checkout silently overwriting a system
-  // file this install edited, and that has to keep working while a withheld
-  // update is pending.
-  const { dir, g } = repo();
-  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');
-  g('add', 'sys.mjs');
-  g('commit', '-qm', 'staged update content');
-  g('update-ref', STAGED_UPDATE_REF, g('rev-parse', 'HEAD'));
-  writeFileSync(join(dir, 'sys.mjs'), 'v3-upstream\n');
-  g('commit', '-qam', 'upstream moved on');
-  g('tag', 'upstream');
-  g('reset', '-q', '--hard', 'HEAD~1');
-  writeFileSync(join(dir, 'sys.mjs'), 'my own local fix\n');   // the user's edit
+  // file this install edited, and it has to keep working while an update waits.
+  const { dir, gitAt } = repoWithWithheldUpdate();
+  recordStagedUpdate('2.0.0', { git: gitAt });
+  writeFileSync(join(dir, 'sys.mjs'), 'my own local fix\n');
 
-  const atRisk = locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: (...a) => gitIn(dir, ...a), root: dir });
-  if (atRisk.includes('sys.mjs')) {
+  if (atRiskIn(dir, gitAt).includes('sys.mjs')) {
     pass('a real local edit is still flagged while a withheld update is pending');
   } else {
-    fail('the recorded baseline swallowed a genuine local edit');
+    fail('the recorded snapshot swallowed a genuine local edit');
+  }
+}
+
+// ── 14. Discarding the withheld update by hand must self-heal ──────────
+{
+  // The ref is durable; the state it describes is not. A contributor who throws
+  // the withheld update away leaves the ref behind, and believing it on sight
+  // makes every system file read as a local edit against a snapshot that is no
+  // longer there — the invisible skip this guard exists to remove, one step
+  // further out. Measured before the check existed: `sys.mjs` came back at risk
+  // with the working tree untouched.
+  for (const [label, discard] of [
+    ['git reset --hard', (g) => g('reset', '--hard', 'HEAD')],
+    ['git restore', (g) => { g('restore', '--staged', '--worktree', 'sys.mjs'); }],
+  ]) {
+    const { dir, g, gitAt } = repoWithWithheldUpdate();
+    recordStagedUpdate('2.0.0', { git: gitAt });
+    discard(g);
+
+    const atRisk = atRiskIn(dir, gitAt);
+    if (!atRisk.includes('sys.mjs')) {
+      pass(`discarded by hand (${label}): the stale snapshot is distrusted`);
+    } else {
+      fail(`${label}: stale snapshot still trusted, atRisk=${JSON.stringify(atRisk)}`);
+    }
+  }
+}
+
+// ── 16. …and distrust must not become deletion ─────────────────────────
+{
+  // Deleting a snapshot that fails the check would be tidier, but it makes the
+  // damage permanent in the one sequence where the state comes back: the
+  // notice's own option 2 is `git stash push --staged` then a branch switch, and
+  // an updater run in that window sees an index that does not match. Delete
+  // there and `git stash pop` restores the update with nothing left to explain
+  // it — the false positives return, on the default branch this time. Keeping
+  // the ref costs nothing: the check is a content comparison, so a ref that
+  // matches the index describes the tree truthfully whatever produced it.
+  const { dir, g, gitAt } = repoWithWithheldUpdate();
+  g('checkout', '-q', '-b', 'feat/x');
+  recordStagedUpdate('2.0.0', { git: gitAt });
+
+  g('stash', 'push', '--staged', '-m', 'career-ops');
+  g('switch', '-q', 'main');
+  const whileStashed = atRiskIn(dir, gitAt);      // distrusted: nothing is staged
+  g('stash', 'pop');
+  const afterPop = atRiskIn(dir, gitAt);          // trusted again: the state is back
+
+  if (!whileStashed.includes('sys.mjs') && !afterPop.includes('sys.mjs')) {
+    pass('a stashed-and-restored update is still explained after the round trip');
+  } else {
+    fail(`stash round trip: stashed=${JSON.stringify(whileStashed)} popped=${JSON.stringify(afterPop)}`);
+  }
+}
+
+// ── 15. Staging unrelated work does not invalidate the snapshot ─────────
+{
+  // The check is scoped to the paths being asked about, because a contributor
+  // with a withheld update pending is also, by definition, working on something
+  // else in the same tree. Invalidating on that would put the false positives
+  // straight back.
+  const { dir, g, gitAt } = repoWithWithheldUpdate();
+  recordStagedUpdate('2.0.0', { git: gitAt });
+  writeFileSync(join(dir, 'my-feature.mjs'), 'export const x = 1;\n');
+  g('add', 'my-feature.mjs');
+
+  if (!atRiskIn(dir, gitAt).includes('sys.mjs')) {
+    pass('the contributor\'s own staged work leaves the snapshot trusted');
+  } else {
+    fail('unrelated staged work invalidated the withheld snapshot');
   }
 }
 

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -18,10 +18,11 @@
  * apply() runs, so a caller wired up wrong cannot pass here.
  */
 
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { pass, fail, warn } from './helpers.mjs';
+import { pass, fail, warn, getBash, bashSource } from './helpers.mjs';
 import {
   COMMIT_ON_BRANCH_FLAG,
   commitOnBranchOptIn,
@@ -266,12 +267,78 @@ console.log('\n🧪 Testing updater branch guard (#3846)...');
     currentBranch: 'feat/x', defaultBranch: 'main', version: '1.33.0',
     commitCommand: 'git commit -m "x"',
   };
-  const warned = skippedBranchCommitNotice({ ...args, hasUnrelatedStaged: true });
-  const quiet = skippedBranchCommitNotice({ ...args, hasUnrelatedStaged: false });
-  if (/other changes staged/.test(warned) && !/other changes staged/.test(quiet)) {
+  const warned = skippedBranchCommitNotice({
+    ...args, unrelatedStaged: ['mine.txt', 'my notes.md'],
+  });
+  const quiet = skippedBranchCommitNotice({ ...args, unrelatedStaged: [] });
+  const fires = /staged besides this update/.test(warned)
+    && !/staged besides this update/.test(quiet);
+  if (fires) {
     pass('option 2 warns when other staged work would ride along, and only then');
   } else {
     fail('the unrelated-staged warning is missing or unconditional');
+  }
+  // The remedy names the paths, and quotes the ones that need it. Asserted on
+  // the rendered line rather than on the array, because an unquoted path with a
+  // space is what turns a correct remedy into two wrong ones.
+  if (/git stash push -m 'my work' -- mine\.txt 'my notes\.md'/.test(warned)) {
+    pass("option 2's remedy is scoped to the unrelated paths, quoted");
+  } else {
+    fail(`option 2's remedy does not name the paths to move:\n${warned}`);
+  }
+}
+
+// ── 11d. …and running that remedy actually leaves the update behind ────
+{
+  // The point of 11c is not the wording, it is that the printed command works.
+  // Both unscoped readings of an unscoped remedy fail, and they fail AS the two
+  // things this guard exists to prevent: a bare `git commit` puts the update's
+  // snapshot on the feature branch (#3846), and a bare `git stash push` takes
+  // the refreshed files out of the tree (the staleness the guard avoids). So
+  // run the line the notice prints and check what survives.
+  //
+  // Through getBash(), not execSync(): the notice quotes paths the POSIX way
+  // (shellQuoteArg), and cmd.exe — what execSync() spawns on win32 — passes
+  // `'my notes.md'` through as two literal arguments, quotes included. The
+  // command under test IS a shell string, so it needs the shell it was written
+  // for; running it under the wrong one would test the quoting of a shell no
+  // reader of this notice is in.
+  const bash = getBash();
+  const { dir, g } = makeRepo();
+  try {
+    g('checkout', '-qb', 'feat/x');
+    writeFileSync(join(dir, 'sys.mjs'), 'refreshed by the update\n');
+    writeFileSync(join(dir, 'mine.txt'), 'my own work\n');
+    writeFileSync(join(dir, 'my notes.md'), 'my own notes\n');
+    g('add', 'sys.mjs', 'mine.txt', 'my notes.md');
+
+    const unrelatedStaged = ['mine.txt', 'my notes.md'];
+    const notice = skippedBranchCommitNotice({
+      currentBranch: 'feat/x', defaultBranch: 'main', version: '1.33.0',
+      commitCommand: 'git commit -m "x"', unrelatedStaged,
+    });
+    const remedy = notice.split('\n').map(l => l.trim())
+      .find(l => l.startsWith('git stash push -m'));
+    if (bashSource() === 'unresolved') {
+      // Skip loudly rather than pass: this assertion is the only one that runs
+      // the remedy, so a silent skip would read as coverage that is not there.
+      warn('no POSIX shell found — the remedy was not executed, only its text checked');
+    } else if (!remedy) {
+      fail(`no runnable remedy line in the notice:\n${notice}`);
+    } else {
+      execFileSync(bash, ['-c', remedy], { cwd: dir, stdio: 'pipe' });
+      const staged = gitIn(dir, 'diff', '--cached', '--name-only').split('\n').filter(Boolean);
+      const onDisk = existsSync(join(dir, 'sys.mjs'));
+      const movedOut = unrelatedStaged.every(p => !staged.includes(p) && !existsSync(join(dir, p)));
+      if (staged.includes('sys.mjs') && onDisk && movedOut) {
+        pass("the remedy moves the contributor's work out and leaves the update staged");
+      } else {
+        fail(`after \`${remedy}\`: staged=[${staged}], sys.mjs on disk=${onDisk}, `
+          + `unrelated moved out=${movedOut}`);
+      }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -264,6 +264,22 @@ function repoWithWithheldUpdate() {
 const atRiskIn = (dir, gitAt) =>
   locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: gitAt, root: dir });
 
+// `git stash push --staged` needs git 2.35, and nothing in this repo declares a
+// minimum — so on an older git it would throw out of gitIn() and take the whole
+// suite file down with it, turning a version difference into a mystery failure.
+// Plain `stash push` performs the same index-and-worktree transition for a
+// fixture whose only change IS the staged one, so the scenario stays real on
+// every version; the flag is used where it exists because that is the exact
+// command the withheld-update notice hands the user.
+function stashStagedArgs(g) {
+  const version = /(\d+)\.(\d+)/.exec(g('--version')) || [];
+  const [major, minor] = [Number(version[1]), Number(version[2])];
+  const supportsStagedStash = major > 2 || (major === 2 && minor >= 35);
+  return supportsStagedStash
+    ? ['stash', 'push', '--staged', '-m', 'career-ops']
+    : ['stash', 'push', '-m', 'career-ops'];
+}
+
 // ── 12. NEGATIVE CONTROL + fix: pending snapshot is not a local edit ────
 {
   const { dir, gitAt } = repoWithWithheldUpdate();
@@ -333,7 +349,7 @@ const atRiskIn = (dir, gitAt) =>
   g('checkout', '-q', '-b', 'feat/x');
   recordStagedUpdate('2.0.0', { git: gitAt });
 
-  g('stash', 'push', '--staged', '-m', 'career-ops');
+  g(...stashStagedArgs(g));
   g('switch', '-q', 'main');
   const whileStashed = atRiskIn(dir, gitAt);      // distrusted: nothing is staged
   g('stash', 'pop');

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -431,10 +431,28 @@ function stashStagedArgs(g) {
   g('config', '--unset', 'user.email');
   g('config', '--unset', 'user.name');
 
+  // Isolating the config files is not enough: git also takes an identity from
+  // GIT_AUTHOR_*/GIT_COMMITTER_* and from a bare EMAIL, and any of them makes
+  // `commit-tree` succeed. Measured — with the config isolated and either set,
+  // the bare call returns a sha. A runner that exports one would leave this test
+  // warning instead of testing, so all of them are cleared here.
   const noConfig = join(dir, 'no-such-gitconfig');   // absent file reads as empty, on every platform
-  const restore = { global: process.env.GIT_CONFIG_GLOBAL, system: process.env.GIT_CONFIG_SYSTEM };
-  process.env.GIT_CONFIG_GLOBAL = noConfig;
-  process.env.GIT_CONFIG_SYSTEM = noConfig;
+  const overrides = {
+    GIT_CONFIG_GLOBAL: noConfig,
+    GIT_CONFIG_SYSTEM: noConfig,
+    GIT_AUTHOR_NAME: undefined,
+    GIT_AUTHOR_EMAIL: undefined,
+    GIT_COMMITTER_NAME: undefined,
+    GIT_COMMITTER_EMAIL: undefined,
+    EMAIL: undefined,
+  };
+  const restore = Object.fromEntries(
+    Object.keys(overrides).map((key) => [key, process.env[key]]),
+  );
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   try {
     // NEGATIVE CONTROL: the same call without a pinned identity is what fails.
     let bareCommitTreeFailed = false;
@@ -463,10 +481,10 @@ function stashStagedArgs(g) {
       fail(`no-identity: recorded=${recorded}, atRisk=${JSON.stringify(atRiskIn(dir, gitAt))}`);
     }
   } finally {
-    if (restore.global === undefined) delete process.env.GIT_CONFIG_GLOBAL;
-    else process.env.GIT_CONFIG_GLOBAL = restore.global;
-    if (restore.system === undefined) delete process.env.GIT_CONFIG_SYSTEM;
-    else process.env.GIT_CONFIG_SYSTEM = restore.system;
+    for (const [key, value] of Object.entries(restore)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 }
 

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -31,6 +31,7 @@ import {
   locallyModifiedSystemFiles,
   recordStagedUpdate,
   resolveUpdateCommitBranch,
+  shellQuoteArg,
   skippedBranchCommitNotice,
   updateCommitBranchDecision,
   updateCommitCommand,
@@ -232,6 +233,44 @@ console.log('\n🧪 Testing updater branch guard (#3846)...');
     pass('notice names the branch and offers keep / move / undo');
   } else {
     fail(`notice is missing: ${missing.join(', ')}`);
+  }
+}
+
+// ── 11b. The printed commands must survive being pasted into a shell ───
+{
+  // Git's ref rules forbid spaces and some glob characters but allow `;`, `&`,
+  // `$` and backticks, so a branch name is not the safe token it looks like —
+  // and these commands exist to be copied into a terminal.
+  const notice = skippedBranchCommitNotice({
+    currentBranch: 'feat/x',
+    defaultBranch: 'release;whoami',
+    version: '1.33.0',
+    commitCommand: 'git commit -m "x"',
+  });
+  const bare = shellQuoteArg('main') === 'main' && shellQuoteArg('feat/x') === 'feat/x';
+  if (notice.includes("git switch 'release;whoami'") && !notice.includes('git switch release;whoami') && bare) {
+    pass('a branch name carrying shell syntax is quoted in the printed commands');
+  } else {
+    fail(`unquoted interpolation in the notice:\n${notice}`);
+  }
+}
+
+// ── 11c. Option 2 must not move the contributor's own staged work ──────
+{
+  // `stash push --staged` takes the whole index, not this update's share of it.
+  // The updater already knows when something else is staged — the same signal
+  // that scopes its commit — so the recipe has to say so instead of quietly
+  // carrying that work onto the default branch.
+  const args = {
+    currentBranch: 'feat/x', defaultBranch: 'main', version: '1.33.0',
+    commitCommand: 'git commit -m "x"',
+  };
+  const warned = skippedBranchCommitNotice({ ...args, hasUnrelatedStaged: true });
+  const quiet = skippedBranchCommitNotice({ ...args, hasUnrelatedStaged: false });
+  if (/other changes staged/.test(warned) && !/other changes staged/.test(quiet)) {
+    pass('option 2 warns when other staged work would ride along, and only then');
+  } else {
+    fail('the unrelated-staged warning is missing or unconditional');
   }
 }
 

--- a/tests/updater-branch-guard.test.mjs
+++ b/tests/updater-branch-guard.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * updater-branch-guard.test.mjs — the update commit must not land on a
+ * contributor's feature branch (#3846).
+ *
+ * `apply()` committed to whatever HEAD pointed at. For someone who contributes
+ * from the same checkout they use, that dropped a full system snapshot onto
+ * their branch: PR #3648 arrived as +173,092/-13,920 over a 39-line change.
+ *
+ * The guard's failure mode in the other direction is worse than the bug — an
+ * updater that withholds too eagerly leaves users on stale system files, and
+ * staleness is invisible until something breaks. So the tests below pin BOTH
+ * halves: the skip on a real feature branch, and every uncertain case
+ * (detached HEAD, no discoverable default branch, opt-in) still committing.
+ *
+ * Behavioural, driven against throwaway repos through the git-runner seam —
+ * same approach as tests/updater-commit-file-modes.test.mjs. The repo-facing
+ * tests call resolveUpdateCommitBranch(), which is the exact composition
+ * apply() runs, so a caller wired up wrong cannot pass here.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import {
+  COMMIT_ON_BRANCH_FLAG,
+  commitOnBranchOptIn,
+  currentBranchIn,
+  defaultBranchIn,
+  STAGED_UPDATE_REF,
+  locallyModifiedSystemFiles,
+  resolveUpdateCommitBranch,
+  skippedBranchCommitNotice,
+  updateCommitBranchDecision,
+  updateCommitCommand,
+  gitIn,
+} from '../update-system.mjs';
+
+// A throwaway repo with one commit on `main`, no remote. Remotes are added per
+// test, because whether `origin/HEAD` exists is exactly what the fallback in
+// defaultBranchIn() is for.
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-branchguard-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  writeFileSync(join(dir, 'VERSION'), '1.0.0\n');
+  g('add', 'VERSION');
+  g('commit', '-qm', 'base');
+  return { dir, g };
+}
+
+// Point refs/remotes/origin/HEAD at a branch the way `git clone` records it,
+// without needing a second repo to clone from.
+function setOriginHead(g, branch) {
+  g('update-ref', `refs/remotes/origin/${branch}`, 'HEAD');
+  g('symbolic-ref', 'refs/remotes/origin/HEAD', `refs/remotes/origin/${branch}`);
+}
+
+const cleanups = [];
+const repo = () => {
+  const r = makeRepo();
+  cleanups.push(r.dir);
+  return r;
+};
+
+console.log('\n🧪 Testing updater branch guard (#3846)...');
+
+// ── 1. The bug: a feature branch does not receive the commit ────────────
+{
+  const { dir, g } = repo();
+  setOriginHead(g, 'main');
+  g('checkout', '-q', '-b', 'feat/posted-date-sort');
+  const decision = resolveUpdateCommitBranch(dir, { optIn: false });
+  if (decision.commit === false && decision.reason === 'non-default-branch' &&
+      decision.currentBranch === 'feat/posted-date-sort' && decision.defaultBranch === 'main') {
+    pass('feature branch: update commit is withheld');
+  } else {
+    fail(`feature branch should withhold the commit, got ${JSON.stringify(decision)}`);
+  }
+}
+
+// ── 2. The plain-user path is untouched ────────────────────────────────
+{
+  const { dir, g } = repo();
+  setOriginHead(g, 'main');
+  const decision = resolveUpdateCommitBranch(dir, { optIn: false });
+  if (decision.commit === true && decision.reason === 'on-default-branch') {
+    pass('default branch: commits exactly as before');
+  } else {
+    fail(`default branch must still commit, got ${JSON.stringify(decision)}`);
+  }
+}
+
+// ── 3. A non-`main` default branch is honoured, not assumed ────────────
+{
+  const { dir, g } = repo();
+  g('branch', '-m', 'trunk');
+  setOriginHead(g, 'trunk');
+  const onTrunk = resolveUpdateCommitBranch(dir, { optIn: false });
+  g('checkout', '-q', '-b', 'main');
+  const onMain = resolveUpdateCommitBranch(dir, { optIn: false });
+  if (onTrunk.commit === true && onMain.commit === false) {
+    pass("origin/HEAD wins over the name 'main'");
+  } else {
+    fail(`default branch must come from origin/HEAD, got trunk=${onTrunk.commit} main=${onMain.commit}`);
+  }
+}
+
+// ── 4. Uncertain cases keep updating: detached HEAD ────────────────────
+{
+  const { dir, g } = repo();
+  setOriginHead(g, 'main');
+  g('checkout', '-q', '--detach', 'HEAD');
+  const decision = resolveUpdateCommitBranch(dir, { optIn: false });
+  if (currentBranchIn(dir) === null && decision.commit === true && decision.reason === 'detached-head') {
+    pass('detached HEAD: behaves as before rather than withholding');
+  } else {
+    fail(`detached HEAD must not withhold, got ${JSON.stringify(decision)}`);
+  }
+}
+
+// ── 5. Uncertain cases keep updating: no discoverable default branch ────
+{
+  const { dir, g } = repo();
+  g('branch', '-m', 'trunk');            // no origin/HEAD, no main, no master
+  g('checkout', '-q', '-b', 'feat/x');
+  const decision = resolveUpdateCommitBranch(dir, { optIn: false });
+  if (defaultBranchIn(dir) === null && decision.commit === true &&
+      decision.reason === 'unknown-default-branch') {
+    pass('unknown default branch: behaves as before rather than withholding');
+  } else {
+    fail(`unknown default branch must not withhold, got ${JSON.stringify(decision)}`);
+  }
+}
+
+// ── 6. The main/master fallback when origin/HEAD is absent ─────────────
+{
+  const { dir, g } = repo();
+  g('checkout', '-q', '-b', 'feat/x');
+  const withMain = resolveUpdateCommitBranch(dir, { optIn: false });
+
+  const { dir: dir2, g: g2 } = repo();
+  g2('branch', '-m', 'master');
+  g2('checkout', '-q', '-b', 'feat/x');
+  const withMaster = resolveUpdateCommitBranch(dir2, { optIn: false });
+
+  if (withMain.defaultBranch === 'main' && withMain.commit === false &&
+      withMaster.defaultBranch === 'master' && withMaster.commit === false) {
+    pass('no origin/HEAD: falls back to a main/master branch that exists locally');
+  } else {
+    fail(`fallback failed: ${JSON.stringify(withMain)} / ${JSON.stringify(withMaster)}`);
+  }
+}
+
+// ── 7. The opt-in restores the old behaviour ───────────────────────────
+{
+  const { dir, g } = repo();
+  setOriginHead(g, 'main');
+  g('checkout', '-q', '-b', 'feat/x');
+  const decision = resolveUpdateCommitBranch(dir, { optIn: true });
+  if (decision.commit === true && decision.reason === 'opt-in') {
+    pass('opt-in: commits on a feature branch on request');
+  } else {
+    fail(`opt-in must commit, got ${JSON.stringify(decision)}`);
+  }
+}
+
+// ── 8. Where the opt-in comes from ─────────────────────────────────────
+{
+  const flag = commitOnBranchOptIn([COMMIT_ON_BRANCH_FLAG], {});
+  const env = commitOnBranchOptIn([], { CAREER_OPS_UPDATE_COMMIT_ON_BRANCH: '1' });
+  const neither = commitOnBranchOptIn(['apply', '--confirm', '--force'], {});
+  const notOne = commitOnBranchOptIn([], { CAREER_OPS_UPDATE_COMMIT_ON_BRANCH: '0' });
+  if (flag && env && !neither && !notOne) {
+    pass('opt-in reads the flag and the env twin, and nothing else');
+  } else {
+    fail(`opt-in detection wrong: flag=${flag} env=${env} neither=${neither} notOne=${notOne}`);
+  }
+}
+
+// ── 9. --force does not imply the branch opt-in ────────────────────────
+{
+  // The two mean different things (#2337 vs #3846). Folding them together
+  // would make `--force`, which users reach for to resolve local system-file
+  // edits, silently reintroduce the commit this guard exists to withhold.
+  const decision = updateCommitBranchDecision({
+    currentBranch: 'feat/x', defaultBranch: 'main',
+    optIn: commitOnBranchOptIn(['apply', '--force', '--confirm'], {}),
+  });
+  if (decision.commit === false) {
+    pass('--force does not authorize committing on a feature branch');
+  } else {
+    fail('--force must not imply --commit-on-branch');
+  }
+}
+
+// ── 10. The suggested command matches the commit that was withheld ─────
+{
+  // Index form vs pathspec form are not interchangeable: the pathspec form
+  // drops staged mode bits where core.fileMode is false. Handing the user the
+  // wrong one turns the recovery step into the bug it recovers from.
+  const indexForm = updateCommitCommand('1.31.0', true, ['a.mjs']);
+  const pathspecForm = updateCommitCommand('1.31.0', false, ['a.mjs', "it's.mjs"]);
+  if (indexForm === 'git commit -m "chore: auto-update system files to v1.31.0"' &&
+      pathspecForm.includes("-- 'a.mjs' 'it'\\''s.mjs'")) {
+    pass('suggested commit command matches the form the updater would have used');
+  } else {
+    fail(`commit command wrong: ${indexForm} / ${pathspecForm}`);
+  }
+}
+
+// ── 11. The user is told, and given every exit ─────────────────────────
+{
+  const notice = skippedBranchCommitNotice({
+    currentBranch: 'feat/x',
+    defaultBranch: 'main',
+    version: '1.31.0',
+    commitCommand: 'git commit -m "chore: auto-update system files to v1.31.0"',
+  });
+  const missing = [
+    "'feat/x'",                       // which branch they are on
+    "'main'",                         // and what it is not
+    'git commit -m',                  // 1. keep it here
+    'git switch main',                // 2. move it
+    'node update-system.mjs rollback',// 3. undo it
+    COMMIT_ON_BRANCH_FLAG,            // how to stop being asked
+  ].filter(fragment => !notice.includes(fragment));
+  if (missing.length === 0 && /NOT committed/.test(notice)) {
+    pass('notice names the branch and offers keep / move / undo');
+  } else {
+    fail(`notice is missing: ${missing.join(', ')}`);
+  }
+}
+
+// ── 12. A withheld update must not read as a local edit next time ──────
+{
+  // NEGATIVE CONTROL FIRST. Without the recorded baseline, the second update on
+  // the same branch sees the FIRST update's own staged files, finds no updater
+  // commit to explain them, and classifies them as edits this install made — so
+  // it preserves them, writes .bak copies, and skips exactly the delta it came
+  // to install. That is the staleness failure the issue warns is worse than the
+  // bug being fixed, arriving one run later.
+  const { dir, g } = repo();
+  const gitAt = (...args) => gitIn(dir, ...args);
+
+  // v1 is the last committed updater snapshot; v2 is the update whose commit
+  // the guard withheld (staged only); v3 is what upstream has moved on to.
+  writeFileSync(join(dir, 'sys.mjs'), 'v1\n');
+  g('add', 'sys.mjs');
+  g('commit', '-qm', 'chore: auto-update system files to v1');
+  g('checkout', '-q', '-b', 'upstream-line');
+  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');
+  g('commit', '-qam', 'upstream v2');
+  const upstreamV2 = g('rev-parse', 'HEAD');
+  writeFileSync(join(dir, 'sys.mjs'), 'v3\n');
+  g('commit', '-qam', 'upstream v3');
+  g('tag', 'upstream');
+  g('checkout', '-q', 'main');
+  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');   // what the withheld run left staged
+  g('add', 'sys.mjs');
+
+  const withoutRef = locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: gitAt, root: dir });
+  g('update-ref', STAGED_UPDATE_REF, upstreamV2);
+  const withRef = locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: gitAt, root: dir });
+
+  if (withoutRef.includes('sys.mjs') && !withRef.includes('sys.mjs')) {
+    pass('withheld update is not mistaken for a local edit on the next run');
+  } else {
+    fail(`baseline wrong: without ref=${JSON.stringify(withoutRef)} with ref=${JSON.stringify(withRef)}`);
+  }
+}
+
+// ── 13. A genuine local edit is still caught with the ref recorded ──────
+{
+  // The recorded baseline must not become a blanket amnesty: the preservation
+  // guard (#2337) exists to stop the checkout silently overwriting a system
+  // file this install edited, and that has to keep working while a withheld
+  // update is pending.
+  const { dir, g } = repo();
+  writeFileSync(join(dir, 'sys.mjs'), 'v2\n');
+  g('add', 'sys.mjs');
+  g('commit', '-qm', 'staged update content');
+  g('update-ref', STAGED_UPDATE_REF, g('rev-parse', 'HEAD'));
+  writeFileSync(join(dir, 'sys.mjs'), 'v3-upstream\n');
+  g('commit', '-qam', 'upstream moved on');
+  g('tag', 'upstream');
+  g('reset', '-q', '--hard', 'HEAD~1');
+  writeFileSync(join(dir, 'sys.mjs'), 'my own local fix\n');   // the user's edit
+
+  const atRisk = locallyModifiedSystemFiles(['sys.mjs'], 'upstream', { git: (...a) => gitIn(dir, ...a), root: dir });
+  if (atRisk.includes('sys.mjs')) {
+    pass('a real local edit is still flagged while a withheld update is pending');
+  } else {
+    fail('the recorded baseline swallowed a genuine local edit');
+  }
+}
+
+for (const dir of cleanups) rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2282,6 +2282,24 @@ export function resolveUpdateCommitBranch(root = ROOT, options = {}) {
 }
 
 /**
+ * A value safe to paste into a shell, quoted only when it needs to be.
+ *
+ * The notice's commands are copied by hand into a terminal, so a value carrying
+ * shell syntax executes it there. Git's own ref rules forbid spaces and a
+ * handful of glob characters but allow `;`, `&`, `$`, backticks and parentheses,
+ * so a branch name is not the safe token it looks like. Plain names are left
+ * bare because the commands are read as much as they are run.
+ *
+ * @param {string} value - Value to interpolate into a printed command.
+ * @returns {string} The value, single-quoted if it carries anything unusual.
+ */
+export function shellQuoteArg(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9._@+/-]+$/.test(text)) return text;
+  return `'${text.replace(/'/g, "'\\''")}'`;
+}
+
+/**
  * The commit command for a given staging outcome — the one the updater runs,
  * and therefore the one to hand the user when it does not run it itself.
  *
@@ -2365,7 +2383,11 @@ export function clearStagedUpdate(ctx = {}) {
  * @param {string} params.commitCommand - From updateCommitCommand().
  * @returns {string} Multi-line notice.
  */
-export function skippedBranchCommitNotice({ currentBranch, defaultBranch, version, commitCommand }) {
+export function skippedBranchCommitNotice({
+  currentBranch, defaultBranch, version, commitCommand, hasUnrelatedStaged = false,
+}) {
+  const branch = shellQuoteArg(defaultBranch);
+  const stashMessage = shellQuoteArg(`career-ops v${version}`);
   return [
     '',
     `Update applied but NOT committed: you are on '${currentBranch}', not '${defaultBranch}'.`,
@@ -2377,8 +2399,17 @@ export function skippedBranchCommitNotice({ currentBranch, defaultBranch, versio
     '  1. Keep the update on this branch:',
     `       ${commitCommand}`,
     `  2. Move it to '${defaultBranch}' (git 2.35+ for --staged):`,
-    `       git stash push --staged -m "career-ops v${version}"`,
-    `       git switch ${defaultBranch} && git stash pop && ${commitCommand}`,
+    `       git stash push --staged -m ${stashMessage}`,
+    `       git switch ${branch} && git stash pop && ${commitCommand}`,
+    // `--staged` takes the whole index, not just this update's share of it, so
+    // for a contributor with their own work staged option 2 would carry that
+    // work onto the default branch too. The updater already knows when that is
+    // the case — it is the same signal that scopes the commit — so say it here
+    // rather than letting the recipe do it quietly.
+    ...(hasUnrelatedStaged ? [
+      '       NOTE: you have other changes staged. `stash push --staged` takes the whole',
+      '       index, so this would move them too — commit or unstage them first.',
+    ] : []),
     '  3. Undo the update entirely:',
     '       node update-system.mjs rollback',
     '',
@@ -2895,6 +2926,7 @@ async function apply() {
           defaultBranch: branchDecision.defaultBranch,
           version: remote,
           commitCommand: updateCommitCommand(remote, usedIndexCommit, expandedPathsToStage),
+          hasUnrelatedStaged: unrelated.length > 0,
         }));
       } else if (usedIndexCommit) {
         git('commit', '-m', `chore: auto-update system files to v${remote}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -107,10 +107,16 @@ function isLegacyReexec() {
 }
 
 const CANONICAL_REPO = 'https://github.com/career-ops-hq/career-ops.git';
-// Where an update whose commit the branch guard withheld records the upstream
-// commit its staged files came from (#3846). A local ref, like the WIP stash
-// ref above it: invisible to `git status`, carried by no branch, and therefore
-// unable to leak into a contributor's pull request. See stagedUpdateBaseline().
+// Where an update whose commit the branch guard withheld records the snapshot it
+// staged (#3846). A local ref, like the WIP stash ref above it: invisible to
+// `git status`, carried by no branch, and therefore unable to leak into a
+// contributor's pull request.
+//
+// It points at a commit whose TREE is the index the withheld update produced —
+// not at the upstream commit those files came from. The upstream commit would
+// describe what the update INTENDED; the staged tree describes what this install
+// actually holds, preserved files included, which is what a baseline has to mean.
+// It also makes the ref checkable: see stagedUpdateBaseline().
 export const STAGED_UPDATE_REF = 'refs/career-ops/staged-update';
 const RAW_VERSION_URL = 'https://raw.githubusercontent.com/career-ops-hq/career-ops/main/VERSION';
 const RELEASES_API = 'https://api.github.com/repos/career-ops-hq/career-ops/releases/latest';
@@ -1177,6 +1183,79 @@ export function systemTreeDiffers(systemPaths, upstreamRef = 'FETCH_HEAD', ctx =
  * @param {{git?: Function}} [ctx] - injectable git runner, for tests.
  * @returns {string[]} repo-relative file paths, sorted.
  */
+/**
+ * The withheld update's staged snapshot, when it is still the state on disk.
+ *
+ * The ref is durable and the state it describes is not, so trusting it on sight
+ * is a bug of its own: a contributor who discards a withheld update by hand
+ * (`git reset --hard`, `git restore`, a stash and a branch switch) leaves the
+ * ref behind, and every system file then reads as a local edit against a
+ * snapshot that is no longer there — preserved, `.bak`, delta skipped, the same
+ * invisible skip this guard exists to remove, one step further out. Measured:
+ * with the ref recorded and the tree reset to HEAD, `sys.mjs` came back in the
+ * at-risk set even though the working tree was untouched.
+ *
+ * So the ref is checked against the index before it is believed, over the paths
+ * actually being asked about. Being wrong in the safe direction costs a fallback
+ * to the ordinary baseline; being wrong in the other direction costs a skipped
+ * update the user cannot see.
+ *
+ * A ref that fails the check is distrusted but NOT deleted, which is a
+ * deliberate departure from "drop it otherwise". Deleting is what makes the
+ * damage permanent in the one sequence where the state comes back: the notice's
+ * own option 2 is `git stash push --staged` then a branch switch, and an
+ * updater run in that window would delete a ref that `git stash pop` is about
+ * to make current again — measured, the false positives return after the pop.
+ * A stale ref that is kept costs nothing, because the check is a content
+ * comparison: if it matches the index it describes the state on disk truthfully,
+ * whatever history produced it. The ref is cleared where the update genuinely
+ * ends — a commit, or a rollback (see clearStagedUpdate).
+ *
+ * @param {Function} runGit - Git runner (injectable for tests).
+ * @param {string[]} paths - Pathspecs the caller is asking about.
+ * @returns {string|null} Commit to use as the baseline, or null.
+ */
+export function stagedUpdateBaseline(runGit, paths) {
+  let ref;
+  try {
+    ref = runGit('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`).trim();
+  } catch {
+    return null; // No withheld update recorded — the normal case.
+  }
+  if (!ref) return null;
+  // `--quiet` makes each of these an exit-code question: zero when the snapshot
+  // is still there, a throw when it is not. Scoped to `paths`, so a contributor
+  // staging their own work elsewhere in the tree does not invalidate it.
+  //
+  // The INDEX and the WORKING TREE are both asked, because the snapshot survives
+  // in one or the other depending on how it got here, and each check alone has a
+  // blind spot that costs a real case:
+  //   - index only: `git stash push --staged` + `git stash pop` restores the
+  //     files unstaged, so the index is back at HEAD and the snapshot — sitting
+  //     right there on disk — reads as gone. Measured: the false positives came
+  //     back after the pop.
+  //   - worktree only: a user edit to one system file while the update waits
+  //     makes the whole snapshot fail, taking the baseline away from every other
+  //     file with it.
+  // Either match is proof enough: the checks compare content, so a snapshot that
+  // matches what is on disk describes this tree truthfully whatever produced it.
+  for (const check of [
+    () => runGit('diff-index', '--cached', '--quiet', ref, '--', ...paths),
+    () => runGit('diff', '--quiet', ref, '--', ...paths),
+  ]) {
+    try {
+      check();
+      return ref;
+    } catch {
+      // Try the next one.
+    }
+  }
+  // Neither the index nor the tree holds it, so it says nothing about this
+  // install. Fall back to the ordinary baseline; see above for why the ref is
+  // left in place rather than deleted.
+  return null;
+}
+
 export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ctx = {}) {
   const runGit = ctx.git || git;
   if (!paths || paths.length === 0) return [];
@@ -1219,16 +1298,10 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
   // run would read the previous run's own files as local edits — preserving
   // them, writing .bak copies, and skipping exactly the delta it came to
   // install. Measured: with an updater commit at v1, an uncommitted v2 tree and
-  // upstream at v3, the file lands in the at-risk set. The ref written when the
-  // commit was withheld names the commit those files came from, so it is the
-  // truthful baseline whenever it exists.
-  let baseline = null;
-  try {
-    baseline = runGit('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`).trim() || null;
-  } catch {
-    // No withheld update recorded — the normal case. Fall through.
-    baseline = null;
-  }
+  // upstream at v3, the file lands in the at-risk set. stagedUpdateBaseline()
+  // answers with that snapshot while it is genuinely still staged, and with
+  // null — pruning the ref — once it is not.
+  let baseline = stagedUpdateBaseline(runGit, paths);
   if (!baseline) {
     try {
       const updaterCommit = runGit(
@@ -2227,32 +2300,48 @@ export function updateCommitCommand(version, usedIndexCommit, expandedPathsToSta
 }
 
 /**
- * Record/clear the commit a withheld update's staged files came from.
+ * Record the snapshot a withheld update staged, so the next run can tell it
+ * apart from the user's own edits.
  *
- * Both are best-effort: this bookkeeping improves the NEXT run's diagnosis, and
- * an update that succeeded must not be reported as failed because a local ref
- * could not be written. A stale ref is self-correcting — it names real content
- * the install actually holds, so it stays a truthful baseline until cleared.
+ * Best-effort: this bookkeeping improves the NEXT run's diagnosis, and an update
+ * that succeeded must not be reported as failed because a local ref could not be
+ * written. The recorded commit hangs off HEAD with the staged index as its tree,
+ * which also makes it a snapshot the user could check out if they ever want it.
  *
- * @param {string} upstreamRef - Ref whose commit the staged files came from.
+ * @param {string} version - Target version, for the recorded commit's message.
+ * @param {object} [ctx] - `{ git }` runner override, for tests.
  * @returns {void}
  */
-export function recordStagedUpdate(upstreamRef = 'FETCH_HEAD') {
+export function recordStagedUpdate(version, ctx = {}) {
+  const runGit = ctx.git || git;
   try {
-    git('update-ref', STAGED_UPDATE_REF, git('rev-parse', `${upstreamRef}^{commit}`));
+    const tree = runGit('write-tree');
+    const commit = runGit(
+      'commit-tree', tree, '-p', runGit('rev-parse', 'HEAD'),
+      '-m', `career-ops staged update to v${version} (uncommitted)`,
+    );
+    runGit('update-ref', STAGED_UPDATE_REF, commit);
   } catch {
     // Non-fatal, see above.
   }
 }
 
-export function clearStagedUpdate() {
+/**
+ * Drop the recorded snapshot: the withheld update is no longer pending, either
+ * because it was committed or because a rollback replaced the tree.
+ *
+ * @param {object} [ctx] - `{ git }` runner override, for tests.
+ * @returns {void}
+ */
+export function clearStagedUpdate(ctx = {}) {
+  const runGit = ctx.git || git;
   try {
-    gitQuiet('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`);
+    (ctx.git || gitQuiet)('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`);
   } catch {
     return; // Nothing recorded.
   }
   try {
-    git('update-ref', '-d', STAGED_UPDATE_REF);
+    runGit('update-ref', '-d', STAGED_UPDATE_REF);
   } catch {
     // Non-fatal, see above.
   }
@@ -2798,7 +2887,7 @@ async function apply() {
         // Leave the next run a truthful baseline for these staged files, so it
         // does not mistake this update's own output for the user's local edits
         // and preserve the very files it came to install (#3846).
-        recordStagedUpdate('FETCH_HEAD');
+        recordStagedUpdate(remote);
         console.log(skippedBranchCommitNotice({
           currentBranch: branchDecision.currentBranch,
           defaultBranch: branchDecision.defaultBranch,

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2333,10 +2333,24 @@ export function updateCommitCommand(version, usedIndexCommit, expandedPathsToSta
  * @returns {void}
  */
 export function recordStagedUpdate(version, ctx = {}) {
-  const runGit = ctx.git || git;
+  // gitQuiet, not git: every failure here is swallowed on purpose, so git's raw
+  // stderr ("Please tell me who you are") must not surface in the middle of an
+  // update that is otherwise succeeding.
+  const runGit = ctx.git || gitQuiet;
   try {
     const tree = runGit('write-tree');
     const commit = runGit(
+      // A fixed synthetic identity, not the user's. `commit-tree` needs an
+      // author and a committer, and an install with no git identity configured
+      // — a container, a fresh machine, a harness that isolates the global
+      // config — makes it fail: measured, `fatal: unable to auto-detect email
+      // address`. The catch below would swallow that, and the next update would
+      // fall back to an older baseline and read this update's own files as the
+      // user's edits, which is the bug this ref exists to prevent. The identity
+      // is also honest about what the commit is: machinery, not authored work.
+      // `.invalid` is reserved by RFC 2606, so it can never route anywhere.
+      '-c', 'user.name=career-ops updater',
+      '-c', 'user.email=updater@career-ops.invalid',
       'commit-tree', tree, '-p', runGit('rev-parse', 'HEAD'),
       '-m', `career-ops staged update to v${version} (uncommitted)`,
     );

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1299,8 +1299,10 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
   // them, writing .bak copies, and skipping exactly the delta it came to
   // install. Measured: with an updater commit at v1, an uncommitted v2 tree and
   // upstream at v3, the file lands in the at-risk set. stagedUpdateBaseline()
-  // answers with that snapshot while it is genuinely still staged, and with
-  // null — pruning the ref — once it is not.
+  // answers with that snapshot while it is genuinely still there, and with null
+  // once it is not. It leaves the ref in place either way — deleting a snapshot
+  // that fails the check breaks the stash round trip, which is why that case is
+  // pinned by a test; read its doc before changing that.
   let baseline = stagedUpdateBaseline(runGit, paths);
   if (!baseline) {
     try {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2395,13 +2395,17 @@ export function clearStagedUpdate(ctx = {}) {
  * @param {string} params.defaultBranch
  * @param {string} params.version
  * @param {string} params.commitCommand - From updateCommitCommand().
+ * @param {string[]} [params.unrelatedStaged] - Staged paths this update does not
+ *   own, from stagedPathsOutside(). The paths themselves, not a flag: option 2's
+ *   escape hatch is only runnable if it can name what to move.
  * @returns {string} Multi-line notice.
  */
 export function skippedBranchCommitNotice({
-  currentBranch, defaultBranch, version, commitCommand, hasUnrelatedStaged = false,
+  currentBranch, defaultBranch, version, commitCommand, unrelatedStaged = [],
 }) {
   const branch = shellQuoteArg(defaultBranch);
   const stashMessage = shellQuoteArg(`career-ops v${version}`);
+  const ownWorkMessage = shellQuoteArg('my work');
   return [
     '',
     `Update applied but NOT committed: you are on '${currentBranch}', not '${defaultBranch}'.`,
@@ -2420,9 +2424,24 @@ export function skippedBranchCommitNotice({
     // work onto the default branch too. The updater already knows when that is
     // the case — it is the same signal that scopes the commit — so say it here
     // rather than letting the recipe do it quietly.
-    ...(hasUnrelatedStaged ? [
-      '       NOTE: you have other changes staged. `stash push --staged` takes the whole',
-      '       index, so this would move them too — commit or unstage them first.',
+    //
+    // Naming the paths is the whole point. Both of the obvious unscoped reads
+    // fail, and they fail as the two things this guard exists to prevent:
+    // a bare `git commit` puts the update's own snapshot on the feature branch
+    // (#3846 itself), and a bare `git stash push` takes the refreshed files out
+    // of the tree, which is the staleness the guard is careful never to cause.
+    // Unstaging fails a third way: the change stays in the working tree, so the
+    // `git switch` below either carries it across or refuses to run.
+    //
+    // The path list is never truncated. A shortened command is a wrong command,
+    // and wrong-but-runnable is the failure this note is being written to fix;
+    // a long line that wraps is only ugly. stagedPathsOutside() reads `-z` to
+    // keep paths holding spaces intact, so they are quoted here to match.
+    ...(unrelatedStaged.length > 0 ? [
+      `       NOTE: ${unrelatedStaged.length === 1 ? 'one other path is' : `${unrelatedStaged.length} other paths are`} staged besides this update. \`stash push --staged\``,
+      '       takes the whole index, so option 2 would move them too. Take them out of',
+      '       the index first, scoped to their own paths — unstaging is not enough:',
+      `         git stash push -m ${ownWorkMessage} -- ${unrelatedStaged.map(shellQuoteArg).join(' ')}`,
     ] : []),
     '  3. Undo the update entirely:',
     '       node update-system.mjs rollback',
@@ -2940,7 +2959,7 @@ async function apply() {
           defaultBranch: branchDecision.defaultBranch,
           version: remote,
           commitCommand: updateCommitCommand(remote, usedIndexCommit, expandedPathsToStage),
-          hasUnrelatedStaged: unrelated.length > 0,
+          unrelatedStaged: unrelated,
         }));
       } else if (usedIndexCommit) {
         git('commit', '-m', `chore: auto-update system files to v${remote}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -14,6 +14,11 @@
  *                                     # …and overwrite system files this
  *                                     # install edited locally (#2337). Without
  *                                     # it those files are kept and listed.
+ *   node update-system.mjs apply --commit-on-branch --confirm
+ *                                     # …and commit even when HEAD is not on
+ *                                     # the default branch (#3846). Without it
+ *                                     # the update is applied and staged there,
+ *                                     # and the commit is left to you.
  *   node update-system.mjs rollback   # Rollback last update
  *   node update-system.mjs dismiss    # Dismiss update check
  *
@@ -102,6 +107,11 @@ function isLegacyReexec() {
 }
 
 const CANONICAL_REPO = 'https://github.com/career-ops-hq/career-ops.git';
+// Where an update whose commit the branch guard withheld records the upstream
+// commit its staged files came from (#3846). A local ref, like the WIP stash
+// ref above it: invisible to `git status`, carried by no branch, and therefore
+// unable to leak into a contributor's pull request. See stagedUpdateBaseline().
+export const STAGED_UPDATE_REF = 'refs/career-ops/staged-update';
 const RAW_VERSION_URL = 'https://raw.githubusercontent.com/career-ops-hq/career-ops/main/VERSION';
 const RELEASES_API = 'https://api.github.com/repos/career-ops-hq/career-ops/releases/latest';
 
@@ -781,10 +791,22 @@ function git(...args) {
  * @returns {string} Trimmed stdout.
  */
 function gitQuiet(...args) {
+  return gitQuietIn(ROOT, ...args);
+}
+
+/**
+ * gitQuiet against an arbitrary root, so callers that must work on a throwaway
+ * repo (and the tests that drive them) share the same runner as the updater.
+ *
+ * @param {string} root - Working directory for the git call.
+ * @param {...string} args - git arguments.
+ * @returns {string} Trimmed stdout.
+ */
+export function gitQuietIn(root, ...args) {
   const timeout = gitTimeoutMs(args);
   try {
     return execFileSync('git', args, {
-      cwd: ROOT, encoding: 'utf-8', timeout, stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: root, encoding: 'utf-8', timeout, stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch (err) {
     if (isTimeoutLikeError(err)) {
@@ -1191,17 +1213,34 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
   // using the original merge-base would mistake the previous update's files
   // for user edits. Keep the merge-base fallback for installations without a
   // recorded updater commit.
+  //
+  // A withheld update (branch guard, #3846) leaves that snapshot STAGED and
+  // uncommitted, so there is no updater commit to be the baseline and the next
+  // run would read the previous run's own files as local edits — preserving
+  // them, writing .bak copies, and skipping exactly the delta it came to
+  // install. Measured: with an updater commit at v1, an uncommitted v2 tree and
+  // upstream at v3, the file lands in the at-risk set. The ref written when the
+  // commit was withheld names the commit those files came from, so it is the
+  // truthful baseline whenever it exists.
   let baseline = null;
   try {
-    const updaterCommit = runGit(
-      'log', '-1', '--format=%H', '--grep=^chore: auto-update system files', 'HEAD',
-    ).trim();
-    if (updaterCommit) {
-      runGit('merge-base', '--is-ancestor', updaterCommit, 'HEAD');
-      baseline = updaterCommit;
-    }
+    baseline = runGit('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`).trim() || null;
   } catch {
+    // No withheld update recorded — the normal case. Fall through.
     baseline = null;
+  }
+  if (!baseline) {
+    try {
+      const updaterCommit = runGit(
+        'log', '-1', '--format=%H', '--grep=^chore: auto-update system files', 'HEAD',
+      ).trim();
+      if (updaterCommit) {
+        runGit('merge-base', '--is-ancestor', updaterCommit, 'HEAD');
+        baseline = updaterCommit;
+      }
+    } catch {
+      baseline = null;
+    }
   }
   if (!baseline) {
     try {
@@ -2054,6 +2093,209 @@ export function reconcileGitignore(localText, upstreamText) {
   return { text: `${localText}${separator}${body}${eol}`, added };
 }
 
+// ── BRANCH SAFETY (#3846) ───────────────────────────────────────
+
+/**
+ * Opt-in that restores the pre-#3846 behaviour: commit the update onto
+ * whatever branch HEAD is on. Kept as its own switch rather than folded into
+ * `--force`, which already means something else entirely ("overwrite system
+ * files this install edited locally") — a fourth meaning on that flag would
+ * make neither state readable.
+ */
+export const COMMIT_ON_BRANCH_FLAG = '--commit-on-branch';
+
+export function commitOnBranchOptIn(argv = process.argv, env = process.env) {
+  return argv.includes(COMMIT_ON_BRANCH_FLAG) ||
+    env.CAREER_OPS_UPDATE_COMMIT_ON_BRANCH === '1';
+}
+
+/**
+ * The checked-out branch name, or null on a detached HEAD (or no git at all).
+ *
+ * @param {string} [root=ROOT] - Repository to read.
+ * @returns {string|null} Branch name, or null.
+ */
+export function currentBranchIn(root = ROOT) {
+  try {
+    return gitQuietIn(root, 'symbolic-ref', '--quiet', '--short', 'HEAD') || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * This checkout's default branch, or null when it cannot be established.
+ *
+ * `origin/HEAD` is the authoritative answer and is what `git clone` records,
+ * so a stock install always has it. The `main`/`master` fallback covers
+ * checkouts whose `origin/HEAD` was never set or has been pruned; it only
+ * answers with a branch that actually exists locally.
+ *
+ * Returning null is a real outcome, not a failure: the caller treats "cannot
+ * tell" as "behave exactly as before", because an updater that guesses wrong
+ * about the default branch would withhold the commit from the very users the
+ * plain path is for.
+ *
+ * @param {string} [root=ROOT] - Repository to read.
+ * @returns {string|null} Default branch name, or null.
+ */
+export function defaultBranchIn(root = ROOT) {
+  try {
+    const ref = gitQuietIn(root, 'symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD');
+    if (ref.startsWith('origin/') && ref.length > 'origin/'.length) {
+      return ref.slice('origin/'.length);
+    }
+  } catch {
+    // No origin/HEAD (never set, pruned, or no remote). Fall through.
+  }
+  for (const name of ['main', 'master']) {
+    try {
+      gitQuietIn(root, 'show-ref', '--verify', '--quiet', `refs/heads/${name}`);
+      return name;
+    } catch {
+      // Not this one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether the update commit may land on the branch HEAD is on.
+ *
+ * Pure, so the policy is testable without a repo; the git reads that feed it
+ * live in currentBranchIn/defaultBranchIn.
+ *
+ * Every uncertain case answers `commit: true`. The plain-user path — on the
+ * default branch, no local commits — is the overwhelming majority of runs and
+ * must not change or grow a prompt (#3846), and the mirror-image failure of an
+ * updater that withholds too eagerly is worse than the bug being fixed:
+ * stale system files are invisible until something breaks.
+ *
+ * @param {object} params
+ * @param {string|null} params.currentBranch - From currentBranchIn().
+ * @param {string|null} params.defaultBranch - From defaultBranchIn().
+ * @param {boolean} [params.optIn] - From commitOnBranchOptIn().
+ * @returns {{commit: boolean, reason: string}} Decision and why.
+ */
+export function updateCommitBranchDecision({ currentBranch, defaultBranch, optIn = false }) {
+  if (optIn) return { commit: true, reason: 'opt-in' };
+  if (!currentBranch) return { commit: true, reason: 'detached-head' };
+  if (!defaultBranch) return { commit: true, reason: 'unknown-default-branch' };
+  if (currentBranch === defaultBranch) return { commit: true, reason: 'on-default-branch' };
+  return { commit: false, reason: 'non-default-branch' };
+}
+
+/**
+ * updateCommitBranchDecision against a real repository: the exact composition
+ * apply() runs, exported so a test drives the same entry point rather than
+ * re-deriving the branch reads around a pure function that would then pass on
+ * its own while the caller wired it up wrong.
+ *
+ * @param {string} [root=ROOT] - Repository to read.
+ * @param {{optIn?: boolean}} [options] - Defaults to the CLI/env opt-in.
+ * @returns {{commit: boolean, reason: string, currentBranch: string|null, defaultBranch: string|null}}
+ */
+export function resolveUpdateCommitBranch(root = ROOT, options = {}) {
+  const optIn = options.optIn ?? commitOnBranchOptIn();
+  const currentBranch = currentBranchIn(root);
+  const defaultBranch = defaultBranchIn(root);
+  return {
+    ...updateCommitBranchDecision({ currentBranch, defaultBranch, optIn }),
+    currentBranch,
+    defaultBranch,
+  };
+}
+
+/**
+ * The commit command for a given staging outcome — the one the updater runs,
+ * and therefore the one to hand the user when it does not run it itself.
+ *
+ * The pathspec form is NOT interchangeable with the index form: it drops
+ * staged mode bits where `core.fileMode` is false. Suggesting it after the
+ * index form was selected would tell the user to reintroduce that bug.
+ *
+ * @param {string} version - Target version for the commit message.
+ * @param {boolean} usedIndexCommit - Whether the index form is safe here.
+ * @param {string[]} expandedPathsToStage - Concrete staged file list.
+ * @returns {string} A runnable git command.
+ */
+export function updateCommitCommand(version, usedIndexCommit, expandedPathsToStage) {
+  const message = `chore: auto-update system files to v${version}`;
+  if (usedIndexCommit) return `git commit -m "${message}"`;
+  const pathspec = expandedPathsToStage.map(p => `'${p.replace(/'/g, "'\\''")}'`).join(' ');
+  return `git commit -m "${message}" -- ${pathspec}`;
+}
+
+/**
+ * Record/clear the commit a withheld update's staged files came from.
+ *
+ * Both are best-effort: this bookkeeping improves the NEXT run's diagnosis, and
+ * an update that succeeded must not be reported as failed because a local ref
+ * could not be written. A stale ref is self-correcting — it names real content
+ * the install actually holds, so it stays a truthful baseline until cleared.
+ *
+ * @param {string} upstreamRef - Ref whose commit the staged files came from.
+ * @returns {void}
+ */
+export function recordStagedUpdate(upstreamRef = 'FETCH_HEAD') {
+  try {
+    git('update-ref', STAGED_UPDATE_REF, git('rev-parse', `${upstreamRef}^{commit}`));
+  } catch {
+    // Non-fatal, see above.
+  }
+}
+
+export function clearStagedUpdate() {
+  try {
+    gitQuiet('rev-parse', '--verify', '--quiet', `${STAGED_UPDATE_REF}^{commit}`);
+  } catch {
+    return; // Nothing recorded.
+  }
+  try {
+    git('update-ref', '-d', STAGED_UPDATE_REF);
+  } catch {
+    // Non-fatal, see above.
+  }
+}
+
+/**
+ * What the user is told when the update is applied but not committed.
+ *
+ * The whole point of #3846 is that this is not silent and leaves a choice, so
+ * the notice names the branch, says exactly what state the tree is in, and
+ * gives all three exits: keep it here, move it to the default branch, or undo
+ * it. `rollback` is the sanctioned undo — apply() already created a backup
+ * branch this run — so no destructive `reset --hard` is ever suggested.
+ *
+ * @param {object} params
+ * @param {string} params.currentBranch
+ * @param {string} params.defaultBranch
+ * @param {string} params.version
+ * @param {string} params.commitCommand - From updateCommitCommand().
+ * @returns {string} Multi-line notice.
+ */
+export function skippedBranchCommitNotice({ currentBranch, defaultBranch, version, commitCommand }) {
+  return [
+    '',
+    `Update applied but NOT committed: you are on '${currentBranch}', not '${defaultBranch}'.`,
+    'The refreshed system files are staged in your working tree. Committing them here',
+    'would put a full system snapshot on your branch, which is how a small pull request',
+    'turns into an unreviewable one (#3846).',
+    '',
+    'Pick one:',
+    '  1. Keep the update on this branch:',
+    `       ${commitCommand}`,
+    `  2. Move it to '${defaultBranch}' (git 2.35+ for --staged):`,
+    `       git stash push --staged -m "career-ops v${version}"`,
+    `       git switch ${defaultBranch} && git stash pop && ${commitCommand}`,
+    '  3. Undo the update entirely:',
+    '       node update-system.mjs rollback',
+    '',
+    `Always want it committed here? Re-run with ${COMMIT_ON_BRANCH_FLAG}, or set`,
+    'CAREER_OPS_UPDATE_COMMIT_ON_BRANCH=1.',
+  ].join('\n');
+}
+
 // ── APPLY ───────────────────────────────────────────────────────
 
 async function apply() {
@@ -2066,6 +2308,7 @@ async function apply() {
     (process.argv.includes('--confirm') && process.env.CAREER_OPS_UPDATE_REEXEC === '1');
   const updateForce = process.argv.includes('--force') ||
     (isReexec && process.env.CAREER_OPS_UPDATE_FORCE === '1');
+  const commitOnBranch = commitOnBranchOptIn();
   const updateConfirmed = process.argv.includes('--confirm') ||
     (isReexec && (process.env.CAREER_OPS_UPDATE_CONFIRM === '1' || legacyReexec));
   const initialStatusPaths = new Set(gitStatusEntries().map(entry => entry.path));
@@ -2148,6 +2391,10 @@ async function apply() {
           'apply',
           '--confirm',
           ...(updateForce ? ['--force'] : []),
+          // The child is the process that commits, so the branch opt-in has to
+          // reach it. The env twin below covers older targets that do not know
+          // the flag; a target that does know it reads either.
+          ...(commitOnBranch ? [COMMIT_ON_BRANCH_FLAG] : []),
         ], {
           cwd: ROOT,
           stdio: 'inherit',
@@ -2161,6 +2408,7 @@ async function apply() {
             CAREER_OPS_UPDATE_REEXEC: '1',
             CAREER_OPS_UPDATE_BACKUP_BRANCH: backupBranch,
             ...(updateForce ? { CAREER_OPS_UPDATE_FORCE: '1' } : {}),
+            ...(commitOnBranch ? { CAREER_OPS_UPDATE_COMMIT_ON_BRANCH: '1' } : {}),
             // Keep the legacy confirmation channel for older target updaters;
             // this process still requires the authenticated marker above.
             CAREER_OPS_UPDATE_CONFIRM: '1',
@@ -2488,6 +2736,9 @@ async function apply() {
     // Which commit form was used, so the failure path can suggest the matching
     // recovery command. Declared outside the try because the catch reads it.
     let usedIndexCommit = false;
+    // Set when the branch guard withheld the commit, so the closing summary
+    // reports what actually happened instead of implying a commit was made.
+    let skippedBranchCommit = false;
 
     // The staging and scoped-commit paths must use the same concrete file list.
     // Passing a manifest directory to `git commit -- <dir>` reads matching
@@ -2538,10 +2789,28 @@ async function apply() {
         preservedPaths,
       );
       usedIndexCommit = unrelated.length === 0;
-      if (usedIndexCommit) {
+      // Which branch receives the commit is decided here, after staging, so a
+      // withheld commit still leaves the refreshed files in the tree: the user
+      // is never left on stale system files by this guard (#3846).
+      const branchDecision = resolveUpdateCommitBranch(ROOT, { optIn: commitOnBranch });
+      if (!branchDecision.commit) {
+        skippedBranchCommit = true;
+        // Leave the next run a truthful baseline for these staged files, so it
+        // does not mistake this update's own output for the user's local edits
+        // and preserve the very files it came to install (#3846).
+        recordStagedUpdate('FETCH_HEAD');
+        console.log(skippedBranchCommitNotice({
+          currentBranch: branchDecision.currentBranch,
+          defaultBranch: branchDecision.defaultBranch,
+          version: remote,
+          commitCommand: updateCommitCommand(remote, usedIndexCommit, expandedPathsToStage),
+        }));
+      } else if (usedIndexCommit) {
         git('commit', '-m', `chore: auto-update system files to v${remote}`);
+        clearStagedUpdate();
       } else {
         git('commit', '-m', `chore: auto-update system files to v${remote}`, '--', ...expandedPathsToStage);
+        clearStagedUpdate();
       }
     } catch (e) {
       let commitFailed = false;
@@ -2558,14 +2827,11 @@ async function apply() {
       }
 
       if (commitFailed) {
-        const pathspec = expandedPathsToStage.map(p => `'${p.replace(/'/g, "'\\''")}'`).join(' ');
         // Print the command matching the path actually taken. Suggesting the
         // pathspec form after the index form was selected would tell the user to
         // run the very thing that drops the staged mode bits — a recovery step
         // that quietly reintroduces the bug it is recovering from.
-        const recovery = usedIndexCommit
-          ? `git commit -m "chore: auto-update system files to v${remote}"`
-          : `git commit -m "chore: auto-update system files to v${remote}" -- ${pathspec}`;
+        const recovery = updateCommitCommand(remote, usedIndexCommit, expandedPathsToStage);
         throw new Error(
           `Update commit failed (files may be staged but not committed).\n` +
           `    Error: ${e.message.split('\n')[0]}\n` +
@@ -2595,7 +2861,7 @@ async function apply() {
     }
 
     console.log(`\nUpdate complete: v${local} → v${remote}`);
-    console.log(`Updated ${updated.length} system paths.`);
+    console.log(`Updated ${updated.length} system paths.${skippedBranchCommit ? ' Staged, not committed (see above).' : ''}`);
     console.log(`Rollback available: node update-system.mjs rollback`);
 
     console.log('\n-- The CareerOps Manifesto ------------------------------');
@@ -2701,6 +2967,10 @@ function rollback() {
       // disk full) will resurface on the next normal git operation.
     }
 
+    // The tree no longer holds the staged update those files came from, so the
+    // recorded baseline would now describe content that is not there (#3846).
+    clearStagedUpdate();
+
     console.log(`Rollback complete. Restored ${restored.length} path(s) from ${latest}, removed ${removed.length} path(s) added after the backup.`);
     console.log('Your data (CV, profile, tracker, reports) was not affected.');
   } catch (err) {
@@ -2758,7 +3028,7 @@ if (isCli) {
       case 'rollback': rollback(); break;
       case 'dismiss': dismiss(); break;
       default:
-        console.log('Usage: node update-system.mjs [check|apply --confirm [--force]|rollback|dismiss]');
+        console.log('Usage: node update-system.mjs [check|apply --confirm [--force] [--commit-on-branch]|rollback|dismiss]');
         process.exit(1);
     }
   } catch (err) {


### PR DESCRIPTION
The updater committed its refreshed system files onto whatever branch HEAD pointed at. On a non-default branch it now applies the update but withholds the commit, tells the user, and leaves the choice to them.

Closes #3846

## Behaviour

Following the issue's "bias toward warn and proceed over refuse": the files are still refreshed and staged, so nobody is left on stale system files. Only the commit is withheld.

```
Update applied but NOT committed: you are on 'feat/posted-date-sort', not 'main'.
The refreshed system files are staged in your working tree. Committing them here
would put a full system snapshot on your branch, which is how a small pull request
turns into an unreviewable one (#3846).

Pick one:
  1. Keep the update on this branch:
       git commit -m "chore: auto-update system files to v1.33.0"
  2. Move it to 'main' (git 2.35+ for --staged):
       git stash push --staged -m "career-ops v1.33.0"
       git switch main && git stash pop && git commit -m "chore: auto-update system files to v1.33.0"
  3. Undo the update entirely:
       node update-system.mjs rollback

Always want it committed here? Re-run with --commit-on-branch, or set
CAREER_OPS_UPDATE_COMMIT_ON_BRANCH=1.
```

**The plain-user path is untouched** — on the default branch nothing changes, no new output and no prompt. Every uncertain case also commits exactly as before: detached HEAD, and a checkout where the default branch cannot be established (no `origin/HEAD`, no local `main`/`master`, no git at all). Guessing wrong there would withhold the commit from precisely the users the plain path exists for.

`--commit-on-branch` / `CAREER_OPS_UPDATE_COMMIT_ON_BRANCH=1` restores the old behaviour. It is a separate switch rather than a fourth meaning on `--force`, as the issue asked, and is forwarded across the self-reexec because the child process is the one that commits.

## The second-order failure this also had to fix

A withheld update has to survive the *next* run. With its snapshot staged but uncommitted there is no `chore: auto-update system files` commit to serve as `locallyModifiedSystemFiles`' baseline, so the next run read the previous run's own files as edits this install made: it preserved them, wrote `.bak` copies, and skipped exactly the delta it came to install. Measured against a throwaway repo (updater commit at v1, uncommitted v2 tree, upstream at v3), the file landed in the at-risk set — the invisible-staleness failure the issue warns about, arriving one run later. #3648's author ran the updater three times, so this is the same population.

A local ref, `refs/career-ops/staged-update`, records the upstream commit the staged files came from and is used as the baseline while it exists; it is cleared when a commit does land and on rollback. A ref rather than a marker file: it never shows in `git status`, needs no gitignore entry, and cannot leak into a contributor's PR — the same reasoning as the existing `refs/backup-pre-update-wip/*`.

## Changes

- `update-system.mjs` — branch resolution (`currentBranchIn`, `defaultBranchIn` via `origin/HEAD` with a `main`/`master` fallback), the decision (`updateCommitBranchDecision` / `resolveUpdateCommitBranch`), the notice, the opt-in, and the staged-update baseline ref. `updateCommitCommand` is extracted so the command handed to the user is byte-identical to the one the updater would have run — index form vs pathspec form are not interchangeable (the pathspec form drops staged mode bits where `core.fileMode` is false).
- `modes/update.md` — a relay rule, so the `update` mode does not summarize the notice away. It is the only place the user learns their tree is staged-but-uncommitted.
- `tests/updater-branch-guard.test.mjs` — 13 behavioural tests over throwaway repos, following `tests/updater-commit-file-modes.test.mjs`. The repo-facing ones drive `resolveUpdateCommitBranch`, the exact composition `apply()` runs, so a caller wired up wrong cannot pass. The baseline regression carries a negative control, and a companion test pins that a genuine local edit is still flagged (#2337 protection must not become a blanket amnesty).

## The third-order failure, after review

@santifer caught that the ref recording a withheld update was believed on sight, while the state it describes is transient: discarding the update by hand (`git reset --hard`, `git restore`, or the stash-and-switch this guard's own notice suggests) left the ref behind, and every system file then read as a local edit against a snapshot that was no longer there. Reproduced before fixing (`sys.mjs` at risk with the working tree untouched), fixed in ae8fea3.

The ref now points at the snapshot that was actually staged rather than at the upstream commit, and `stagedUpdateBaseline()` asks whether that snapshot is still here — of both the index and the working tree, since each check alone has a blind spot with a real case behind it — before trusting it. A failed check distrusts the ref without deleting it; deleting makes the damage permanent across a `stash push --staged` / `stash pop` round trip, which is measured in scenario 16 below.

## Testing

`node test-all.mjs`: 8,644 passed, 0 failed.

`tests/updater-branch-guard.test.mjs` — behavioural, over throwaway git repos, driving the same functions `apply()` calls:

| # | Scenario | Setup | Expected | What it pins |
|---|---|---|---|---|
| 1 | Feature branch | `origin/HEAD`→`main`, HEAD on `feat/…` | `commit: false`, `non-default-branch` | The bug itself |
| 2 | Default branch | HEAD on `main` | `commit: true`, `on-default-branch` | Plain path unchanged; positive control against over-withholding |
| 3 | Non-`main` default | `origin/HEAD`→`trunk`, then HEAD on `main` | trunk commits, `main` withheld | Default branch is read, not assumed |
| 4 | Detached HEAD | `checkout --detach` | `commit: true`, `detached-head` | Uncertainty must not withhold |
| 5 | No discoverable default | no `origin/HEAD`, no `main`/`master` | `commit: true`, `unknown-default-branch` | Same, for exotic checkouts |
| 6 | `origin/HEAD` absent | local `main` / local `master` | falls back to the one that exists | Fallback answers only with a real branch |
| 7 | Opt-in | `optIn: true` on a feature branch | `commit: true`, `opt-in` | Escape hatch works |
| 8 | Opt-in sources | flag / env / neither / `=0` | true, true, false, false | No accidental activation |
| 9 | `--force` | `--force --confirm`, feature branch | still withheld | No fourth meaning on `--force`; #2337 stays separate |
| 10 | Suggested command | index form vs pathspec form + quoting | matches what the updater would have run | Recovery must not reintroduce the mode-bit loss |
| 11 | Notice content | withheld on `feat/x` | names both branches, keep / move / undo, opt-in | Told, and given a choice |
| 12 | Second run, snapshot pending | v1 committed, v2 staged, upstream v3 | **negative control:** flagged without the snapshot, clean with it | A withheld update is not a local edit |
| 13 | Real local edit, update pending | snapshot recorded, then the user edits the file | still flagged | #2337 protection must not become a blanket amnesty |
| 14a | Discarded by hand | `git reset --hard` | not flagged | Durable ref, transient state |
| 14b | Discarded by hand | `git restore --staged --worktree` | not flagged | Same, second discard shape |
| 15 | Unrelated staged work | contributor stages their own file | snapshot still trusted | The check is scoped to the queried paths |
| 16 | Stash round trip | `stash push --staged` → switch → updater run → `stash pop` | not flagged at either point | Why a failed check distrusts rather than deletes |

Scenarios 12, 14 and 16 each correspond to a defect reproduced with a probe before it was fixed, not to a hypothetical. 2, 4 and 5 are the reverse insurance: they fail if the guard ever starts withholding too eagerly, which is the worse of the two failure directions.

## Left out, deliberately

`rollback` still commits onto the current branch. With this guard in place a feature branch should rarely have an updater commit to roll back, and rolling back a withheld (uncommitted) update produces an empty commit that the existing broad catch already tolerates — but it is the same shape of problem and probably deserves its own issue rather than a widened diff here. Happy to take it if you want it in this PR.

There is also no end-to-end `apply()` test: that needs network and a real remote, so the branch check is covered at the seam `apply()` itself calls. Same boundary as the existing updater suites, noted so it is not mistaken for full coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `update-system.mjs:2180`: Prevents automatic commits on non-default branches unless users opt in.
- `update-system.mjs:2357`: Records and validates the staged update snapshot.
- `update-system.mjs:2389`: Shows commands to keep, move, or roll back the staged update.
- `modes/update.md:105`: Requires the updater notice and recovery guidance.
- `tests/updater-branch-guard.test.mjs:70`: Covers branch checks, recovery flows, snapshot validation, and Git identity handling.

## User impact

On a feature branch, the updater still refreshes and stages system files. It does not commit them automatically. Users can commit the update on the current branch, move it to the default branch, or run `node update-system.mjs rollback`.

Use `--commit-on-branch` or `CAREER_OPS_UPDATE_COMMIT_ON_BRANCH=1` to restore automatic commits. Default-branch and uncertain-case behavior remain unchanged. `--force` does not enable branch commits.

Tests report 8,644 passes and zero failures.

## Touched system files

`AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
