### PR TITLE
fix(web): strip the core's HTML markers before rendering a report

### DIFF
--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 import type { Application } from "@/lib/career-ops";
 import { Badge } from "@/components/ui/badge";
 import { scoreTone, scoreNum, legitimacyTone, parseReport } from "@/lib/format";
-import { cleanHeading, isVerdictHeading, splitSections } from "@/lib/report-sections.mjs";
+import { cleanHeading, isVerdictHeading, splitSections, stripCoreMarkers } from "@/lib/report-sections.mjs";
 import { StatusSelect } from "@/components/status-select";
 import { CompanyLogo } from "@/components/company-logo";
 import { ScoreMethodology } from "@/components/score-methodology";
@@ -133,13 +133,16 @@ export function ReportView({
       {report ? (
         <>
           {(() => {
-            const { intro, sections } = splitSections(meta?.body ?? report);
+            // One strip, at the single point the report enters the view: everything
+            // below is derived from `body`, so no renderer needs to know about markers.
+            const body = stripCoreMarkers(meta?.body ?? report);
+            const { intro, sections } = splitSections(body);
             // Tolerant fallback: unrecognized layout → render the whole body as
             // before, so an old/odd report never loses content.
             if (sections.length === 0) {
               return (
                 <article className="report-prose mt-8">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{meta?.body ?? report}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
                 </article>
               );
             }

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -46,6 +46,28 @@ const HEADING_PREFIX = /^\s*(?:Block\s+([A-Z])(?:[).:]\s*|\s+(?:[—–-]+\s*)?)
 const HEADING_LETTER = /^(?:Block\s+([A-Z])(?:[).:]|\s)|([A-Z])[).:])/i;
 
 /**
+ * Remove the core's own HTML marker lines from a report before it is rendered.
+ *
+ * The core anchors machine-readable sections with comments like
+ * `<!-- career-ops:draft-answers -->` (#3889) because a comment is invisible
+ * wherever HTML is interpreted, and a marker beats a heading name that is
+ * translated in 15 of the 19 evaluation modes. It is invisible on GitHub. It is
+ * NOT invisible here: `report-view.tsx` renders with react-markdown and no
+ * `rehype-raw`, so raw HTML is ESCAPED rather than interpreted, and the reader
+ * sees `&lt;!-- career-ops:draft-answers --&gt;` printed above their own drafts.
+ * Measured, not assumed — renderToStaticMarkup on the real dependency.
+ *
+ * Scoped to the `career-ops:` namespace on purpose: a comment someone wrote in
+ * their own report is their content, and this is not a general HTML stripper.
+ *
+ * @param {string} md
+ * @returns {string}
+ */
+export function stripCoreMarkers(md) {
+  return String(md ?? "").replace(/^[ \t]*<!--\s*career-ops:[\s\S]*?-->[ \t]*\r?\n?/gm, "");
+}
+
+/**
  * @typedef {{ heading: string, letter: string | null, content: string }} Section
  */
 

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -6,7 +6,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { cleanHeading, authorLetter, isVerdictHeading, splitSections } from "../../src/lib/report-sections.mjs";
+import { cleanHeading, authorLetter, isVerdictHeading, splitSections, stripCoreMarkers } from "../../src/lib/report-sections.mjs";
 
 test("strips the author letter from the blocks the core has always written", () => {
   assert.equal(cleanHeading("A) Role Summary"), "Role Summary");
@@ -165,4 +165,43 @@ test("the authoring marker names the verdict, in any language", () => {
   assert.equal(isVerdictHeading("B) Verdict"), true);
   // ...but a heading that merely mentions the word is not the verdict block.
   assert.equal(isVerdictHeading("D) Verdict rationale and caveats"), false);
+});
+
+// ── the core's markers must not reach the reader (#3889) ────────────────────
+// A comment is invisible wherever HTML is interpreted, which is why the core
+// picked it: a marker survives the 15 of 19 evaluation modes that translate the
+// heading. It is NOT invisible in report-view, which renders with react-markdown
+// and no rehype-raw — raw HTML is ESCAPED, so without this the reader sees
+// `&lt;!-- career-ops:draft-answers --&gt;` printed above their own drafts.
+
+test("stripCoreMarkers removes a career-ops marker line, leaving the content", () => {
+  const md = "## H) Draft Application Answers\n<!-- career-ops:draft-answers -->\n\n**Q:** why us?\n";
+  const out = stripCoreMarkers(md);
+  assert.ok(!out.includes("career-ops:draft-answers"), "the marker must not survive into the rendered body");
+  assert.ok(out.includes("## H) Draft Application Answers"), "the heading stays");
+  assert.ok(out.includes("**Q:** why us?"), "the content stays");
+  assert.ok(!/\n\n\n/.test(out), "removing the line must not leave a blank-line scar");
+});
+
+test("stripCoreMarkers leaves the reader's own HTML comments alone", () => {
+  // Scoped to the career-ops namespace: someone else's comment is their content.
+  const md = "## A) Role Summary\n<!-- my own note to self -->\n\ntext\n";
+  assert.ok(stripCoreMarkers(md).includes("my own note to self"), "only career-ops: markers are ours to remove");
+});
+
+test("stripCoreMarkers survives a marker the core spells differently later", () => {
+  // The namespace is the contract, not the exact slug — a future
+  // `career-ops:machine-summary` must be stripped by the same rule.
+  const md = "<!--   career-ops:something-we-have-not-invented-yet   -->\nbody\n";
+  const out = stripCoreMarkers(md);
+  assert.equal(out.trim(), "body");
+});
+
+test("splitSections on a marked report keeps the marker out of the content", () => {
+  const md = "## G) Posting Legitimacy\nok\n\n## H) Draft Application Answers\n<!-- career-ops:draft-answers -->\n\n**Q:** a\n";
+  const { sections } = splitSections(stripCoreMarkers(md));
+  const h = sections.find((s) => s.letter === "H");
+  assert.ok(h, "section H is still found after stripping");
+  assert.ok(!h.content.includes("career-ops:"), "no marker reaches the rendered section content");
+  assert.ok(h.content.includes("**Q:** a"), "the drafts themselves survive");
 });


### PR DESCRIPTION
Unblocks #3889 (@Abhishek84313). **The core side needs no change** — the marker idea is right, the gap is on my side.

## Why the marker is invisible everywhere except here

#3889 anchors the drafts block with `<!-- career-ops:draft-answers -->`, and the reasoning holds: a comment is invisible wherever HTML is interpreted, and a marker beats a heading name that is **translated in 15 of the 19 evaluation modes** (and sits under `G)` in twelve of them and `H)` in seven, so neither the name nor the letter can locate it).

`report-view.tsx` renders with react-markdown and **no `rehype-raw`**, so raw HTML is *escaped* rather than interpreted. Measured with `renderToStaticMarkup` on the real dependency rather than reasoned about:

```
input:  "<!-- career-ops:draft-answers -->\n\n**Q:** why us?"

before  →  &lt;!-- career-ops:draft-answers --&gt;
           <p><strong>Q:</strong> why us?…
after   →  <p><strong>Q:</strong> why us?…
```

Without this, every reader of every new report sees the marker printed above their own drafts, in all 19 languages.

## The change

One `stripCoreMarkers()` in `report-sections.mjs`, applied **once** at the single point the report enters the view — everything below is derived from that body, so no renderer needs to know markers exist.

Scoped to the `career-ops:` namespace rather than stripping all HTML comments: a comment someone wrote in their own report is their content, not our noise. The namespace is the contract, so a future `career-ops:machine-summary` is covered by the same rule — one of the tests pins exactly that, with a slug we have not invented.

## Tests

`report-sections.test.mjs` 20/20. Four new: the marker goes and the heading and drafts stay; a reader's own comment survives; an unknown `career-ops:` slug is still stripped; and `splitSections` on a marked report yields a section H whose content carries no marker. Also pins that removing the line leaves no blank-line scar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The web application now removes core `career-ops:` HTML markers before it renders reports.

Users will no longer see escaped marker comments in report content. User-authored comments remain visible. Unknown markers in the `career-ops:` namespace are also removed.

### Changes

- Added `stripCoreMarkers()` in `web/src/lib/report-sections.mjs`.
- Applied marker removal before section splitting and Markdown rendering in `web/src/components/report-view.tsx`.
- Added coverage for marker removal, comment preservation, unknown markers, section splitting, and blank-line handling in `web/tests/lib/report-sections.test.mjs`.

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->