### PR TITLE
docs: update path instructions in dashboard README

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -14,7 +14,7 @@ component.
 Requires Go 1.24+ (`go.mod`). From the repo root:
 
 ```bash
-npm run serve:dashboard    # go run . --path .. (launch against the repo root)
+npm run serve:dashboard    # go run . --path .. (The script automatically resolves external data directories by falling back through CAREER_OPS_ROOT and CAREER_OPS_DATA_DIR enviornment variables,defaulting to repository root.)
 npm run build:dashboard    # build the standalone binary
 ```
 


### PR DESCRIPTION
Follow-up to #3929 to remove the outdated \--path ..\ instructions and document the new environment variable resolution fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### User impact

Users can run the dashboard without the outdated `--path ..\` argument. The dashboard now resolves the external data directory through `CAREER_OPS_ROOT` and `CAREER_OPS_DATA_DIR`, with a repository-root fallback: `dashboard/README.md:38`.

### Files changed

`dashboard/README.md`: Updated the dashboard serve command documentation.

The system files `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->