### PR TITLE
fix(paths): anchor relative tracker overrides to the codebase

### DIFF
--- a/path-resolver.mjs
+++ b/path-resolver.mjs
@@ -52,6 +52,8 @@ export function canonicalizeTrackerPath(path) {
 /**
  * Returns the canonical path to the tracker applications.md file for reading.
  * Priority: process.env.CAREER_OPS_TRACKER > root/data/applications.md > root/applications.md.
+ * Relative environment overrides are anchored to the codebase root, not cwd
+ * or rootDir (which may be an external data directory).
  *
  * @param {string} rootDir The career-ops data root directory
  * @returns {string} Canonical absolute path to the tracker file
@@ -59,7 +61,7 @@ export function canonicalizeTrackerPath(path) {
 export function resolveTrackerPath(rootDir) {
   const env = process.env.CAREER_OPS_TRACKER?.trim();
   const raw = env
-    ? env
+    ? resolve(__dirname, env)
     : existsSync(join(rootDir, 'data/applications.md'))
       ? join(rootDir, 'data/applications.md')
       : join(rootDir, 'applications.md');
@@ -80,8 +82,7 @@ export function resolveTrackerPathForWrite(root) {
     // Same canonicalization as the read path (see the re-export above): an
     // un-canonicalized env override derives divergent lock paths on symlinked
     // tmpdirs and breaks shared writer exclusion.
-    return canonicalizeTrackerPath(env);
+    return canonicalizeTrackerPath(resolve(__dirname, env));
   }
   return join(root, 'data/applications.md');
 }
-

--- a/tests/tracker-relative-override.test.mjs
+++ b/tests/tracker-relative-override.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { ROOT, pass, fail, rmSync } from './helpers.mjs';
+
+const sandbox = mkdtempSync(join(tmpdir(), 'co-relative-tracker-'));
+const cwd = process.cwd();
+const original = process.env.CAREER_OPS_TRACKER;
+try {
+  const code = join(sandbox, 'code');
+  const data = join(sandbox, 'data');
+  const a = join(sandbox, 'a');
+  const b = join(sandbox, 'b');
+  for (const dir of [code, data, a, b, join(code, 'custom'), join(data, 'data')]) mkdirSync(dir, { recursive: true });
+  copyFileSync(join(ROOT, 'path-resolver.mjs'), join(code, 'path-resolver.mjs'));
+  const { resolveTrackerPath, resolveTrackerPathForWrite } = await import(pathToFileURL(join(code, 'path-resolver.mjs')));
+  writeFileSync(join(code, 'custom', 'existing.md'), 'synthetic tracker');
+  symlinkSync(join(code, 'custom'), join(code, 'alias'), process.platform === 'win32' ? 'junction' : 'dir');
+  for (const [name, env, expected] of [
+    ['existing relative override', 'custom/existing.md', realpathSync(join(code, 'custom/existing.md'))],
+    ['missing relative override', 'new/tracker.md', join(code, 'new/tracker.md')],
+    ['symlinked directory override', 'alias/existing.md', realpathSync(join(code, 'custom/existing.md'))],
+    ['absolute override', join(code, 'custom/existing.md'), realpathSync(join(code, 'custom/existing.md'))],
+  ]) {
+    try {
+      process.env.CAREER_OPS_TRACKER = env;
+      for (const current of [a, b]) {
+        process.chdir(current);
+        assert.equal(resolveTrackerPath(data), expected, 'read target must not depend on cwd or external data root');
+        assert.equal(resolveTrackerPathForWrite(data), expected, 'write target agrees with read target');
+      }
+      pass(name);
+    } catch (error) { fail(name + ': ' + error.message); }
+  }
+  try {
+    delete process.env.CAREER_OPS_TRACKER;
+    writeFileSync(join(data, 'applications.md'), 'legacy');
+    assert.equal(resolveTrackerPath(data), realpathSync(join(data, 'applications.md')));
+    assert.equal(resolveTrackerPathForWrite(data), join(data, 'data/applications.md'));
+    writeFileSync(join(data, 'data/applications.md'), 'canonical');
+    assert.equal(resolveTrackerPath(data), realpathSync(join(data, 'data/applications.md')));
+    pass('no override keeps data-root canonical/legacy precedence');
+  } catch (error) { fail(error.message); }
+} finally {
+  process.chdir(cwd);
+  if (original === undefined) delete process.env.CAREER_OPS_TRACKER;
+  else process.env.CAREER_OPS_TRACKER = original;
+  rmSync(sandbox, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Description
A relative `CAREER_OPS_TRACKER` override currently resolves against the process working directory, so launching the same operation elsewhere can select a different tracker. Resolve it against the codebase root before canonicalization, consistently for both reads and writes, matching the documented override contract.

This anchor is the codebase, not the external data root passed by callers. Absolute overrides, canonical/legacy fallback precedence, and realpath canonicalization are preserved.

**Compatibility:** users who intentionally relied on the old working-directory-relative behavior should use an absolute override to preserve their chosen target.

## Related work / duplicate check
Checked current main (`fe06051b`) and existing open/closed work. #3932 changes the Go dashboard tracker path; this patch only changes the Node resolver and does not duplicate that patch. No equivalent Node fix was found.

## Verification
- 5 new regression cases passed; before the fix, 2 passed and 3 failed.
- Covers different working directories, existing/missing relative targets, absolute overrides, directory symlinks/junctions, and fallback defaults.
- Existing tracker-utils: 6 passed; tracker-cwd-independence: 4 passed.
- Combined-branch tracker tests: 5 passed.
- JavaScript syntax and updater coverage passed (1,390 tracked files).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist
- [x] Read CONTRIBUTING.md; bug fixes are exempt from issue-first.
- [x] No personal data; fixtures are synthetic and disposable.
- [x] Respects the Data Contract and existing core workflow.
- [ ] Ran the full `node test-all.mjs` on this patch and all tests pass.

**Draft:** targeted tests pass, but full-suite and cross-platform verification are not complete. Windows baseline testing has exposed timeouts; these are disclosed, not assumed to be caused by this patch. No live model calls were used. Prepared with Codex assistance.
