### PR TITLE
fix(update-system): a preserved directory with an unreadable upstream lookup no longer aborts the whole update (#3824)

### DIFF
--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { pass, fail } from './helpers.mjs';
-import { gitIn, locallyModifiedSystemFiles, pathFullyPreserved } from '../update-system.mjs';
+import { gitIn, locallyModifiedSystemFiles, pathFullyPreserved, checkoutErrorIsBenign } from '../update-system.mjs';
 
 // A repo with an `upstream` branch standing in for FETCH_HEAD, and `main` as
 // the install. Both start from a shared base commit, which is what gives
@@ -347,8 +347,8 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
   }
 }
 
-// ── 9f. pathFullyPreserved: an unreadable upstream lookup degrades to "not
-//    fully preserved" for a directory, never throws ──
+// ── 9f. pathFullyPreserved: an unreadable upstream lookup is 'unknown' for a
+//    directory (not false), and never throws (#3824) ──
 {
   const preservedPaths = ['modes/pdf.md'];
   const preservedSet = new Set(preservedPaths);
@@ -361,10 +361,39 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
   } catch {
     threw = true;
   }
-  if (!threw && result === false) {
-    pass('an unreadable directory lookup degrades to "not fully preserved" instead of throwing');
+  if (!threw && result === 'unknown') {
+    pass('an unreadable directory lookup returns "unknown" instead of throwing or claiming "not preserved"');
   } else {
-    fail(`#9f threw=${threw} result=${result}`);
+    fail(`#9f threw=${threw} result=${JSON.stringify(result)}`);
+  }
+}
+
+// ── 9g. checkoutErrorIsBenign: the cancel-out abort a fully-preserved
+//    directory with an unreadable ls-tree used to trigger is now benign (#3824) ──
+{
+  // The error git actually raises when :(exclude) pathspecs cancel a checkout
+  // out (pinned live in section 9 above); stderr is where gitQuiet surfaces it.
+  const cancelOut = Object.assign(new Error('Command failed: git checkout FETCH_HEAD -- modes/'), {
+    stderr: "error: pathspec 'modes/' did not match any file(s) known to git\n",
+  });
+  const realFailure = Object.assign(new Error('Command failed: git checkout FETCH_HEAD -- modes/'), {
+    stderr: 'fatal: unable to write new index file\n',
+  });
+
+  const ok =
+    // 'unknown' + cancel-out message → benign, so apply() skips instead of aborting
+    checkoutErrorIsBenign(cancelOut, { absentUpstream: false, preservedState: 'unknown' }) === true &&
+    // 'unknown' + a real failure → still rethrown
+    checkoutErrorIsBenign(realFailure, { absentUpstream: false, preservedState: 'unknown' }) === false &&
+    // a genuinely absent path stays benign regardless of the message
+    checkoutErrorIsBenign(realFailure, { absentUpstream: true, preservedState: false }) === true &&
+    // 'false' (real content not preserved) never softens a cancel-out message
+    checkoutErrorIsBenign(cancelOut, { absentUpstream: false, preservedState: false }) === false;
+
+  if (ok) {
+    pass('checkoutErrorIsBenign: cancel-out is benign only for an "unknown" directory, real failures still abort');
+  } else {
+    fail('#9g checkoutErrorIsBenign did not gate the cancel-out message correctly');
   }
 }
 

--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { pass, fail } from './helpers.mjs';
-import { gitIn, locallyModifiedSystemFiles, pathFullyPreserved, checkoutErrorIsBenign } from '../update-system.mjs';
+import { gitIn, locallyModifiedSystemFiles, pathFullyPreserved, checkoutErrorIsBenign, probeAbsentUpstream } from '../update-system.mjs';
 
 // A repo with an `upstream` branch standing in for FETCH_HEAD, and `main` as
 // the install. Both start from a shared base commit, which is what gives
@@ -394,6 +394,45 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     pass('checkoutErrorIsBenign: cancel-out is benign only for an "unknown" directory, real failures still abort');
   } else {
     fail('#9g checkoutErrorIsBenign did not gate the cancel-out message correctly');
+  }
+}
+
+// ── 9h. probeAbsentUpstream — the helper apply()'s catch calls, driven
+//    directly against a real repo AND with a throwing probe (#1998, #3824,
+//    #3955 review): a retired path lists empty → benign skip; a present path
+//    does not → real error rethrows; a probe that THROWS → false, never a skip ──
+{
+  const repo = makeRepo();
+  repo.g('fetch', '.', 'upstream'); // populate FETCH_HEAD, same ref apply() uses
+  const ctx = { git: (...args) => gitIn(repo.dir, ...args) };
+
+  // 'modes/pdf.md' is in the tree; 'lib/retired.mjs' never was — the shape of a
+  // SYSTEM_PATHS entry removed upstream but still present on an old install.
+  const retiredIsAbsent = probeAbsentUpstream('lib/retired.mjs', ctx);
+  const presentIsAbsent = probeAbsentUpstream('modes/pdf.md', ctx);
+
+  // The regression this guards: a probe that could not run must NOT report
+  // absence, or a real checkout failure gets masked as an expected skip.
+  const throwingProbe = probeAbsentUpstream('modes/pdf.md', {
+    git: () => { throw new Error('fatal: not a git repository'); },
+  });
+
+  const realCheckoutFailure = Object.assign(new Error('git checkout FETCH_HEAD -- modes/'), {
+    stderr: 'fatal: unable to write new index file\n',
+  });
+
+  const ok =
+    retiredIsAbsent === true &&
+    presentIsAbsent === false &&
+    throwingProbe === false &&
+    // composed the way apply()'s catch does: retired path → skip, throwing probe → rethrow
+    checkoutErrorIsBenign(realCheckoutFailure, { absentUpstream: retiredIsAbsent, preservedState: false }) === true &&
+    checkoutErrorIsBenign(realCheckoutFailure, { absentUpstream: throwingProbe, preservedState: false }) === false;
+
+  if (ok) {
+    pass('probeAbsentUpstream: a retired path skips, a present path and a throwing probe both rethrow');
+  } else {
+    fail(`#9h retired=${retiredIsAbsent} present=${presentIsAbsent} throwing=${throwingProbe}`);
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1267,39 +1267,35 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
  * preserved by definition — the match IS the file's only content, so no
  * upstream lookup can add information. Only a directory `path` needs the
  * upstream ls-tree lookup, to confirm EVERY file it would check out is
- * preserved; an unreadable lookup degrades to "not fully preserved" so the
- * real checkout runs and reports its own diagnostics, same contract as
- * `locallyModifiedSystemFiles`.
+ * preserved.
  *
- * Two limits are deliberate, both raised in review of #3781:
+ * Tri-state, because for a directory the ls-tree lookup can fail and `false`
+ * would then mean two different things (#3824):
  *
- * 1. The single-file shortcut diverges from the pre-extraction inline check
- *    for a preserved file ABSENT from FETCH_HEAD. That check fell through to
- *    the real checkout, which failed and put the path in apply()'s "Skipped
- *    N path(s) absent upstream" summary; this returns true and skips it
- *    silently. Unreachable while preserved paths come from
- *    `locallyModifiedSystemFiles`, which only reports files that exist
- *    upstream (it gates each candidate on `cat-file -e <ref>:<file>`), so
- *    nothing today can construct the case — but it is a real divergence, not
- *    a behaviour-preserving one, and a future caller sourcing preservedPaths
- *    some other way would hit it.
+ *   - `true`    — nothing is left to check out; apply() skips the entry.
+ *   - `false`   — real upstream content is not preserved; apply() checks it
+ *                 out and any error it hits is a genuine failure.
+ *   - `'unknown'` — the directory's upstream content could not be enumerated
+ *                 (unreadable ls-tree). apply() still checks it out, but a
+ *                 "did not match any file(s)" cancel-out error is then benign:
+ *                 the directory may in fact have been fully preserved, and
+ *                 that is not distinguishable here from a real failure without
+ *                 matching git's stderr at the call site.
  *
- * 2. The directory branch's `catch → false` does NOT close the cancel-out
- *    abort for directories. A throwing ls-tree still falls through to
- *    `git checkout FETCH_HEAD -- modes/ :(exclude)modes/pdf.md`, which
- *    aborts the update when the directory happens to be fully preserved.
- *    That is exactly the pre-extraction behaviour, carried over unchanged —
- *    this function makes the check testable and drops a redundant lookup for
- *    the single-file case; it does not fix the directory case. Closing it
- *    needs a tri-state result whose "unknown" makes the checkout's "did not
- *    match any file(s)" benign at the call site; tracked separately rather
- *    than folded in here, since that means matching on git's stderr text.
+ * One limit is deliberate, raised in review of #3781: the single-file
+ * shortcut diverges from the pre-extraction inline check for a preserved file
+ * ABSENT from FETCH_HEAD (that check fell through to the real checkout and
+ * listed the path in apply()'s "Skipped N path(s) absent upstream" summary;
+ * this returns true and skips it silently). Unreachable while preserved paths
+ * come from `locallyModifiedSystemFiles`, which only reports files that exist
+ * upstream, but a future caller sourcing preservedPaths another way would hit
+ * it.
  *
  * @param {string} path - a SYSTEM_PATHS entry, file or `dir/`-suffixed directory.
  * @param {string[]} preservedPaths - files this run is keeping local content for.
  * @param {Set<string>} preservedSet - the same paths, as a Set, for lookup.
  * @param {{git?: Function}} [ctx] - injection point for tests; defaults to gitQuiet.
- * @returns {boolean}
+ * @returns {boolean | 'unknown'}
  */
 export function pathFullyPreserved(path, preservedPaths, preservedSet, ctx = {}) {
   if (preservedSet.size === 0) return false;
@@ -1313,9 +1309,44 @@ export function pathFullyPreserved(path, preservedPaths, preservedSet, ctx = {})
     upstreamFiles = runGitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', path)
       .split('\n').map((f) => f.trim()).filter(Boolean);
   } catch {
-    return false;
+    // Can't enumerate the directory's upstream content: it might be fully
+    // preserved (skip) or not (check out). The call site checks it out and
+    // treats a cancel-out error as benign — see checkoutErrorIsBenign.
+    return 'unknown';
   }
   return upstreamFiles.length > 0 && upstreamFiles.every((f) => preservedSet.has(f));
+}
+
+// git's pathspec cancel-out message. `git checkout <ref> -- <dir>/ :(exclude)…`
+// prints `error: pathspec '<dir>/' did not match any file(s) known to git` when
+// the exclusions leave nothing to check out. Match loosely: the wording has
+// been stable for years but the quoting and the "known to git" tail vary.
+const PATHSPEC_CANCELLED_RE = /did not match any file/i;
+
+/**
+ * Whether a checkout error thrown inside apply()'s per-path loop is a benign
+ * skip rather than a real failure that must abort the update.
+ *
+ * Two benign shapes:
+ *   - `absentUpstream` — the path is genuinely gone from FETCH_HEAD (a stale
+ *     SYSTEM_PATHS entry such as an old `.gemini/commands/` directory).
+ *   - a `pathFullyPreserved` result of `'unknown'` paired with git's pathspec
+ *     cancel-out message — the directory's upstream content could not be
+ *     enumerated up front, the exclusion pathspecs cancelled the whole
+ *     checkout out, and nothing was left to install (#3824).
+ *
+ * Anything else — timeouts, permission errors, repo corruption — is a real
+ * failure and is rethrown by the caller.
+ *
+ * @param {unknown} err - the error execFileSync threw.
+ * @param {{absentUpstream: boolean, preservedState: boolean | 'unknown'}} opts
+ * @returns {boolean}
+ */
+export function checkoutErrorIsBenign(err, { absentUpstream, preservedState }) {
+  if (absentUpstream) return true;
+  if (preservedState !== 'unknown') return false;
+  const text = `${(err && err.stderr) || ''}\n${(err && err.message) || ''}`;
+  return PATHSPEC_CANCELLED_RE.test(text);
 }
 
 /**
@@ -2235,9 +2266,12 @@ async function apply() {
       // `git checkout <ref> -- <path> :(exclude)<path>` errors with "did not
       // match any file(s)" when the exclusions cancel the whole pathspec — and
       // that error is indistinguishable from a genuine failure at the catch
-      // below, so it would abort the entire update. Skip the entry instead when
-      // nothing would be left to check out (see pathFullyPreserved).
-      if (pathFullyPreserved(path, preservedPaths, preservedSet)) continue;
+      // below, so it would abort the entire update. Skip the entry outright
+      // when nothing would be left to check out; when the directory's upstream
+      // content could not be enumerated ('unknown'), still check it out but let
+      // the catch treat a cancel-out error as benign (#3824).
+      const preservedState = pathFullyPreserved(path, preservedPaths, preservedSet);
+      if (preservedState === true) continue;
       try {
         // stderr is piped rather than inherited here. A path absent upstream is
         // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),
@@ -2253,11 +2287,15 @@ async function apply() {
         // reported them as skips too — letting a partial update reach the
         // success banner (#1998). Confirm the path is actually absent from
         // FETCH_HEAD before treating the failure as benign; otherwise rethrow.
+        // A fully-preserved directory whose upstream content we could not
+        // enumerate up front ('unknown') is the second benign shape: the
+        // exclusions cancelled the checkout out and git said "did not match
+        // any file(s)" (#3824).
         const spec = path.endsWith('/') ? path.slice(0, -1) : path;
         let absentUpstream = false;
         try { gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`); }
         catch { absentUpstream = true; }
-        if (!absentUpstream) throw err;
+        if (!checkoutErrorIsBenign(err, { absentUpstream, preservedState })) throw err;
         skippedPaths.push(path);
       }
     }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1350,6 +1350,31 @@ export function checkoutErrorIsBenign(err, { absentUpstream, preservedState }) {
 }
 
 /**
+ * Whether `spec` is absent from FETCH_HEAD's tree — the answer that makes a
+ * checkout failure in apply()'s per-path loop a benign skip rather than a real
+ * error to rethrow (#1998, #3824).
+ *
+ * Only a SUCCESSFUL empty `git ls-tree --name-only FETCH_HEAD -- <spec>` counts:
+ * ls-tree prints the entry when the path is in the tree and nothing when it is
+ * not, both at exit 0. A THROW (bad ref, unreadable repo, timeout) is the probe
+ * failing to run, not an answer — return false so the checkout error rethrows
+ * instead of being masked as a skip. Extracted from apply()'s catch so the
+ * throwing-probe path is testable without running apply() (#3955 review).
+ *
+ * @param {string} spec - path to probe; a `dir/` entry is passed without its trailing slash.
+ * @param {{git?: Function}} [ctx] - injection point for tests; defaults to gitQuiet.
+ * @returns {boolean}
+ */
+export function probeAbsentUpstream(spec, ctx = {}) {
+  const runGitQuiet = ctx.git || gitQuiet;
+  try {
+    return runGitQuiet('ls-tree', '--name-only', 'FETCH_HEAD', '--', spec).trim() === '';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Preserve byte-for-byte copies of system files before an unavoidable
  * overwrite. The self-bootstrap stage cannot use the normal "keep local"
  * path: it must load the fetched updater to remain forward-compatible. A
@@ -2292,9 +2317,7 @@ async function apply() {
         // exclusions cancelled the checkout out and git said "did not match
         // any file(s)" (#3824).
         const spec = path.endsWith('/') ? path.slice(0, -1) : path;
-        let absentUpstream = false;
-        try { gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`); }
-        catch { absentUpstream = true; }
+        const absentUpstream = probeAbsentUpstream(spec);
         if (!checkoutErrorIsBenign(err, { absentUpstream, preservedState })) throw err;
         skippedPaths.push(path);
       }

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -379,11 +379,14 @@ const twoPassManifestChecks = [
     pattern: /ls-tree', '-r', '--name-only', 'FETCH_HEAD'[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
   },
   {
-    // A checkout failure is only an expected skip when the path is truly absent
-    // from FETCH_HEAD; timeouts/permission errors must rethrow, not report
-    // success (#1998 CodeRabbit review).
-    name: 'a checkout failure only skips when the path is absent upstream, else rethrows (#1998)',
-    pattern: /catch \{ absentUpstream = true; \}\s*if \(!absentUpstream\) throw err;/,
+    // A checkout failure is an expected skip only when the path is truly absent
+    // from FETCH_HEAD, or (for a directory whose upstream content could not be
+    // enumerated, #3824) when the exclusions cancelled the pathspec out.
+    // Timeouts/permission errors must rethrow, not report success
+    // (#1998 CodeRabbit review). The rethrow condition routes through the
+    // checkoutErrorIsBenign predicate so both shapes are decided in one place.
+    name: 'a checkout failure only skips when it is benign, else rethrows (#1998, #3824)',
+    pattern: /catch \{ absentUpstream = true; \}[\s\S]{0,400}?if \(!checkoutErrorIsBenign\(err, \{ absentUpstream, preservedState \}\)\) throw err;/,
   },
   {
     // `git checkout HEAD -- docs/` restores tracked content but never removes

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -379,14 +379,22 @@ const twoPassManifestChecks = [
     pattern: /ls-tree', '-r', '--name-only', 'FETCH_HEAD'[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
   },
   {
-    // A checkout failure is an expected skip only when the path is truly absent
-    // from FETCH_HEAD, or (for a directory whose upstream content could not be
-    // enumerated, #3824) when the exclusions cancelled the pathspec out.
-    // Timeouts/permission errors must rethrow, not report success
-    // (#1998 CodeRabbit review). The rethrow condition routes through the
-    // checkoutErrorIsBenign predicate so both shapes are decided in one place.
-    name: 'a checkout failure only skips when it is benign, else rethrows (#1998, #3824)',
-    pattern: /catch \{ absentUpstream = true; \}[\s\S]{0,400}?if \(!checkoutErrorIsBenign\(err, \{ absentUpstream, preservedState \}\)\) throw err;/,
+    // A checkout failure is an expected skip only when `probeAbsentUpstream`
+    // returns true (a SUCCESSFUL empty `ls-tree` — the path is truly gone from
+    // FETCH_HEAD), or — for a directory whose upstream content could not be
+    // enumerated (#3824) — when the exclusions cancelled the pathspec out. A
+    // thrown probe, a timeout or a permission error must rethrow, not report
+    // success (#1998). The catch must NOT set `absentUpstream` any other way:
+    // an inline `catch { absentUpstream = true }` is exactly the regression.
+    name: 'the checkout catch derives absentUpstream only from probeAbsentUpstream (#1998, #3824)',
+    pattern: /const absentUpstream = probeAbsentUpstream\(spec\);\s*if \(!checkoutErrorIsBenign\(err, \{ absentUpstream, preservedState \}\)\) throw err;/,
+  },
+  {
+    name: 'the checkout catch never assigns absentUpstream = true directly (#1998 regression)',
+    // The old blanket `catch { absentUpstream = true }` — must not reappear in
+    // the per-path checkout loop.
+    pattern: /absentUpstream = true;?\s*\}/,
+    expectAbsent: true,
   },
   {
     // `git checkout HEAD -- docs/` restores tracked content but never removes
@@ -424,7 +432,9 @@ const twoPassManifestChecks = [
 ];
 
 for (const check of twoPassManifestChecks) {
-  if (check.pattern.test(source)) pass(check.name);
+  const present = check.pattern.test(source);
+  const want = check.expectAbsent ? !present : present;
+  if (want) pass(check.name);
   else fail(check.name);
 }
 


### PR DESCRIPTION
Closes #3824.

## The bug

`pathFullyPreserved()` returns a boolean. For a `dir/` entry, an unreadable `ls-tree` on `FETCH_HEAD` degrades to `false` — "not fully preserved, run the real checkout". But when every upstream file under that directory *is* preserved, `git checkout FETCH_HEAD -- modes/ :(exclude)modes/a.md :(exclude)modes/b.md` has its whole pathspec cancelled out, git exits with `error: pathspec 'modes/' did not match any file(s) known to git`, and apply()'s catch — which can't tell that from a genuine checkout failure — rethrows and **aborts the entire update over files the user explicitly asked to keep**.

@santifer confirmed the shape on #3824:

> Right shape — three states, and the "unknown" row (check out, but treat the cancel-out error as benign) is what a boolean can't say.

Pre-existing, not a regression: #3781 extracted this check and carried the directory branch over from the pre-extraction inline version unchanged (limit #2 in its docstring, now removed).

## The fix

- **`pathFullyPreserved()` is tri-state:** `true` (skip the entry) · `false` (check it out; any error is real) · `'unknown'` (check it out, but a cancel-out error is benign — the directory may have been fully preserved after all).
- A small exported **`checkoutErrorIsBenign(err, { absentUpstream, preservedState })`** turns the call-site decision into one testable predicate. It softens only the specific `'unknown'` + "did not match any file" pairing; timeouts, permission errors and repo corruption are still rethrown, so #1998's "don't report a partial update as success" guarantee is intact.
- apply()'s per-path loop captures the tri-state and passes it through.

## Tests — `tests/updater-local-system-edits.test.mjs`

- **9f updated:** an unreadable directory lookup now returns `'unknown'` (not `false`), still never throws.
- **9g added:** `checkoutErrorIsBenign` directly — a cancel-out message is benign only for an `'unknown'` directory; an absent path stays benign regardless of the message; a real failure and a `false` state both still abort.
- 9d/9e (successful `ls-tree`, `true`/`false`) unchanged and green — the pre-existing directory behaviour is not regressed.
- `updater-migration-tests.mjs`: the source-pattern check that pinned the old rethrow line is re-pointed at the `checkoutErrorIsBenign` guard, same intent.

## Test plan

- [x] `node --test tests/updater-*.test.mjs` — all green
- [x] `node updater-migration-tests.mjs` — 368 passed, 0 failed
- [x] `node test-all.mjs` — 8688 passed, 0 failed (16 pre-existing warnings: external board 503s, Workday truncation notes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can update repositories when a preserved directory has an unreadable upstream `ls-tree` lookup.

`update-system.mjs:1300-1378` adds tri-state preservation, strict pathspec-error matching, and upstream-absence probing. `apply():2304-2327` checks out unknown directories but ignores only the specific cancellation error. Other checkout failures still abort the update.

Tests cover preserved, non-preserved, unknown, absent-upstream, and failure cases: `tests/updater-local-system-edits.test.mjs:269-452` and `updater-migration-tests.mjs:382-391`.

System files checked: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`. Only `update-system.mjs` changed among these system files. Test files also changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->