### PR TITLE
fix(scan): recheck_after_days frees a row, then pipeline.md pins it again

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1574,19 +1574,20 @@ export function collectSeenUrls(sources = {}, policy = {}, { extraTokensFor } = 
   // under `## Processed`, is finished work: no queue entry can be duplicated, so
   // the scan-history TTL is allowed to govern it alone. Release also requires the
   // URL to be a recheck candidate, so a pipeline-only URL is never un-pinned.
+  // Sections are `##` in PIPELINE_SKELETON — `# Pipeline` is the document title,
+  // `## Pending` and `## Processed` are the sections. So only a level-2 heading
+  // opens or closes one; anything deeper is a subdivision INSIDE the current
+  // section and must leave the section alone. Matching `Processed` at any depth
+  // breaks both ways: `### Processed leftovers` under `## Pending` would release
+  // rows that are still queued for work — the exact duplication this function
+  // exists to prevent — while `### August` under `## Processed` has to keep the
+  // section open.
+  const SECTION_LEVEL = 2;
   let inProcessed = false;
-  let processedHeadingLevel = 0;
   for (const line of pipelineText.split('\n')) {
     const heading = line.match(/^(#+)\s+(.*)$/);
-    if (heading) {
-      const level = heading[1].length;
-      if (/^processed\b/i.test(heading[2].trim())) {
-        inProcessed = true;
-        processedHeadingLevel = level;
-      } else if (inProcessed && level <= processedHeadingLevel) {
-        inProcessed = false;
-        processedHeadingLevel = 0;
-      }
+    if (heading && heading[1].length === SECTION_LEVEL) {
+      inProcessed = /^processed\b/i.test(heading[2].trim());
     }
     const url = extractPipelineUrl(line);
     if (!url) continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -1575,9 +1575,19 @@ export function collectSeenUrls(sources = {}, policy = {}, { extraTokensFor } = 
   // the scan-history TTL is allowed to govern it alone. Release also requires the
   // URL to be a recheck candidate, so a pipeline-only URL is never un-pinned.
   let inProcessed = false;
+  let processedHeadingLevel = 0;
   for (const line of pipelineText.split('\n')) {
-    const heading = line.match(/^#+\s+(.*)$/);
-    if (heading) inProcessed = /^processed\b/i.test(heading[1].trim());
+    const heading = line.match(/^(#+)\s+(.*)$/);
+    if (heading) {
+      const level = heading[1].length;
+      if (/^processed\b/i.test(heading[2].trim())) {
+        inProcessed = true;
+        processedHeadingLevel = level;
+      } else if (inProcessed && level <= processedHeadingLevel) {
+        inProcessed = false;
+        processedHeadingLevel = 0;
+      }
+    }
     const url = extractPipelineUrl(line);
     if (!url) continue;
     const key = normalizeUrlForDedup(url);

--- a/scan.mjs
+++ b/scan.mjs
@@ -1575,19 +1575,29 @@ export function collectSeenUrls(sources = {}, policy = {}, { extraTokensFor } = 
   // the scan-history TTL is allowed to govern it alone. Release also requires the
   // URL to be a recheck candidate, so a pipeline-only URL is never un-pinned.
   // Sections are `##` in PIPELINE_SKELETON — `# Pipeline` is the document title,
-  // `## Pending` and `## Processed` are the sections. So only a level-2 heading
-  // opens or closes one; anything deeper is a subdivision INSIDE the current
-  // section and must leave the section alone. Matching `Processed` at any depth
-  // breaks both ways: `### Processed leftovers` under `## Pending` would release
-  // rows that are still queued for work — the exact duplication this function
-  // exists to prevent — while `### August` under `## Processed` has to keep the
-  // section open.
+  // `## Pending` and `## Processed` are the sections. Heading depth decides what
+  // a heading does, in both directions:
+  //
+  //   deeper than a section (`###`)  a subdivision INSIDE it; changes nothing,
+  //                                  so `### August` under `## Processed` stays
+  //                                  released and `### Processed leftovers`
+  //                                  under `## Pending` releases nothing
+  //   at section level (`##`)        ends the previous section and opens this
+  //                                  one; released only if it is `Processed`
+  //   shallower (`#`)                outranks a section, so it ends it too — a
+  //                                  `# Backlog` after `## Processed` must not
+  //                                  inherit the released state
+  //
+  // Both failures are the same failure: a row that is still queued gets handed
+  // back to the scanner, which appends a second copy of a job already on the
+  // list. That duplication is what this function exists to prevent.
   const SECTION_LEVEL = 2;
   let inProcessed = false;
   for (const line of pipelineText.split('\n')) {
     const heading = line.match(/^(#+)\s+(.*)$/);
-    if (heading && heading[1].length === SECTION_LEVEL) {
-      inProcessed = /^processed\b/i.test(heading[2].trim());
+    if (heading && heading[1].length <= SECTION_LEVEL) {
+      inProcessed = heading[1].length === SECTION_LEVEL
+        && /^processed\b/i.test(heading[2].trim());
     }
     const url = extractPipelineUrl(line);
     if (!url) continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -1539,7 +1539,11 @@ function extractPipelineCompanyRole(line) {
 export function collectSeenUrls(sources = {}, policy = {}, { extraTokensFor } = {}) {
   const { scanHistoryText = '', pipelineText = '', applicationsText = '' } = sources;
   const seen = new Set();
-  let recheckEligible = 0;
+  // Rows the age policy has released. Held rather than counted here: the two
+  // sources parsed below carry no age policy of their own, so a row the TTL has
+  // just freed can be re-pinned a few lines later. The count is taken at the end,
+  // against the finished set, so it reports what is actually rescannable.
+  const recheckCandidates = new Set();
 
   // scan-history.tsv
   for (const line of scanHistoryText.split('\n').slice(1)) { // skip header
@@ -1552,21 +1556,46 @@ export function collectSeenUrls(sources = {}, policy = {}, { extraTokensFor } = 
           if (token) seen.add(token);
         }
       }
-    } else recheckEligible++;
+    } else recheckCandidates.add(normalizeUrlForDedup(url));
   }
 
   // pipeline.md — extract URLs from checkbox lines, wherever the URL sits in the
   // line (see extractPipelineUrl: five of the six documented shapes lead with a
   // report number, a report link, or a strikethrough rather than the URL).
+  //
+  // This loop carried no age policy, which is what made
+  // `scan_history.recheck_after_days` a no-op: on an install that has been
+  // scanning for a while every URL the TTL releases above is listed here too, so
+  // it was re-pinned immediately and the window never freed anything.
+  //
+  // What may be released is decided by whether the row is still ACTIONABLE. A
+  // `- [ ]` row is a line the user can still pull from, and re-scanning it would
+  // append a SECOND copy of a job already on the list. A `- [x]` row, or any row
+  // under `## Processed`, is finished work: no queue entry can be duplicated, so
+  // the scan-history TTL is allowed to govern it alone. Release also requires the
+  // URL to be a recheck candidate, so a pipeline-only URL is never un-pinned.
+  let inProcessed = false;
   for (const line of pipelineText.split('\n')) {
+    const heading = line.match(/^#+\s+(.*)$/);
+    if (heading) inProcessed = /^processed\b/i.test(heading[1].trim());
     const url = extractPipelineUrl(line);
-    if (url) seen.add(normalizeUrlForDedup(url));
+    if (!url) continue;
+    const key = normalizeUrlForDedup(url);
+    const done = /^\s*- \[x\]/i.test(line);
+    if ((done || inProcessed) && recheckCandidates.has(key)) continue;
+    seen.add(key);
   }
 
   // applications.md — extract URLs from report links and any inline URLs
   for (const match of applicationsText.matchAll(/https?:\/\/[^\s|)]+/g)) {
     seen.add(normalizeUrlForDedup(match[0]));
   }
+
+  // Counted against the finished set: a released row that applications.md or an
+  // actionable pipeline row pinned again is not eligible, and saying so keeps the
+  // number the scanners print honest.
+  let recheckEligible = 0;
+  for (const key of recheckCandidates) if (!seen.has(key)) recheckEligible++;
 
   return { seen, recheckEligible };
 }

--- a/tests/scan-recheck-pipeline-repin.test.mjs
+++ b/tests/scan-recheck-pipeline-repin.test.mjs
@@ -1,0 +1,113 @@
+// tests/scan-recheck-pipeline-repin.test.mjs — `scan_history.recheck_after_days`
+// must actually release a row, and must not release one that is still queued.
+//
+// collectSeenUrls builds the seen-set from three sources. Only the first,
+// scan-history.tsv, consults the age policy; pipeline.md and applications.md are
+// parsed with no policy at all. Every URL in scan-history that has ever been
+// queued is also in pipeline.md, so a row the TTL released was re-pinned a few
+// lines later and the window freed nothing on any install with a pipeline —
+// which is every install past its first run. The counter said otherwise: it was
+// incremented at the release site, before the two later sources could pin the
+// row again, so it reported rows as "eligible again" that the same call had
+// already put back in the set.
+//
+// The release cannot be unconditional, and that is the other half of the
+// invariant. A `- [ ]` row under ## Pending is a line the user can still pull
+// from: re-scanning it appends a SECOND copy of a job already on the list. Only
+// finished work — `- [x]`, or anything under ## Processed — is safe to hand back
+// to the TTL, and only when scan-history is what released it. A pipeline-only
+// URL has no scan-history row to have released it, so it stays pinned whatever
+// its checkbox says.
+import { pass, fail, finish } from './helpers.mjs';
+import { collectSeenUrls } from '../scan.mjs';
+
+console.log('\nscan.mjs — recheck_after_days survives the pipeline.md pass');
+
+const HEADER = 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation';
+const DONE = 'https://boards.greenhouse.io/acme/jobs/1';
+const OPEN = 'https://boards.greenhouse.io/acme/jobs/2';
+const PROCESSED = 'https://jobs.lever.co/beta/3';
+const PIPELINE_ONLY = 'https://jobs.ashbyhq.com/gamma/4';
+const FRESH = 'https://boards.greenhouse.io/delta/5';
+
+// today = 2026-08-07, window = 30d. The 2026-01-01 rows are past it; the
+// 2026-08-01 row is inside it.
+const POLICY = { recheckAfterDays: 30, today: '2026-08-07' };
+
+const SOURCES = {
+  scanHistoryText: [
+    HEADER,
+    `${DONE}\t2026-01-01\tgreenhouse\tQuant\tAcme\tadded\tNY`,
+    `${OPEN}\t2026-01-01\tgreenhouse\tTrader\tAcme\tadded\tNY`,
+    `${PROCESSED}\t2026-01-01\tlever\tSRE\tBeta\tadded\tBerlin`,
+    `${FRESH}\t2026-08-01\tgreenhouse\tAnalyst\tDelta\tadded\tRemote`,
+    '',
+  ].join('\n'),
+  pipelineText: [
+    '# Pipeline — Pending URLs',
+    '',
+    '## Pending',
+    '',
+    `- [ ] ${OPEN} | Acme | Trader | NY`,
+    `- [x] ${DONE} | Acme | Quant | NY`,
+    `- [ ] ${PIPELINE_ONLY} | Gamma | Researcher | Remote`,
+    '',
+    '## Processed',
+    '',
+    `- [ ] ${PROCESSED} | Beta | SRE | Berlin`,
+    '',
+  ].join('\n'),
+  applicationsText: '',
+};
+
+const { seen, recheckEligible } = collectSeenUrls(SOURCES, POLICY);
+
+if (!seen.has(DONE)) {
+  pass('a `- [x]` row past the window is released — the TTL is not undone by pipeline.md');
+} else {
+  fail('a `- [x]` row past the window is still pinned: recheck_after_days is a no-op');
+}
+
+if (!seen.has(PROCESSED)) {
+  pass('a row under ## Processed is released too, whatever its checkbox says');
+} else {
+  fail('a row under ## Processed is still pinned: the heading is not being read');
+}
+
+if (seen.has(OPEN)) {
+  pass('an actionable `- [ ]` row stays pinned — rescanning it would duplicate a queued job');
+} else {
+  fail('an actionable `- [ ]` row was released: the next scan appends a second copy of it');
+}
+
+if (seen.has(PIPELINE_ONLY)) {
+  pass('a pipeline-only URL stays pinned — nothing released it, so nothing may un-pin it');
+} else {
+  fail('a pipeline-only URL was released, which no scan-history row ever authorised');
+}
+
+if (seen.has(FRESH)) {
+  pass('a row inside the window is untouched by any of this');
+} else {
+  fail('a row inside the recheck window was released');
+}
+
+if (recheckEligible === 2) {
+  pass('the counter reports the 2 rows that are genuinely rescannable, not the 3 released');
+} else {
+  fail(`recheckEligible is ${recheckEligible}, want 2 — it must be counted against the finished set, after pipeline.md and applications.md have had their say`);
+}
+
+// applications.md pins unconditionally: an applied job must never be re-offered,
+// and there is no checkbox there to distinguish finished work from open work.
+const applied = collectSeenUrls(
+  { ...SOURCES, applicationsText: `| 1 | 2026-02-01 | Acme | Quant | 4/5 | Applied | ✅ | [1](reports/001.md) | ${DONE} |` },
+  POLICY,
+);
+if (applied.seen.has(DONE) && applied.recheckEligible === 1) {
+  pass('a released row that applications.md pins is neither rescanned nor counted as eligible');
+} else {
+  fail(`applications.md pin leaked: seen=${applied.seen.has(DONE)} eligible=${applied.recheckEligible} (want true/1)`);
+}
+
+finish();

--- a/tests/scan-recheck-pipeline-repin.test.mjs
+++ b/tests/scan-recheck-pipeline-repin.test.mjs
@@ -30,6 +30,7 @@ const PROCESSED = 'https://jobs.lever.co/beta/3';
 const PIPELINE_ONLY = 'https://jobs.ashbyhq.com/gamma/4';
 const FRESH = 'https://boards.greenhouse.io/delta/5';
 const PROCESSED_CHILD = 'https://jobs.lever.co/beta/6';
+const NESTED_IN_PENDING = 'https://boards.greenhouse.io/epsilon/7';
 
 // today = 2026-08-07, window = 30d. The 2026-01-01 rows are past it; the
 // 2026-08-01 row is inside it.
@@ -43,6 +44,7 @@ const SOURCES = {
     `${PROCESSED}\t2026-01-01\tlever\tSRE\tBeta\tadded\tBerlin`,
     `${FRESH}\t2026-08-01\tgreenhouse\tAnalyst\tDelta\tadded\tRemote`,
     `${PROCESSED_CHILD}\t2026-01-01\tlever\tOps\tBeta\tadded\tBerlin`,
+    `${NESTED_IN_PENDING}\t2026-01-01\tgreenhouse\tWriter\tEpsilon\tadded\tRemote`,
     '',
   ].join('\n'),
   pipelineText: [
@@ -53,6 +55,10 @@ const SOURCES = {
     `- [ ] ${OPEN} | Acme | Trader | NY`,
     `- [x] ${DONE} | Acme | Quant | NY`,
     `- [ ] ${PIPELINE_ONLY} | Gamma | Researcher | Remote`,
+    // A subdivision inside ## Pending whose name happens to start with
+    // "Processed". It is still Pending: the rows under it are queued work.
+    '### Processed last week, still to file',
+    `- [ ] ${NESTED_IN_PENDING} | Epsilon | Writer | Remote`,
     '',
     '## Processed',
     '',
@@ -82,6 +88,12 @@ if (!seen.has(PROCESSED_CHILD)) {
   pass('a row under a child heading of ## Processed is still released');
 } else {
   fail('a row under a child heading of ## Processed was pinned: nested processed headings are not being retained');
+}
+
+if (seen.has(NESTED_IN_PENDING)) {
+  pass('a `### Processed…` subdivision inside ## Pending does not release its rows');
+} else {
+  fail('a row under a nested `### Processed…` heading inside ## Pending was released: the heading level is being ignored, so queued work is handed back to the scanner and duplicated');
 }
 
 if (seen.has(OPEN)) {

--- a/tests/scan-recheck-pipeline-repin.test.mjs
+++ b/tests/scan-recheck-pipeline-repin.test.mjs
@@ -31,6 +31,7 @@ const PIPELINE_ONLY = 'https://jobs.ashbyhq.com/gamma/4';
 const FRESH = 'https://boards.greenhouse.io/delta/5';
 const PROCESSED_CHILD = 'https://jobs.lever.co/beta/6';
 const NESTED_IN_PENDING = 'https://boards.greenhouse.io/epsilon/7';
+const AFTER_TOP_LEVEL = 'https://jobs.lever.co/zeta/8';
 
 // today = 2026-08-07, window = 30d. The 2026-01-01 rows are past it; the
 // 2026-08-01 row is inside it.
@@ -45,6 +46,7 @@ const SOURCES = {
     `${FRESH}\t2026-08-01\tgreenhouse\tAnalyst\tDelta\tadded\tRemote`,
     `${PROCESSED_CHILD}\t2026-01-01\tlever\tOps\tBeta\tadded\tBerlin`,
     `${NESTED_IN_PENDING}\t2026-01-01\tgreenhouse\tWriter\tEpsilon\tadded\tRemote`,
+    `${AFTER_TOP_LEVEL}\t2026-01-01\tlever\tDesigner\tZeta\tadded\tRemote`,
     '',
   ].join('\n'),
   pipelineText: [
@@ -65,6 +67,12 @@ const SOURCES = {
     `- [ ] ${PROCESSED} | Beta | SRE | Berlin`,
     '### Archived by retry wave',
     `- [ ] ${PROCESSED_CHILD} | Beta | Ops | Berlin`,
+    '',
+    // A level-1 heading outranks a section, so it ends ## Processed. The rows
+    // under it are a fresh queue, not leftovers of the released section.
+    '# Backlog',
+    '',
+    `- [ ] ${AFTER_TOP_LEVEL} | Zeta | Designer | Remote`,
     '',
   ].join('\n'),
   applicationsText: '',
@@ -94,6 +102,12 @@ if (seen.has(NESTED_IN_PENDING)) {
   pass('a `### Processed…` subdivision inside ## Pending does not release its rows');
 } else {
   fail('a row under a nested `### Processed…` heading inside ## Pending was released: the heading level is being ignored, so queued work is handed back to the scanner and duplicated');
+}
+
+if (seen.has(AFTER_TOP_LEVEL)) {
+  pass('a `#` heading ends ## Processed — a section cannot outlive a shallower heading');
+} else {
+  fail('a row under a `#` heading following ## Processed was released: the processed state leaked past a heading that outranks the section, so queued work is handed back to the scanner and duplicated');
 }
 
 if (seen.has(OPEN)) {

--- a/tests/scan-recheck-pipeline-repin.test.mjs
+++ b/tests/scan-recheck-pipeline-repin.test.mjs
@@ -18,7 +18,7 @@
 // to the TTL, and only when scan-history is what released it. A pipeline-only
 // URL has no scan-history row to have released it, so it stays pinned whatever
 // its checkbox says.
-import { pass, fail, finish } from './helpers.mjs';
+import { pass, fail } from './helpers.mjs';
 import { collectSeenUrls } from '../scan.mjs';
 
 console.log('\nscan.mjs — recheck_after_days survives the pipeline.md pass');
@@ -29,6 +29,7 @@ const OPEN = 'https://boards.greenhouse.io/acme/jobs/2';
 const PROCESSED = 'https://jobs.lever.co/beta/3';
 const PIPELINE_ONLY = 'https://jobs.ashbyhq.com/gamma/4';
 const FRESH = 'https://boards.greenhouse.io/delta/5';
+const PROCESSED_CHILD = 'https://jobs.lever.co/beta/6';
 
 // today = 2026-08-07, window = 30d. The 2026-01-01 rows are past it; the
 // 2026-08-01 row is inside it.
@@ -41,6 +42,7 @@ const SOURCES = {
     `${OPEN}\t2026-01-01\tgreenhouse\tTrader\tAcme\tadded\tNY`,
     `${PROCESSED}\t2026-01-01\tlever\tSRE\tBeta\tadded\tBerlin`,
     `${FRESH}\t2026-08-01\tgreenhouse\tAnalyst\tDelta\tadded\tRemote`,
+    `${PROCESSED_CHILD}\t2026-01-01\tlever\tOps\tBeta\tadded\tBerlin`,
     '',
   ].join('\n'),
   pipelineText: [
@@ -55,6 +57,8 @@ const SOURCES = {
     '## Processed',
     '',
     `- [ ] ${PROCESSED} | Beta | SRE | Berlin`,
+    '### Archived by retry wave',
+    `- [ ] ${PROCESSED_CHILD} | Beta | Ops | Berlin`,
     '',
   ].join('\n'),
   applicationsText: '',
@@ -72,6 +76,12 @@ if (!seen.has(PROCESSED)) {
   pass('a row under ## Processed is released too, whatever its checkbox says');
 } else {
   fail('a row under ## Processed is still pinned: the heading is not being read');
+}
+
+if (!seen.has(PROCESSED_CHILD)) {
+  pass('a row under a child heading of ## Processed is still released');
+} else {
+  fail('a row under a child heading of ## Processed was pinned: nested processed headings are not being retained');
 }
 
 if (seen.has(OPEN)) {
@@ -92,10 +102,10 @@ if (seen.has(FRESH)) {
   fail('a row inside the recheck window was released');
 }
 
-if (recheckEligible === 2) {
-  pass('the counter reports the 2 rows that are genuinely rescannable, not the 3 released');
+if (recheckEligible === 3) {
+  pass('the counter reports the 3 rows that are genuinely rescannable, not the 4 released');
 } else {
-  fail(`recheckEligible is ${recheckEligible}, want 2 — it must be counted against the finished set, after pipeline.md and applications.md have had their say`);
+  fail(`recheckEligible is ${recheckEligible}, want 3 — it must be counted against the finished set, after pipeline.md and applications.md have had their say`);
 }
 
 // applications.md pins unconditionally: an applied job must never be re-offered,
@@ -104,10 +114,8 @@ const applied = collectSeenUrls(
   { ...SOURCES, applicationsText: `| 1 | 2026-02-01 | Acme | Quant | 4/5 | Applied | ✅ | [1](reports/001.md) | ${DONE} |` },
   POLICY,
 );
-if (applied.seen.has(DONE) && applied.recheckEligible === 1) {
+if (applied.seen.has(DONE) && applied.recheckEligible === 2) {
   pass('a released row that applications.md pins is neither rescanned nor counted as eligible');
 } else {
-  fail(`applications.md pin leaked: seen=${applied.seen.has(DONE)} eligible=${applied.recheckEligible} (want true/1)`);
+  fail(`applications.md pin leaked: seen=${applied.seen.has(DONE)} eligible=${applied.recheckEligible} (want true/2)`);
 }
-
-finish();


### PR DESCRIPTION
## The bug

`collectSeenUrls` builds the seen-set from three sources, but only the first consults the age policy. scan-history.tsv releases a row once it is past `scan_history.recheck_after_days`; pipeline.md and applications.md are then parsed with no policy at all — and every URL in scan-history that has ever been queued is also in pipeline.md. The row is re-pinned a few lines later, so the window frees nothing on any install past its first run.

The counter hid it. `recheckEligible` was incremented at the release site, before the two later sources could pin the row again, so it reported rows as eligible that the same call had already put back in the set.

Measured on one install: **252 of 252** scan-history URLs were also in pipeline.md, so a 30-day window "released" 244 rows, re-pinned every one of them, and printed `244 eligible`.

## Why the release has to be conditional

A `- [ ]` row under `## Pending` is a line the user can still pull from. Re-scanning it appends a **second copy** of a job already on the list, so an unconditional release would trade a silent no-op for a duplicate-entry bug.

Only finished work is safe to hand back to the TTL:

- `- [x]`, or anything under `## Processed` → released, but **only** if scan-history is what released it
- a pipeline-only URL → always pinned; nothing authorised un-pinning it
- applications.md → still pins unconditionally. An applied job must not be re-offered, and there is no checkbox there to tell finished from open.

The count moves to the end, against the finished set, so it reports what is actually rescannable rather than what was momentarily released.

## Tests

New suite `tests/scan-recheck-pipeline-repin.test.mjs`, 7 assertions. It **fails 4 of 7 on the unpatched collector** and passes all 7 with the fix; the three that pass either way are the over-release guards, which is deliberate — they protect the fix, not the bug.

`tests/scan-dedup-snapshot.test.mjs` is unaffected. Its recheck candidates (`jobs.lever.co/beta/2`, `jobs.example.com/eps/5`) are not in its pipeline fixture, so both the golden seen-set and the golden `recheckEligible: 2` come out byte-identical — the behaviour proof still holds.

Full suite on this branch: **756 tests, 752 pass, 0 fail, 4 skipped.** `check-syntax.mjs`: 694 files.

## Scope

One function. No signature change, no change to the `{ seen, recheckEligible }` shape, nothing else touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can re-scan completed pipeline URLs after `scan_history.recheck_after_days` expires: `scan.mjs:1539-1621`.

Pending URLs, pipeline-only URLs, and application URLs remain pinned. Processed status continues under deeper headings and ends at same-level or shallower headings: `scan.mjs:1577-1606`.

Added regression coverage for release, re-pinning, heading handling, and final `recheckEligible` counting: `tests/scan-recheck-pipeline-repin.test.mjs:61-146`.

No function signatures or return shapes changed.

System files not touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->