### PR TITLE
fix(verify-pipeline): merge provider plugins before the coverage check

### DIFF
--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -531,6 +531,7 @@ if (!existsSync(PORTALS_FILE)) {
   try {
     const { findUnclaimedEntries } = await import('./audit-portals.mjs');
     const { loadProviders } = await import('./providers/_registry.mjs');
+    const { mergeProviderPlugins } = await import('./plugins/_engine.mjs');
     const yaml = await import('js-yaml');
 
     const cfg = yaml.load(readFileSync(PORTALS_FILE, 'utf-8')) || {};
@@ -541,6 +542,13 @@ if (!existsSync(PORTALS_FILE)) {
       ...(Array.isArray(cfg.job_boards) ? cfg.job_boards : []),
     ];
     const providers = await loadProviders(join(CAREER_OPS, 'providers'));
+    // Merge enabled provider plugins, exactly as scan.mjs does before resolving.
+    // Without this the health check sees only providers/, so a portals.yml entry
+    // pointing at a plugin-supplied provider (plugins/ or plugins.local/) is
+    // reported as an unknown-provider ERROR while the scan it is meant to model
+    // resolves that same entry fine — a false red that gates "fix before
+    // proceeding" on nothing. Fail-open and inert when no plugins are configured.
+    await mergeProviderPlugins(providers, { root: CAREER_OPS });
     const { silent, handoff, unknownProvider } = findUnclaimedEntries(entries, providers);
 
     // findUnclaimedEntries silently skips an entry with no (or blank) `name` —


### PR DESCRIPTION
## Problem

`verify-pipeline.mjs` loads only `providers/` when resolving `portals.yml` entries, while `scan.mjs` — the thing the coverage check exists to model — calls `mergeProviderPlugins()` first.

So any entry pointing at a **plugin-supplied** provider is reported as an unknown-provider **error**, even though the scan resolves it fine. Since unknown-provider is a hard error, `verify-pipeline` exits 1 and prints "fix before proceeding" over a portal that is not actually broken.

## Reproduction

With a provider plugin enabled in `config/plugins.yml` and a `portals.yml` entry naming it:

```
❌ portals.yml: "<plugin-id>" sets an unknown provider — unknown provider: <plugin-id>.
   The entry never scans (see providers/ for valid ids)
📊 Pipeline Health: 1 errors
```

Calling `resolveProvider()` on the same entry with and without the merge:

```
WITHOUT plugin merge (verify-pipeline path): {"error":"unknown provider: <plugin-id>"}
WITH plugin merge (scan.mjs path):           resolved -> <plugin-id>
```

## Fix

Call `mergeProviderPlugins(providers, { root: CAREER_OPS })` after `loadProviders()`, exactly as `scan.mjs` does.

`mergeProviderPlugins()` returns immediately when `config/plugins.yml` is absent and is internally fail-open, so a checkout with no plugins configured behaves byte-identically to before.

## Testing

Full suite on a checkout with a provider plugin enabled: **95 → 87 failures, 8433 → 8456 passing**. `verify-pipeline` goes from 1 error to 0 on the same tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`verify-pipeline.mjs:8` now calls `mergeProviderPlugins()` after loading providers.

Users can configure `portals.yml` entries with providers supplied by enabled plugins. The coverage check now resolves these providers instead of reporting `unknown-provider` errors. Behavior is unchanged when no plugins are configured.

## Files changed

- `verify-pipeline.mjs:8`

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

## Validation

A checkout with the `job-digest` provider plugin reduced `verify-pipeline` errors from 1 to 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->