### PR TITLE
fix(generate-pdf): key the PDF manifest on report number and artifact kind

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -343,6 +343,9 @@ Usage:
     await renderHtmlToPdf(html, outputPath, {
       format: args.format || "a4",
       reportNum: args.report,
+      // Declared, never inferred: this script always renders a cover letter, and
+      // the manifest must not file it as the report's CV (#3887).
+      kind: 'cover',
       inputPath: payloadPath,
     });
     console.log(`\nCover letter PDF: ${payload.output_path}`);

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -4,7 +4,7 @@
  * generate-pdf.mjs — HTML → PDF via Playwright
  *
  * Usage:
- *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages] [--skip-fact-check]
+ *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--kind=cv|cover] [--allow-reorder] [--max-pages=N] [--strict-pages] [--skip-fact-check]
  *   node career-ops/generate-pdf.mjs --batch=<manifest.json> [--format=letter|a4] [--allow-reorder] [--max-pages=N] [--strict-pages]
  *
  * --batch renders every document in a JSON manifest (an array of
@@ -1157,43 +1157,130 @@ export function injectPrintPageCss(html, format = 'a4') {
   return `${pageStyle}\n${html}`;
 }
 
+/** The artifact kinds data/pdf-index.tsv keys on, alongside the report number. */
+export const ARTIFACT_KINDS = ['cv', 'cover'];
+
+/**
+ * Decide which artifact a render produces, for the manifest's `kind` column.
+ *
+ * Resolved here rather than in the CLI because every path converges on
+ * renderInPage(): the CLI, the --batch manifest, generate-cover-letter.mjs, and
+ * the ad-hoc scripts that call the exported renderHtmlToPdf() directly. A
+ * caller that forgets to declare a cover letter is the normal case, not the
+ * exceptional one, so the default has to be derived rather than assumed to be
+ * a CV (#3887).
+ *
+ * Precedence, most specific first:
+ *   1. An explicit kind (the --kind flag, a batch entry's `kind`, opts.kind).
+ *   2. A `cv-` prefix, the CV convention every generator writes. It wins over
+ *      the cover check so a company whose own name starts with "Cover" keeps
+ *      its CV filed as a CV.
+ *   3. `cover` as the leading or trailing token: both real conventions, the
+ *      `cover-...` prefix and the `{company}-{role}-cover.pdf` suffix that
+ *      generate-cover-letter.mjs writes.
+ *   4. 'cv', the overwhelmingly common render.
+ *
+ * Anchored to the ends of the name on purpose: an unanchored "cover" would read
+ * a company or role carrying the word mid-name as a cover letter, and --kind is
+ * the escape hatch for a name that signals nothing either way.
+ *
+ * @param {string|undefined} explicit - A caller-declared kind, if any.
+ * @param {string} [outputPath] - Destination PDF path, used for inference.
+ * @returns {{kind: 'cv'|'cover'|null, source: 'declared'|'name'|'default'}}
+ *   `kind` is null when `explicit` is not a recognized kind, so the caller can
+ *   reject it rather than silently rendering something else.
+ */
+export function resolveArtifactKind(explicit, outputPath) {
+  if (explicit !== undefined && explicit !== null && String(explicit).trim() !== '') {
+    const declared = String(explicit).trim().toLowerCase();
+    return ARTIFACT_KINDS.includes(declared)
+      ? { kind: declared, source: 'declared' }
+      : { kind: null, source: 'declared' };
+  }
+
+  const name = basename(outputPath || '').toLowerCase().replace(/\.[^.]*$/, '');
+  if (name.startsWith('cv-')) return { kind: 'cv', source: 'name' };
+  if (/^cover([-_]|$)/.test(name) || /[-_]cover$/.test(name)) {
+    return { kind: 'cover', source: 'name' };
+  }
+  return { kind: 'cv', source: 'default' };
+}
+
+/**
+ * Merge one generated-PDF row into the manifest's existing data lines.
+ *
+ * The manifest holds one row per report number AND artifact kind, so a CV and
+ * a cover letter for the same application coexist (#3887). Superseding on the
+ * report number alone meant whichever document was generated last deleted the
+ * other, and readers that resolve "the PDF for report N" then returned a cover
+ * letter as the CV.
+ *
+ * @param {string[]} existingLines - Current manifest lines, comments included.
+ * @param {{reportNum: string, pdf: string, html: string, format: string, date: string, kind?: 'cv'|'cover'}} row
+ * @returns {string[]} Data lines to write, the incoming row last.
+ */
+export function applyManifestRow(existingLines, row) {
+  // "008" and "8" are the same report - zero-padded report-link form vs
+  // unpadded tracker-# form. Normalize so replacement rows match.
+  const normKey = (s) => (s || '').trim().replace(/^0+(?=\d)/, '');
+  const incomingKind = row.kind === 'cover' ? 'cover' : 'cv';
+
+  const kept = existingLines.filter((line) => {
+    if (!line.trim() || line.startsWith('#')) return false;
+    const fields = line.split('\t');
+    if (fields[1] === row.pdf) return false;
+    if (!row.reportNum || normKey(fields[0]) !== normKey(row.reportNum)) return true;
+    // Same report: the incoming row supersedes only its own kind's slot. A
+    // legacy row carries no kind, so an incoming CV claims it (the manifest
+    // must not grow a duplicate every time an untagged row's CV is
+    // regenerated) while an incoming cover letter leaves it alone rather than
+    // guessing that an unmarked row was a cover.
+    const existingKind = (fields[5] || '').trim();
+    return incomingKind === 'cover'
+      ? existingKind !== 'cover'
+      : existingKind === 'cover';
+  });
+
+  kept.push([row.reportNum || '', row.pdf, row.html, row.format, row.date, incomingKind].join('\t'));
+  return kept;
+}
+
 /**
  * Record a generated PDF in data/pdf-index.tsv so tools can map a tracker
  * report number to the exact PDF (and its source HTML for regeneration).
  *
- * Columns: report \t pdf \t html \t format \t date — paths relative to the
- * tracker workspace with forward slashes. One row per PDF path; when a report
- * number is given, older rows for that report are dropped too (regenerated
- * CVs supersede stale entries). The file is gitignored: it references
- * gitignored output/ artifacts and is meaningless on another machine.
+ * Columns: report \t pdf \t html \t format \t date \t kind - paths relative to
+ * the tracker workspace with forward slashes. One row per PDF path, and one row
+ * per (report number, kind) so a report's CV and its cover letter coexist while
+ * a regenerated document still supersedes its own stale entry. kind is appended
+ * last because find.mjs, outcome.mjs and the web reader all parse this file
+ * positionally; a reordered header would break them silently. The file is
+ * gitignored: it references gitignored output/ artifacts and is meaningless on
+ * another machine.
  */
-function updatePDFManifest(reportNum, pdfPath, htmlPath, format) {
+function updatePDFManifest(reportNum, pdfPath, htmlPath, format, kind) {
   const manifestPath = resolvePdfIndexPath(trackerPath);
   const toRel = (p) => relative(workspaceRoot, p).split(sep).join('/');
   const relPDF = toRel(pdfPath);
   const relHTML = workspaceRelativeManifestPath(htmlPath, workspaceRoot);
   const date = new Date().toISOString().slice(0, 10);
-  // "008" and "8" are the same report — zero-padded report-link form vs
-  // unpadded tracker-# form. Normalize so replacement rows match.
-  const normKey = (s) => (s || '').trim().replace(/^0+(?=\d)/, '');
 
-  let lines = [];
-  if (existsSync(manifestPath)) {
-    lines = readFileSync(manifestPath, 'utf-8').split('\n').filter((line) => {
-      if (!line.trim() || line.startsWith('#')) return false;
-      const fields = line.split('\t');
-      if (fields[1] === relPDF) return false;
-      if (reportNum && normKey(fields[0]) === normKey(reportNum)) return false;
-      return true;
-    });
-  }
-
-  lines.push([reportNum || '', relPDF, relHTML, format, date].join('\t'));
+  const existing = existsSync(manifestPath)
+    ? readFileSync(manifestPath, 'utf-8').split('\n')
+    : [];
+  const lines = applyManifestRow(existing, {
+    reportNum,
+    pdf: relPDF,
+    html: relHTML,
+    format,
+    date,
+    kind,
+  });
 
   mkdirSync(dirname(manifestPath), { recursive: true });
   writeFileSync(
     manifestPath,
-    '# report\tpdf\thtml\tformat\tdate — written by generate-pdf.mjs, do not edit\n' +
+    '# report\tpdf\thtml\tformat\tdate\tkind - written by generate-pdf.mjs, do not edit\n' +
       lines.join('\n') + '\n'
   );
   return relPDF;
@@ -1210,6 +1297,9 @@ async function generatePDF() {
   let skipFactCheck = false;
 
   // Parse arguments
+  // Empty, not 'cv': an omitted --kind must fall through to inference from the
+  // output filename rather than pinning every render to a CV.
+  let kindFlag = '';
   let inputPath, outputPath, format = 'a4', reportNum = '', allowReorder = false;
   let maxPages = 2, maxPagesInput = '2', strictPages = false, batchManifestPath = null;
 
@@ -1218,6 +1308,8 @@ async function generatePDF() {
       format = arg.split('=')[1].toLowerCase();
     } else if (arg.startsWith('--report=')) {
       reportNum = arg.split('=')[1].trim();
+    } else if (arg.startsWith('--kind=')) {
+      kindFlag = arg.slice('--kind='.length).trim();
     } else if (arg.startsWith('--batch=')) {
       batchManifestPath = arg.slice('--batch='.length);
     } else if (arg.startsWith('--max-pages=')) {
@@ -1234,6 +1326,14 @@ async function generatePDF() {
     } else if (!outputPath) {
       outputPath = arg;
     }
+  }
+
+  // A --kind that was passed and is unusable is a hard error: silently filing a
+  // cover letter as a CV is the failure the flag exists to prevent. Checked
+  // before any rendering work starts.
+  if (kindFlag && !resolveArtifactKind(kindFlag).kind) {
+    console.error(`Invalid --kind "${kindFlag}". Use: ${ARTIFACT_KINDS.join(', ')}`);
+    process.exit(1);
   }
 
   if (!Number.isInteger(maxPages) || maxPages < 1) {
@@ -1258,11 +1358,11 @@ async function generatePDF() {
   }
 
   if (!inputPath || !outputPath) {
-    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages]');
+    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--kind=cv|cover] [--allow-reorder] [--max-pages=N] [--strict-pages]');
     console.error('   or: node generate-pdf.mjs --batch=<manifest.json> [--format=letter|a4] [--allow-reorder] [--max-pages=N] [--strict-pages]');
     console.error('');
     console.error('Batch mode renders every document in the JSON manifest (an array of');
-    console.error('{input, output, format?, reportNum?}) through one shared Chromium and writes');
+    console.error('{input, output, format?, reportNum?, kind?}) through one shared Chromium and writes');
     console.error('<manifest>.results.json; it exits non-zero if any document fails.');
     console.error('');
     console.error('This script only converts an already-built HTML file to PDF.');
@@ -1371,6 +1471,7 @@ async function generatePDF() {
     format,
     baseDir: dirname(inputPath),
     reportNum,
+    kind: kindFlag,
     inputPath,
     maxPages,
     strictPages,
@@ -1463,6 +1564,12 @@ async function runBatchFromManifest(manifestPath, globals) {
         throw new Error(`invalid format "${entryFormat}" (use: ${validFormats.join(', ')})`);
       }
 
+      // An omitted kind falls through to inference from the entry's output name.
+      const entryKind = (spec.kind ?? '').toString().trim();
+      if (entryKind && !resolveArtifactKind(entryKind).kind) {
+        throw new Error(`invalid kind "${entryKind}" (use: ${ARTIFACT_KINDS.join(', ')})`);
+      }
+
       const entryReport = (spec.reportNum ?? '').toString().trim();
       if (entryReport && !/^\d+$/.test(entryReport)) {
         throw new Error(`invalid reportNum "${entryReport}" (use the numeric report number)`);
@@ -1499,6 +1606,7 @@ async function runBatchFromManifest(manifestPath, globals) {
         format: entryFormat,
         baseDir: dirname(entryInput),
         reportNum: entryReport,
+        kind: entryKind,
         inputPath: entryInput,
         maxPages: globals.maxPages,
         strictPages: globals.strictPages,
@@ -1690,6 +1798,9 @@ async function renderInPage(browser, html, outputPath, opts = {}) {
   ) ? requestedBaseDir : resolve(outputRoot);
   const reportNum = opts.reportNum || '';
   const inputPath = opts.inputPath || '';
+  // Every render path converges here, so the manifest's kind is decided here
+  // too rather than in each caller (#3887).
+  const { kind: artifactKind } = resolveArtifactKind(opts.kind, outputPath);
 
   // Reject an escaping destination before creating directories, launching
   // Chromium, or writing any renderer temporary files (#2844).
@@ -1782,7 +1893,7 @@ async function renderInPage(browser, html, outputPath, opts = {}) {
     console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
 
     try {
-      updatePDFManifest(reportNum, outputPath, inputPath, format);
+      updatePDFManifest(reportNum, outputPath, inputPath, format, artifactKind);
       console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
     } catch (err) {
       // The PDF itself succeeded — never fail the run over manifest bookkeeping.

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -1799,8 +1799,17 @@ async function renderInPage(browser, html, outputPath, opts = {}) {
   const reportNum = opts.reportNum || '';
   const inputPath = opts.inputPath || '';
   // Every render path converges here, so the manifest's kind is decided here
-  // too rather than in each caller (#3887).
+  // too rather than in each caller (#3887). A null kind means the caller
+  // declared one this manifest cannot key on: the CLI and the batch loop
+  // validate before rendering, but a direct renderHtmlToPdf() caller has
+  // nothing else in front of it, and applyManifestRow() reads null as 'cv' —
+  // so an unrecognized kind would evict the report's real CV row and hand the
+  // apply flow the wrong document. Rejected here, before the page renders, so
+  // a mislabelled artifact never reaches disk either.
   const { kind: artifactKind } = resolveArtifactKind(opts.kind, outputPath);
+  if (!artifactKind) {
+    throw new Error(`Invalid artifact kind "${opts.kind}". Use: ${ARTIFACT_KINDS.join(', ')}`);
+  }
 
   // Reject an escaping destination before creating directories, launching
   // Chromium, or writing any renderer temporary files (#2844).

--- a/tests/pdf-index-kind.test.mjs
+++ b/tests/pdf-index-kind.test.mjs
@@ -7,8 +7,16 @@
 // letter to an employer as the tailored CV. The manifest could not say what a
 // row was, so the eviction had nothing but the report number to key on. The
 // kind column is that key; these cases pin both halves of it.
-import { pass, fail } from './helpers.mjs';
-import { applyManifestRow, resolveArtifactKind, ARTIFACT_KINDS } from '../generate-pdf.mjs';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, rmSync } from './helpers.mjs';
+import {
+  applyManifestRow,
+  resolveArtifactKind,
+  renderHtmlToPdf,
+  ARTIFACT_KINDS,
+} from '../generate-pdf.mjs';
 
 console.log('\nPDF manifest keys on report number and artifact kind (#3887)');
 
@@ -133,4 +141,70 @@ for (const [explicit, path, wantKind, wantSource, label] of kindCases) {
   ARTIFACT_KINDS.includes('cv') && ARTIFACT_KINDS.includes('cover') && ARTIFACT_KINDS.length === 2
     ? pass('ARTIFACT_KINDS names exactly the kinds the manifest keys on')
     : fail(`ARTIFACT_KINDS = ${JSON.stringify(ARTIFACT_KINDS)}`);
+}
+
+// ...and the render path has to act on that null. The --kind flag and the batch
+// manifest both validate before rendering, which leaves the exported
+// renderHtmlToPdf() as the one way an unrecognized kind reaches the manifest: it
+// resolved to null, applyManifestRow() read null as 'cv', and the render
+// silently evicted the report's real CV row. Rejecting it here also keeps the
+// PDF from being written at all, so a mislabelled artifact never reaches apply.
+{
+  const sandbox = realpathSync(mkdtempSync(join(tmpdir(), 'career-ops-kind-guard-')));
+  const manifestPath = join(sandbox, 'pdf-index.tsv');
+  const before = `${HEADER}\n${cvRow}\n`;
+  writeFileSync(manifestPath, before, 'utf-8');
+
+  const previousIndex = process.env.CAREER_OPS_PDF_INDEX;
+  process.env.CAREER_OPS_PDF_INDEX = manifestPath;
+
+  let rendered = false;
+  const launchBrowser = async () => {
+    return {
+      async newPage() {
+        rendered = true;
+        return {
+          async goto() {},
+          async evaluate() {},
+          async pdf() {
+            return Buffer.from(
+              '%PDF-1.7\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n'
+              + '2 0 obj\n<< /Type /Pages /Count 1 >>\nendobj\n%%EOF',
+            );
+          },
+        };
+      },
+      async close() {},
+    };
+  };
+
+  const outputPath = join(sandbox, 'resume-acme.pdf');
+  let thrown = null;
+  try {
+    await renderHtmlToPdf('<!doctype html><html><body>x</body></html>', outputPath, {
+      reportNum: '7',
+      kind: 'resume',
+      workspaceRoot: sandbox,
+      styleTokens: {},
+      launchBrowser,
+    });
+  } catch (err) {
+    thrown = err;
+  } finally {
+    if (previousIndex === undefined) delete process.env.CAREER_OPS_PDF_INDEX;
+    else process.env.CAREER_OPS_PDF_INDEX = previousIndex;
+  }
+
+  const after = readFileSync(manifestPath, 'utf-8');
+  thrown && /resume/.test(thrown.message) && /cv/.test(thrown.message) && /cover/.test(thrown.message)
+    ? pass('renderHtmlToPdf rejects an unrecognized kind instead of filing it as a CV')
+    : fail(`unrecognized kind was not rejected: ${thrown ? thrown.message : 'no error thrown'}`);
+  !rendered && !existsSync(outputPath)
+    ? pass('an unrecognized kind is rejected before the PDF is rendered')
+    : fail('an unrecognized kind rendered a PDF before it was rejected');
+  after === before
+    ? pass("a rejected kind leaves the report's existing CV manifest row untouched")
+    : fail(`a rejected kind rewrote the manifest: ${JSON.stringify(after)}`);
+
+  rmSync(sandbox, { recursive: true, force: true });
 }

--- a/tests/pdf-index-kind.test.mjs
+++ b/tests/pdf-index-kind.test.mjs
@@ -1,0 +1,136 @@
+// tests/pdf-index-kind.test.mjs — a report's CV and its cover letter are two
+// artifacts, and generating one must never delete the other (#3887).
+//
+// data/pdf-index.tsv held one row per report number, and both documents are
+// rendered through renderHtmlToPdf() and indexed under the same --report. The
+// second render therefore evicted the first, so the apply flow uploaded a cover
+// letter to an employer as the tailored CV. The manifest could not say what a
+// row was, so the eviction had nothing but the report number to key on. The
+// kind column is that key; these cases pin both halves of it.
+import { pass, fail } from './helpers.mjs';
+import { applyManifestRow, resolveArtifactKind, ARTIFACT_KINDS } from '../generate-pdf.mjs';
+
+console.log('\nPDF manifest keys on report number and artifact kind (#3887)');
+
+const HEADER = '# report\tpdf\thtml\tformat\tdate\tkind — written by generate-pdf.mjs, do not edit';
+const cvRow = '7\toutput/cv-acme-2026-09-05.pdf\t\tletter\t2026-09-05\tcv';
+const coverRow = '7\toutput/cover-acme-2026-09-05.pdf\t\tletter\t2026-09-05\tcover';
+
+const row = (over = {}) => ({
+  reportNum: '7', pdf: 'output/x.pdf', html: '', format: 'letter', date: '2026-09-06', ...over,
+});
+const paths = (lines) => lines.map((l) => l.split('\t')[1]);
+const kinds = (lines) => lines.map((l) => l.split('\t')[5]);
+
+// The bug, in both orders. Neither order was safe before: cover-after-CV served
+// the cover as the CV, CV-after-cover left the cover unresolvable.
+{
+  const out = applyManifestRow([HEADER, cvRow], row({ pdf: 'output/cover-acme-2026-09-05.pdf', kind: 'cover' }));
+  const p = paths(out);
+  p.includes('output/cv-acme-2026-09-05.pdf') && p.includes('output/cover-acme-2026-09-05.pdf') && p.length === 2
+    ? pass('a cover letter for report 7 leaves report 7 CV row in place')
+    : fail(`a cover evicted the CV row: ${JSON.stringify(p)}`);
+}
+{
+  const out = applyManifestRow([HEADER, coverRow], row({ pdf: 'output/cv-acme-2026-09-05.pdf', kind: 'cv' }));
+  const p = paths(out);
+  p.includes('output/cv-acme-2026-09-05.pdf') && p.includes('output/cover-acme-2026-09-05.pdf') && p.length === 2
+    ? pass('a CV for report 7 leaves report 7 cover-letter row in place')
+    : fail(`a CV evicted the cover row: ${JSON.stringify(p)}`);
+}
+
+// Superseding still works, which is the behaviour the eviction existed for.
+{
+  const out = applyManifestRow([HEADER, cvRow, coverRow], row({ pdf: 'output/cv-acme-2026-09-06.pdf', kind: 'cv' }));
+  const p = paths(out);
+  p.length === 2 && p.includes('output/cover-acme-2026-09-05.pdf') && p.includes('output/cv-acme-2026-09-06.pdf')
+    ? pass('a regenerated CV supersedes only the CV row')
+    : fail(`regenerated CV did not supersede cleanly: ${JSON.stringify(p)}`);
+}
+{
+  const out = applyManifestRow([HEADER, cvRow, coverRow], row({ pdf: 'output/cover-acme-2026-09-06.pdf', kind: 'cover' }));
+  const p = paths(out);
+  p.length === 2 && p.includes('output/cv-acme-2026-09-05.pdf') && p.includes('output/cover-acme-2026-09-06.pdf')
+    ? pass('a regenerated cover letter supersedes only the cover row')
+    : fail(`regenerated cover did not supersede cleanly: ${JSON.stringify(p)}`);
+}
+
+// A manifest written by an older version has five columns and no kind. It keeps
+// today's meaning for CV lookups, so existing manifests are not invalidated.
+{
+  const legacy = '7\toutput/cv-old-2026-09-01.pdf\t\tletter\t2026-09-01';
+  const out = applyManifestRow([HEADER, legacy], row({ pdf: 'output/cv-new-2026-09-06.pdf', kind: 'cv' }));
+  paths(out).length === 1 && paths(out)[0] === 'output/cv-new-2026-09-06.pdf'
+    ? pass('an incoming CV claims a legacy kind-less row rather than duplicating it')
+    : fail(`legacy row was not claimed by the CV: ${JSON.stringify(paths(out))}`);
+}
+{
+  const legacy = '7\toutput/cv-old-2026-09-01.pdf\t\tletter\t2026-09-01';
+  const out = applyManifestRow([HEADER, legacy], row({ pdf: 'output/cover-acme-2026-09-06.pdf', kind: 'cover' }));
+  paths(out).length === 2 && paths(out).includes('output/cv-old-2026-09-01.pdf')
+    ? pass('an incoming cover letter leaves a legacy kind-less row alone')
+    : fail(`cover guessed at an unmarked row: ${JSON.stringify(paths(out))}`);
+}
+
+// "007" and "7" are the same report: zero-padded report-link form vs unpadded
+// tracker-# form. The kind key must not reintroduce a padding split.
+{
+  const padded = '007\toutput/cv-acme-2026-09-05.pdf\t\tletter\t2026-09-05\tcv';
+  const out = applyManifestRow([HEADER, padded], row({ pdf: 'output/cv-acme-2026-09-06.pdf', kind: 'cv' }));
+  paths(out).length === 1
+    ? pass('a padded report number still supersedes its unpadded twin within a kind')
+    : fail(`padding split the key: ${JSON.stringify(paths(out))}`);
+}
+
+// One row per PDF path, whatever kind claims it.
+{
+  const out = applyManifestRow([HEADER, cvRow], row({ pdf: 'output/cv-acme-2026-09-05.pdf', kind: 'cv' }));
+  paths(out).length === 1
+    ? pass('re-rendering the same PDF path does not duplicate its row')
+    : fail(`duplicate path rows: ${JSON.stringify(paths(out))}`);
+}
+
+// The column is appended last so the five existing columns keep their index:
+// find.mjs, outcome.mjs and the web reader all parse this file positionally.
+{
+  const out = applyManifestRow([HEADER], row({ pdf: 'output/cover-acme-2026-09-06.pdf', kind: 'cover' }));
+  const f = out[0].split('\t');
+  f.length === 6 && f[0] === '7' && f[1] === 'output/cover-acme-2026-09-06.pdf' && f[3] === 'letter' && f[5] === 'cover'
+    ? pass('kind is the sixth column, leaving the first five in place')
+    : fail(`column layout changed: ${JSON.stringify(f)}`);
+}
+{
+  const out = applyManifestRow([HEADER], row({ pdf: 'output/whatever.pdf' }));
+  kinds(out)[0] === 'cv'
+    ? pass('a row written with no kind is recorded as a CV, not left blank')
+    : fail(`undeclared kind was written as ${JSON.stringify(kinds(out)[0])}`);
+}
+
+// resolveArtifactKind: a caller that forgets to declare a cover is the normal
+// case, so the default is derived from the name rather than assumed to be cv.
+const kindCases = [
+  ['cover', 'output/cv-acme.pdf', 'cover', 'declared', 'an explicit kind overrides the filename'],
+  [undefined, 'output/cover-acme-2026-09-05.pdf', 'cover', 'name', 'a cover- prefix reads as a cover letter'],
+  [undefined, 'output/acme-vp-marketing-cover.pdf', 'cover', 'name', 'a -cover suffix reads as a cover letter'],
+  [undefined, 'output/cv-acme-2026-09-05.pdf', 'cv', 'name', 'a cv- prefix reads as a CV'],
+  [undefined, 'output/cv-covered-bridge-group.pdf', 'cv', 'name', 'a cv- prefix wins over a company named "Covered..."'],
+  [undefined, 'output/discover-weekly-brief.pdf', 'cv', 'default', 'an unanchored "cover" inside a name is not a cover letter'],
+  [undefined, 'output/acme.pdf', 'cv', 'default', 'a name that signals nothing falls back to CV'],
+];
+for (const [explicit, path, wantKind, wantSource, label] of kindCases) {
+  const got = resolveArtifactKind(explicit, path);
+  got.kind === wantKind && got.source === wantSource
+    ? pass(`resolveArtifactKind: ${label}`)
+    : fail(`resolveArtifactKind(${JSON.stringify(explicit)}, ${JSON.stringify(path)}) = ${JSON.stringify(got)}, wanted ${wantKind}/${wantSource}`);
+}
+{
+  const got = resolveArtifactKind('resume', 'output/cv-acme.pdf');
+  got.kind === null
+    ? pass('resolveArtifactKind returns null for an unrecognized declared kind so the caller can reject it')
+    : fail(`unrecognized kind silently resolved to ${JSON.stringify(got)}`);
+}
+{
+  ARTIFACT_KINDS.includes('cv') && ARTIFACT_KINDS.includes('cover') && ARTIFACT_KINDS.length === 2
+    ? pass('ARTIFACT_KINDS names exactly the kinds the manifest keys on')
+    : fail(`ARTIFACT_KINDS = ${JSON.stringify(ARTIFACT_KINDS)}`);
+}


### PR DESCRIPTION
Closes #3887.

## What was wrong

Generating a cover letter for a report evicted that report's tailored-CV row from `data/pdf-index.tsv`. `updatePDFManifest()` dropped every row sharing the incoming report number, and `generate-cover-letter.mjs --report` routes its render through the same writer, so the second document deleted the first. The apply flow then uploaded the cover letter to an employer as the tailored CV.

The eviction was correct for its original purpose, a regenerated CV superseding a stale row. The root cause is that the manifest could not say what a row was, so the eviction had nothing but the report number to key on.

## What this does

Adds a `kind` column (`cv` or `cover`) and supersedes on the pair, so a regenerated document still replaces its own stale row while the sibling artifact survives.

Following the two constraints you set:

- **`kind` is appended as the sixth column**, with the five existing ones untouched. I checked the positional readers rather than assuming: `find.mjs` `parsePdfIndex` and the web's `cv-selection.mjs` both read fields 0 and 1 only, and `outcome.mjs` goes through `parsePdfIndex`. The web suite is 497/497 green with the wider rows.
- **On the writers**, `updatePDFManifest()` carries the column here. `sync-pdf-flags.mjs` on current `main` never writes the manifest (no `writeFileSync`, and it only accepts `--dry-run` and `--json`), so the `--prune` path from #3898 is the one that still has to carry it. Flagging that so whichever lands second picks it up.

On your two open questions from the issue:

1. A legacy row with no `kind` keeps today's meaning for CV lookups, so existing manifests are not invalidated. An incoming CV claims such a row rather than duplicating it; an incoming cover letter leaves it alone rather than guessing that an unmarked row was a cover.
2. An explicit kind wins, and filename inference is the fallback rather than the contract. The inference is anchored to the ends of the name (`cv-` prefix, `cover-` prefix, `-cover` suffix), so a company or role carrying "cover" mid-name is not misfiled, and a `cv-` prefix beats the cover check outright. `--kind` and the per-entry batch `kind` are validated before any rendering starts, because filing a cover letter as a CV without saying so is the failure the flag exists to prevent. `generate-cover-letter.mjs` declares its kind instead of relying on inference.

Resolution happens in `renderInPage()` because every path converges there: the CLI, the batch manifest, `generate-cover-letter.mjs`, and ad-hoc callers of the exported `renderHtmlToPdf()`.

## Sequencing, and one thing this PR does not fix

Your note that the web resolver returns the first row per report is worth reading as a live constraint, not a nicety. Running the issue's reproduction against this branch, both artifacts now survive in either order, but `pdfIndexEntryForReport` returns whichever row was written first:

    cover rendered second -> {"found":true,"path":"output/cv-acme-2026-09-05.pdf"}
    cover rendered first  -> {"found":true,"path":"output/cover-acme-2026-09-05.pdf"}

So the manifest is correct and the resolver is now genuinely ambiguous where before it was merely wrong. The `cv-selection` change to prefer `kind=cv` does need to land in the same cycle, as you said. This PR deliberately leaves that file alone.

## Verification

`node test-all.mjs --quick` passes 8706, 0 failed, with the 16 warnings unchanged from `main`. `web/` passes 497, 0 failed.

New suite `tests/pdf-index-kind.test.mjs`, 19 cases, auto-discovered. It covers both orders of the original bug, superseding within a kind, the legacy kind-less row in both directions, padded and unpadded report numbers resolving to the same key, and the column layout. I also checked it is not vacuous: reverting `applyManifestRow` to the old report-only eviction fails exactly the five cases that encode the bug, and nothing else.

End-to-end against the issue's reproduction, real renders through Chromium:

    [1] tailored CV for report 7
        7  output/cv-acme-2026-09-05.pdf     cv.html     letter  cv
    [2] cover letter, same report 7
        7  output/cv-acme-2026-09-05.pdf     cv.html     letter  cv
        7  output/cover-acme-2026-09-05.pdf  cover.html  letter  cover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can generate both a tailored CV and a cover letter for the same report. Generating one artifact no longer removes the other from `data/pdf-index.tsv`.

### Changes

- `generate-pdf.mjs`: Adds `cv` and `cover` artifact kinds. Manifest replacement now uses report number and kind. Legacy five-column rows remain valid for CV lookups. CLI and batch inputs validate kinds before rendering.
- `generate-cover-letter.mjs`: Declares `kind: 'cover'` when rendering cover letters.
- `tests/pdf-index-kind.test.mjs`: Adds coverage for coexistence, replacement, legacy rows, validation, serialization, and filename inference.

The web resolver still uses its existing first-row behavior. A separate update must prefer `kind=cv`.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->