### PR TITLE
fix(dashboard): surface open failures in the UI instead of stderr

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -39,6 +39,15 @@ type PipelineOpenPDFMsg struct {
 	Path string
 }
 
+// PipelineOpenFailedMsg reports that an external open (job URL, manifesto or
+// CV PDF) failed. The dashboard runs under an alt-screen, so the failure has to
+// travel back to the pipeline screen as a flash: anything written to stderr is
+// never seen. Target is the URL or path that could not be opened.
+type PipelineOpenFailedMsg struct {
+	Target string
+	Err    string
+}
+
 // PipelineGeneratePDFMsg requests a PDF regeneration via generate-pdf.mjs
 // from the application's recorded source HTML. Paths are relative to
 // CareerOpsPath (as recorded in the manifest).
@@ -478,6 +487,9 @@ func (m PipelineModel) Update(msg tea.Msg) (PipelineModel, tea.Cmd) {
 		} else {
 			m.flash = "PDF regenerated and opened: " + filepath.Base(msg.Path)
 		}
+		return m, nil
+	case PipelineOpenFailedMsg:
+		m.flash = "Could not open " + msg.Target + ": " + msg.Err
 		return m, nil
 	case pipelineStartDiscardPickerMsg:
 		// Issue 1380: initialise the discard reason picker state.

--- a/dashboard/internal/ui/screens/pipeline_open_failure_test.go
+++ b/dashboard/internal/ui/screens/pipeline_open_failure_test.go
@@ -1,0 +1,24 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue 3913: a failed open must surface in the pipeline flash line, because
+// stderr is invisible under the alt-screen.
+func TestPipelineOpenFailedMsgSetsFlash(t *testing.T) {
+	pm := newPDFTestModel(t, t.TempDir(), nil)
+
+	failed, _ := pm.Update(PipelineOpenFailedMsg{
+		Target: "https://example.com/jobs?id=1",
+		Err:    "executable file not found in $PATH",
+	})
+
+	if !strings.Contains(failed.flash, "executable file not found in $PATH") {
+		t.Fatalf("expected failure flash to carry the error, got %q", failed.flash)
+	}
+	if !strings.Contains(failed.flash, "https://example.com/jobs?id=1") {
+		t.Fatalf("expected failure flash to name the target, got %q", failed.flash)
+	}
+}

--- a/dashboard/main.go
+++ b/dashboard/main.go
@@ -254,7 +254,10 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func openCmd(target string) tea.Cmd {
 	return func() tea.Msg {
 		if err := openWithDefaultApp(target); err != nil {
-			fmt.Fprintf(os.Stderr, "WARN: failed to open %q: %v\n", target, err)
+			// Issue 3913: the dashboard runs with tea.WithAltScreen(), so a
+			// message on stderr is never visible. Report the failure back to
+			// the pipeline screen, which flashes it in the help bar.
+			return screens.PipelineOpenFailedMsg{Target: target, Err: err.Error()}
 		}
 		return nil
 	}

--- a/dashboard/open_command_failure_test.go
+++ b/dashboard/open_command_failure_test.go
@@ -1,0 +1,51 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/santifer/career-ops/dashboard/internal/ui/screens"
+)
+
+// Issue 3913: the dashboard runs under a Bubble Tea alt-screen, so anything
+// written to stderr is invisible. A failed open must come back as a message the
+// pipeline screen can flash instead.
+func TestOpenCmdReportsFailureAsMessage(t *testing.T) {
+	previous := runOpenCommand
+	defer func() { runOpenCommand = previous }()
+
+	runOpenCommand = func(name string, args ...string) error {
+		return errors.New("exec: \"xdg-open\": executable file not found in $PATH")
+	}
+
+	target := "https://example.com/jobs?id=1"
+	msg := openCmd(target)()
+
+	failed, ok := msg.(screens.PipelineOpenFailedMsg)
+	if !ok {
+		t.Fatalf("expected screens.PipelineOpenFailedMsg, got %T (%v)", msg, msg)
+	}
+	if failed.Target != target {
+		t.Fatalf("Target = %q, want %q", failed.Target, target)
+	}
+	if failed.Err == "" {
+		t.Fatal("expected a non-empty Err on the failure message")
+	}
+	if !strings.Contains(failed.Err, "xdg-open") {
+		t.Fatalf("expected Err to carry the underlying error, got %q", failed.Err)
+	}
+}
+
+func TestOpenCmdReturnsNilOnSuccess(t *testing.T) {
+	previous := runOpenCommand
+	defer func() { runOpenCommand = previous }()
+
+	runOpenCommand = func(name string, args ...string) error { return nil }
+
+	if msg := openCmd("https://example.com"); msg() != nil {
+		t.Fatalf("expected no message on success, got %#v", msg())
+	}
+}


### PR DESCRIPTION
## Problem

`openCmd` reports failures with `fmt.Fprintf(os.Stderr, ...)` and then returns `nil`. But the dashboard runs under `tea.WithAltScreen()` (`main.go:408`), so nothing written to stderr is ever visible. The result is that `o` (open job URL), `m` (open manifesto) and `d` (open CV PDF) are completely silent no-ops whenever the open fails — the user presses the key and gets no feedback at all, not even a hint that something went wrong.

## Fix

`openCmd` now returns a `screens.PipelineOpenFailedMsg{Target, Err}` on failure (and `nil` on success, as before). The pipeline screen handles that message by setting `m.flash`, so the failure shows up in the help bar with both the error and the target that could not be opened (handy to copy out).

This mirrors the pattern already used in this file for the same class of problem: `runGeneratePDF` returns `PipelinePDFGeneratedMsg{Err: ...}`, which `pipeline.go` turns into a flash. The new message needs no extra case in `main.go`'s switch — unknown messages fall through to `default`, which forwards to `m.pipeline.Update` while `m.state == viewPipeline`.

## Tests

Two layers, both written before the fix and confirmed red first:

- `dashboard/open_command_failure_test.go` (package `main`) swaps the injectable `runOpenCommand` for a failing stub — the same idiom as the existing `open_command_test.go` — and asserts `openCmd(target)()` returns a `PipelineOpenFailedMsg` carrying the target and a non-empty error, plus that success still returns no message.
- `dashboard/internal/ui/screens/pipeline_open_failure_test.go` asserts the pipeline screen turns that message into a flash naming both the error and the target.

Worth noting: the first red run printed the warning to stderr and then failed on the `nil` message — which is exactly the bug as the user experiences it, minus the terminal that hides the warning.

`go test ./...` in `dashboard/`: 218 passed across 6 packages (215 before this change). `go vet ./...` is clean. `gofmt` reports only pre-existing formatting in `main.go`, `internal/data/stats.go` and `internal/ui/screens/stats.go`, which I left untouched to keep the diff focused.

## Deliberately out of scope

- **`xdg-open` exiting 0 for some failure classes.** The issue mentions this as a secondary defect, but it is Debian/xdg-utils behaviour that I cannot verify on macOS, so I have not tried to work around it. This PR fixes the case where the open command *does* report an error and that error was being swallowed.
- **`ViewerOpenCoverLetterMsg` (`main.go:152-162`) has the same defect shape.** Its flash would belong to the viewer screen rather than the pipeline, which would widen this change beyond the three keys the issue names. Happy to open a separate issue (or a follow-up PR) for it if you'd like.

Fixes #3913


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Dashboard users now see a flash when opening a job URL, manifesto, or CV PDF fails. Successful opens remain unchanged.

### Changes

- `dashboard/main.go`: `openCmd` returns `PipelineOpenFailedMsg` with the target and error.
- `dashboard/internal/ui/screens/pipeline.go`: Displays opener failures as flash messages.
- Added tests for failed opens, successful opens, and failure flash rendering.
- `go vet` and dashboard tests pass.
- `xdg-open` failures that exit successfully remain out of scope.

### Files touched

- `dashboard/main.go`
- `dashboard/internal/ui/screens/pipeline.go`
- `dashboard/open_command_failure_test.go`
- `dashboard/internal/ui/screens/pipeline_open_failure_test.go`

System files not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->