### PR TITLE
fix(eval): include the profile and send each JD only once

### DIFF
--- a/lib/context-budget.mjs
+++ b/lib/context-budget.mjs
@@ -237,6 +237,7 @@ export function compressSharedContext(sharedContent, targetReduction) {
  * @param {string} [opts.profileYml]    - Raw profile.yml content (optional).
  * @param {string} [opts.profileContent] - Raw _profile.md content (optional).
  * @param {string} opts.jdText          - The job description text to evaluate.
+ * @param {boolean} [opts.jdInContext=true] - Embed the JD here; false when sent separately (still budgeted).
  * @param {number} [opts.maxTokens]     - Model context window (default 128000).
  * @param {number} [opts.safetyMargin]  - Reserved for output tokens (default 8192).
  * @param {boolean} [opts.noCompress]   - If true, skip compression entirely.
@@ -254,6 +255,7 @@ export function buildBudgetedPrompt(opts = {}) {
     profileYml = '',
     profileContent = '',
     jdText = '',
+    jdInContext = true,
     maxTokens = DEFAULT_MAX_TOKENS,
     safetyMargin = DEFAULT_SAFETY_MARGIN,
     noCompress = false,
@@ -300,7 +302,7 @@ export function buildBudgetedPrompt(opts = {}) {
   // If under budget or compression disabled, assemble as-is
   if (estimatedTotal <= budget || noCompress) {
     report.overBudget = estimatedTotal > budget;
-    const contextBody = assembleContext(sections.map(s => ({
+    const contextBody = assembleContext(sections.filter(s => jdInContext || s.name !== 'JD').map(s => ({
       name: s.name,
       content: s.content,
     })));
@@ -327,7 +329,7 @@ export function buildBudgetedPrompt(opts = {}) {
   report.afterTokens = compressedSections.reduce((sum, s) => sum + s.tokens, 0);
   report.overBudget = report.afterTokens > budget;
 
-  const contextBody = assembleContext(compressedSections.map(s => ({
+  const contextBody = assembleContext(compressedSections.filter(s => jdInContext || s.name !== 'JD').map(s => ({
     name: s.name,
     content: s.content,
   })));

--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -322,6 +322,7 @@ const { contextBody, budgetReport } = buildBudgetedPrompt({
   profileYml,
   profileContent,
   jdText,
+  jdInContext: false, // Sent once in the user message, still included in the budget.
   maxTokens: numCtx, // matches options.num_ctx below
 });
 

--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -58,6 +58,7 @@ const PATHS = {
   shared:  join(ROOT, 'modes', '_shared.md'),
   oferta:  join(ROOT, 'modes', 'oferta.md'),
   cv:        join(DATA_ROOT, 'cv.md'),
+  profile:   join(DATA_ROOT, 'modes', '_profile.md'),
   profileYml: join(DATA_ROOT, 'config', 'profile.yml'),
   reports:    join(DATA_ROOT, 'reports'),
   // CAREER_OPS_ADDITIONS mirrors merge-tracker.mjs:43. Writing under DATA_ROOT
@@ -316,6 +317,7 @@ console.log('\n📂  Loading context files...');
 const sharedContext = readFile(PATHS.shared,     'modes/_shared.md');
 const ofertaLogic   = readFile(PATHS.oferta,     'modes/oferta.md');
 const cvContent     = readFile(PATHS.cv,         'cv.md');
+const profileContent = readFile(PATHS.profile, 'modes/_profile.md');
 const profileYml    = readFile(PATHS.profileYml, 'config/profile.yml');
 const languageInstruction = outputLanguageInstruction(parseOutputLanguage(profileYml));
 
@@ -327,7 +329,9 @@ const { contextBody, budgetReport } = buildBudgetedPrompt({
   ofertaContent: ofertaLogic,
   cvContent,
   profileYml,
+  profileContent,
   jdText,
+  jdInContext: false, // Sent once in the user message, still included in the budget.
   noCompress,
   maxTokens: 128_000, // gpt-4o-mini context window
 });

--- a/tests/evaluator-prompt-inputs.test.mjs
+++ b/tests/evaluator-prompt-inputs.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { fail, linkRepoPackage, NODE, pass, rmSync, ROOT } from './helpers.mjs';
+
+const exec = promisify(execFile);
+const evaluation = 'Synthetic evaluation: caf\u00e9.\n---SCORE_SUMMARY---\nCOMPANY: Example\nROLE: Engineer\nSCORE: 4.2\nARCHETYPE: IC\nLEGITIMACY: High Confidence\n---END_SUMMARY---';
+const jd = 'Synthetic JD marker: build reliable software with a team of engineers.\n## Responsibilities\nWrite tests.';
+const systemText = message => typeof message.content === 'string' ? message.content : message.content.map(p => p.text).join('');
+function write(path, text) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, text, 'utf8');
+}
+async function fixture(engine, scenario, check) {
+  const sandbox = mkdtempSync(join(tmpdir(), 'co-eval-contract-'));
+  const code = join(sandbox, 'code');
+  const data = join(sandbox, 'data');
+  let server;
+  const requests = [];
+  try {
+    for (const file of [
+      `${engine}-eval.mjs`, 'path-resolver.mjs', 'profile-language.mjs',
+      'reserve-report-num.mjs', 'tracker-parse.mjs', 'tracker-aliases.json',
+      'tracker-utils.mjs', 'pipeline-lock.mjs', 'lib/is-main-module.mjs',
+      'lib/context-budget.mjs', 'utils/token-tracker.mjs',
+    ]) {
+      const dest = join(code, file);
+      mkdirSync(dirname(dest), { recursive: true });
+      copyFileSync(join(ROOT, file), dest);
+    }
+    linkRepoPackage(code, 'js-yaml');
+    write(join(code, 'modes/_shared.md'), '## Scoring System\nUse evidence.\n');
+    write(join(code, 'modes/oferta.md'), 'Evaluate the job.\n');
+    write(join(data, 'cv.md'), '# Synthetic Candidate\nWrites reliable software.\n');
+    write(join(data, 'config/profile.yml'), 'language:\n  output: en\n');
+    write(join(data, 'modes/_profile.md'), 'SYNTHETIC_PROFILE_TARGET: engineering roles.\n');
+    const env = Object.fromEntries(Object.entries(process.env).filter(([key]) =>
+      !/^(CAREER_OPS_|OPENAI_|OLLAMA_|DOTENV_|NODE_OPTIONS$|NODE_PATH$|HTTPS?_PROXY$|ALL_PROXY$)/i.test(key)));
+    Object.assign(env, { CAREER_OPS_ROOT: data, OPENAI_API_KEY: '', OPENAI_TIMEOUT_MS: '10000',
+      OLLAMA_TIMEOUT_MS: '10000', OLLAMA_NUM_CTX: '32768' });
+    await scenario.setup?.({ code, data, env });
+    server = createServer((req, res) => {
+      if (req.url === '/api/tags') { res.end('{"models":[]}'); return; }
+      let raw = '';
+      req.on('data', chunk => { raw += chunk; });
+      req.on('end', () => {
+        requests.push(JSON.parse(raw));
+        res.setHeader('Content-Type', engine === 'openai' ? 'text/event-stream' : 'application/x-ndjson');
+        const body = Buffer.from(scenario.body ?? complete(engine));
+        if (scenario.fragment) {
+          // Separate writes across turns, including inside the two-byte UTF-8 e-acute.
+          const split = body.indexOf(Buffer.from('\u00e9')) + 1;
+          res.write(body.subarray(0, split));
+          setImmediate(() => res.end(body.subarray(split)));
+        } else res.end(body);
+      });
+    });
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const url = `http://127.0.0.1:${server.address().port}`;
+    let output;
+    try {
+      output = { code: 0, ...await exec(NODE, [join(code, `${engine}-eval.mjs`), '--url',
+        engine === 'openai' ? `${url}/v1` : url, '--model', 'synthetic-test',
+        ...(scenario.args ?? []), jd], { cwd: sandbox, env, timeout: 20000, maxBuffer: 2 * 1024 * 1024 }) };
+    } catch (error) {
+      output = { code: error.code, stdout: error.stdout ?? '', stderr: error.stderr ?? '' };
+    }
+    await check({ ...output, requests, codeRoot: code, data, env });
+    pass(`${engine}: ${scenario.name}`);
+  } catch (error) {
+    fail(`${engine}: ${scenario.name}: ${error.message}`);
+  } finally {
+    if (server?.listening) {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+function content(engine, text = evaluation) {
+  return engine === 'openai'
+    ? `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`
+    : JSON.stringify({ message: { content: text }, done: false }) + '\n';
+}
+function terminal(engine, reason = 'stop') {
+  return engine === 'openai'
+    ? `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: reason }] })}\n\ndata: [DONE]\n\n`
+    : JSON.stringify({ message: { content: '' }, done: true, done_reason: reason, prompt_eval_count: 321, eval_count: 123 }) + '\n';
+}
+function complete(engine) { return content(engine) + terminal(engine); }
+function files(path) { return existsSync(path) ? readdirSync(path) : []; }
+
+console.log('\nEvaluator prompt inputs');
+for (const engine of ['openai', 'ollama']) {
+  for (const name of ['external profile', 'absent optional profile', 'marker data root']) {
+    await fixture(engine, { name, args: ['--no-save'], setup: ({ code, data, env }) => {
+      if (name === 'absent optional profile') rmSync(join(data, 'modes/_profile.md'));
+      if (name === 'marker data root') {
+        delete env.CAREER_OPS_ROOT;
+        write(join(code, '.career-ops-data'), '../data\n');
+      }
+    } }, ({ code, stdout, stderr, requests }) => {
+      assert.equal(code, 0, stderr);
+      const system = systemText(requests[0].messages[0]);
+      const user = requests[0].messages[1].content;
+      assert.ok(system.includes('Synthetic Candidate'));
+      assert.equal(system.includes('SYNTHETIC_PROFILE_TARGET'), name !== 'absent optional profile');
+      assert.equal(system.includes(jd), false, 'JD must not also be in system context');
+      assert.equal(user.split(jd).length - 1, 1, 'user message carries the one verbatim JD');
+    });
+  }
+}
+const { buildBudgetedPrompt, estimateTokens } = await import('../lib/context-budget.mjs');
+for (const noCompress of [true, false]) {
+  try {
+    const longJd = 'Synthetic requirements '.repeat(400);
+    const opts = { sharedContent: '## Writing Style\n' + 'Optional style '.repeat(300),
+      ofertaContent: 'Score the job', cvContent: 'Synthetic CV', jdText: longJd,
+      maxTokens: 4096, safetyMargin: 1500, noCompress };
+    const original = buildBudgetedPrompt(opts);
+    const separated = buildBudgetedPrompt({ ...opts, jdInContext: false });
+    assert.deepEqual(separated.budgetReport, original.budgetReport, 'JD stays budgeted once');
+    assert.ok(original.contextBody.includes(longJd), 'default behavior preserved for other engines');
+    assert.equal(separated.contextBody.includes(longJd), false);
+    assert.ok(separated.budgetReport.afterTokens >= estimateTokens(longJd));
+    pass(`separate JD remains budgeted with noCompress=${noCompress}`);
+  } catch (error) { fail(error.message); }
+}


### PR DESCRIPTION
## Description
OpenAI omitted the optional candidate profile, while both OpenAI and Ollama sent the JD twice: inside the system context and again as the user message. This could discard relevant profile guidance and spend the context allowance on duplicate input.

- Load `DATA_ROOT/modes/_profile.md` when present for OpenAI, matching the existing optional-profile behavior.
- Add a default-preserving `jdInContext` option to the shared builder. Both evaluators set it to false and retain the verbatim JD in the user message.
- Continue counting the JD in the context budget even when it is not embedded in system context.

## Related work / duplicate check
Checked current main (`fe06051b`) and existing open/closed work. Earlier Ollama profile changes (#2488, #2664) do not cover this OpenAI omission or duplicated JD. The evaluator change in #2427 concerns Gemini; this does not replace that work or #3906. No equivalent fix was found.

## Verification
- New real-CLI/local mock-server regression suite: 8 passed; all 8 failed before the fix.
- Existing context-budget: 54 passed; Ollama: 10 passed; profile-context: 3 passed.
- Changed JavaScript syntax and updater coverage check passed (1,390 tracked files).
- Combined integration currently has one unresolved evaluator exit-code failure under a concurrent full-suite run; this remains a draft while that is investigated.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist
- [x] Read CONTRIBUTING.md; bug fixes are exempt from issue-first.
- [x] No personal data; fixtures are synthetic and disposable.
- [x] Respects the Data Contract and existing core workflow.
- [ ] Ran the full `node test-all.mjs` on this patch and all tests pass.

**Draft:** targeted tests pass, but full-suite and cross-platform verification are not complete. Windows baseline testing has exposed timeouts; these are disclosed, not assumed to be caused by this patch. No live model calls were used. Prepared with Codex assistance.
