### PR TITLE
fix(update-system): refuse manifest entries that name the user layer

### DIFF
--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -23,7 +23,7 @@
  */
 
 import { pass, fail } from './helpers.mjs';
-import { rejectUserLayerPaths } from '../update-system.mjs';
+import { rejectUserLayerPaths, manifestProbes } from '../update-system.mjs';
 
 // A stand-in for effectiveUserPaths() covering both declaration forms: a
 // trailing `/` is a directory, anything else is an exact file path.
@@ -266,5 +266,85 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
     pass('an empty fetched manifest yields nothing on either side');
   } else {
     fail('an empty fetched manifest must yield nothing on either side');
+  }
+}
+
+// manifestProbes() is what apply() actually hands the rule. The blocks above use
+// doubles, so they verify the RULE; these verify the WIRING — that the probes read
+// the git output they are given. Left inline in apply(), this could only be checked
+// by pattern-matching the source, and a source pattern cannot tell
+// `trackedFiles.has(path)` from `() => true`.
+console.log('\n🧪 Testing manifestProbes (git output -> the rule\'s three questions)...');
+
+{
+  // Given: `ls-files -z` output naming two tracked files
+  const probes = manifestProbes({
+    trackedOutput: 'writing-samples/README.md\0documents/README.md\0',
+    upstreamOutput: '',
+  });
+
+  // When: the tracked probe is asked about a listed and an unlisted path
+  // Then: it answers from that output, not from the surrounding checkout
+  if (probes.tracked('writing-samples/README.md') && !probes.tracked('data/applications.md')) {
+    pass('tracked() answers from the ls-files output it was given');
+  } else {
+    fail('tracked() does not read the ls-files output');
+  }
+}
+
+{
+  // Given: a NUL-delimited name that a newline split would mangle. core.quotePath
+  // makes this the realistic shape, and it is why -z is used.
+  const probes = manifestProbes({
+    trackedOutput: 'documents/résumé notes.md\0documents/README.md\0',
+    upstreamOutput: '',
+  });
+
+  // When/Then: the whole name survives as one entry
+  if (probes.tracked('documents/résumé notes.md') && probes.tracked('documents/README.md')) {
+    pass('tracked() parses NUL-delimited names whole');
+  } else {
+    fail('tracked() mangles NUL-delimited names');
+  }
+}
+
+{
+  // Given: an upstream tree that ships files under data/outcomes but not under
+  // documents/GUIDE.md, which is a blob
+  const probes = manifestProbes({
+    trackedOutput: '',
+    upstreamOutput: 'data/outcomes/posting.md\0documents/GUIDE.md\0',
+  });
+
+  // When/Then: only the path with files beneath it is a subtree claim
+  if (probes.claimsSubtree('data/outcomes') && !probes.claimsSubtree('documents/GUIDE.md')) {
+    pass('claimsSubtree() distinguishes a tree from a blob using the upstream listing');
+  } else {
+    fail('claimsSubtree() does not read the upstream listing');
+  }
+}
+
+{
+  // Given: any probes, asked about a trailing-slash entry
+  const probes = manifestProbes({ trackedOutput: '', upstreamOutput: '' });
+
+  // When/Then: an explicit slash is a subtree claim without consulting the tree,
+  // so an entry upstream ships nothing under yet is still refused
+  if (probes.claimsSubtree('documents/')) {
+    pass('claimsSubtree() honours an explicit trailing slash with an empty tree');
+  } else {
+    fail('claimsSubtree() ignores an explicit trailing slash');
+  }
+}
+
+{
+  // Given: a root the exists probe should resolve against
+  const probes = manifestProbes({ trackedOutput: '', upstreamOutput: '', root: process.cwd() });
+
+  // When/Then: it reports on the real filesystem under that root
+  if (probes.exists('update-system.mjs') && !probes.exists('no-such-file-xyz.md')) {
+    pass('exists() resolves against the root it was given');
+  } else {
+    fail('exists() does not resolve against the given root');
   }
 }

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -3,11 +3,12 @@
  * guard on the FETCHED manifest.
  *
  * apply() reads SYSTEM_PATHS out of the updater it just fetched and merges it
- * into updatePaths. That list decides what the checkout overwrites AND, through
- * `updatePaths.includes(file)` in userLayerViolations(), what is excused from
- * the user-layer safety check — so an upstream entry naming a user path both
- * causes the damage and waives the check written to catch it. The guard is
- * disabled by the same entry that triggers it.
+ * into updatePaths, the list the per-path `git checkout FETCH_HEAD -- <path>`
+ * walks. An entry naming user territory therefore writes upstream's content over
+ * the user's own, and an UNTRACKED local file is invisible to the diff-based
+ * #2337 detector — so it gets no .bak, is not preserved, and is then deleted by
+ * the abort path as an addition HEAD lacks, while the run prints "your content
+ * was NOT overwritten". Refusing the entry is what stops that sequence starting.
  *
  * rejectUserLayerPaths() is pure and exported for the same reason
  * userLayerViolations() is: apply() is ROOT-bound and full of side effects, so
@@ -36,6 +37,24 @@ const USER_PATHS = [
   'writing-samples/',
 ];
 
+// Deterministic stand-ins for the three local-state questions the rule asks.
+// Every block passes these: without them rejectUserLayerPaths falls back to a
+// real `git ls-files` and existsSync against whatever checkout the suite happens
+// to run in, which makes the outcome depend on the developer's tree and throws
+// outright where there is no git. The values below deliberately DISAGREE with
+// this repo — documents/GUIDE.md and data/outcomes/posting.md do not exist here —
+// so a regression to the real probes cannot keep these assertions green.
+const TRACKED = new Set(['writing-samples/README.md', 'documents/README.md',
+  'documents/.gitkeep', 'interview-prep/sessions/.gitkeep']);
+const ON_DISK = new Set([...TRACKED, 'data/applications.md', 'interview-prep/story-bank.md']);
+const UPSTREAM = ['data/outcomes/posting.md', 'documents/README.md', 'modes/pdf/hm-audit.md'];
+const probes = {
+  tracked: (p) => TRACKED.has(p),
+  exists: (p) => ON_DISK.has(p),
+  claimsSubtree: (p) => p.endsWith('/')
+    || UPSTREAM.some((f) => f.startsWith(`${p.replace(/\/$/, '')}/`)),
+};
+
 console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user layer)...');
 
 {
@@ -43,7 +62,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   const remote = ['modes/oferta.md', 'cv.md'];
 
   // When: the manifest is split against the local user layer
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: the user file is refused and never reaches the checkout list
   if (refused.includes('cv.md') && !kept.includes('cv.md')) {
@@ -59,7 +78,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   const remote = ['documents/'];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: the directory entry is refused
   if (refused.includes('documents/') && kept.length === 0) {
@@ -75,7 +94,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   const remote = ['data/outcomes/'];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: it is refused too — the overlap test runs in both directions
   if (refused.includes('data/outcomes/') && kept.length === 0) {
@@ -91,7 +110,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   const remote = ['modes/'];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: refused, because the overlap is checked in the containing direction
   if (refused.includes('modes/') && kept.length === 0) {
@@ -112,7 +131,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   ];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: every one is kept. Refusing them is the #958 silent-non-arrival bug.
   if (refused.length === 0 && kept.length === remote.length) {
@@ -128,7 +147,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   const remote = ['documents/GUIDE.md'];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: it is allowed through, so new upstream files still arrive
   if (kept.includes('documents/GUIDE.md') && refused.length === 0) {
@@ -143,7 +162,7 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   const remote = ['modes/pdf/', 'modes/de/interview/', 'scan.mjs', 'AGENTS.md'];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: it passes through untouched, in input order
   if (refused.length === 0 && kept.join('\n') === remote.join('\n')) {
@@ -152,19 +171,6 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
     fail(`an ordinary manifest must pass through unchanged — kept=${JSON.stringify(kept)}`);
   }
 }
-
-// The two holes review found in the first version. Both need explicit probes,
-// because the rule for an entry inside a user directory turns on local state
-// rather than on the path's shape.
-const TRACKED = new Set(['writing-samples/README.md', 'documents/README.md']);
-const ON_DISK = new Set([...TRACKED, 'data/applications.md', 'interview-prep/story-bank.md']);
-const UPSTREAM = ['data/outcomes/posting.md', 'documents/README.md', 'modes/pdf/hm-audit.md'];
-const probes = {
-  tracked: (p) => TRACKED.has(p),
-  exists: (p) => ON_DISK.has(p),
-  claimsSubtree: (p) => p.endsWith('/')
-    || UPSTREAM.some((f) => f.startsWith(`${p.replace(/\/$/, '')}/`)),
-};
 
 {
   // Given: the SAME claims spelled without a trailing slash. `git checkout <ref>
@@ -253,7 +259,7 @@ const probes = {
   const remote = [];
 
   // When: the manifest is split
-  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
 
   // Then: both sides are empty and the caller falls back as before
   if (kept.length === 0 && refused.length === 0) {

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -1,0 +1,170 @@
+/**
+ * updater-remote-manifest-user-paths.test.mjs — BEHAVIORAL coverage for the
+ * guard on the FETCHED manifest.
+ *
+ * apply() reads SYSTEM_PATHS out of the updater it just fetched and merges it
+ * into updatePaths. That list decides what the checkout overwrites AND, through
+ * `updatePaths.includes(file)` in userLayerViolations(), what is excused from
+ * the user-layer safety check — so an upstream entry naming a user path both
+ * causes the damage and waives the check written to catch it. The guard is
+ * disabled by the same entry that triggers it.
+ *
+ * rejectUserLayerPaths() is pure and exported for the same reason
+ * userLayerViolations() is: apply() is ROOT-bound and full of side effects, so
+ * the rule is pinned directly rather than inferred from an end-to-end run.
+ *
+ * The `writing-samples/README.md` case below is the important one. The obvious
+ * implementation reuses the matcher already inlined in userLayerViolations()
+ * and filters every remote path that touches the user layer — which silently
+ * drops the four system-owned docs that legitimately ship inside user
+ * directories today. That failure raises no error and produces no output; it
+ * looks exactly like upstream not having changed those files, which is #958.
+ */
+
+import { pass, fail } from './helpers.mjs';
+import { rejectUserLayerPaths } from '../update-system.mjs';
+
+// A stand-in for effectiveUserPaths() covering both declaration forms: a
+// trailing `/` is a directory, anything else is an exact file path.
+const USER_PATHS = [
+  'cv.md',
+  'config/profile.yml',
+  'modes/_profile.md',
+  'documents/',
+  'data/',
+  'interview-prep/',
+  'writing-samples/',
+];
+
+console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user layer)...');
+
+{
+  // Given: upstream's manifest names a declared user FILE
+  const remote = ['modes/oferta.md', 'cv.md'];
+
+  // When: the manifest is split against the local user layer
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: the user file is refused and never reaches the checkout list
+  if (refused.includes('cv.md') && !kept.includes('cv.md')) {
+    pass('a declared user file (cv.md) is refused');
+  } else {
+    fail(`a declared user file (cv.md) must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: upstream broadened a file entry to the user directory that holds it,
+  // the realistic manifest-editing mistake this guard exists for
+  const remote = ['documents/'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: the directory entry is refused
+  if (refused.includes('documents/') && kept.length === 0) {
+    pass('a user directory (documents/) is refused');
+  } else {
+    fail(`a user directory (documents/) must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: upstream names a directory NESTED under a user directory, which no
+  // exact-match rule would catch
+  const remote = ['data/outcomes/'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: it is refused too — the overlap test runs in both directions
+  if (refused.includes('data/outcomes/') && kept.length === 0) {
+    pass('a directory nested under a user directory (data/outcomes/) is refused');
+  } else {
+    fail(`a nested user directory must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: a directory entry that CONTAINS a declared user file rather than
+  // sitting inside a user directory — `modes/` would claim modes/_profile.md
+  const remote = ['modes/'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: refused, because the overlap is checked in the containing direction
+  if (refused.includes('modes/') && kept.length === 0) {
+    pass('a directory containing a declared user file (modes/) is refused');
+  } else {
+    fail(`a directory containing a user file must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: the shipped pattern — system-owned docs living inside user
+  // directories, exactly as SYSTEM_PATHS declares them today
+  const remote = [
+    'writing-samples/README.md',
+    'documents/README.md',
+    'documents/.gitkeep',
+    'interview-prep/sessions/.gitkeep',
+  ];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: every one is kept. Refusing them is the #958 silent-non-arrival bug.
+  if (refused.length === 0 && kept.length === remote.length) {
+    pass('system-owned files inside user directories are kept (#958 guard)');
+  } else {
+    fail(`system-owned files inside user dirs must be kept — refused=${JSON.stringify(refused)}`);
+  }
+}
+
+{
+  // Given: upstream ships a genuinely NEW system-owned doc inside a user
+  // directory, the case that makes this a filter and not an allowlist
+  const remote = ['documents/GUIDE.md'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: it is allowed through, so new upstream files still arrive
+  if (kept.includes('documents/GUIDE.md') && refused.length === 0) {
+    pass('a new system-owned file inside a user directory is kept');
+  } else {
+    fail(`a new system-owned file must be kept — refused=${JSON.stringify(refused)}`);
+  }
+}
+
+{
+  // Given: an ordinary manifest with nothing touching the user layer
+  const remote = ['modes/pdf/', 'modes/de/interview/', 'scan.mjs', 'AGENTS.md'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: it passes through untouched, in input order
+  if (refused.length === 0 && kept.join('\n') === remote.join('\n')) {
+    pass('an ordinary manifest passes through unchanged and in order');
+  } else {
+    fail(`an ordinary manifest must pass through unchanged — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: an empty fetched manifest, the older-target fallback path where
+  // extractArrayFromSource() found nothing
+  const remote = [];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS);
+
+  // Then: both sides are empty and the caller falls back as before
+  if (kept.length === 0 && refused.length === 0) {
+    pass('an empty fetched manifest yields nothing on either side');
+  } else {
+    fail('an empty fetched manifest must yield nothing on either side');
+  }
+}

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -254,6 +254,43 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
 }
 
 {
+  // Given: entries that MEAN the user layer without spelling it that way.
+  // `git checkout <ref> -- ./data` resolves to the same directory as `data/`,
+  // and the checkout does not pass --literal-pathspecs, so `:(glob)` magic is
+  // honoured too. Every comparison in the rule is literal segment work, so each
+  // of these matches nothing and would sail through (CodeRabbit, PR #3947).
+  const remote = [
+    './data/', './documents', './/data', 'data//', 'documents/./',
+    '..\\data', ':(glob)data/**', '/data/', 'data/../data/',
+  ];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: all of them are refused as malformed, before any overlap check
+  if (refused.length === remote.length && kept.length === 0) {
+    pass('non-canonical manifest spellings are refused as malformed');
+  } else {
+    fail(`non-canonical spellings must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: the ordinary canonical spellings the real manifest actually ships
+  const remote = ['modes/pdf/', 'scan.mjs', 'lib/context-budget.mjs', 'docs/FAQ.md'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: the canonicality check refuses none of them
+  if (refused.length === 0 && kept.length === remote.length) {
+    pass('canonical system paths are unaffected by the malformed-path check');
+  } else {
+    fail(`canonical paths must pass — refused=${JSON.stringify(refused)}`);
+  }
+}
+
+{
   // Given: an empty fetched manifest, the older-target fallback path where
   // extractArrayFromSource() found nothing
   const remote = [];

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -22,7 +22,7 @@
  * looks exactly like upstream not having changed those files, which is #958.
  */
 
-import { pass, fail } from './helpers.mjs';
+import { pass, fail, ROOT } from './helpers.mjs';
 import { rejectUserLayerPaths, manifestProbes } from '../update-system.mjs';
 
 // A stand-in for effectiveUserPaths() covering both declaration forms: a
@@ -266,6 +266,10 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
     './data/', './documents', './/data', 'data//', 'documents/./',
     '..\\data', ':(glob)data/**', '/data/', 'data/../data/',
     `data${String.fromCharCode(0)}entry`,
+    // Wildcards are magic without the announcing `:`, and the checkout cannot
+    // pass --literal-pathspecs because it relies on :(exclude) specs. A default
+    // pathspec wildcard matches `/` too, so `modes/*` claims modes/_profile.md.
+    'modes/*', 'modes/?_profile.md', 'modes/[_]profile.md', 'mode*/',
   ];
 
   // When: the manifest is split
@@ -379,8 +383,10 @@ console.log('\n🧪 Testing manifestProbes (git output -> the rule\'s three ques
 }
 
 {
-  // Given: a root the exists probe should resolve against
-  const probes = manifestProbes({ trackedOutput: '', upstreamOutput: '', root: process.cwd() });
+  // Given: the repo root, derived from import.meta.url by helpers.mjs rather
+  // than from process.cwd(), so the case does not depend on where the suite
+  // was launched from
+  const probes = manifestProbes({ trackedOutput: '', upstreamOutput: '', root: ROOT });
 
   // When/Then: it reports on the real filesystem under that root
   if (probes.exists('update-system.mjs') && !probes.exists('no-such-file-xyz.md')) {

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -270,6 +270,10 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
     // pass --literal-pathspecs because it relies on :(exclude) specs. A default
     // pathspec wildcard matches `/` too, so `modes/*` claims modes/_profile.md.
     'modes/*', 'modes/?_profile.md', 'modes/[_]profile.md', 'mode*/',
+    // A colon is magic at the front (`:(glob)`), a Windows drive whether
+    // absolute or drive-relative, and an NTFS alternate data stream in the
+    // middle. None is a repo-relative path, and no shipped entry has one.
+    'C:/user/file', 'C:foo', 'D:/data/applications.md', 'file.txt:stream',
   ];
 
   // When: the manifest is split

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -259,9 +259,13 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   // and the checkout does not pass --literal-pathspecs, so `:(glob)` magic is
   // honoured too. Every comparison in the rule is literal segment work, so each
   // of these matches nothing and would sail through (CodeRabbit, PR #3947).
+  // A NUL is included deliberately: child_process rejects the argument with
+  // ERR_INVALID_ARG_VALUE before git starts, so an unrefused one kills apply()
+  // with an opaque runtime error rather than naming the bad entry.
   const remote = [
     './data/', './documents', './/data', 'data//', 'documents/./',
     '..\\data', ':(glob)data/**', '/data/', 'data/../data/',
+    `data${String.fromCharCode(0)}entry`,
   ];
 
   // When: the manifest is split

--- a/tests/updater-remote-manifest-user-paths.test.mjs
+++ b/tests/updater-remote-manifest-user-paths.test.mjs
@@ -153,6 +153,100 @@ console.log('\n🧪 Testing rejectUserLayerPaths (fetched manifest vs local user
   }
 }
 
+// The two holes review found in the first version. Both need explicit probes,
+// because the rule for an entry inside a user directory turns on local state
+// rather than on the path's shape.
+const TRACKED = new Set(['writing-samples/README.md', 'documents/README.md']);
+const ON_DISK = new Set([...TRACKED, 'data/applications.md', 'interview-prep/story-bank.md']);
+const UPSTREAM = ['data/outcomes/posting.md', 'documents/README.md', 'modes/pdf/hm-audit.md'];
+const probes = {
+  tracked: (p) => TRACKED.has(p),
+  exists: (p) => ON_DISK.has(p),
+  claimsSubtree: (p) => p.endsWith('/')
+    || UPSTREAM.some((f) => f.startsWith(`${p.replace(/\/$/, '')}/`)),
+};
+
+{
+  // Given: the SAME claims spelled without a trailing slash. `git checkout <ref>
+  // -- documents` and `-- documents/` name one tree, so a rule keyed on the slash
+  // is bypassed by dropping one character (CodeRabbit, PR #3947).
+  const remote = ['documents', 'data', 'modes', 'interview-prep'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: every one is refused, exactly as its slashed spelling would be
+  if (refused.length === remote.length && kept.length === 0) {
+    pass('slashless user-directory entries are refused (documents, data, modes, interview-prep)');
+  } else {
+    fail(`slashless entries must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: a directory nested in user territory, spelled without a slash. Its
+  // directory-ness is knowable only from the tree being checked out.
+  const remote = ['data/outcomes'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: refused — a subtree claim is open-ended, so it cannot be adjudicated once
+  if (refused.includes('data/outcomes') && kept.length === 0) {
+    pass('a slashless nested directory is refused via the upstream tree');
+  } else {
+    fail(`a slashless nested directory must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: single files inside user directories that are the USER's own work —
+  // untracked and present. Path shape cannot tell these from a system-owned doc.
+  const remote = ['data/applications.md', 'interview-prep/story-bank.md'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: refused. Untracked-and-present is precisely the unrecoverable case —
+  // no .bak, nothing in the stash, nothing on the backup branch.
+  if (refused.length === remote.length && kept.length === 0) {
+    pass('an untracked user file inside a user directory is refused');
+  } else {
+    fail(`an untracked user file must be refused — kept=${JSON.stringify(kept)}`);
+  }
+}
+
+{
+  // Given: a system-owned doc inside a user directory, tracked by this install
+  const remote = ['writing-samples/README.md', 'documents/README.md'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: kept — git can restore it, and refusing it is the #958 non-arrival
+  if (kept.length === remote.length && refused.length === 0) {
+    pass('a tracked system-owned doc inside a user directory is kept');
+  } else {
+    fail(`a tracked system doc must be kept — refused=${JSON.stringify(refused)}`);
+  }
+}
+
+{
+  // Given: a new upstream file inside a user directory, absent from this install
+  const remote = ['documents/GUIDE.md'];
+
+  // When: the manifest is split
+  const { kept, refused } = rejectUserLayerPaths(remote, USER_PATHS, probes);
+
+  // Then: kept — there is nothing local to lose, so refusing it would only stop
+  // new upstream files from ever arriving (#958)
+  if (kept.includes('documents/GUIDE.md') && refused.length === 0) {
+    pass('a new upstream file absent from this install is kept');
+  } else {
+    fail(`a new absent upstream file must be kept — refused=${JSON.stringify(refused)}`);
+  }
+}
+
 {
   // Given: an empty fetched manifest, the older-target fallback path where
   // extractArrayFromSource() found nothing

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -738,8 +738,14 @@ function isCanonicalManifestPath(path) {
   // instead of naming the malformed entry. It is also the delimiter both probes
   // parse their git output on, so such a path could never match anything anyway.
   if (path.includes('\0')) return false;
-  // Windows separators, absolute paths, and git pathspec magic (a leading colon).
-  if (path.includes('\\') || path.startsWith('/') || path.startsWith(':')) return false;
+  // Windows separators and absolute paths.
+  if (path.includes('\\') || path.startsWith('/')) return false;
+  // Any colon, not just a leading one. It is git pathspec magic at the front
+  // (`:(glob)`, `:!`), a drive on Windows whether absolute (`C:/x`) or
+  // drive-relative (`C:x`), and an NTFS alternate data stream in the middle
+  // (`file.txt:stream`). A colon is not legal in a Windows filename either, and
+  // no entry the manifest ships contains one, so the whole character goes.
+  if (path.includes(':')) return false;
   // Wildcards are pathspec magic too, without the `:` that announces it, and the
   // checkout cannot defuse them: it builds :(exclude) specs for preserved paths,
   // so --literal-pathspecs would disable the very magic it depends on. A default

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -740,6 +740,13 @@ function isCanonicalManifestPath(path) {
   if (path.includes('\0')) return false;
   // Windows separators, absolute paths, and git pathspec magic (a leading colon).
   if (path.includes('\\') || path.startsWith('/') || path.startsWith(':')) return false;
+  // Wildcards are pathspec magic too, without the `:` that announces it, and the
+  // checkout cannot defuse them: it builds :(exclude) specs for preserved paths,
+  // so --literal-pathspecs would disable the very magic it depends on. A default
+  // pathspec wildcard also matches `/`, so `modes/*` claims modes/_profile.md
+  // while matching none of the segment comparisons below. Refusing here is the
+  // only place this can be stopped.
+  if (/[*?[]/.test(path)) return false;
   // One trailing slash is the directory spelling this file uses; anything else
   // empty is a doubled separator.
   const segments = (path.endsWith('/') ? path.slice(0, -1) : path).split('/');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -714,6 +714,34 @@ export function manifestProbes({ trackedOutput, upstreamOutput, root = ROOT }) {
 }
 
 /**
+ * Is this manifest entry a plain, canonical, repo-relative path?
+ *
+ * Every comparison the guard makes is literal string work on segments, so a path
+ * that means the user layer without spelling it that way slips past all of it:
+ * `./data/` is not `data/`, yet `git checkout <ref> -- ./data` resolves to the
+ * same directory. Backslashes, doubled separators, a leading `/`, and git's own
+ * pathspec magic (`:(glob)`, `:!`) do the same in their own ways — and the
+ * checkout does not pass --literal-pathspecs, so magic would be honoured.
+ *
+ * Normalizing instead of refusing would mean reimplementing git's pathspec
+ * resolution and staying bug-compatible with it. A manifest entry has no reason
+ * to be spelled any way but plainly, so anything else is refused as malformed.
+ * Every entry the real manifest ships is canonical, so nothing legitimate is lost.
+ *
+ * @param {string} path - Raw manifest entry, trailing slash allowed.
+ * @returns {boolean} True when the entry is a plain relative path.
+ */
+function isCanonicalManifestPath(path) {
+  if (typeof path !== 'string' || path === '') return false;
+  // Windows separators, absolute paths, and git pathspec magic (a leading colon).
+  if (path.includes('\\') || path.startsWith('/') || path.startsWith(':')) return false;
+  // One trailing slash is the directory spelling this file uses; anything else
+  // empty is a doubled separator.
+  const segments = (path.endsWith('/') ? path.slice(0, -1) : path).split('/');
+  return !segments.some((segment) => segment === '' || segment === '.' || segment === '..');
+}
+
+/**
  * Split a manifest into entries apply() may write and entries it must refuse.
  *
  * A manifest entry naming a user path is a data-loss bug regardless of intent: the
@@ -788,6 +816,13 @@ export function rejectUserLayerPaths(manifestPaths, userPaths, probes = {}) {
   const kept = [];
   const refused = [];
   for (const path of manifestPaths) {
+    // Before any comparison: a non-canonical spelling means the same tree while
+    // matching none of the checks below, so it is refused as malformed rather
+    // than normalized.
+    if (!isCanonicalManifestPath(path)) {
+      refused.push(path);
+      continue;
+    }
     const entry = trimSlash(path);
     // Names a user path, or stands above one and would sweep it up.
     if (declared.some((userPath) => entry === userPath || isUnder(userPath, entry))) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -733,6 +733,11 @@ export function manifestProbes({ trackedOutput, upstreamOutput, root = ROOT }) {
  */
 function isCanonicalManifestPath(path) {
   if (typeof path !== 'string' || path === '') return false;
+  // A NUL never reaches git: child_process rejects the argument with
+  // ERR_INVALID_ARG_VALUE first, so apply() would die on an opaque runtime error
+  // instead of naming the malformed entry. It is also the delimiter both probes
+  // parse their git output on, so such a path could never match anything anyway.
+  if (path.includes('\0')) return false;
   // Windows separators, absolute paths, and git pathspec magic (a leading colon).
   if (path.includes('\\') || path.startsWith('/') || path.startsWith(':')) return false;
   // One trailing slash is the directory spelling this file uses; anything else

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -21,7 +21,7 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, lstatSync, mkdtempSync, realpathSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, lstatSync, statSync, mkdtempSync, realpathSync } from 'fs';
 import { join, dirname, basename, resolve, posix as pathPosix } from 'path';
 import { tmpdir } from 'os';
 import { randomBytes, timingSafeEqual } from 'crypto';
@@ -654,6 +654,31 @@ export function userLayerViolations(changedFiles, updatePaths, userPaths) {
 }
 
 /**
+ * Does the ref ship files BENEATH this path, i.e. is the entry a directory?
+ *
+ * The manifest's own spelling cannot answer this — `documents` and `documents/`
+ * are the same pathspec to git — and the update is about to check this path out
+ * of `ref`, so `ref` is the authority on what it actually is.
+ *
+ * -z and --literal-pathspecs for the reasons expandStagingPaths documents: raw
+ * NUL-separated names survive core.quotePath, and no name is reinterpreted as a
+ * glob. An unreadable ref answers "not a subtree" rather than throwing — the
+ * caller then falls back to the single-file rule, which is the stricter branch.
+ *
+ * @param {string} path - Manifest entry, without a trailing slash.
+ * @param {string} [ref='FETCH_HEAD'] - Tree to interrogate.
+ * @returns {boolean} True when at least one file sits strictly under `path`.
+ */
+function upstreamShipsUnder(path, ref = 'FETCH_HEAD') {
+  try {
+    const listed = gitQuiet('--literal-pathspecs', 'ls-tree', '-r', '--name-only', '-z', ref, '--', path);
+    return listed.split('\0').filter(Boolean).some((file) => file.startsWith(`${path}/`));
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Split a manifest into entries apply() may write and entries it must refuse.
  *
  * A manifest entry naming a user path is a data-loss bug regardless of intent: the
@@ -669,31 +694,86 @@ export function userLayerViolations(changedFiles, updatePaths, userPaths) {
  * list. There is no local half left to trust, and filtering only `remoteSystemPaths`
  * lets the identical entry back in through the "local" one.
  *
- * Only the two shapes that can only be a mistake are refused: a directory entry
- * overlapping the user layer in either direction (`documents/`, `data/outcomes/`),
- * and an entry naming a declared user path outright (`cv.md`, `writing-samples/`).
+ * Comparison is on path SEGMENTS, and a trailing slash carries no meaning here.
+ * `git checkout <ref> -- documents` and `-- documents/` name the same tree, so a
+ * rule keyed on the slash is bypassed by omitting one character. Two claims are
+ * refused however they are spelled: an entry equal to a declared user path, and an
+ * entry that is an ANCESTOR of one (`modes` would claim the user's
+ * modes/_profile.md; `documents` would claim everything under documents/).
  *
- * A specific system-owned FILE inside a user directory stays allowed. That is the
- * established pattern — writing-samples/README.md and documents/README.md ship this
- * way today — and refusing it would stop new upstream files from ever reaching an
- * install, which is #958: a silent non-arrival that raises no error and can go
- * unnoticed for months.
+ * An entry INSIDE a user directory splits two ways. A SUBTREE claim is refused
+ * outright: its contents are whatever upstream decides, now and in every later
+ * release, so it is an open-ended claim over user territory that cannot be
+ * adjudicated once. Directory-ness is read from upstream's own tree rather than a
+ * trailing slash, for the same reason the slash is ignored above.
+ *
+ * A single FILE inside a user directory cannot be judged by shape at all:
+ * writing-samples/README.md is a system-owned doc that must keep arriving, while
+ * interview-prep/story-bank.md is the user's own work. So the test is recoverability
+ * rather than intent — refuse only when the entry would land on a file this install
+ * does not track. Untracked-and-present is exactly the case the update cannot undo:
+ * the #2337 detector is diff-based and never sees such a file, so no .bak is written,
+ * `git stash create` captures nothing, and the backup branch holds only committed
+ * state. A tracked file is restorable from git, and a path absent locally has nothing
+ * to lose — refusing that one would block new upstream files, which is #958.
  *
  * @param {string[]} manifestPaths - The merged manifest apply() is about to write.
  * @param {string[]} userPaths - User-layer paths, normally effectiveUserPaths().
+ * @param {object} [probes] - Seams for the three state questions, so the rule stays
+ *   unit-testable without a repo. Default to the real checkout and FETCH_HEAD.
+ * @param {(path: string) => boolean} [probes.tracked] - Is the path in the index?
+ * @param {(path: string) => boolean} [probes.exists] - Is it on disk?
+ * @param {(path: string) => boolean} [probes.claimsSubtree] - Does upstream ship files
+ *   beneath it, i.e. is this entry a directory rather than a single file?
  * @returns {{kept: string[], refused: string[]}} Entries to check out, and entries to
  *   report and drop. Order within each list follows the input.
  */
-export function rejectUserLayerPaths(manifestPaths, userPaths) {
+export function rejectUserLayerPaths(manifestPaths, userPaths, probes = {}) {
+  const tracked = probes.tracked || ((path) => isTracked(path));
+  const exists = probes.exists || ((path) => existsSync(join(ROOT, path)));
+  // Default to the tree apply() is about to check out. A path that is a directory
+  // on disk counts too, so an entry naming a user directory the install already has
+  // is refused even when upstream ships nothing under it yet.
+  const claimsSubtree = probes.claimsSubtree || ((path) => {
+    if (path.endsWith('/')) return true;
+    try {
+      if (existsSync(join(ROOT, path)) && statSync(join(ROOT, path)).isDirectory()) return true;
+    } catch { /* unreadable: fall through to the upstream tree */ }
+    return upstreamShipsUnder(path);
+  });
+  // A trailing slash is a spelling, not a fact about the path — strip it on both
+  // sides so `documents` and `documents/` are the same claim.
+  const trimSlash = (path) => (path.endsWith('/') ? path.slice(0, -1) : path);
+  // Segment-boundary containment: `cv` must not claim `cv.md`, and `cv.md` must
+  // not claim `cv.md.bak` (the over-match userLayerViolations documents at :655).
+  const isUnder = (child, parent) => child.startsWith(`${parent}/`);
+  const declared = userPaths.map(trimSlash);
+  const declaredDirs = userPaths.filter((path) => path.endsWith('/')).map(trimSlash);
+
   const kept = [];
   const refused = [];
   for (const path of manifestPaths) {
-    // Both directions: the entry may sit inside a user path (`data/outcomes/` under
-    // `data/`) or contain one (`modes/` would claim the user's `modes/_profile.md`).
-    const overlapsUserDir = path.endsWith('/')
-      && userPaths.some((userPath) => path.startsWith(userPath) || userPath.startsWith(path));
-    if (overlapsUserDir || userPaths.includes(path)) refused.push(path);
-    else kept.push(path);
+    const entry = trimSlash(path);
+    // Names a user path, or stands above one and would sweep it up.
+    if (declared.some((userPath) => entry === userPath || isUnder(userPath, entry))) {
+      refused.push(path);
+      continue;
+    }
+    if (declaredDirs.some((dir) => isUnder(entry, dir))) {
+      // A subtree claim inside user territory is open-ended — upstream decides its
+      // contents in this release and every later one — so it cannot be adjudicated
+      // once and is refused outright.
+      if (claimsSubtree(path)) {
+        refused.push(path);
+        continue;
+      }
+      // A single file is a bounded claim: keep it only if losing it is recoverable.
+      if (!tracked(entry) && exists(entry)) {
+        refused.push(path);
+        continue;
+      }
+    }
+    kept.push(path);
   }
   return { kept, refused };
 }
@@ -2244,9 +2324,23 @@ async function apply() {
     // one. Refuse loudly rather than aborting — one bad manifest entry must not
     // brick every install's updates, but staying silent is what would keep the
     // mistake invisible.
+    // One `ls-files` and one `ls-tree` for the whole manifest rather than one per
+    // entry: the merged list is ~340 paths, and the per-path defaults would spawn
+    // git that many times each.
+    const trackedFiles = new Set(git('ls-files').split('\n').filter(Boolean));
+    const upstreamFiles = git('ls-tree', '-r', '--name-only', 'FETCH_HEAD').split('\n').filter(Boolean);
     const { kept: updatePaths, refused } = rejectUserLayerPaths(
       mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS),
       effectiveUserPaths(),
+      {
+        tracked: (path) => trackedFiles.has(path),
+        exists: (path) => existsSync(join(ROOT, path)),
+        claimsSubtree: (path) => {
+          if (path.endsWith('/')) return true;
+          const prefix = `${path}/`;
+          return upstreamFiles.some((file) => file.startsWith(prefix));
+        },
+      },
     );
     if (refused.length > 0) {
       console.log('');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -2327,8 +2327,12 @@ async function apply() {
     // One `ls-files` and one `ls-tree` for the whole manifest rather than one per
     // entry: the merged list is ~340 paths, and the per-path defaults would spawn
     // git that many times each.
-    const trackedFiles = new Set(git('ls-files').split('\n').filter(Boolean));
-    const upstreamFiles = git('ls-tree', '-r', '--name-only', 'FETCH_HEAD').split('\n').filter(Boolean);
+    // -z on both, for the reason expandStagingPaths documents: core.quotePath
+    // quotes a non-ASCII name, and both probes below key on exact membership and
+    // prefix. A quoted name would read as untracked, so a tracked system doc
+    // inside a user directory would be refused instead of updated.
+    const trackedFiles = new Set(git('ls-files', '-z').split('\0').filter(Boolean));
+    const upstreamFiles = git('ls-tree', '-r', '--name-only', '-z', 'FETCH_HEAD').split('\0').filter(Boolean);
     const { kept: updatePaths, refused } = rejectUserLayerPaths(
       mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS),
       effectiveUserPaths(),
@@ -2342,6 +2346,7 @@ async function apply() {
         },
       },
     );
+    const refusedSet = new Set(refused);
     if (refused.length > 0) {
       console.log('');
       console.log(`Refused ${refused.length} manifest entry(ies) naming the user layer:`);
@@ -2740,7 +2745,14 @@ async function apply() {
     // Re-running apply fixes it (the first pass did update update-system.mjs
     // itself, so the second pass uses the target manifest) — but only if the
     // user is told, instead of being shown "Update complete" (#1998).
-    const unmaterialized = missingFromTargetManifest(remoteSystemPaths);
+    // Refused entries were never checked out, so verifying them would report a
+    // gap this run deliberately created and exit 1 with advice to re-run — which
+    // refuses the same entry and fails identically, forever. That would turn a
+    // manifest mistake into a permanently dead updater, the opposite of the
+    // refuse-loudly-do-not-abort contract at 3a.
+    const unmaterialized = missingFromTargetManifest(
+      remoteSystemPaths.filter((path) => !refusedSet.has(path)),
+    );
     if (unmaterialized.length > 0) {
       console.error(`\nUpdate incomplete: v${local} → v${remote}`);
       console.error(`${unmaterialized.length} path(s) from the target manifest were not checked out:`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -679,6 +679,41 @@ function upstreamShipsUnder(path, ref = 'FETCH_HEAD') {
 }
 
 /**
+ * Build the local-state probes rejectUserLayerPaths() asks its three questions of.
+ *
+ * Extracted and exported rather than inlined at the call site for the reason
+ * userLayerViolations() gives for being pure: apply() is ROOT-bound and full of
+ * side effects, so anything left inside it can only be checked by pattern-matching
+ * the source — and a source pattern cannot tell `trackedFiles.has(path)` from
+ * `() => true`. Gutting the probes that way disables the whole named-file half of
+ * the guard while every structural check still passes, which is precisely what
+ * happened before this was pulled out.
+ *
+ * Takes raw git output rather than parsed collections so the NUL parsing is part
+ * of what gets tested: `-z` is what makes a non-ASCII name survive
+ * core.quotePath, and both probes key on exact membership and prefix.
+ *
+ * @param {object} args
+ * @param {string} args.trackedOutput - Raw `git ls-files -z` output.
+ * @param {string} args.upstreamOutput - Raw `git ls-tree -r --name-only -z <ref>` output.
+ * @param {string} [args.root=ROOT] - Checkout the `exists` probe resolves against.
+ * @returns {{tracked: Function, exists: Function, claimsSubtree: Function}}
+ */
+export function manifestProbes({ trackedOutput, upstreamOutput, root = ROOT }) {
+  const trackedFiles = new Set(String(trackedOutput).split('\0').filter(Boolean));
+  const upstreamFiles = String(upstreamOutput).split('\0').filter(Boolean);
+  return {
+    tracked: (path) => trackedFiles.has(path),
+    exists: (path) => existsSync(join(root, path)),
+    claimsSubtree: (path) => {
+      if (path.endsWith('/')) return true;
+      const prefix = `${path}/`;
+      return upstreamFiles.some((file) => file.startsWith(prefix));
+    },
+  };
+}
+
+/**
  * Split a manifest into entries apply() may write and entries it must refuse.
  *
  * A manifest entry naming a user path is a data-loss bug regardless of intent: the
@@ -2328,23 +2363,16 @@ async function apply() {
     // entry: the merged list is ~340 paths, and the per-path defaults would spawn
     // git that many times each.
     // -z on both, for the reason expandStagingPaths documents: core.quotePath
-    // quotes a non-ASCII name, and both probes below key on exact membership and
+    // quotes a non-ASCII name, and both probes key on exact membership and
     // prefix. A quoted name would read as untracked, so a tracked system doc
     // inside a user directory would be refused instead of updated.
-    const trackedFiles = new Set(git('ls-files', '-z').split('\0').filter(Boolean));
-    const upstreamFiles = git('ls-tree', '-r', '--name-only', '-z', 'FETCH_HEAD').split('\0').filter(Boolean);
     const { kept: updatePaths, refused } = rejectUserLayerPaths(
       mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS),
       effectiveUserPaths(),
-      {
-        tracked: (path) => trackedFiles.has(path),
-        exists: (path) => existsSync(join(ROOT, path)),
-        claimsSubtree: (path) => {
-          if (path.endsWith('/')) return true;
-          const prefix = `${path}/`;
-          return upstreamFiles.some((file) => file.startsWith(prefix));
-        },
-      },
+      manifestProbes({
+        trackedOutput: git('ls-files', '-z'),
+        upstreamOutput: git('ls-tree', '-r', '--name-only', '-z', 'FETCH_HEAD'),
+      }),
     );
     const refusedSet = new Set(refused);
     if (refused.length > 0) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -653,6 +653,51 @@ export function userLayerViolations(changedFiles, updatePaths, userPaths) {
   return violations;
 }
 
+/**
+ * Split a manifest into entries apply() may write and entries it must refuse.
+ *
+ * A manifest entry naming a user path is a data-loss bug regardless of intent: the
+ * per-path `git checkout FETCH_HEAD -- <dir>` writes upstream's files over the user's,
+ * and an UNTRACKED user file the install has no history for is invisible to the
+ * #2337 local-edit detector, so it gets no .bak and is not preserved. The abort path
+ * then deletes it as an addition HEAD lacks, while reporting "your content was NOT
+ * overwritten". Refusing the entry up front is what keeps that sequence from starting.
+ *
+ * Apply this to the MERGED manifest, never to the fetched half alone. apply()
+ * self-bootstraps — it checks the fetched update-system.mjs out and re-execs it — so
+ * by the time the merge runs, the SYSTEM_PATHS constant in this file IS upstream's
+ * list. There is no local half left to trust, and filtering only `remoteSystemPaths`
+ * lets the identical entry back in through the "local" one.
+ *
+ * Only the two shapes that can only be a mistake are refused: a directory entry
+ * overlapping the user layer in either direction (`documents/`, `data/outcomes/`),
+ * and an entry naming a declared user path outright (`cv.md`, `writing-samples/`).
+ *
+ * A specific system-owned FILE inside a user directory stays allowed. That is the
+ * established pattern — writing-samples/README.md and documents/README.md ship this
+ * way today — and refusing it would stop new upstream files from ever reaching an
+ * install, which is #958: a silent non-arrival that raises no error and can go
+ * unnoticed for months.
+ *
+ * @param {string[]} manifestPaths - The merged manifest apply() is about to write.
+ * @param {string[]} userPaths - User-layer paths, normally effectiveUserPaths().
+ * @returns {{kept: string[], refused: string[]}} Entries to check out, and entries to
+ *   report and drop. Order within each list follows the input.
+ */
+export function rejectUserLayerPaths(manifestPaths, userPaths) {
+  const kept = [];
+  const refused = [];
+  for (const path of manifestPaths) {
+    // Both directions: the entry may sit inside a user path (`data/outcomes/` under
+    // `data/`) or contain one (`modes/` would claim the user's `modes/_profile.md`).
+    const overlapsUserDir = path.endsWith('/')
+      && userPaths.some((userPath) => path.startsWith(userPath) || userPath.startsWith(path));
+    if (overlapsUserDir || userPaths.includes(path)) refused.push(path);
+    else kept.push(path);
+  }
+  return { kept, refused };
+}
+
 function parseVersionFile(raw) {
   // VERSION may carry a release-please marker, e.g. "1.6.0 # x-release-please-version".
   // Take the first whitespace-delimited token so the marker doesn't break semver parsing.
@@ -2191,7 +2236,25 @@ async function apply() {
 
     // 3a. Keep bootstrap paths as a fallback for very old targets, but the
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
+    // Being the source of truth stops at the user layer. The filter runs over the
+    // MERGED list, not just remoteSystemPaths: by the time this code executes it is
+    // itself the fetched updater (apply() self-bootstraps and re-execs, step 2), so
+    // the local SYSTEM_PATHS constant above is upstream's list too. Filtering only
+    // the remote half would leave the identical entry to walk in through the "local"
+    // one. Refuse loudly rather than aborting — one bad manifest entry must not
+    // brick every install's updates, but staying silent is what would keep the
+    // mistake invisible.
+    const { kept: updatePaths, refused } = rejectUserLayerPaths(
+      mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS),
+      effectiveUserPaths(),
+    );
+    if (refused.length > 0) {
+      console.log('');
+      console.log(`Refused ${refused.length} manifest entry(ies) naming the user layer:`);
+      for (const path of refused) console.log(`  ${path}`);
+      console.log('Your files were NOT touched. Please report this — it is a manifest error.');
+      console.log('');
+    }
 
     // 3b. Local edits to system files (#2337). The checkout is a raw overwrite,
     // so anything this install fixed locally and upstream has not adopted is

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -307,6 +307,14 @@ const twoPassManifestChecks = [
     pattern: /mergePathLists\(SYSTEM_PATHS,\s*remoteSystemPaths[\s\S]*?\)/,
   },
   {
+    // The guard must wrap the MERGED manifest. apply() self-bootstraps into the
+    // fetched updater before this runs, so the local SYSTEM_PATHS constant is
+    // upstream's list too — a regression that filters only remoteSystemPaths
+    // reads as protection while the same entry walks in through the other half.
+    name: 'apply filters the MERGED manifest against the user layer, not just the fetched half',
+    pattern: /rejectUserLayerPaths\(\s*\n?\s*mergePathLists\(SYSTEM_PATHS,\s*remoteSystemPaths,\s*BOOTSTRAP_PATHS\),\s*\n?\s*effectiveUserPaths\(\),?\s*\n?\s*\)/,
+  },
+  {
     name: 'apply checks out the merged manifest instead of only the local manifest',
     pattern: /for\s*\(const path of updatePaths\)/,
   },

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -328,7 +328,16 @@ const twoPassManifestChecks = [
     // defaults inside the guard are per-path git calls; the call site batches them,
     // and a regression that drops either seam silently disables half the rule.
     name: 'the guard probes tracked state and the upstream tree from real git output',
-    pattern: /git\('ls-files'\)[\s\S]{0,400}?git\('ls-tree',\s*'-r',\s*'--name-only',\s*'FETCH_HEAD'\)[\s\S]{0,600}?claimsSubtree:/,
+    pattern: /git\('ls-files',\s*'-z'\)[\s\S]{0,500}?git\('ls-tree',\s*'-r',\s*'--name-only',\s*'-z',\s*'FETCH_HEAD'\)[\s\S]{0,700}?claimsSubtree:/,
+  },
+  {
+    // A refused entry was never checked out, so verifying it would report a gap
+    // this run created on purpose, exit 1, and advise a re-run that refuses the
+    // same entry and fails identically — a manifest mistake turned into a
+    // permanently dead updater, which is the opposite of refusing loudly without
+    // aborting. Subtracting the refused set is what keeps that contract.
+    name: 'the completeness check skips entries the guard refused',
+    pattern: /missingFromTargetManifest\(\s*remoteSystemPaths\.filter\(\(path\) => !refusedSet\.has\(path\)\),\s*\)/,
   },
   {
     name: 'apply checks out the merged manifest instead of only the local manifest',
@@ -355,7 +364,11 @@ const twoPassManifestChecks = [
     // paths, so everything added upstream since is silently absent and apply
     // still printed "Update complete" (#1998).
     name: 'apply verifies the target manifest materialized before claiming success (#1998)',
-    pattern: /missingFromTargetManifest\(remoteSystemPaths\)/,
+    // The TARGET manifest is what must be verified — verifying the local one
+    // would re-introduce #1998, since a client whose manifest predates the
+    // target's is exactly the case this check exists for. Which entries are
+    // subtracted before the comparison is pinned separately below.
+    pattern: /missingFromTargetManifest\(\s*remoteSystemPaths/,
   },
   {
     name: 'an incomplete apply exits non-zero instead of reporting success (#1998)',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -323,12 +323,14 @@ const twoPassManifestChecks = [
     pattern: /rejectUserLayerPaths\([\s\S]{0,200}?effectiveUserPaths\(\)/,
   },
   {
-    // Both probes must come from the install and the tree being checked out: a
-    // tracked-file set from `ls-files`, and the upstream tree from `ls-tree`. The
-    // defaults inside the guard are per-path git calls; the call site batches them,
-    // and a regression that drops either seam silently disables half the rule.
-    name: 'the guard probes tracked state and the upstream tree from real git output',
-    pattern: /git\('ls-files',\s*'-z'\)[\s\S]{0,500}?git\('ls-tree',\s*'-r',\s*'--name-only',\s*'-z',\s*'FETCH_HEAD'\)[\s\S]{0,700}?claimsSubtree:/,
+    // The probes must be built by manifestProbes() from real git output, INSIDE
+    // the rejectUserLayerPaths() call. A source pattern cannot tell
+    // `trackedFiles.has(path)` from `() => true`, so what the probes DO is
+    // verified behaviourally in tests/updater-remote-manifest-user-paths.test.mjs
+    // against the factory's own exports; this only has to pin that apply() feeds
+    // it `ls-files -z` and `ls-tree -z` rather than something of its own.
+    name: 'the guard is handed probes built by manifestProbes from real git output',
+    pattern: /rejectUserLayerPaths\([\s\S]{0,300}?manifestProbes\(\{\s*trackedOutput:\s*git\('ls-files',\s*'-z'\),\s*upstreamOutput:\s*git\('ls-tree',\s*'-r',\s*'--name-only',\s*'-z',\s*'FETCH_HEAD'\),\s*\}\),/,
   },
   {
     // A refused entry was never checked out, so verifying it would report a gap

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -312,7 +312,23 @@ const twoPassManifestChecks = [
     // upstream's list too — a regression that filters only remoteSystemPaths
     // reads as protection while the same entry walks in through the other half.
     name: 'apply filters the MERGED manifest against the user layer, not just the fetched half',
-    pattern: /rejectUserLayerPaths\(\s*\n?\s*mergePathLists\(SYSTEM_PATHS,\s*remoteSystemPaths,\s*BOOTSTRAP_PATHS\),\s*\n?\s*effectiveUserPaths\(\),?\s*\n?\s*\)/,
+    pattern: /rejectUserLayerPaths\(\s*mergePathLists\(SYSTEM_PATHS,\s*remoteSystemPaths,\s*BOOTSTRAP_PATHS\),/,
+  },
+  {
+    // The unit suite drives the rule with a synthetic user-path list and synthetic
+    // probes, so THIS is the only assertion tying the guard to the real sources.
+    // Weakening it to a shape-only match would let the rule keep passing while
+    // apply() fed it something other than the user layer and the real checkout.
+    name: 'the guard reads the real user layer, not a local stand-in',
+    pattern: /rejectUserLayerPaths\([\s\S]{0,200}?effectiveUserPaths\(\)/,
+  },
+  {
+    // Both probes must come from the install and the tree being checked out: a
+    // tracked-file set from `ls-files`, and the upstream tree from `ls-tree`. The
+    // defaults inside the guard are per-path git calls; the call site batches them,
+    // and a regression that drops either seam silently disables half the rule.
+    name: 'the guard probes tracked state and the upstream tree from real git output',
+    pattern: /git\('ls-files'\)[\s\S]{0,400}?git\('ls-tree',\s*'-r',\s*'--name-only',\s*'FETCH_HEAD'\)[\s\S]{0,600}?claimsSubtree:/,
   },
   {
     name: 'apply checks out the merged manifest instead of only the local manifest',

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -323,11 +323,13 @@ function canary() {
   const targetSha = git(ROOT, 'rev-parse', 'HEAD');
   const newestOld = newestAncestorTag(targetSha);
   if (!newestOld) { console.error('No release tag is an ancestor of HEAD'); process.exit(1); }
-  const { failures } = runLeg({
+  const { failures, output } = runLeg({
     oldTag: newestOld, targetSha, label: 'canary',
     mutateMirror: (mirror, work) => {
-      // Poison commit: track cv.md and add it to SYSTEM_PATHS so the old
-      // updater checks it out over the user's CV.
+      // Poison commit: track cv.md and add it to SYSTEM_PATHS so the updater's
+      // user-layer guard must either refuse the entry or the harness must catch
+      // a byte-level clobber. Both outcomes prove this canary can go red on a
+      // dangerous manifest. A completely silent pass proves nothing.
       const wt = join(work, 'poison-wt');
       git(mirror, 'worktree', 'add', wt, 'main');
       writeFileSync(join(wt, 'cv.md'), '# CLOBBERED BY UPDATE\n');
@@ -344,8 +346,14 @@ function canary() {
     },
   });
   const clobbered = failures.some((f) => f.startsWith('user file byte-identical: cv.md'));
-  if (clobbered) { console.log('CANARY GREEN: harness detected the planted user-file clobber'); process.exit(0); }
-  console.error('CANARY RED: planted clobber was NOT detected — the harness cannot fail; do not trust its green');
+  const refused = /Refused \d+ manifest entry\(ies\) naming the user layer:[\s\S]*\bcv\.md\b/.test(output || '');
+  if (clobbered || refused) {
+    console.log(clobbered
+      ? 'CANARY GREEN: harness detected the planted user-file clobber'
+      : 'CANARY GREEN: updater refused the planted user-layer manifest entry');
+    process.exit(0);
+  }
+  console.error('CANARY RED: planted clobber was neither refused nor detected — do not trust this gate');
   process.exit(1);
 }
 


### PR DESCRIPTION
## What does this PR do?

Refuses system-manifest entries that name the user layer, before `apply()` checks anything out.

A manifest entry naming user territory makes the per-path `git checkout FETCH_HEAD -- <path>` write upstream's content over the user's own. When the target is an **untracked** file, nothing recovers it: the #2337 detector is diff-based and never sees it, so no `.bak` is written, `git stash create` captures nothing, and the backup branch holds only committed state. The abort path then deletes it as an addition `HEAD` lacks, while printing `your content was NOT overwritten`. Reproduction script in #3946.

## Related issue

Fixes #3946

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first
- [x] My PR does not include personal data
- [ ] I ran `node test-all.mjs` and all tests pass — ran it; left unticked deliberately because the suite is not green. The failures are pre-existing and unrelated; see "Tests" below.
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## What the guard refuses

Comparison is on path **segments**, treating a trailing slash as a spelling rather than a fact — `git checkout <ref> -- documents` and `-- documents/` name one tree.

- an entry equal to a declared user path, or an **ancestor** of one (`modes` would claim `modes/_profile.md`)
- a **subtree claim** inside user territory — open-ended, since upstream decides its contents in this release and every later one. Directory-ness is read from the tree being checked out, not from the slash.
- a **single file** inside a user directory that would land on a file this install does not track. Keyed to recoverability rather than intent, because `writing-samples/README.md` and `interview-prep/story-bank.md` are indistinguishable by shape, and untracked-and-present is exactly the state nothing can undo.
- **malformed spellings**: `.` / `..` / empty segments, backslashes, a leading `/`, git pathspec magic (a leading `:`, and the wildcards `*` `?` `[` that carry the same power without announcing it — a default pathspec wildcard matches `/`, so `modes/*` claims `modes/_profile.md`), and NUL bytes (which `child_process` rejects with `ERR_INVALID_ARG_VALUE` before git starts, killing `apply()` on an opaque error).

A **tracked** file inside a user directory stays allowed. Refusing those would stop new upstream docs from ever arriving — the #958 silent non-arrival. All 342 entries the real manifest ships pass unchanged.

Refusal is loud but non-fatal, and refused entries are subtracted from the completeness check — otherwise a single manifest mistake would make `apply()` exit 1 on every subsequent run, forever.

## Review notes

**The filter wraps the merged manifest, not `remoteSystemPaths`.** `apply()` self-bootstraps into the fetched updater before this point, so the local `SYSTEM_PATHS` constant is upstream's list too. I wrote the fetched-half-only version first and the repro still destroyed the file; filtering one half lets the identical entry in through the other.

**`manifestProbes()` was extracted rather than left inline.** Review asked instead for larger regexes proving the probes are consumed. A regex cannot do dataflow analysis, and I verified the gap rather than assuming it: gutting both probes to constants disabled the entire named-file half of the guard while every structural check still passed. The seam follows the same reasoning `userLayerViolations()` gives for being pure, and the probes' behaviour is now tested directly instead of pattern-matched.

**I relaxed a pre-existing assertion.** The #1998 structural check pinned `missingFromTargetManifest(remoteSystemPaths)` literally; the new filter wraps that argument, so it now pins `missingFromTargetManifest(\s*remoteSystemPaths` — still the property that matters (the *target* manifest is verified, not the local one), with the subtraction pinned by a separate check. Flagging it because it is someone else's guard, not mine.

**The canary, and what the fix costs.** `upgrade-tests.mjs --canary` went red here *because* the guard works: its poison adds `cv.md` to `SYSTEM_PATHS`, which is now refused, so the harness never sees a byte-level clobber. @chipoto69 diagnosed this and published a patch (`8efa988`), cherry-picked here with authorship preserved, so the canary greens on either detection path.

Worth stating plainly rather than leaving to be discovered: with the guard in place the refusal path **always** wins, so the `clobbered` branch is now unreachable and the `user file byte-identical` oracle is no longer exercised by anything. The gate still proves it can fail, and newly proves the guard fires — but the specific guarantee the canary was built for is gone. If you want it kept, the poison should also strip the guard from the mirrored updater, so both properties stay covered. That is your call on your own safety net, not something I wanted to decide by editing it.

**One suggestion skipped:** renaming the suite to `tests/update-system.test.mjs`. The cited rule (`{module}.test.mjs`) is CONTRIBUTING.md's **web** convention, for suites mirroring `web/src/` paths under `web/tests/`. Root-script suites follow `tests/<subject>.test.mjs` per `.coderabbit.yaml`, and 15 existing `updater-*.test.mjs` files all cover `update-system.mjs`. Renaming would add a 16th under a scheme none of the others use. Happy to change it if you would rather.

**Why the malformed-spelling check has to be the whole defence.** The checkout cannot pass `--literal-pathspecs`: it builds `:(exclude)` specs for preserved paths, so the flag would disable the very magic it depends on. There is no second line here — an entry carrying a wildcard past validation reaches git as a live pathspec. An earlier revision of this description called `--literal-pathspecs` a deliberate hot-path omission; that was wrong, and it is structurally unavailable.

## Tests

`node test-all.mjs` → **8708 passed, 1 failed**. The failure is the `web/` group (`apply-cv-resolver.test.mjs`, `explore-ai-dedup.test.mjs`), which I confirmed fails identically on a clean `origin/main` worktree — pre-existing and untouched by this change.

`node upgrade-tests.mjs --canary` → GREEN (via the refusal path, as described above).

The unit suite drives the real exported `rejectUserLayerPaths` and `manifestProbes` with explicit doubles, so it verifies the rule and the probe behaviour; the structural checks in `updater-migration-tests.mjs` pin the wiring to the real sources. Both refusal and acceptance are asserted, so neither a guard that keeps everything nor one that refuses everything can pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`update-system` now refuses manifest entries that name or overlap the user layer before checkout. This protects declared user paths, user directories, and untracked files inside user directories.

The filter applies to the merged manifest used by `apply()`. Refused entries are reported and excluded from completeness checks. Tracked system files inside user directories remain allowed.

## User impact

Users can update without losing user-layer files when a manifest entry covers them. Malformed paths and pathspec-like entries are refused. The update continues with the remaining safe entries.

## Files changed

- `update-system.mjs`: Adds `manifestProbes()` and `rejectUserLayerPaths()`; filters the merged manifest.
- `tests/updater-remote-manifest-user-paths.test.mjs`: Adds coverage for overlaps, untracked files, malformed paths, and Git probes.
- `updater-migration-tests.mjs`: Verifies merged-manifest filtering and completeness handling.
- `upgrade-tests.mjs`: Accepts explicit refusal in the upgrade canary.

System files touched: `update-system.mjs`. `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
