### PR TITLE
feat(pdf): multilingual CV rendering — running footer, engagements, skill notes

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -61,12 +61,27 @@ const DEFAULT_SECTION_TITLES = {
   awards: 'Awards & Honors',
   interests: 'Interests',
   skills: 'Skills',
+  engagements: 'Selected engagements',
 };
 
 // Escape user text for HTML text/attribute context. Covers the five characters
 // that change meaning in markup so tailored bullets containing &, <, >, quotes
 // (e.g. "R&D", "scaled 10x < budget", 'the "north star" metric') render as
 // literal text instead of breaking the document or injecting tags.
+// Converts a literal newline in payload.summary into a <br> line break, so a
+// multi-paragraph summary can be written as plain text with a blank line
+// between paragraphs — "\n\n" becomes "<br><br>", a visible gap (#3961
+// follow-up). Escaping runs first, the same safety ordering already used for
+// the "**bold**" convention (see modes/pdf.md): only a literal newline the
+// agent typed is converted afterward, nothing already escaped is
+// re-interpreted.
+// Shared by SUMMARY_TEXT and skill-category items (#3961 follow-up, page-fit):
+// a literal "\n" becomes a line break, "\n\n" a paragraph gap, and escaping
+// runs first so a "<script>" typed into either field stays inert.
+function renderMultilineText(text) {
+  return escapeHtml(text).replace(/\n/g, '<br>');
+}
+
 function escapeHtml(text) {
   // Blank out only truly absent/structural values. A number or boolean scalar
   // (e.g. a payload with `year: 2024` instead of `"2024"`) must render its value,
@@ -346,7 +361,25 @@ function buildCompetencies(entries, partial) {
     .join('\n      ');
 }
 
-function buildExperience(entries, partial) {
+// Renders experience[].engagements — a "Selected engagements" sub-list for a
+// role that bundles several named client/project engagements under one
+// umbrella employer (e.g. an independent-consulting entry). Deliberately NOT
+// bulleted at this label line (matches the .job's own bullet list visually
+// outranking it); each engagement below it IS its own bulleted <li> with the
+// name in bold, styled by .sub-label/.sub-list (see the CV template CSS).
+// Returns '' when there is nothing to render, so callers can splice it in
+// unconditionally without an extra presence check.
+function buildEngagementsBlock(engagements, label = DEFAULT_SECTION_TITLES.engagements) {
+  if (!Array.isArray(engagements) || engagements.length === 0) return '';
+  const items = engagements
+    .filter(Boolean)
+    .map(en => `    <li><strong>${escapeHtml(en.name || '')}</strong>${escapeHtml(en.detail || '')}</li>`)
+    .join('\n');
+  if (!items) return '';
+  return `\n  <div class="sub-label">${escapeHtml(label)}</div>\n  <ul class="sub-list">\n${items}\n  </ul>`;
+}
+
+function buildExperience(entries, partial, engagementsLabel = DEFAULT_SECTION_TITLES.engagements) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
   if (!partial) {
     return entries.filter(e => hasRequiredFields(e, 'experience', 'html')).map(e => {
@@ -356,7 +389,14 @@ function buildExperience(entries, partial) {
       const location = e.location
         ? `\n    <div class="job-location">${escapeHtml(e.location)}</div>`
         : '';
-      return `<div class="job">
+      // keepTogether (opt-in, #3961 follow-up): stops a bullet-heavy entry —
+      // usually the last one on a trimmed CV — from splitting across a page
+      // boundary mid-bullet. Off by default: most entries are better packed
+      // tight than pushed whole onto the next page (see the CSS rule this
+      // class hooks).
+      const jobClass = e.keepTogether ? ' job--keep-together' : '';
+      const engagements = buildEngagementsBlock(e.engagements, engagementsLabel);
+      return `<div class="job${jobClass}">
     <div class="job-header">
       <span class="job-company">${escapeHtml(e.company)}</span>
       <span class="job-period">${escapeHtml(e.dates || e.period || '')}</span>
@@ -364,7 +404,7 @@ function buildExperience(entries, partial) {
     <div class="job-role">${escapeHtml(e.role)}</div>${location}
     <ul>
 ${bullets}
-    </ul>
+    </ul>${engagements}
   </div>`;
     }).join('\n  ');
   }
@@ -383,6 +423,8 @@ ${bullets}
       ROLE: escapeHtml(e.role || ''),
       LOCATION: escapeHtml(e.location || ''),
       BULLETS: bullets,
+      JOB_CLASS: e.keepTogether ? ' job--keep-together' : '',
+      ENGAGEMENTS: buildEngagementsBlock(e.engagements, engagementsLabel),
     }, blockValues);
   }).join('\n  ');
 }
@@ -564,7 +606,16 @@ function buildSkills(categories, partial) {
       const cat = c.category
         ? `<span class="skill-category">${escapeHtml(c.category)}:</span> `
         : '';
-      return `    <div class="skill-item">${cat}${escapeHtml(joinItems(c.items))}</div>`;
+      // note (opt-in): a qualifier line under the items — "which of these am I
+      // only working-familiar with". Rendered as its own indented, muted line
+      // rather than a bare "\n" inside items, because once the items line is
+      // long enough to wrap on its own (routinely, in a language that runs
+      // longer than English) a plain line break is indistinguishable from an
+      // accidental wrap. See .skill-note in the template CSS.
+      const note = c.note
+        ? `<span class="skill-note">${renderMultilineText(c.note)}</span>`
+        : '';
+      return `    <div class="skill-item">${cat}${renderMultilineText(joinItems(c.items))}${note}</div>`;
     }).join('\n');
     return `<div class="skills-grid">\n${items}\n  </div>`;
   }
@@ -575,10 +626,12 @@ function buildSkills(categories, partial) {
   const items = kept.map(c => {
     const blockValues = new Map([
       ['CATEGORY_BLOCK', { value: escapeHtml(c.category || ''), present: Boolean(c.category) }],
+      ['NOTE_BLOCK',     { value: renderMultilineText(c.note || ''), present: Boolean(c.note) }],
     ]);
     return fillEntry(entryTemplate, blocks, {
       CATEGORY:    escapeHtml(c.category || ''),
-      ITEMS_TEXT:  escapeHtml(joinItems(c.items)),
+      ITEMS_TEXT:  renderMultilineText(joinItems(c.items)),
+      NOTE:        renderMultilineText(c.note || ''),
     }, blockValues);
   }).join('\n');
   return `<div class="skills-grid">\n${items}\n  </div>`;
@@ -636,11 +689,11 @@ function renderReport(payload, partials) {
     PAGE_WIDTH: pageWidth,
     NAME: escapeHtml(candidate.name || ''),
     SECTION_SUMMARY: escapeHtml(sectionTitles.summary),
-    SUMMARY_TEXT: escapeHtml(payload.summary || ''),
+    SUMMARY_TEXT: renderMultilineText(payload.summary || ''),
     SECTION_COMPETENCIES: escapeHtml(sectionTitles.competencies),
     COMPETENCIES: buildCompetencies(payload.competencies, partials.get('competencies')),
     SECTION_EXPERIENCE: escapeHtml(sectionTitles.experience),
-    EXPERIENCE: buildExperience(payload.experience, partials.get('experience')),
+    EXPERIENCE: buildExperience(payload.experience, partials.get('experience'), sectionTitles.engagements),
     SECTION_PROJECTS: escapeHtml(sectionTitles.projects),
     PROJECTS: buildProjects(payload.projects, partials.get('projects')),
     SECTION_EDUCATION: escapeHtml(sectionTitles.education),
@@ -880,6 +933,62 @@ async function runSelfTest() {
     process.exit(1);
   }
 
+  // Guard renderMultilineText() via SUMMARY_TEXT (#3961 follow-up): a literal
+  // "\n\n" in the summary becomes a paragraph gap ("<br><br>"), a single "\n"
+  // becomes one line break, and escaping still runs first — a "<script>"
+  // typed into the summary must stay escaped even once it sits next to a
+  // real <br>.
+  const summaryHtml = renderHtml(template, {
+    ...sample,
+    summary: 'First line.\nSecond line, same paragraph.\n\nSecond paragraph opens with a <script> tag.',
+  }, TEMPLATE_PATH);
+  if (!summaryHtml.includes('First line.<br>Second line, same paragraph.<br><br>Second paragraph')) {
+    console.error('Self-test failed: summary newlines did not render as <br>/<br><br> line breaks');
+    process.exit(1);
+  }
+  // Case-insensitive and prefix-only: a regression that let through <SCRIPT>
+  // or <script src=…> must fail this assertion too, not just a bare <script>.
+  if (!summaryHtml.includes('&lt;script&gt; tag') || /<script/i.test(summaryHtml)) {
+    console.error('Self-test failed: summary escaping did not run before newline-to-<br> conversion');
+    process.exit(1);
+  }
+
+  // Guard renderMultilineText() via skill-category items (#3961 follow-up,
+  // page-fit): the same "\n" -> <br> conversion is available on a skill
+  // category's items string (not its array form — a joined array has no
+  // newlines to convert), letting a dense category wrap a caveat like
+  // "(working familiarity)" onto its own line instead of running one long
+  // line. The "**...**" stays literal here — that markdown-bold-to-<strong>
+  // pass runs later, in generate-pdf.mjs's ATS normalization, not here.
+  const skillsNewlineHtml = renderHtml(template, {
+    ...sample,
+    skills: [{ category: 'Cloud', items: 'Docker, Kubernetes\n**Working familiarity:** Terraform' }],
+  }, TEMPLATE_PATH);
+  if (!skillsNewlineHtml.includes('Docker, Kubernetes<br>**Working familiarity:** Terraform')) {
+    console.error('Self-test failed: skill-category items newline did not render as <br>');
+    process.exit(1);
+  }
+
+  // Guard skills[].note (#3961 follow-up, page-fit): an opt-in qualifier line
+  // rendered as its own indented .skill-note block, escaped like every other
+  // free-text field; absent (the base sample) renders no such block.
+  const skillsNoteHtml = renderHtml(template, {
+    ...sample,
+    skills: [{ category: 'Cloud', items: 'Docker, Coolify', note: '**Working familiarity:** Terraform <Cloud>' }],
+  }, TEMPLATE_PATH);
+  if (!skillsNoteHtml.includes('class="skill-note"')) {
+    console.error('Self-test failed: skills[].note did not render a .skill-note block');
+    process.exit(1);
+  }
+  if (!skillsNoteHtml.includes('**Working familiarity:** Terraform &lt;Cloud&gt;')) {
+    console.error('Self-test failed: skills[].note did not render escaped note text');
+    process.exit(1);
+  }
+  if (html.includes('class="skill-note"')) {
+    console.error('Self-test failed: .skill-note rendered when skills[].note was not set');
+    process.exit(1);
+  }
+
   // Guard buildInterests(): comma-joined, sentence-cased (only the first item
   // keeps its capital), and escaped like every other free-text field.
   if (!html.includes('Reading sci-fi &amp; fantasy, hiking, chess')) {
@@ -992,6 +1101,71 @@ async function runSelfTest() {
   }
   if (noLocHtml.includes('class="edu-location"')) {
     console.error('Self-test failed: edu-location block rendered when education location is absent');
+    process.exit(1);
+  }
+
+  // Guard experience[].keepTogether (#3961 follow-up): true adds the
+  // page-break-avoiding class; absent/false renders exactly like the base
+  // sample above (no stray class, no dangling space in the attribute).
+  const keepTogetherSample = {
+    ...sample,
+    experience: [{ ...sample.experience[0], keepTogether: true }],
+    projects: [],
+  };
+  const keepTogetherHtml = renderHtml(template, keepTogetherSample, TEMPLATE_PATH);
+  if (!keepTogetherHtml.includes('class="job job--keep-together"')) {
+    console.error('Self-test failed: experience[].keepTogether did not add the job--keep-together class');
+    process.exit(1);
+  }
+  if (html.includes('class="job job--keep-together"')) {
+    // Checked against markup usage, not a bare substring match — the
+    // stylesheet's own .job--keep-together rule definition is always present
+    // regardless of whether any entry uses it.
+    console.error('Self-test failed: job--keep-together class rendered when keepTogether was not set');
+    process.exit(1);
+  }
+
+  // Guard experience[].engagements (#3961 follow-up): renders a sub-label plus
+  // one bold-name <li> per engagement, HTML-escaped like every other free-text
+  // field; absent (the base sample) renders neither.
+  const engagementsSample = {
+    ...sample,
+    experience: [{
+      ...sample.experience[0],
+      engagements: [
+        { name: 'Acme <Co>', detail: ' (2020–2021): built the thing' },
+      ],
+    }],
+    projects: [],
+  };
+  const engagementsHtml = renderHtml(template, engagementsSample, TEMPLATE_PATH);
+  if (!engagementsHtml.includes('class="sub-label"') || !engagementsHtml.includes('Selected engagements')) {
+    console.error('Self-test failed: experience[].engagements did not render the sub-label');
+    process.exit(1);
+  }
+  if (!engagementsHtml.includes('<strong>Acme &lt;Co&gt;</strong> (2020–2021): built the thing')) {
+    console.error('Self-test failed: experience[].engagements did not render an escaped, bold-name sub-list item');
+    process.exit(1);
+  }
+  if (html.includes('class="sub-label"')) {
+    console.error('Self-test failed: sub-label rendered when experience[].engagements was not set');
+    process.exit(1);
+  }
+
+  // Guard payload.sections.engagements (#3961 follow-up, localization): the
+  // sub-label text is overridable the same way every other section title is,
+  // e.g. for a French-language CV ("Mandats sélectionnés" vs "Selected
+  // engagements") — same mechanism as SECTION_SUMMARY/SECTION_EXPERIENCE/etc.
+  const localizedEngagementsHtml = renderHtml(template, {
+    ...engagementsSample,
+    sections: { engagements: 'Mandats sélectionnés' },
+  }, TEMPLATE_PATH);
+  if (!localizedEngagementsHtml.includes('class="sub-label">Mandats sélectionnés<')) {
+    console.error('Self-test failed: payload.sections.engagements did not override the sub-label text');
+    process.exit(1);
+  }
+  if (localizedEngagementsHtml.includes('Selected engagements')) {
+    console.error('Self-test failed: default "Selected engagements" label leaked through a sections.engagements override');
     process.exit(1);
   }
 

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -4,7 +4,7 @@
  * generate-pdf.mjs — HTML → PDF via Playwright
  *
  * Usage:
- *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages] [--skip-fact-check]
+ *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages] [--skip-fact-check] [--running-footer]
  *   node career-ops/generate-pdf.mjs --batch=<manifest.json> [--format=letter|a4] [--allow-reorder] [--max-pages=N] [--strict-pages]
  *
  * --batch renders every document in a JSON manifest (an array of
@@ -28,6 +28,13 @@
  * The actual page count is checked after Chromium writes the PDF; overflow
  * warns with trimming guidance by default. --strict-pages turns that warning
  * into a hard rejection without publishing the render as successful.
+ *
+ * --running-footer adds a small footer to every rendered page but the first —
+ * name, a contact method, and "N of TOTAL" — so a page separated from the
+ * rest of a multi-page CV can still be traced back and the reader knows one
+ * is missing. Page 1 is skipped because the visible header already carries
+ * that information there. Off by default (single-CV path only, not --batch).
+ * A single-page CV never shows it at all — nothing to exclude page 1 from.
  *
  * Requires: @playwright/test (or playwright) installed.
  * Uses Chromium headless to render the HTML and produce a clean, ATS-parseable PDF.
@@ -187,7 +194,15 @@ function normalizeTextForATS(html) {
     t = t.replace(/[\u2018\u2019\u201A\u201B]/g, () => { bump('smart-single-quote', 1); return "'"; });
     t = t.replace(/\u2026/g, () => { bump('ellipsis', 1); return '...'; });
     t = t.replace(/[\u200B\u200C\u200D\u2060\uFEFF]/g, () => { bump('zero-width', 1); return ''; });
-    t = t.replace(/\u00A0/g, () => { bump('nbsp', 1); return ' '; });
+    // A stray/pasted NBSP is flattened to a normal space (some ATS text
+    // extractors mis-tokenize U+00A0 as a non-space, gluing the words either
+    // side of it together) \u2014 EXCEPT immediately before :;!? , which is French
+    // typographic convention (espace ins\u00E9cable) and must reach Chromium's
+    // layout engine intact: this pass runs on the raw HTML string before
+    // page.setContent(), so a stripped-to-plain-space NBSP here can never be
+    // un-stripped later \u2014 it was never "unbreakable" at all by the time the
+    // browser paginates the page.
+    t = t.replace(/\u00A0(?![:;!?])/g, () => { bump('nbsp', 1); return ' '; });
     // Arrows often stripped by PDF text extractors \u2014 replace with ASCII for ATS safety.
     // Consume surrounding whitespace to avoid double-spacing in output.
     t = t.replace(/\s*\u2192\s*/g, () => { bump('right-arrow', 1); return ' to '; });
@@ -1212,6 +1227,7 @@ async function generatePDF() {
   // Parse arguments
   let inputPath, outputPath, format = 'a4', reportNum = '', allowReorder = false;
   let maxPages = 2, maxPagesInput = '2', strictPages = false, batchManifestPath = null;
+  let runningFooter = false;
 
   for (const arg of args) {
     if (arg.startsWith('--format=')) {
@@ -1229,6 +1245,8 @@ async function generatePDF() {
       strictPages = true;
     } else if (arg === '--skip-fact-check') {
       skipFactCheck = true;
+    } else if (arg === '--running-footer') {
+      runningFooter = true;
     } else if (!inputPath) {
       inputPath = arg;
     } else if (!outputPath) {
@@ -1258,7 +1276,7 @@ async function generatePDF() {
   }
 
   if (!inputPath || !outputPath) {
-    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages]');
+    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder] [--max-pages=N] [--strict-pages] [--running-footer]');
     console.error('   or: node generate-pdf.mjs --batch=<manifest.json> [--format=letter|a4] [--allow-reorder] [--max-pages=N] [--strict-pages]');
     console.error('');
     console.error('Batch mode renders every document in the JSON manifest (an array of');
@@ -1308,6 +1326,7 @@ async function generatePDF() {
   console.log(`📁 Output: ${outputPath}`);
   console.log(`📏 Format: ${format.toUpperCase()}`);
   console.log(`📐 Page budget: ${maxPages}${strictPages ? ' (strict)' : ' (warning only)'}`);
+  if (runningFooter) console.log('🦶 Running footer: on (every page but the first)');
 
   let html = await readFile(inputPath, 'utf-8');
   let cvMarkdown = '';
@@ -1374,6 +1393,7 @@ async function generatePDF() {
     inputPath,
     maxPages,
     strictPages,
+    runningFooter,
     styleTokens: readStyleTokens(resolve(workspaceRoot, 'config', 'profile.yml')),
   });
 }
@@ -1630,6 +1650,7 @@ export async function inlineLocalFonts(html) {
  *   workspaceRoot?: string,
  *   maxPages?: number,
  *   strictPages?: boolean,
+ *   runningFooter?: boolean,
  *   launchBrowser?: (options: {headless: boolean}) => Promise<import('playwright').Browser>
  * }} [opts]
  * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
@@ -1671,7 +1692,8 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
  *   inputPath?: string,
  *   maxPages?: number,
  *   strictPages?: boolean,
- *   styleTokens?: object
+ *   styleTokens?: object,
+ *   runningFooter?: boolean
  * }} [opts]
  * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
  */
@@ -1751,24 +1773,121 @@ async function renderInPage(browser, html, outputPath, opts = {}) {
     // Wait for fonts and images to settle
     await page.evaluate(() => document.fonts.ready);
 
-    // Generate PDF
-    const pdfBuffer = await page.pdf({
-      printBackground: true,
-      margin: {
-        top: '0',
-        right: '0',
-        bottom: '0',
-        left: '0',
-      },
-      preferCSSPageSize: true,
-    });
+    // Running footer (opt-in, #3961): "page lost off a desk/inbox" recovery —
+    // name, a contact method, and N of TOTAL on every page but the first (the
+    // visible header already carries that on page 1) so a stray page can be
+    // reunited with the rest.
+    //
+    // Chromium's print engine applies one header/footer template uniformly to
+    // every page — there is no per-page conditional inside headerTemplate/
+    // footerTemplate, so "skip page 1" cannot be expressed in a single render
+    // call. Instead this renders the document TWICE with identical page
+    // geometry (same `margin`, so pagination is guaranteed to break in the
+    // same places both times) — once with a blank footer, once with the real
+    // one — and keeps page 1 from the blank render and every later page from
+    // the real one, stitched together with pdf-lib.
+    //
+    // knownPageCount short-circuits the page-tree count below for the merged
+    // case: countRenderedPdfPages() finds /Type /Catalog by pattern-matching
+    // classic "N 0 obj ... endobj" text, which is how Chromium writes a PDF
+    // but not how pdf-lib writes the one it produces (different object/xref
+    // layout) — so re-parsing a pdf-lib buffer the same way finds nothing.
+    // The page count was already established (and cross-checked between both
+    // Chromium passes) while building it, so re-deriving it from the merged
+    // bytes would be redundant even where it did work.
+    let pdfBuffer;
+    let knownPageCount = null;
+    if (opts.runningFooter) {
+      const identity = await page.evaluate(() => {
+        const name = document.querySelector('.header h1')?.textContent?.trim() || '';
+        const email = document.querySelector('.contact-row a[href^="mailto:"]')?.textContent?.trim() || '';
+        const phone = document.querySelector('.contact-row a[href^="tel:"]')?.textContent?.trim() || '';
+        const lang = document.documentElement.getAttribute('lang') || '';
+        return { name, email, phone, lang };
+      });
+      const identityLine = [identity.name, identity.email, identity.phone].filter(Boolean).join(' &middot; ');
+      // "N of TOTAL" localized off the rendered document's own <html lang="">
+      // (set from payload.lang) rather than a CLI flag, so it always matches
+      // whatever language the CV body itself was actually written in.
+      const PAGE_OF_WORD = { fr: 'sur' };
+      const ofWord = PAGE_OF_WORD[identity.lang.slice(0, 2).toLowerCase()] || 'of';
+      const footerTemplate = `<div style="font-family: Arial, Helvetica, sans-serif; font-size: 8px; color: #888; width: 100%; padding: 0 ${PDF_PAGE_MARGIN}; display: flex; justify-content: space-between; box-sizing: border-box;"><span>${identityLine}</span><span><span class="pageNumber"></span> ${ofWord} <span class="totalPages"></span></span></div>`;
+      // Reserve room for the footer band on BOTH passes, even the blank one —
+      // the reserved margin (not the template content) is what determines
+      // where content wraps to the next page, so an unequal margin between
+      // the two passes would let them paginate differently and break apart
+      // when merged. @page's own CSS margin (read via preferCSSPageSize)
+      // still governs the body content's margin on every other edge.
+      const sharedMargin = { top: '0', right: '0', bottom: '0.35in', left: '0' };
+      const blankBuffer = await page.pdf({
+        printBackground: true,
+        margin: sharedMargin,
+        preferCSSPageSize: true,
+        displayHeaderFooter: true,
+        headerTemplate: '<span></span>',
+        footerTemplate: '<span></span>',
+      });
+      const pageCount = countRenderedPdfPages(blankBuffer);
+      if (pageCount <= 1) {
+        // Nothing to exclude page 1 from — a single page never needs the
+        // footer at all, so the blank-footer render is already the answer.
+        pdfBuffer = blankBuffer;
+        knownPageCount = pageCount;
+      } else {
+        const footerBuffer = await page.pdf({
+          printBackground: true,
+          margin: sharedMargin,
+          preferCSSPageSize: true,
+          displayHeaderFooter: true,
+          headerTemplate: '<span></span>',
+          footerTemplate,
+        });
+        const footerPageCount = countRenderedPdfPages(footerBuffer);
+        if (footerPageCount !== pageCount) {
+          // Same content, same geometry — this should be unreachable. If the
+          // two passes ever disagree, merging page-by-page would misalign
+          // content, so fall back to the footer-on-every-page render (still
+          // correct, just not page-1-excluded) rather than produce a broken
+          // PDF.
+          console.warn(`⚠️  Running-footer passes disagreed on page count (${pageCount} vs ${footerPageCount}); showing the footer on every page instead of excluding page 1.`);
+          pdfBuffer = footerBuffer;
+          knownPageCount = footerPageCount;
+        } else {
+          const { PDFDocument } = await import('pdf-lib');
+          const finalDoc = await PDFDocument.create();
+          const blankDoc = await PDFDocument.load(blankBuffer);
+          const footerDoc = await PDFDocument.load(footerBuffer);
+          const [firstPage] = await finalDoc.copyPages(blankDoc, [0]);
+          finalDoc.addPage(firstPage);
+          const restIndices = Array.from({ length: pageCount - 1 }, (_, i) => i + 1);
+          const restPages = await finalDoc.copyPages(footerDoc, restIndices);
+          for (const restPage of restPages) finalDoc.addPage(restPage);
+          pdfBuffer = Buffer.from(await finalDoc.save());
+          knownPageCount = pageCount;
+        }
+      }
+    } else {
+      pdfBuffer = await page.pdf({
+        printBackground: true,
+        margin: {
+          top: '0',
+          right: '0',
+          bottom: '0',
+          left: '0',
+        },
+        preferCSSPageSize: true,
+      });
+    }
 
     // Write PDF only after rendering has completed. Renderer cleanup still runs
     // if an injected browser fails before producing a buffer.
     await writeFile(outputPath, pdfBuffer);
 
     // Read the root page-tree count so page-like text in streams is ignored.
-    const pageCount = countRenderedPdfPages(pdfBuffer);
+    // Skipped when a running-footer pass already established it (see
+    // knownPageCount above) — re-parsing a pdf-lib-produced buffer with the
+    // same Chromium-oriented pattern match would find nothing.
+    const pageCount = knownPageCount ?? countRenderedPdfPages(pdfBuffer);
 
     // Strict overflow leaves the draft on disk but stops before success logs
     // and manifest publication. Default overflow warns and continues.

--- a/lib/cv-payload-schema.mjs
+++ b/lib/cv-payload-schema.mjs
@@ -21,7 +21,7 @@ export const ENTRY_FIELD_SPECS = {
   html: {
     experience: {
       required: ['company', 'role'],
-      known: ['company', 'role', 'location', 'dates', 'period', 'bullets'],
+      known: ['company', 'role', 'location', 'dates', 'period', 'bullets', 'engagements', 'keepTogether'],
     },
     projects: {
       required: ['name'],
@@ -34,7 +34,7 @@ export const ENTRY_FIELD_SPECS = {
     certifications: { required: ['title'], known: ['title', 'org', 'year'] },
     awards: { required: ['title'], known: ['title', 'org', 'year'] },
     // category is optional — buildSkills() renders the line without its prefix.
-    skills: { required: ['items'], known: ['category', 'items'], rules: { items: hasRenderableItems } },
+    skills: { required: ['items'], known: ['category', 'items', 'note'], rules: { items: hasRenderableItems } },
   },
   tex: {
     experience: {

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -56,6 +56,7 @@ Run `npm run jd:similarity -- {bundle-root}/jd/current.md {bundle-root}/jd/previ
     - The rendered PDF has a two-page warning threshold by default. `--max-pages=N` accepts a positive integer; pass `--max-pages=1` when the user or market prefers a one-page CV.
     - If the rendered PDF exceeds its threshold, generation warns loudly with the actual and allowed page counts plus trimming guidance, then reports and indexes the unchanged PDF so existing longer-CV flows keep working.
     - Pass `--strict-pages` only when the user or market requires a hard limit. Strict overflow leaves the draft available for inspection but does not report or index it as successful; trim lower-priority content and rerun.
+    - Pass `--running-footer` when the user wants a page-loss-recovery footer (name, a contact method, "N of TOTAL") on every rendered page but the first — useful for a CV that's more than one page and travels through a forwarding chain (recruiter → account manager → client) where a page could go missing. Off by default. Page 1 is skipped because the visible header already carries that information there; a CV that renders to a single page shows no footer at all. The "of" wording follows the CV's own `lang` (payload `lang`, rendered as `<html lang="...">`): `fr` → "sur" (e.g. `2 sur 3`), everything else → "of".
 22. Report: PDF path, number of pages, keyword coverage %, and any skill gaps from Step 4 still unaddressed
 
 ## ATS Rules (clean parsing)
@@ -155,7 +156,8 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
     "education": "Education",
     "certifications": "Certifications",
     "awards": "Awards & Honors",
-    "skills": "Skills"
+    "skills": "Skills",
+    "engagements": "Selected engagements"
   },
   "summary": "Personalized summary with JD keywords injected (honest vs cv.md).",
   "competencies": ["RAG Pipelines", "LLMOps", "Kubernetes & Docker"],
@@ -165,7 +167,11 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
       "role": "Job Title",
       "location": "Remote",
       "dates": "June 2022 - Present",
-      "bullets": ["Achievement bullet with JD keywords injected", "Another quantified-impact bullet"]
+      "bullets": ["Achievement bullet with JD keywords injected", "Another quantified-impact bullet"],
+      "engagements": [
+        { "name": "Client Org", "detail": " (2020–2021): what was delivered there" }
+      ],
+      "keepTogether": false
     }
   ],
   "projects": [
@@ -202,15 +208,18 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `candidate.location` | string | From `profile.yml`. |
 | `candidate.photo` | string | Opt-in profile photo (#264): a local path or `data:` URL. Empty/absent emits **no `<img>`**, rendering pixel-for-pixel identical to the photoless layout (US/UK/many-market ATS penalize photos; opt in for DACH/European markets). |
 | `candidate.photo_style` | string | Optional photo framing: `rounded` (default), `circle`, or `square`. Read it from `candidate.photo_style` in `config/profile.yml`; invalid values fail before HTML is written. |
-| `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. |
-| `summary` | string | Personalized summary with keywords. Supports `**…**` emphasis (see **Markdown bold** below). |
+| `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. `sections.engagements` (default `"Selected engagements"`) is the same override mechanism, applied to the `experience[].engagements` sub-label described below — set it for any non-English CV (e.g. `"Mandats sélectionnés"` for `fr`). |
+| `summary` | string | Personalized summary with keywords. Supports `**…**` emphasis (see **Markdown bold** below) and a literal `\n`/`\n\n` for line/paragraph breaks (see **Multi-paragraph summary** above). |
 | `competencies` | string[] | 6-8 keyword phrases → competency tags. |
-| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected; `**…**` emphasis supported). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
+| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected; `**…**` emphasis supported), `engagements` (optional, see below), `keepTogether` (optional, see below). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
+| `experience[].engagements` | object[] | Optional (#3961 follow-up). A "Selected engagements" sub-list for a role that bundles several named client/project engagements under one umbrella employer — e.g. an independent-consulting or fractional entry with multiple retained clients. Each item is `{ name, detail }`: `name` renders in bold, `detail` renders immediately after it verbatim (write your own leading punctuation/spacing — `" (2020–2021): what was delivered"`, not `"2020–2021 what was delivered"`). Renders below the entry's own bullets, under a plain (non-bulleted) "Selected engagements" label; the engagements themselves ARE bulleted. Omit the key, or leave it `[]`, for an entry with no sub-engagements — most entries. |
+| `experience[].keepTogether` | boolean | Optional (#3961 follow-up), default `false`. Forces that one entry to stay whole across a page break instead of the template's normal behavior of letting a multi-bullet role flow across pages to pack tighter. Reach for it when trimming leaves the LAST entry on a CV split awkwardly mid-bullet — pushing it whole onto the next page reads better there than a mostly-empty gap above a stranded bullet fragment. Not a general-purpose fix: setting it on every entry defeats the packing this template deliberately does by default, and can itself push a CV over its page budget (see `--max-pages`/`--strict-pages` in Step 21). |
 | `projects[]` | object | `name`, `url` (optional project/repo link), `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `location` (optional, city/state), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |
 | `awards[]` | object | `title` (award name), `org` (issuing body, optional), `year` (optional). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Use it for competitive or academic distinctions (olympiad medals, hackathon wins, dean's list) that carry more signal than a thin experience section. |
-| `skills[]` | object | `items` (**required**): a non-blank comma-separated string, or a non-empty array of non-blank strings — every element must be text, since the builder joins the whole array. `category` (optional): omitted, the line renders without its prefix. |
+| `skills[]` | object | `items` (**required**): a non-blank comma-separated string, or a non-empty array of non-blank strings — every element must be text, since the builder joins the whole array. A **string** `items` also supports a literal `\n`/`\n\n` for line/paragraph breaks (see **Multi-paragraph summary** below); an `items` **array** is always comma-joined into one line, so it has no newlines to convert. `category` (optional): omitted, the line renders without its prefix. `note` (optional): see the row below. |
+| `skills[].note` | string | Optional (#3961 follow-up). A qualifier line rendered under that category's items as its own indented, muted `.skill-note` block — the honest place for "which of these is working familiarity rather than depth" (`"**Working familiarity:** Kubernetes, Terraform, Azure"`). **Prefer this over a `\n` inside `items`** for a qualifier: a bare line break is indistinguishable from an accidental wrap once the items line is long enough to wrap on its own, which it routinely is in any language that runs longer than English (a French CV is ~15% longer for the same content). |
 
 `build-cv-html.mjs` errors out (non-zero exit) if any template placeholder is left unresolved, so a malformed payload fails loudly instead of shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.
 
@@ -221,6 +230,16 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 - **A top-level section name the builder does not read → warning**, naming the nearest known key. A payload with `educations` instead of `education` used to validate clean and drop the section silently; it now says so.
 
 Do **not** substitute the LaTeX builder's vocabulary — `institution`/`degree`/`dates`/`coursework` is the `modes/latex.md` education schema, **not** this one — nor `employer` for a company or `name` for a certification. Such an entry used to render as an empty block while the report still said `"valid": true`, and CVs went out with no education section at all. It is now rejected by name. When in doubt, check `counts.educationEntries` (and its siblings) in the JSON report: a zero there means the section is empty in the PDF.
+
+### Multi-paragraph summary
+
+Write a literal newline in `summary` to break it into paragraphs — a single `\n` becomes one `<br>` line break, a blank line (`\n\n`) becomes a paragraph gap (`<br><br>`). Every other field stays single-block text except `skills[].items` (string form), which gets the same `\n`/`\n\n` handling — see the `skills[]` row above (#3961 follow-up — a summary that runs 3-4 dense lines with no break reads as a wall of text in the six-second scan, and a dense skills category runs into the same problem).
+
+```json
+"summary": "**Role Title — Domain Focus.** Languages spoken, availability.\n\nOpening paragraph leading with the strongest quantified proof point.\n\nSecond paragraph: location and availability."
+```
+
+Escaping runs first here too (same ordering as `**…**` below): a literal `<` typed into the summary stays escaped even once it sits next to a real `<br>`.
 
 ### Markdown bold
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@google/generative-ai": "^0.24.1",
     "dotenv": "^17.0.0",
     "js-yaml": "^5.3.0",
+    "pdf-lib": "^1.17.1",
     "playwright": "1.62.1"
   }
 }

--- a/templates/ats/cv-template.ats.html
+++ b/templates/ats/cv-template.ats.html
@@ -183,6 +183,36 @@ version: 1.0.0
     font-weight: 600;
   }
 
+  /* Opt-in via experience[].keepTogether (#3961 follow-up); see cv-template.html
+     for the full rationale. */
+  .job--keep-together {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Opt-in via experience[].engagements (#3961 follow-up); see
+     cv-template.html for the full rationale. */
+  .job .sub-label {
+    font-size: 10.5px;
+    font-weight: 600;
+    color: #333;
+    margin-top: 6px;
+    margin-bottom: 4px;
+  }
+
+  .job .sub-list {
+    list-style: disc;
+    padding-left: 34px;
+    margin-top: 0;
+  }
+
+  .job .sub-list li {
+    font-size: 10.5px;
+    line-height: 1.6;
+    color: #333;
+    margin-bottom: 3px;
+  }
+
   /* PROJECTS */
   .project {
     margin-bottom: 10px;
@@ -309,6 +339,15 @@ version: 1.0.0
   .skill-category {
     font-weight: 600;
     color: #2c3e50;
+  }
+
+  /* Optional qualifier line under a skill category (see .skill-note in the base
+     template for why this is its own block rather than a line break inside the
+     items text). */
+  .skill-note {
+    display: block;
+    padding-left: 14px;
+    color: #555;
   }
 
   /* PAGE BREAK CONTROL */

--- a/templates/ats/sections/experience.html
+++ b/templates/ats/sections/experience.html
@@ -7,18 +7,20 @@
     ROLE             — job title
     BULLETS          — rendered <li> tags
     LOCATION_BLOCK   — conditional: .job-location div when location present; omitted when absent
+    JOB_CLASS        — '' or ' job--keep-together' when entry.keepTogether is set (#3961 follow-up)
+    ENGAGEMENTS      — rendered "Selected engagements" sub-list, or '' when entry.engagements is absent
 
   Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
 <!--ENTRY-->
-<div class="job">
+<div class="job{{JOB_CLASS}}">
   <div class="job-role">{{ROLE}}</div>
   <div class="job-company">{{COMPANY}}</div>
   {{LOCATION_BLOCK}}
   <div class="job-period">{{PERIOD}}</div>
   <ul>
     {{BULLETS}}
-  </ul>
+  </ul>{{ENGAGEMENTS}}
 </div>
 <!--LOCATION_BLOCK--><div class="job-location">{{LOCATION}}</div><!--/LOCATION_BLOCK-->
 <!--/ENTRY-->

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -237,6 +237,43 @@
     font-weight: 600;
   }
 
+  /* Opt-in via experience[].keepTogether (#3961 follow-up): stops a
+     bullet-heavy entry — usually the last one on a trimmed CV — from
+     splitting across a page boundary mid-bullet. Off by default; see
+     PAGE BREAK CONTROL below for why multi-bullet entries are otherwise
+     allowed to flow across pages. */
+  .job--keep-together {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Opt-in via experience[].engagements (#3961 follow-up): a "Selected
+     engagements" sub-list for a role that bundles several named
+     client/project engagements under one umbrella employer (e.g. an
+     independent-consulting entry). The label itself is not bulleted —
+     only the entries under it are — so it reads as a sub-heading, not
+     another bullet at the same level as the role's own achievements. */
+  .job .sub-label {
+    font-size: 10.5px;
+    font-weight: 600;
+    color: #333;
+    margin-top: 6px;
+    margin-bottom: 4px;
+  }
+
+  .job .sub-list {
+    list-style: disc;
+    padding-left: 34px;
+    margin-top: 0;
+  }
+
+  .job .sub-list li {
+    font-size: 10.5px;
+    line-height: 1.6;
+    color: #333;
+    margin-bottom: 4px;
+  }
+
   /* === PROJECTS === */
   .project {
     margin-bottom: 12px;
@@ -419,6 +456,20 @@
     font-size: 10.5px;
   }
 
+  /* Optional qualifier line under a skill category — typically "which of these
+     is working familiarity rather than depth". Its own block, indented and
+     muted, so it reads as a deliberate annotation. A bare line break inside the
+     items text cannot do this job: once the items line wraps on its own (which
+     it routinely does in a language that runs longer than English) the reader
+     cannot tell the intentional break from the accidental one. */
+  .skill-note {
+    display: block;
+    padding-left: 14px;
+    color: #666;
+    font-size: 10px;
+    line-height: 1.5;
+  }
+
   /* === PRINT === */
   @media print {
     body {
@@ -442,7 +493,11 @@
   /* Only avoid breaking small atomic units (a cert row, an education line, the
      header, a single competency or skill).  Sections and multi-bullet roles are
      allowed to flow across a page boundary so content packs tight instead of
-     jumping wholesale and leaving large bottom gaps. */
+     jumping wholesale and leaving large bottom gaps. When a specific entry
+     needs the opposite — usually the last role on a trimmed CV, where an
+     awkward mid-bullet split reads worse than a mostly-empty page above it —
+     set that one entry's keepTogether instead of changing this default; see
+     .job--keep-together above. */
   .header,
   .edu-item,
   .cert-item,

--- a/templates/sections/experience.html
+++ b/templates/sections/experience.html
@@ -7,11 +7,13 @@
     ROLE             — job title
     BULLETS          — rendered <li> tags
     LOCATION_BLOCK   — conditional: .job-location div when location present; omitted when absent
+    JOB_CLASS        — '' or ' job--keep-together' when entry.keepTogether is set (#3961 follow-up)
+    ENGAGEMENTS      — rendered "Selected engagements" sub-list, or '' when entry.engagements is absent
 
   Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
 <!--ENTRY-->
-<div class="job">
+<div class="job{{JOB_CLASS}}">
   <div class="job-header">
     <span class="job-company">{{COMPANY}}</span>
     <span class="job-period">{{PERIOD}}</span>
@@ -20,7 +22,7 @@
   {{LOCATION_BLOCK}}
   <ul>
     {{BULLETS}}
-  </ul>
+  </ul>{{ENGAGEMENTS}}
 </div>
 <!--LOCATION_BLOCK--><div class="job-location">{{LOCATION}}</div><!--/LOCATION_BLOCK-->
 <!--/ENTRY-->

--- a/templates/sections/skills.html
+++ b/templates/sections/skills.html
@@ -4,10 +4,12 @@
   Field placeholders filled per skill category:
     CATEGORY_BLOCK — conditional: category label span when category is present; omitted otherwise
     ITEMS_TEXT     — comma-joined items string
+    NOTE_BLOCK     — conditional: qualifier line under the items when note is present; omitted otherwise
 
   Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
 <!--ENTRY-->
-<div class="skill-item">{{CATEGORY_BLOCK}}{{ITEMS_TEXT}}</div>
+<div class="skill-item">{{CATEGORY_BLOCK}}{{ITEMS_TEXT}}{{NOTE_BLOCK}}</div>
 <!--CATEGORY_BLOCK--><span class="skill-category">{{CATEGORY}}: </span><!--/CATEGORY_BLOCK-->
+<!--NOTE_BLOCK--><span class="skill-note">{{NOTE}}</span><!--/NOTE_BLOCK-->
 <!--/ENTRY-->

--- a/tests/nbsp-french-punctuation.test.mjs
+++ b/tests/nbsp-french-punctuation.test.mjs
@@ -1,0 +1,63 @@
+// tests/nbsp-french-punctuation.test.mjs — normalizeTextForATS() flattens a
+// stray NBSP to a plain space for ATS safety (#1728), but French typography
+// requires an espace insécable immediately before :;!? — and this pass runs
+// on the raw HTML string BEFORE page.setContent(), so an NBSP flattened here
+// can never become "unbreakable" again once Chromium lays out the page.
+// #3961 follow-up: a negative lookahead exempts NBSP directly before :;!?
+// from the flatten, so it survives into the rendered PDF's line-breaking.
+import { pass, fail } from './helpers.mjs';
+import { normalizeTextForATS } from '../generate-pdf.mjs';
+
+console.log('\nnormalizeTextForATS — French espace insécable before :;!?');
+
+const NBSP = ' ';
+
+function bumpedNbsp(html) {
+  return normalizeTextForATS(html).replacements.nbsp || 0;
+}
+
+// NBSP directly before each of :;!? survives untouched.
+for (const punct of [':', ';', '!', '?']) {
+  const html = `<div>Expirée${NBSP}${punct} Certified Ethical Hacker</div>`;
+  const { html: out, replacements } = normalizeTextForATS(html);
+  if (out.includes(`Expirée${NBSP}${punct}`)) {
+    pass(`NBSP before "${punct}" is preserved`);
+  } else {
+    fail(`NBSP before "${punct}" was flattened: ${JSON.stringify(out)}`);
+  }
+  if (!replacements.nbsp) {
+    pass(`NBSP before "${punct}" is not counted as a replacement`);
+  } else {
+    fail(`NBSP before "${punct}" was still counted as a replacement`);
+  }
+}
+
+// An NBSP anywhere else — mid-sentence, before a letter, at the very end of
+// the string — is still flattened exactly as before this change.
+{
+  const html = `<div>10${NBSP}000 $ (a pasted figure)</div>`;
+  const { html: out, replacements } = normalizeTextForATS(html);
+  if (out.includes('10 000')) {
+    pass('an unrelated NBSP (mid-number) is still flattened to a plain space');
+  } else {
+    fail(`unrelated NBSP was not flattened: ${JSON.stringify(out)}`);
+  }
+  if (replacements.nbsp === 1) {
+    pass('the flattened NBSP is still counted in the replacements tally');
+  } else {
+    fail(`expected nbsp:1 in replacements, got ${JSON.stringify(replacements)}`);
+  }
+}
+
+// An NBSP followed by ordinary text, not punctuation, is flattened even when
+// a :;!? appears later in the same string — the lookahead must be anchored
+// immediately after the NBSP, not "somewhere ahead of it".
+{
+  const html = `<div>word${NBSP}not-punctuation: rest</div>`;
+  const { html: out } = normalizeTextForATS(html);
+  if (out.includes('word not-punctuation:')) {
+    pass('NBSP not immediately before :;!? is flattened even when punctuation follows later');
+  } else {
+    fail(`unexpected output: ${JSON.stringify(out)}`);
+  }
+}


### PR DESCRIPTION
Closes #3961.

## What

Five additions to the HTML CV builder, all opt-in and additive — an existing payload renders byte-identically.

| Feature | Shape |
|---|---|
| Running footer | `--running-footer` flag: name, a contact method, "N of TOTAL" on every page |
| Selected engagements | `experience[].engagements: [{ name, detail }]` |
| Keep entry whole | `experience[].keepTogether: boolean` (default `false`) |
| Skill qualifier | `skills[].note: string` |
| Multi-paragraph summary | literal `\n` → `<br>`, `\n\n` → paragraph gap |

## Why

Rendering a CV for a bilingual consulting profile currently means flattening real client engagements into ordinary bullets — where they read as unrelated achievements — or hand-editing generated HTML, which defeats the payload being the source of truth.

`skills[].note` exists for honesty: it's the place to say "working familiarity" instead of silently implying equal depth across everything in a category.

## French typography

Multi-paragraph summary support comes with NBSP handling: a negative lookahead exempts NBSP directly before `:;!?` (French spacing) while still normalising stray NBSP to a plain space for ATS safety, continuing #1728. Covered by `tests/nbsp-french-punctuation.test.mjs`.

## Second commit

`fix(cv-schema)` widens `ENTRY_FIELD_SPECS` for the three new keys. Without it the strict key validator from #3523 warns "a key no builder reads" on every payload using them — even though the builder renders them.

## Notes for review

- Both `templates/cv-template.html` and the ATS variant are updated; `keepTogether` and `engagements` are CSS-only opt-ins that no existing payload triggers.
- `--running-footer` composes with the existing `--skip-fact-check`; both are listed in the usage block.
- The `modes/pdf.md` schema table gains rows for each new key, alongside upstream's #3523 key-enforcement section.

## Testing

`node build-cv-html.mjs --test` renders valid with zero warnings. Full suite against current `main`: no failures attributable to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can create multilingual and consulting-focused CVs from one payload.

- Add `--running-footer` for candidate details and localized page numbers on multi-page PDFs: `generate-pdf.mjs`
- Add `experience[].engagements` and `experience[].keepTogether`: `build-cv-html.mjs`, `templates/sections/experience.html`, `templates/ats/sections/experience.html`
- Add `skills[].note` and multiline summaries: `build-cv-html.mjs`, `templates/sections/skills.html`
- Preserve French NBSP before `:;!?` during ATS normalization: `generate-pdf.mjs`, `tests/nbsp-french-punctuation.test.mjs`
- Accept the new fields in strict schema validation: `lib/cv-payload-schema.mjs`
- Document the options and newline behavior: `modes/pdf.md`
- Add `pdf-lib` for footer stamping: `package.json`

Existing payloads remain unchanged. No changes were made to `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->