### PR TITLE
fix(updater): stop apply() deleting a fork's own files under system path prefixes

### DIFF
--- a/tests/updater-local-paths.test.mjs
+++ b/tests/updater-local-paths.test.mjs
@@ -9,8 +9,8 @@
  * moves that statement OUT of the system layer.
  *
  * What is pinned here is the property that makes the feature safe to ship:
- * absent file changes nothing, and a declaration that would silently stop a
- * system file from updating is refused instead of honored.
+ * absent file changes nothing, a declaration is honored, and one that would
+ * stop a system file from updating says so out loud instead of doing it quietly.
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from 'fs';
@@ -25,6 +25,7 @@ import {
   localUserPaths,
   effectiveUserPaths,
   userLayerViolations,
+  staleSystemFiles,
 } from '../update-system.mjs';
 
 /** A throwaway root with an optional declaration file already written. */
@@ -106,36 +107,66 @@ console.log('\n🧪 Local user-paths declaration file (#2421)\n');
   }
 }
 
-// ── 6. A SYSTEM_PATHS collision is refused, loudly, naming the path ──
-//    Honoring it would be worse than refusing: the user would stop receiving
-//    updates for a system file and get no signal that it happened.
-{
-  let threw = null;
+/** Run `fn` with console.error captured, returning [result, capturedText]. */
+function withStderr(fn) {
+  const original = console.error;
+  const lines = [];
+  console.error = (...args) => lines.push(args.join(' '));
   try {
-    localUserPaths(root('merge-tracker.mjs\n'));
-  } catch (err) {
-    threw = err;
-  }
-  if (threw && threw.message.includes('merge-tracker.mjs')) {
-    pass('declaring a SYSTEM_PATHS entry throws and names the path');
-  } else {
-    fail(`#6 expected a throw naming merge-tracker.mjs, got ${threw ? threw.message : 'no throw'}`);
+    return [fn(), lines.join('\n')];
+  } finally {
+    console.error = original;
   }
 }
 
-// ── 7. A collision inside a SYSTEM_PATHS *directory* is refused too ──
-//    'modes/' is a directory entry; modes/pdf.md is shipped by it.
+// ── 6. A SYSTEM_PATHS collision is HONORED, and warns, naming the path ──
+//    This refused until a fork hit the real failure: refusing assumed a
+//    SYSTEM_PATHS match proves upstream ships the path, and it does not. An
+//    exact entry can be stale (naming a file the fetched tree no longer has),
+//    so the refusal fired on a fork's OWN file and left it undeclarable — after
+//    which the stale-file prune in apply() deleted it as a dropped system file.
+//    The rationale was about silence, not refusal, so the warning carries it.
 {
-  let threw = null;
-  try {
-    localUserPaths(root('modes/pdf.md\n'));
-  } catch (err) {
-    threw = err;
-  }
-  if (threw && threw.message.includes('modes/pdf.md')) {
-    pass('a file inside a system directory is refused too');
+  const [declared, stderr] = withStderr(() => localUserPaths(root('merge-tracker.mjs\n')));
+  if (declared.includes('merge-tracker.mjs') && stderr.includes('merge-tracker.mjs')) {
+    pass('declaring a SYSTEM_PATHS entry is honored and warns, naming the path');
   } else {
-    fail(`#7 expected a throw naming modes/pdf.md, got ${threw ? threw.message : 'no throw'}`);
+    fail(`#6 expected it honored + warned, got declared=${JSON.stringify(declared)} stderr=${JSON.stringify(stderr)}`);
+  }
+}
+
+// ── 7. A path inside a SYSTEM_PATHS *directory* is honored and warns too ──
+//    'providers/' is the case that matters: it covers upstream's greenhouse.mjs
+//    and a provider that exists only in this fork, so the prefix cannot tell
+//    them apart. Honoring both is what keeps the fork's file alive; the warning
+//    is what stops a genuine fork-of-a-shipped-file being silent.
+{
+  const [declared, stderr] = withStderr(() => localUserPaths(root('providers/my-own-board.mjs\n')));
+  if (declared.includes('providers/my-own-board.mjs') && stderr.includes('providers/')) {
+    pass('a file inside a system directory is honored and warns');
+  } else {
+    fail(`#7 expected it honored + warned, got declared=${JSON.stringify(declared)} stderr=${JSON.stringify(stderr)}`);
+  }
+}
+
+// ── 7b. The prune must not delete a declared fork-local file ──
+//    The regression this whole change exists for: a fork's provider/skill/doc
+//    under an owned prefix is absent upstream, so staleSystemFiles() saw it as
+//    a system file upstream had dropped. Protection must not depend on the file
+//    having uncommitted edits, which is all that used to spare it.
+{
+  const declaredRoot = root('providers/my-own-board.mjs\n');
+  const [userPaths] = withStderr(() => effectiveUserPaths(declaredRoot));
+  const stale = staleSystemFiles(
+    ['providers/my-own-board.mjs', 'providers/dropped-upstream.mjs'],
+    ['providers/greenhouse.mjs'],          // upstream ships neither of the above
+    ['providers/'],
+    userPaths,
+  );
+  if (!stale.includes('providers/my-own-board.mjs') && stale.includes('providers/dropped-upstream.mjs')) {
+    pass('a declared fork-local file survives the prune; an undeclared stale one still goes');
+  } else {
+    fail(`#7b expected only dropped-upstream.mjs pruned, got ${JSON.stringify(stale)}`);
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -582,6 +582,7 @@ export function localUserPaths(root = ROOT) {
   const reject = (path, why) => {
     throw new Error(`${LOCAL_PATHS_FILE}: refusing "${path}" — ${why}`);
   };
+  const underSystemPath = [];
 
   for (const path of declared) {
     if (path === LOCAL_PATHS_FILE) {
@@ -619,16 +620,33 @@ export function localUserPaths(root = ROOT) {
     if (segments.includes('.')) {
       reject(path, 'paths must be written plainly, with no "." segment (use "merge-tracker.mjs", not "./merge-tracker.mjs")');
     }
+    // Warned, not refused. This check assumed a SYSTEM_PATHS match proves
+    // upstream ships the path, and it does not:
+    //
+    //   - a directory entry is a wildcard, so `providers/` covers upstream's
+    //     greenhouse.mjs and a provider that exists only in a fork alike;
+    //   - even an exact entry can be stale, naming a file the fetched tree no
+    //     longer has (the checkout loop already tolerates exactly that, calling
+    //     it "a path genuinely absent upstream").
+    //
+    // So the refusal fired on precisely the files this mechanism exists for —
+    // a fork's own provider, skill or doc under an owned prefix — leaving them
+    // undeclarable, after which staleSystemFiles() deleted them as though
+    // upstream had dropped them. Answering "does upstream ship this?" needs the
+    // fetched tree, which this function cannot reach: it is also called by
+    // validate-system-paths-coverage.mjs, offline. Warning keeps the original
+    // rationale, which was about *silence* rather than refusal: fork a
+    // genuinely shipped file and you are told it stops updating.
     const collision = SYSTEM_PATHS.find((sys) =>
       sys.endsWith('/') ? path.startsWith(sys) : path === sys,
     );
-    if (collision) {
-      reject(
-        path,
-        `the system layer ships it (SYSTEM_PATHS entry "${collision}"). `
-        + 'Declaring it would stop updates to it with no other signal',
-      );
-    }
+    if (collision) underSystemPath.push({ path, collision });
+  }
+  for (const { path, collision } of underSystemPath) {
+    console.error(
+      `${LOCAL_PATHS_FILE}: "${path}" is inside system path "${collision}" — treating it as yours. `
+      + 'If upstream ships this file, it will no longer receive updates.',
+    );
   }
   return declared;
 }
@@ -2247,9 +2265,20 @@ async function apply() {
     // checking out and restoring afterwards would leave the index holding the
     // upstream blob, so the scoped commit below would record the very content
     // the user asked to keep out.
-    const preserveSpecs = preservedPaths.map((file) => `${EXCLUDE_PATHSPEC_PREFIX}${file}`);
+    // Declared fork-local paths (config/local-paths.txt) are excluded from the
+    // raw checkout too, not only from the stale-file prune below: that file's
+    // whole contract is "apply will never write to it". A declared path upstream
+    // does not ship is unreachable by the checkout anyway, so this matters for
+    // the one upstream DOES ship — which would otherwise be overwritten despite
+    // the declaration. Unconditional, and deliberately outside the `--force`
+    // branch: --force means "discard my local edits to system files", not
+    // "discard the files I told you are mine".
+    const keptFromCheckout = mergePathLists(preservedPaths, localUserPaths(ROOT));
+    const preserveSpecs = keptFromCheckout.map((file) => `${EXCLUDE_PATHSPEC_PREFIX}${file}`);
 
-    const preservedSet = new Set(preservedPaths);
+    // Tracks preserveSpecs, not the .bak messaging (which stays keyed to
+    // atRisk — a declared path is not necessarily a modified one).
+    const preservedSet = new Set(keptFromCheckout);
 
     const skippedPaths = [];
     for (const path of updatePaths) {
@@ -2258,7 +2287,7 @@ async function apply() {
       // that error is indistinguishable from a genuine failure at the catch
       // below, so it would abort the entire update. Skip the entry instead when
       // nothing would be left to check out (see pathFullyPreserved).
-      if (pathFullyPreserved(path, preservedPaths, preservedSet)) continue;
+      if (pathFullyPreserved(path, keptFromCheckout, preservedSet)) continue;
       try {
         // stderr is piped rather than inherited here. A path absent upstream is
         // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),
@@ -2308,7 +2337,13 @@ async function apply() {
         // be deleted here as "stale" — the two checks used to run independently,
         // so a preserved file with no upstream counterpart was backed up to
         // .bak by the block above and then unlinked by this one in the same run.
-        const staleCandidates = staleSystemFiles(localFiles, remoteFiles, SYSTEM_PATHS, mergePathLists(USER_PATHS, preservedPaths));
+        // effectiveUserPaths(), not USER_PATHS: a fork's own file living under a
+        // SYSTEM_PATHS directory prefix (a new provider in providers/, a custom
+        // skill in .claude/skills/, a design doc in docs/) is absent upstream and
+        // therefore looks exactly like a stale system file here. Reading only the
+        // built-in list deleted them. Protection also must not depend on the file
+        // having uncommitted edits, which is all that put it in preservedPaths.
+        const staleCandidates = staleSystemFiles(localFiles, remoteFiles, SYSTEM_PATHS, mergePathLists(effectiveUserPaths(), preservedPaths));
         for (const f of staleCandidates) {
           if (isReferencedByPreservedFile(f, preservedPaths)) {
             console.log(`Kept stale asset still referenced by a preserved file: ${f}`);


### PR DESCRIPTION
## The bug

`config/local-paths.txt` (#2421) tells a fork "list anything you keep in your own fork ... `update-system.mjs apply` will never write to it." Three code paths in `apply()` never consulted it, so a fork's own provider, skill or doc **is deleted** by the stale-file prune.

The mechanism: a fork-local file under a SYSTEM_PATHS *directory* prefix (`providers/`, `.claude/skills/`, `docs/`, `plugins-registry/`) is absent from the fetched tree, so `staleSystemFiles()` reads it as a system file upstream has dropped and unlinks it.

What made it hard to spot is that such files are usually spared by accident. `locallyModifiedSystemFiles()` puts anything differing from the updater baseline into `preservedPaths`, and the prune excludes those. So a file with uncommitted edits survives — and **committing your work is what makes it deletable.**

### Reproduced on a real fork

16 files under `providers/`, `.claude/skills/`, `docs/`, `lib/` and `plugins-registry/`, all absent upstream, all authored in the fork. Running the real `staleSystemFiles(...)` against a real `FETCH_HEAD`:

| | files deleted by `apply` |
|---|---|
| before | **14** |
| after | **0** |

With `preservedPaths` forced empty (i.e. everything committed and clean — the state that removes the accidental protection), it is still 0 after the change.

## The fix

**1. `localUserPaths()` warns instead of refusing on a SYSTEM_PATHS collision.**

The refusal assumed a SYSTEM_PATHS match proves upstream ships the path. It doesn't:

- a directory entry is a wildcard — `providers/` covers upstream's `greenhouse.mjs` and a provider that exists only in a fork, identically;
- even an exact entry can be stale, naming a file the fetched tree no longer has. The checkout loop already tolerates precisely this, calling it "a path genuinely absent upstream".

So the refusal fired on exactly the files this mechanism exists for and left them undeclarable. Answering "does upstream ship this?" needs the fetched tree, which `localUserPaths()` can't reach — `validate-system-paths-coverage.mjs` calls it offline. The original rationale was about *silence*, not refusal, so a warning carries it: fork a genuinely shipped file and you're told it will stop updating.

**2. The prune reads `effectiveUserPaths()` instead of `USER_PATHS`** — the helper that already existed and was already used by `userLayerViolations()`.

**3. The checkout excludes declared paths too**, unconditionally and outside the `--force` branch. `--force` means "discard my local edits to system files", not "discard the files I told you are mine". This one only bites for a declared path upstream *does* ship; a path absent upstream is unreachable by the checkout anyway.

## Tests

`tests/updater-local-paths.test.mjs` #6 and #7 pinned the old refusal and are rewritten to the new contract (honored **and** warned, naming the path). Added **#7b**, the actual regression test: a declared fork-local file survives the prune while an undeclared stale one is still removed.

`node test-all.mjs` on this branch: **8626 passed, 0 failed.**

Happy to split the three changes into separate commits, or to add the `warn` line to the docs in `config/local-paths.example.txt`, if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`update-system.mjs apply` now protects declared fork-owned files under system paths.

- `update-system.mjs:577-662`: `localUserPaths()` warns about collisions with `SYSTEM_PATHS` and keeps the paths user-owned.
- `update-system.mjs:2276-2298`: Checkout skips declared user paths, including with `--force`.
- `update-system.mjs:2340-2346`: Stale-file pruning uses `effectiveUserPaths()`.
- `tests/updater-local-paths.test.mjs:122-169`: Tests warnings, preservation of declared files, and removal of undeclared stale files.

Users can declare fork-owned files under `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` without `apply` deleting or overwriting them. Undeclared stale system files remain removable.

The test suite reports 8,626 passed tests and 0 failed tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->