### PR TITLE
fix(eval): reject incomplete streams and retain reported usage

### DIFF
--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -413,44 +413,34 @@ try {
   // Streamed /api/chat is newline-delimited JSON: one object per token, the last carrying
   // done:true and the token counts.
   let acc = '', buf = '', promptCount = 0, evalCount = 0;
-  const decoder = new TextDecoder();
+  let completed = false;
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  const consumeLine = line => {
+    if (!line.trim()) return;
+    const obj = JSON.parse(line);
+    if (obj.error) throw new Error(String(obj.error));
+    if (completed) throw new Error('Unexpected data after completed evaluation');
+    if (obj.message?.content) acc += obj.message.content;
+    if (obj.done === true) {
+      if (obj.done_reason && obj.done_reason !== 'stop') {
+        throw new Error(`Incomplete evaluation: done_reason=${obj.done_reason}`);
+      }
+      completed = true;
+      promptCount = obj.prompt_eval_count ?? 0;
+      evalCount = obj.eval_count ?? 0;
+    }
+  };
   for await (const chunk of res.body) {
     buf += decoder.decode(chunk, { stream: true });
     let nl;
     while ((nl = buf.indexOf('\n')) !== -1) {
       const line = buf.slice(0, nl).trim();
       buf = buf.slice(nl + 1);
-      if (!line) continue;
-      let obj;
-      try { obj = JSON.parse(line); } catch { continue; }
-      if (obj.error) {
-        console.error(`❌  Ollama error: ${obj.error}`);
-        process.exit(1);
-      }
-      if (obj.message?.content) acc += obj.message.content;
-      if (obj.done) {
-        promptCount = obj.prompt_eval_count ?? 0;
-        evalCount = obj.eval_count ?? 0;
-      }
+      consumeLine(line);
     }
   }
-  // Flush a final line that arrived without a trailing newline. Ollama terminates every
-  // chunk with one, but a body that ends mid-line would otherwise be dropped silently.
-  const tail = buf.trim();
-  if (tail) {
-    try {
-      const obj = JSON.parse(tail);
-      if (obj.error) {
-        console.error(`❌  Ollama error: ${obj.error}`);
-        process.exit(1);
-      }
-      if (obj.message?.content) acc += obj.message.content;
-      if (obj.done) {
-        promptCount = obj.prompt_eval_count ?? promptCount;
-        evalCount = obj.eval_count ?? evalCount;
-      }
-    } catch { /* a truncated final line is not recoverable; the empty-response check below reports it */ }
-  }
+  consumeLine(buf + decoder.decode());
+  if (!completed) throw new Error('Incomplete evaluation: stream ended before done:true');
   evaluationText = acc.trim();
   // Native /api/chat reports tokens as prompt_eval_count / eval_count, not an
   // OpenAI-shaped `usage` object; map them through the shared normalizer.

--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -406,6 +406,7 @@ const headers = { 'Content-Type': 'application/json' };
 if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
 
 let evaluationText;
+let evaluationUsage = null;
 try {
   // Streaming (SSE): llama.cpp/Unsloth brauchen bei langen Generationen den
   // sofortigen Header; Non-Streaming läuft in Node/undici in den 5-Minuten-
@@ -420,6 +421,8 @@ try {
         { role: 'user', content: `JOB DESCRIPTION TO EVALUATE:\n\n${jdText}` },
       ],
       stream:      true,
+      // Compatible endpoints need not support this optional OpenAI parameter.
+      ...(endpointHost === 'api.openai.com' ? { stream_options: { include_usage: true } } : {}),
       temperature: 0.4,
     }),
     signal: AbortSignal.timeout(timeoutMs),
@@ -437,37 +440,73 @@ try {
     process.exit(1);
   }
 
-  // SSE-Zeilen akkumulieren: content + reasoning_content getrennt
+  // Keep transport EOF distinct from a successfully completed generation.
   const parts = [];
   const reader = res.body.getReader();
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder('utf-8', { fatal: true });
   let sseBuf = '';
   let thinkOpen = false;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    sseBuf += decoder.decode(value, { stream: true });
-    let nl;
-    while ((nl = sseBuf.indexOf('\n')) >= 0) {
-      const line = sseBuf.slice(0, nl).trim();
-      sseBuf = sseBuf.slice(nl + 1);
-      if (!line.startsWith('data:')) continue;
-      const payload = line.slice(5).trim();
-      if (payload === '[DONE]') continue;
-      let delta;
-      try { delta = JSON.parse(payload); } catch { continue; }
-      const d = delta.choices?.[0]?.delta ?? {};
-      if (d.reasoning_content) {
-        if (!thinkOpen) { parts.push('\n<think>\n'); thinkOpen = true; }
-        parts.push(d.reasoning_content);
-      } else {
-        if (thinkOpen) { parts.push('\n</think>\n\n'); thinkOpen = false; }
-        if (d.content) parts.push(d.content);
+  let streamDone = false;
+  let finishReason = null;
+  let answer = '';
+  let eventData = [];
+  const consumeEvent = () => {
+    if (!eventData.length) return;
+    const payload = eventData.join('\n').trim();
+    eventData = [];
+    if (payload === '[DONE]') { streamDone = true; return; }
+    const obj = JSON.parse(payload);
+    if (obj.error) throw new Error(obj.error.message || String(obj.error));
+    if (Number.isFinite(obj.usage?.prompt_tokens) && Number.isFinite(obj.usage?.completion_tokens)) {
+      evaluationUsage = {
+        ...obj.usage,
+        total_tokens: obj.usage.total_tokens ?? obj.usage.prompt_tokens + obj.usage.completion_tokens,
+      };
+    }
+    const choice = obj.choices?.[0];
+    if (choice?.finish_reason != null) {
+      finishReason = choice.finish_reason;
+      if (finishReason !== 'stop') throw new Error(`Incomplete evaluation: finish_reason=${finishReason}`);
+    }
+    const d = choice?.delta ?? {};
+    if (d.reasoning_content) {
+      if (!thinkOpen) { parts.push('\n<think>\n'); thinkOpen = true; }
+      parts.push(d.reasoning_content);
+    }
+    if (d.content) {
+      if (thinkOpen) { parts.push('\n</think>\n\n'); thinkOpen = false; }
+      parts.push(d.content);
+      answer += d.content;
+    }
+  };
+  const consumeLine = line => {
+    if (!line) consumeEvent();
+    else if (line.startsWith('data:')) eventData.push(line.slice(5).replace(/^ /, ''));
+  };
+  try {
+    while (!streamDone) {
+      const { done, value } = await reader.read();
+      sseBuf += done ? decoder.decode() : decoder.decode(value, { stream: true });
+      let nl;
+      while (!streamDone && (nl = sseBuf.indexOf('\n')) >= 0) {
+        consumeLine(sseBuf.slice(0, nl).replace(/\r$/, ''));
+        sseBuf = sseBuf.slice(nl + 1);
+      }
+      if (done) {
+        if (sseBuf) consumeLine(sseBuf.replace(/\r$/, ''));
+        consumeEvent();
+        break;
       }
     }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
   }
+  if (!streamDone && finishReason !== 'stop') throw new Error('Incomplete evaluation: stream ended before completion');
+  if (!answer.trim()) throw new Error('The endpoint returned an empty response.');
   if (thinkOpen) parts.push('\n</think>\n');
   evaluationText = parts.join('').trim();
+  if (evaluationUsage) tracker.record('evaluation', normalizeOpenAIUsage(evaluationUsage));
   if (!evaluationText) {
     console.error('❌  The endpoint returned an empty response.');
     process.exit(1);
@@ -600,4 +639,6 @@ console.log('\n' + '─'.repeat(66));
 console.log(`  Score: ${score}/5  |  Archetype: ${archetype}  |  Legitimacy: ${legitimacy}`);
 console.log('─'.repeat(66) + '\n');
 
-console.log(formatBreakdown(tracker, modelName, 'openai'));
+console.log(evaluationUsage
+  ? formatBreakdown(tracker, modelName, 'openai')
+  : `Token breakdown:\n  evaluation:    usage unavailable (endpoint did not report token counts)\n  (metadata: model=${modelName}, provider=openai)`);

--- a/tests/evaluator-stream-integrity.test.mjs
+++ b/tests/evaluator-stream-integrity.test.mjs
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { fail, linkRepoPackage, NODE, pass, rmSync, ROOT } from './helpers.mjs';
+
+const exec = promisify(execFile);
+const evaluation = 'Synthetic evaluation: caf\u00e9.\n---SCORE_SUMMARY---\nCOMPANY: Example\nROLE: Engineer\nSCORE: 4.2\nARCHETYPE: IC\nLEGITIMACY: High Confidence\n---END_SUMMARY---';
+const jd = 'Synthetic JD marker: build reliable software with a team of engineers.\n## Responsibilities\nWrite tests.';
+const systemText = message => typeof message.content === 'string' ? message.content : message.content.map(p => p.text).join('');
+function write(path, text) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, text, 'utf8');
+}
+async function fixture(engine, scenario, check) {
+  const sandbox = mkdtempSync(join(tmpdir(), 'co-eval-contract-'));
+  const code = join(sandbox, 'code');
+  const data = join(sandbox, 'data');
+  let server;
+  const requests = [];
+  try {
+    for (const file of [
+      `${engine}-eval.mjs`, 'path-resolver.mjs', 'profile-language.mjs',
+      'reserve-report-num.mjs', 'tracker-parse.mjs', 'tracker-aliases.json',
+      'tracker-utils.mjs', 'pipeline-lock.mjs', 'lib/is-main-module.mjs',
+      'lib/context-budget.mjs', 'utils/token-tracker.mjs',
+    ]) {
+      const dest = join(code, file);
+      mkdirSync(dirname(dest), { recursive: true });
+      copyFileSync(join(ROOT, file), dest);
+    }
+    linkRepoPackage(code, 'js-yaml');
+    write(join(code, 'modes/_shared.md'), '## Scoring System\nUse evidence.\n');
+    write(join(code, 'modes/oferta.md'), 'Evaluate the job.\n');
+    write(join(data, 'cv.md'), '# Synthetic Candidate\nWrites reliable software.\n');
+    write(join(data, 'config/profile.yml'), 'language:\n  output: en\n');
+    write(join(data, 'modes/_profile.md'), 'SYNTHETIC_PROFILE_TARGET: engineering roles.\n');
+    const env = Object.fromEntries(Object.entries(process.env).filter(([key]) =>
+      !/^(CAREER_OPS_|OPENAI_|OLLAMA_|DOTENV_|NODE_OPTIONS$|NODE_PATH$|HTTPS?_PROXY$|ALL_PROXY$)/i.test(key)));
+    Object.assign(env, { CAREER_OPS_ROOT: data, OPENAI_API_KEY: '', OPENAI_TIMEOUT_MS: '10000',
+      OLLAMA_TIMEOUT_MS: '10000', OLLAMA_NUM_CTX: '32768' });
+    await scenario.setup?.({ code, data, env });
+    server = createServer((req, res) => {
+      if (req.url === '/api/tags') { res.end('{"models":[]}'); return; }
+      let raw = '';
+      req.on('data', chunk => { raw += chunk; });
+      req.on('end', () => {
+        requests.push(JSON.parse(raw));
+        res.setHeader('Content-Type', engine === 'openai' ? 'text/event-stream' : 'application/x-ndjson');
+        const body = Buffer.from(scenario.body ?? complete(engine));
+        if (scenario.fragment) {
+          // Separate writes across turns, including inside the two-byte UTF-8 e-acute.
+          const split = body.indexOf(Buffer.from('\u00e9')) + 1;
+          res.write(body.subarray(0, split));
+          setImmediate(() => res.end(body.subarray(split)));
+        } else res.end(body);
+      });
+    });
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const url = `http://127.0.0.1:${server.address().port}`;
+    let output;
+    try {
+      output = { code: 0, ...await exec(NODE, [join(code, `${engine}-eval.mjs`), '--url',
+        engine === 'openai' ? `${url}/v1` : url, '--model', 'synthetic-test',
+        ...(scenario.args ?? []), jd], { cwd: sandbox, env, timeout: 20000, maxBuffer: 2 * 1024 * 1024 }) };
+    } catch (error) {
+      output = { code: error.code, stdout: error.stdout ?? '', stderr: error.stderr ?? '' };
+    }
+    await check({ ...output, requests, codeRoot: code, data, env });
+    pass(`${engine}: ${scenario.name}`);
+  } catch (error) {
+    fail(`${engine}: ${scenario.name}: ${error.message}`);
+  } finally {
+    if (server?.listening) {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+function content(engine, text = evaluation) {
+  return engine === 'openai'
+    ? `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`
+    : JSON.stringify({ message: { content: text }, done: false }) + '\n';
+}
+function terminal(engine, reason = 'stop') {
+  return engine === 'openai'
+    ? `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: reason }] })}\n\ndata: [DONE]\n\n`
+    : JSON.stringify({ message: { content: '' }, done: true, done_reason: reason, prompt_eval_count: 321, eval_count: 123 }) + '\n';
+}
+function complete(engine) { return content(engine) + terminal(engine); }
+function files(path) { return existsSync(path) ? readdirSync(path) : []; }
+
+console.log('\nEvaluator stream completion contract');
+for (const engine of ['openai', 'ollama']) {
+  const error = engine === 'openai' ? 'data: {"error":{"message":"synthetic provider failure"}}\n\n' : '{"error":"synthetic provider failure"}\n';
+  for (const scenario of [
+    { name: 'complete stream', body: complete(engine), ok: true },
+    { name: 'fragmented UTF-8', body: complete(engine), fragment: true, ok: true },
+    { name: 'terminal without trailing newline', body: complete(engine).trimEnd(), ok: true },
+    { name: 'empty stream', body: '' },
+    { name: 'EOF before terminal', body: content(engine) },
+    { name: 'in-band error after content', body: content(engine) + error },
+    { name: 'malformed middle record', body: content(engine) + (engine === 'openai' ? 'data: {broken}\n\n' : '{broken}\n') + terminal(engine) },
+    { name: 'truncated final record', body: content(engine) + (engine === 'openai' ? 'data: {"choices":' : '{"done":') },
+    { name: 'output limit reached', body: content(engine) + terminal(engine, 'length') },
+    { name: 'empty completed response', body: terminal(engine) },
+  ]) {
+    await fixture(engine, scenario, ({ code, stdout, stderr, data }) => {
+      if (scenario.ok) {
+        assert.equal(code, 0, stderr);
+        assert.ok(stdout.includes(evaluation.split('\n')[0]));
+        assert.equal(files(join(data, 'reports')).filter(f => f.endsWith('.md')).length, 1);
+        assert.equal(files(join(data, 'batch/tracker-additions')).length, 1);
+      } else {
+        assert.equal(code, 1, 'generation failure must exit 1');
+        assert.deepEqual(files(join(data, 'reports')), []);
+        assert.deepEqual(files(join(data, 'batch/tracker-additions')), []);
+        if (scenario.name.includes('in-band')) assert.match(stderr, /synthetic provider failure/);
+      }
+    });
+  }
+}
+for (const [name, body, pattern] of [
+  ['CRLF framing and SSE comment', ': keep-alive\r\n\r\n' + complete('openai').replace(/\n/g, '\r\n'), /Score: 4.2/],
+  ['multiline SSE data', 'data: {"choices": [\n' + 'data: {"delta":{"content":"Synthetic answer"}}]}\n\n' + terminal('openai'), /Synthetic answer/],
+  ['empty usage object is unavailable', content('openai') + 'data: {"choices":[],"usage":{}}\n\n' + terminal('openai'), /evaluation:\s+usage unavailable/],
+  ['usage-only final event', content('openai') + 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+    + 'data: {"choices":[],"usage":{"prompt_tokens":321,"completion_tokens":123,"total_tokens":444,"prompt_tokens_details":{"cached_tokens":200}}}\n\ndata: [DONE]\n\n', /evaluation:\s+0.3k prompt \/ 0.1k completion \(cached: 0.2k\)/],
+  ['usage unavailable', complete('openai'), /evaluation:\s+usage unavailable/],
+  ['finish reason without DONE', content('openai') + 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n', /Score: 4.2/],
+  ['DONE-only compatible endpoint', content('openai') + 'data: [DONE]', /Score: 4.2/],
+]) {
+  await fixture('openai', { name, body }, ({ code, stdout, stderr, requests }) => {
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, pattern);
+    assert.equal(requests[0].stream_options, undefined, 'do not force optional usage flags on compatible servers');
+  });
+}
+for (const [name, body] of [
+  ['filtered response', content('openai') + terminal('openai', 'content_filter')],
+  ['unsupported tool call', content('openai') + terminal('openai', 'tool_calls')],
+  ['reasoning is not an answer', 'data: {"choices":[{"delta":{"reasoning_content":"Still thinking"}}]}\n\n' + terminal('openai')],
+]) {
+  await fixture('openai', { name, body }, ({ code, data }) => {
+    assert.equal(code, 1);
+    assert.deepEqual(files(join(data, 'reports')), []);
+    assert.deepEqual(files(join(data, 'batch/tracker-additions')), []);
+  });
+}

--- a/tests/ollama-profile-context.test.mjs
+++ b/tests/ollama-profile-context.test.mjs
@@ -87,6 +87,8 @@ const server = createServer((req, res) => {
     if (req.url === '/api/chat') {
       res.end(JSON.stringify({
         message: { role: 'assistant', content: responseText },
+        done: true,
+        done_reason: 'stop',
         prompt_eval_count: 10,
         eval_count: 5,
       }));


### PR DESCRIPTION
## What does this PR do?

Prevent partial model output from becoming an Evaluated report/addition. OpenAI SSE and native Ollama NDJSON now reject in-band errors, malformed records, missing completion, output-length termination, and empty answers. SSE handles CRLF, multiline data, fragmented UTF-8, and a final record without a newline. For compatible servers, either a successful stop reason or [DONE] can complete the stream; explicit unsuccessful finish reasons are rejected.

Capture reported OpenAI usage, including usage-only final events and cached tokens. Request include_usage only from api.openai.com, so compatible servers do not receive an unsupported optional field. When usage is absent, print unavailable instead of zero-token-by-design or a fabricated zero cost.

## Related issue / overlap review

Follow-up to the streaming changes in #3501 and #3922, not a replacement. Rechecked active and historical PRs against upstream fe06051b; no equivalent fix found. Does not include #3948's allocator change or #3906's helper consolidation.

## Verification

- Initial 24-case regression matrix on unchanged upstream: 13 passed, 11 failed.
- Expanded real-CLI regression suite: **30 passed, 0 failed** (`node test-all.mjs --only evaluator-stream-integrity`).
- Existing Ollama endpoint/stream suites: 10 passed; profile suite: 3 passed; score-cell suite: 1 passed.
- Corrected the existing profile mock to include native done:true, rather than relaxing production completion checks.
- Syntax, diff whitespace checks, and updater coverage (1390 tracked files) passed.

Protocol references: [Ollama chat](https://docs.ollama.com/api/chat), [OpenAI chat completion types](https://github.com/openai/openai-node/blob/main/src/resources/chat/completions/completions.ts).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist
- [x] Read CONTRIBUTING.md; bug fixes are exempt from issue-first.
- [x] No personal data; fixtures are synthetic and disposable.
- [x] Respects the Data Contract and existing core workflow.
- [ ] Ran the full `node test-all.mjs` on this patch and all tests pass.

**Draft:** targeted tests pass, but full-suite and cross-platform verification are not complete. Windows baseline testing has exposed timeouts; these are disclosed, not assumed to be caused by this patch. No live model calls were used. Prepared with Codex assistance.
