### PR TITLE
fix(tests): a killed test run leaves no trap for the next one

### DIFF
--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -23,6 +23,7 @@
 
 import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { isScratchDir } from './scratch-dirs.mjs';
 
 /**
  * Directories excluded from the walk BY NAME.
@@ -158,6 +159,15 @@ export function collectMjsFiles(root) {
     }
     for (const entry of entries) {
       if (SKIP_DIRS.has(entry.name)) continue;
+      // A scratch copy left behind by an interrupted `test-all.mjs` is a second
+      // copy of this repository that neither exclusion above can see: it is
+      // named unpredictably, so SKIP_DIRS cannot list it, and it is copied
+      // without `.git`, so isNestedCheckout() below does not recognise it
+      // either. Every consumer of this walk then grades a stale duplicate as
+      // source — same shape as the nested worktree in #3499, different marker
+      // (#3940). Skipped here rather than per consumer so a new walker inherits
+      // the exclusion instead of rediscovering the bug.
+      if (isScratchDir(entry.name)) continue;
       // Symlinked directories can point outside the checkout or back into it;
       // neither should make the walk recurse unpredictably.
       if (entry.isSymbolicLink()) continue;

--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -167,7 +167,13 @@ export function collectMjsFiles(root) {
       // source — same shape as the nested worktree in #3499, different marker
       // (#3940). Skipped here rather than per consumer so a new walker inherits
       // the exclusion instead of rediscovering the bug.
-      if (isScratchDir(entry.name)) continue;
+      //
+      // Directories only. The name is a prefix, so a FILE could carry it too —
+      // and skipping `.tmp-script-test-something.mjs` would quietly drop it from
+      // the syntax gate, which is the "gate covering a file set nobody chose"
+      // failure this module exists to remove. Only a directory can hold a copy
+      // of the repository, so only a directory is what this excludes.
+      if (entry.isDirectory() && isScratchDir(entry.name)) continue;
       // Symlinked directories can point outside the checkout or back into it;
       // neither should make the walk recurse unpredictably.
       if (entry.isSymbolicLink()) continue;

--- a/lib/scratch-dirs.mjs
+++ b/lib/scratch-dirs.mjs
@@ -1,0 +1,175 @@
+/**
+ * scratch-dirs.mjs — the one definition of "a throwaway copy of this checkout".
+ *
+ * Section 75 of `test-all.mjs` copies the whole checkout into
+ * `mkdtempSync(join(ROOT, '.tmp-script-test-'))` so the script smoke tests can
+ * run against a tree they are free to damage, and removes it in a `finally`. A
+ * run killed between the two — a timeout, Ctrl-C, a crash — never reaches that
+ * `finally` and leaves the copy behind.
+ *
+ * Nothing then notices. `.gitignore` carries a directory rule for the prefix, so
+ * `git status` is empty; the copy excludes `.git`, so `isNestedCheckout()` in
+ * `mjs-files.mjs` cannot recognise it either. Every walker reads the stale copy
+ * as part of the repository, and the guards that grade file LAYOUT are the ones
+ * that break: a full second copy of `tests/` is, to
+ * `tests/core-test-layout.test.mjs`, several hundred suites sitting outside
+ * `tests/`. Measured on a clean `main`: 264 failures locally against 0 in CI,
+ * naming paths under `.tmp-script-test-OP9Bzd/.tmp-script-test-tBjFgy/…`
+ * (#3940). The nesting in that path is the second half of the bug — the copy
+ * loop did not exclude an existing scratch either, so each run wrapped the
+ * previous leftover inside its own.
+ *
+ * That failure shape is worse than a plain false red. It is unreproducible for
+ * anyone else, it points at correct files, it appears on a commit the developer
+ * did not write, and the state causing it is invisible to every command they
+ * would think to run.
+ *
+ * The prefix lives here rather than at its three use sites because it was
+ * already written twice — the `mkdtempSync` call and `.gitignore` — and had
+ * begun to drift: one of them knew the scratch directory existed and the other
+ * did not. A consumer that must recognise a scratch directory imports
+ * `isScratchDir`; it cannot be spelled slightly differently in a fourth place.
+ *
+ * `.gitignore` is the one copy that cannot import this, since git reads it. Its
+ * rule is the prefix followed by a glob and a directory slash, and
+ * `tests/scratch-dirs.test.mjs` pins the two against each other by asking git
+ * itself whether it ignores a directory named from this constant — a textual
+ * comparison would pass on a rule that no longer matches anything.
+ */
+
+import { readdirSync, rmSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The prefix `mkdtempSync` is called with, and therefore the only thing a
+ * scratch directory is guaranteed to have in common with the next one — the
+ * six random characters after it are the point of `mkdtemp`.
+ */
+export const SCRATCH_PREFIX = '.tmp-script-test-';
+
+/**
+ * Is this directory NAME a throwaway copy left by the script smoke tests?
+ *
+ * Takes a bare name, not a path, because both walkers that consult it are
+ * already iterating `readdirSync` entries and a path-taking predicate would
+ * invite a caller to pass a path and match a legitimate directory that merely
+ * sits inside a scratch tree.
+ *
+ * @param {string} name - A single path segment.
+ * @returns {boolean}
+ */
+export function isScratchDir(name) {
+  return name.startsWith(SCRATCH_PREFIX);
+}
+
+/**
+ * How long a scratch directory must have sat untouched before a sweep will
+ * delete it.
+ *
+ * The sweep is housekeeping, not correctness. What keeps a leftover from
+ * breaking a run is `isScratchDir` in the walkers — the guards never read one
+ * whether it is swept or not. All the sweep does is reclaim the disk, so it can
+ * afford to be timid, and being timid is the whole point here: a second
+ * `test-all.mjs` running in the same checkout has a scratch directory of its
+ * own, and deleting THAT crashes a run that was doing nothing wrong.
+ *
+ * An hour, against a full suite that takes ~4 minutes locally and well under 30
+ * on the slowest CI runner. The leftovers in #3940 were dated 7-aug and 15-aug,
+ * so nothing is being kept that anyone wanted.
+ */
+export const MIN_SCRATCH_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Remove every scratch directory directly under `root` that has been untouched
+ * for at least `minAgeMs`, and say which.
+ *
+ * Called at the start of a run rather than only at the end of one: the leftover
+ * exists precisely because the previous run's cleanup did not get to execute,
+ * so a second cleanup path scheduled the same way would not have run either.
+ * The next run's startup is the first moment that is guaranteed to happen.
+ *
+ * Age is read from the directory's own mtime, which stops advancing once the
+ * copy that filled it has finished — so it measures "when did a run last touch
+ * this", not "when was it created". A live run's scratch is minutes old at
+ * most; a leftover's is as old as the crash.
+ *
+ * Top level only. A scratch directory is created directly under ROOT, so that
+ * is where a stale one is; recursing would mean walking into a tree this
+ * function is about to delete, and a `.tmp-script-test-` name deeper in the
+ * repository belongs to whoever put it there.
+ *
+ * Symlinks are never followed, and never removed: `entry.isDirectory()` is
+ * false for one, so a link named like a scratch directory is skipped before any
+ * of this. That is load-bearing — this function authorises a recursive delete,
+ * and following a link would move that delete somewhere nobody asked for — so
+ * `tests/scratch-dirs.test.mjs` pins it rather than leaving it to be inferred
+ * from `withFileTypes`.
+ *
+ * Returns the names rather than printing them, so the caller decides whether a
+ * sweep is worth a line of output. Silence would be wrong — a run that quietly
+ * deleted a directory is its own small mystery — but that is the caller's call
+ * to make, not this function's.
+ *
+ * A directory that cannot be removed is reported, not thrown: a sweep is
+ * housekeeping in front of the real work, and failing the whole suite because a
+ * stale copy is momentarily locked would replace a false red with another one.
+ * The walkers skip it regardless, so the run stays correct either way.
+ *
+ * @param {string} root - Absolute path to sweep.
+ * @param {object} [options]
+ * @param {number} [options.minAgeMs] - Age floor; see MIN_SCRATCH_AGE_MS.
+ * @param {() => number} [options.now] - Clock seam, so the age gate is testable
+ *   without sleeping for an hour.
+ * @param {(dir: string) => void} [options.remove] - Removal seam, so a test can
+ *   drive the failure branch without arranging an undeletable directory.
+ * @returns {{removed: string[], kept: string[], failed: {name: string, error: string}[]}}
+ */
+export function sweepScratchDirs(root, options = {}) {
+  const {
+    minAgeMs = MIN_SCRATCH_AGE_MS,
+    now = Date.now,
+    remove = (dir) => rmSync(dir, { recursive: true, force: true }),
+  } = options;
+
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    // An unreadable root is the caller's problem, and it is about to be their
+    // very loud problem regardless: everything after this reads the same tree.
+    return { removed: [], kept: [], failed: [] };
+  }
+
+  const removed = [];
+  const kept = [];
+  const failed = [];
+  const at = now();
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !isScratchDir(entry.name)) continue;
+    const dir = join(root, entry.name);
+
+    let age;
+    try {
+      age = at - statSync(dir).mtimeMs;
+    } catch {
+      // Gone between readdir and stat, or unreadable. Either way this sweep has
+      // nothing to do with it: not removed, and not claimed as kept.
+      continue;
+    }
+    if (age < minAgeMs) {
+      // Young enough to belong to a run that is still going. Left alone, and
+      // named, so a caller that wonders why the directory is still there can be
+      // told rather than left guessing.
+      kept.push(entry.name);
+      continue;
+    }
+
+    try {
+      remove(dir);
+      removed.push(entry.name);
+    } catch (err) {
+      failed.push({ name: entry.name, error: err?.message ?? String(err) });
+    }
+  }
+  return { removed: removed.sort(), kept: kept.sort(), failed };
+}

--- a/lib/scratch-dirs.mjs
+++ b/lib/scratch-dirs.mjs
@@ -91,6 +91,22 @@ export const MIN_SCRATCH_AGE_MS = 60 * 60 * 1000;
 export const SCRATCH_OWNER_FILE = '.owner-pid';
 
 /**
+ * The age past which a scratch directory is removed even if its marker claims a
+ * living owner.
+ *
+ * `kill(pid, 0)` answers "is that pid running", not "is that pid the run that
+ * wrote this marker". After a crash the pid is free to be reused, and a marker
+ * pointing at a recycled pid reads as alive forever — so without a ceiling,
+ * "never sweep a live run's tree" quietly becomes "never sweep this tree".
+ *
+ * A week, chosen to be unreachable by any real run rather than to be tight: the
+ * claim being overruled is a liveness signal, and overruling it early would put
+ * back the failure the marker was added to remove. What it bounds is disk, not
+ * correctness — the walkers skip a scratch either way.
+ */
+export const MAX_SCRATCH_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
  * Record this process as the owner of `dir`.
  *
  * Best effort. A scratch that fails to get a marker is not broken, it just
@@ -157,7 +173,10 @@ export function scratchOwnerAlive(dir, signal = (pid) => process.kill(pid, 0)) {
  * laptop that slept — goes on aging while it is very much alive.
  *
  * Age is the fallback, for a directory with no usable marker: leftovers that
- * predate this mechanism, and any run whose marker could not be written.
+ * predate this mechanism, and any run whose marker could not be written. It is
+ * also the ceiling — past `maxAgeMs` a living-owner claim is overruled, because
+ * a pid outlives the run that wrote it and a recycled one would otherwise keep
+ * a dead run's tree forever.
  *
  * Top level only. A scratch directory is created directly under ROOT, so that
  * is where a stale one is; recursing would mean walking into a tree this
@@ -184,6 +203,8 @@ export function scratchOwnerAlive(dir, signal = (pid) => process.kill(pid, 0)) {
  * @param {string} root - Absolute path to sweep.
  * @param {object} [options]
  * @param {number} [options.minAgeMs] - Age floor; see MIN_SCRATCH_AGE_MS.
+ * @param {number} [options.maxAgeMs] - Age past which a living-owner claim is
+ *   overruled; see MAX_SCRATCH_AGE_MS.
  * @param {() => number} [options.now] - Clock seam, so the age gate is testable
  *   without sleeping for an hour.
  * @param {(dir: string) => void} [options.remove] - Removal seam, so a test can
@@ -194,6 +215,7 @@ export function scratchOwnerAlive(dir, signal = (pid) => process.kill(pid, 0)) {
 export function sweepScratchDirs(root, options = {}) {
   const {
     minAgeMs = MIN_SCRATCH_AGE_MS,
+    maxAgeMs = MAX_SCRATCH_AGE_MS,
     now = Date.now,
     remove = (dir) => rmSync(dir, { recursive: true, force: true }),
     isAlive = scratchOwnerAlive,
@@ -216,19 +238,20 @@ export function sweepScratchDirs(root, options = {}) {
     if (!entry.isDirectory() || !isScratchDir(entry.name)) continue;
     const dir = join(root, entry.name);
 
-    // Asked before age, because it is the real question. Age is only the
-    // fallback for a directory that cannot answer it.
-    if (isAlive(dir)) {
-      kept.push(entry.name);
-      continue;
-    }
-
     let age;
     try {
       age = at - statSync(dir).mtimeMs;
     } catch {
       // Gone between readdir and stat, or unreadable. Either way this sweep has
       // nothing to do with it: not removed, and not claimed as kept.
+      continue;
+    }
+
+    // Liveness is asked before age, because it is the real question — but it is
+    // overruled past maxAgeMs, since a marker can outlive its run through pid
+    // reuse and would otherwise protect the directory forever.
+    if (age < maxAgeMs && isAlive(dir)) {
+      kept.push(entry.name);
       continue;
     }
     if (age < minAgeMs) {

--- a/lib/scratch-dirs.mjs
+++ b/lib/scratch-dirs.mjs
@@ -37,7 +37,7 @@
  * comparison would pass on a rule that no longer matches anything.
  */
 
-import { readdirSync, rmSync, statSync } from 'fs';
+import { readdirSync, rmSync, statSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -80,6 +80,67 @@ export function isScratchDir(name) {
 export const MIN_SCRATCH_AGE_MS = 60 * 60 * 1000;
 
 /**
+ * Name of the marker a run drops inside its own scratch directory, holding the
+ * pid that owns it.
+ *
+ * Age alone is a proxy for "is anybody using this", and it is wrong in one
+ * direction that matters: a run paused or blocked after its copy finished stops
+ * touching the tree, so its mtime stales while the run is very much alive. This
+ * turns the question into one the operating system can answer.
+ */
+export const SCRATCH_OWNER_FILE = '.owner-pid';
+
+/**
+ * Record this process as the owner of `dir`.
+ *
+ * Best effort. A scratch that fails to get a marker is not broken, it just
+ * falls back to being judged on age — which is exactly where this started, so
+ * the failure mode is the previous behaviour rather than a new one.
+ *
+ * @param {string} dir - The scratch directory.
+ * @param {number} [pid]
+ */
+export function markScratchOwner(dir, pid = process.pid) {
+  try {
+    writeFileSync(join(dir, SCRATCH_OWNER_FILE), `${pid}\n`);
+  } catch {
+    // See above: no marker means the age gate decides, which is survivable.
+  }
+}
+
+/**
+ * Is the process that owns this scratch directory still running?
+ *
+ * `kill(pid, 0)` sends no signal; it asks whether the pid can be signalled.
+ * ESRCH means gone. EPERM means it exists and belongs to somebody else, which
+ * for this question is a yes — and is the safer reading regardless, since the
+ * caller is deciding whether to delete a directory.
+ *
+ * Unknown (no marker, unreadable, not a number) is deliberately NOT "alive": a
+ * leftover from before this marker existed has none, and treating that as a
+ * live run would mean never sweeping anything.
+ *
+ * @param {string} dir
+ * @param {(pid: number) => void} [signal] - Seam for the liveness probe.
+ * @returns {boolean}
+ */
+export function scratchOwnerAlive(dir, signal = (pid) => process.kill(pid, 0)) {
+  let pid;
+  try {
+    pid = Number.parseInt(readFileSync(join(dir, SCRATCH_OWNER_FILE), 'utf-8').trim(), 10);
+  } catch {
+    return false;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    signal(pid);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM';
+  }
+}
+
+/**
  * Remove every scratch directory directly under `root` that has been untouched
  * for at least `minAgeMs`, and say which.
  *
@@ -88,10 +149,15 @@ export const MIN_SCRATCH_AGE_MS = 60 * 60 * 1000;
  * so a second cleanup path scheduled the same way would not have run either.
  * The next run's startup is the first moment that is guaranteed to happen.
  *
- * Age is read from the directory's own mtime, which stops advancing once the
- * copy that filled it has finished — so it measures "when did a run last touch
- * this", not "when was it created". A live run's scratch is minutes old at
- * most; a leftover's is as old as the crash.
+ * Liveness is asked first, and answered by the operating system: a run marks
+ * its own scratch with its pid (`markScratchOwner`), and a directory whose
+ * owner is still running is never removed no matter how old it looks. That
+ * matters because mtime stops advancing once the copy that filled the tree has
+ * finished, so a run that then blocks — a debugger, a suspended process, a
+ * laptop that slept — goes on aging while it is very much alive.
+ *
+ * Age is the fallback, for a directory with no usable marker: leftovers that
+ * predate this mechanism, and any run whose marker could not be written.
  *
  * Top level only. A scratch directory is created directly under ROOT, so that
  * is where a stale one is; recursing would mean walking into a tree this
@@ -122,6 +188,7 @@ export const MIN_SCRATCH_AGE_MS = 60 * 60 * 1000;
  *   without sleeping for an hour.
  * @param {(dir: string) => void} [options.remove] - Removal seam, so a test can
  *   drive the failure branch without arranging an undeletable directory.
+ * @param {(dir: string) => boolean} [options.isAlive] - Liveness seam.
  * @returns {{removed: string[], kept: string[], failed: {name: string, error: string}[]}}
  */
 export function sweepScratchDirs(root, options = {}) {
@@ -129,6 +196,7 @@ export function sweepScratchDirs(root, options = {}) {
     minAgeMs = MIN_SCRATCH_AGE_MS,
     now = Date.now,
     remove = (dir) => rmSync(dir, { recursive: true, force: true }),
+    isAlive = scratchOwnerAlive,
   } = options;
 
   let entries;
@@ -147,6 +215,13 @@ export function sweepScratchDirs(root, options = {}) {
   for (const entry of entries) {
     if (!entry.isDirectory() || !isScratchDir(entry.name)) continue;
     const dir = join(root, entry.name);
+
+    // Asked before age, because it is the real question. Age is only the
+    // fallback for a directory that cannot answer it.
+    if (isAlive(dir)) {
+      kept.push(entry.name);
+      continue;
+    }
 
     let age;
     try {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -58,6 +58,7 @@ import * as yaml from 'js-yaml';
 import { pass, fail, warn, run, runAcrossUtcDay, lastRunFailure, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, DEFAULT_SCRIPT_TIMEOUT_MS, getBash, toBashPath, hermeticGitEnv } from './tests/helpers.mjs';
 import { flagValue, hasFlag } from './lib/cli-flags.mjs';
 import { collectMjsFiles, isNestedCheckout, isUnderNestedCheckout } from './lib/mjs-files.mjs';
+import { SCRATCH_PREFIX, isScratchDir, sweepScratchDirs } from './lib/scratch-dirs.mjs';
 
 /**
  * Read a repo-relative text file as UTF-8.
@@ -205,6 +206,38 @@ async function runDiscovered(filter = null) {
         if (line.trim()) console.log(`      ${line.trim()}`);
       }
     }
+  }
+}
+
+// A scratch copy left by a killed run used to poison every walker that follows:
+// `.gitignore` hides it and the copy carries no `.git`, so neither `git status`
+// nor `isNestedCheckout()` could see it, and the layout guards read a second
+// copy of `tests/` as several hundred misplaced suites (#3940).
+//
+// What makes the run correct is `isScratchDir` in the walkers, not this sweep —
+// they skip a leftover whether it gets removed or not. This only reclaims the
+// disk, which is why it can afford the age gate that keeps it off a scratch a
+// concurrent run is still writing into.
+//
+// Placed before the `--only` exit below: the 264-failure run is exactly the one
+// a developer then re-runs with `--only core-test-layout` to look closer, and a
+// sweep they skip past would leave that second run behaving differently again.
+{
+  const { removed, failed } = sweepScratchDirs(ROOT);
+  // Only speak when there was something to say. A sweep is silent on the
+  // overwhelming majority of runs, and a line reporting that nothing happened
+  // would be noise at the top of every one of them. `kept` is deliberately not
+  // reported: a young scratch is somebody else's live run, and it is none of
+  // this run's business.
+  for (const name of removed) {
+    console.log(`  🧹 removed a stale scratch copy from an interrupted run: ${name}/`);
+  }
+  for (const { name, error } of failed) {
+    // Not fatal — the walkers skip it, so every guard below still grades the
+    // real tree — but not silent either: something is holding a directory this
+    // run tried to delete, and that is worth knowing before it becomes a
+    // disk-space question.
+    warn(`could not remove the stale scratch copy ${name}/ (${error}) — the guards skip it, so this run is unaffected`);
   }
 }
 
@@ -406,7 +439,7 @@ const scripts = [
   { name: 'archive-posting.mjs --help', expectExit: 0 },
 ];
 
-const scriptTmp = mkdtempSync(join(ROOT, '.tmp-script-test-'));
+const scriptTmp = mkdtempSync(join(ROOT, SCRATCH_PREFIX));
 try {
   // Never copied, at any depth: dependency trees and git metadata. Nothing run
   // from the throwaway copy reads them (module resolution walks up into the
@@ -418,6 +451,20 @@ try {
   const copyDirSync = (src, dest, exclude = []) => {
     const name = src.split(/[\\/]/).pop();
     if (EXCLUDE_AT_ANY_DEPTH.has(name)) return;
+    // A leftover from an earlier interrupted run is not repository source, and
+    // copying one nests it inside this run's scratch — which is how #3940's
+    // `.tmp-script-test-OP9Bzd/.tmp-script-test-tBjFgy/…` came to exist. This
+    // run's OWN scratch is already excluded by name in `excludeDirs` below; what
+    // this adds is the stale one the startup sweep could not remove, and — since
+    // that sweep deliberately leaves a young directory alone — the live one a
+    // concurrent run is writing into right now.
+    //
+    // At any depth, deliberately, where sweepScratchDirs() looks only at the top
+    // level. The two are asymmetric because their costs are: skipping a
+    // directory that turns out to be someone's oddly-named fixture loses a copy
+    // nothing reads, while DELETING it loses their work. Cheap to over-skip,
+    // expensive to over-delete.
+    if (isScratchDir(name)) return;
     // Everything else is a top-level workspace dir (data/, reports/, …) and is
     // matched by basename ONLY at the repo root, so nested fixture subdirs such
     // as test-fixtures/upgrade/state-*/data and .../reports still get copied.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -58,7 +58,7 @@ import * as yaml from 'js-yaml';
 import { pass, fail, warn, run, runAcrossUtcDay, lastRunFailure, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, DEFAULT_SCRIPT_TIMEOUT_MS, getBash, toBashPath, hermeticGitEnv } from './tests/helpers.mjs';
 import { flagValue, hasFlag } from './lib/cli-flags.mjs';
 import { collectMjsFiles, isNestedCheckout, isUnderNestedCheckout } from './lib/mjs-files.mjs';
-import { SCRATCH_PREFIX, isScratchDir, sweepScratchDirs } from './lib/scratch-dirs.mjs';
+import { SCRATCH_PREFIX, isScratchDir, markScratchOwner, sweepScratchDirs } from './lib/scratch-dirs.mjs';
 
 /**
  * Read a repo-relative text file as UTF-8.
@@ -440,6 +440,10 @@ const scripts = [
 ];
 
 const scriptTmp = mkdtempSync(join(ROOT, SCRATCH_PREFIX));
+// Claim it before filling it, so a second run starting mid-copy already sees an
+// owner. Without this the sweep would be judging a live tree on its mtime, and
+// mtime stops advancing the moment this copy finishes (#3940 review).
+markScratchOwner(scriptTmp);
 try {
   // Never copied, at any depth: dependency trees and git metadata. Nothing run
   // from the throwaway copy reads them (module resolution walks up into the
@@ -463,13 +467,16 @@ try {
     // level. The two are asymmetric because their costs are: skipping a
     // directory that turns out to be someone's oddly-named fixture loses a copy
     // nothing reads, while DELETING it loses their work. Cheap to over-skip,
-    // expensive to over-delete.
-    if (isScratchDir(name)) return;
+    // expensive to over-delete. Applied against `stat` below, not here, because
+    // the prefix can name a FILE too and dropping a source file from the copy
+    // would make a script check pass by not running it.
+    //
     // Everything else is a top-level workspace dir (data/, reports/, …) and is
     // matched by basename ONLY at the repo root, so nested fixture subdirs such
     // as test-fixtures/upgrade/state-*/data and .../reports still get copied.
     if (dirname(src) === ROOT && exclude.includes(name)) return;
     const stat = statSync(src);
+    if (stat.isDirectory() && isScratchDir(name)) return;
     if (stat.isDirectory()) {
       // A linked worktree is a whole second checkout of this repo and carries a
       // `.git` FILE, not a directory, so the name-based exclusion above never

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -455,27 +455,29 @@ try {
   const copyDirSync = (src, dest, exclude = []) => {
     const name = src.split(/[\\/]/).pop();
     if (EXCLUDE_AT_ANY_DEPTH.has(name)) return;
-    // A leftover from an earlier interrupted run is not repository source, and
-    // copying one nests it inside this run's scratch — which is how #3940's
-    // `.tmp-script-test-OP9Bzd/.tmp-script-test-tBjFgy/…` came to exist. This
-    // run's OWN scratch is already excluded by name in `excludeDirs` below; what
-    // this adds is the stale one the startup sweep could not remove, and — since
-    // that sweep deliberately leaves a young directory alone — the live one a
-    // concurrent run is writing into right now.
-    //
-    // At any depth, deliberately, where sweepScratchDirs() looks only at the top
-    // level. The two are asymmetric because their costs are: skipping a
-    // directory that turns out to be someone's oddly-named fixture loses a copy
-    // nothing reads, while DELETING it loses their work. Cheap to over-skip,
-    // expensive to over-delete. Applied against `stat` below, not here, because
-    // the prefix can name a FILE too and dropping a source file from the copy
-    // would make a script check pass by not running it.
-    //
     // Everything else is a top-level workspace dir (data/, reports/, …) and is
     // matched by basename ONLY at the repo root, so nested fixture subdirs such
     // as test-fixtures/upgrade/state-*/data and .../reports still get copied.
     if (dirname(src) === ROOT && exclude.includes(name)) return;
     const stat = statSync(src);
+    // A leftover from an earlier interrupted run is not repository source, and
+    // copying one nests it inside this run's scratch — which is how #3940's
+    // `.tmp-script-test-OP9Bzd/.tmp-script-test-tBjFgy/…` came to exist. This
+    // run's OWN scratch is already excluded by name just above; what this adds
+    // is the stale one the startup sweep could not remove, and — since that
+    // sweep deliberately leaves a live run's directory alone — the one a
+    // concurrent run is writing into right now.
+    //
+    // Directories only, which is why this reads `stat` rather than sitting with
+    // the name-based exclusions above: the prefix can name a FILE too, and
+    // dropping a source file from the copy would make a script check pass by
+    // not running it.
+    //
+    // At any depth, deliberately, where sweepScratchDirs() looks only at the top
+    // level. The two are asymmetric because their costs are: skipping a
+    // directory that turns out to be someone's oddly-named fixture loses a copy
+    // nothing reads, while DELETING it loses their work. Cheap to over-skip,
+    // expensive to over-delete.
     if (stat.isDirectory() && isScratchDir(name)) return;
     if (stat.isDirectory()) {
       // A linked worktree is a whole second checkout of this repo and carries a

--- a/tests/scratch-dirs.test.mjs
+++ b/tests/scratch-dirs.test.mjs
@@ -18,7 +18,10 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync,
 import { tmpdir } from 'os';
 import { join, relative, sep } from 'path';
 import { pass, fail, ROOT } from './helpers.mjs';
-import { SCRATCH_PREFIX, MIN_SCRATCH_AGE_MS, isScratchDir, sweepScratchDirs } from '../lib/scratch-dirs.mjs';
+import {
+  SCRATCH_PREFIX, MIN_SCRATCH_AGE_MS, isScratchDir, sweepScratchDirs,
+  markScratchOwner, scratchOwnerAlive,
+} from '../lib/scratch-dirs.mjs';
 import { collectMjsFiles } from '../lib/mjs-files.mjs';
 import { execFileSync } from 'child_process';
 
@@ -216,6 +219,86 @@ const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
     } else {
       fail(`symlink handling wrong: target survived=${survived} `
         + `removed=${JSON.stringify(removed)} kept=${JSON.stringify(kept)} failed=${JSON.stringify(failed)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 8. The prefix names a directory, never a file ─────────────────────
+{
+  // `isScratchDir` tests a NAME, and a file can carry the prefix too. Excluding
+  // one from the walk would drop it from the syntax gate — a check passing by
+  // not running, which is the failure `lib/mjs-files.mjs` exists to remove.
+  // Only a directory can hold a copy of the repository.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-file-'));
+  try {
+    writeFileSync(join(dir, `${SCRATCH_PREFIX}sneaky.mjs`), 'export const a = 1;\n');
+    mkdirSync(join(dir, `${SCRATCH_PREFIX}OP9Bzd`), { recursive: true });
+    writeFileSync(join(dir, `${SCRATCH_PREFIX}OP9Bzd`, 'copied.mjs'), 'export {};\n');
+
+    const found = collectMjsFiles(dir).map(f => relative(dir, f).split(sep).join('/'));
+    if (found.length === 1 && found[0] === `${SCRATCH_PREFIX}sneaky.mjs`) {
+      pass('a FILE carrying the scratch prefix stays in the walk; only the directory is skipped');
+    } else {
+      fail(`walk returned ${JSON.stringify(found)}; expected only ${SCRATCH_PREFIX}sneaky.mjs`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 9. Liveness beats age, in both directions ─────────────────────────
+{
+  // Age is a proxy, and it is wrong in the direction that costs something: a run
+  // stops touching its scratch the moment the copy finishes, so one that then
+  // blocks — a debugger, a suspended process, a laptop that slept — ages while
+  // it is still running. The owner's pid is a question the OS can answer.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-owner-'));
+  try {
+    const live = join(dir, `${SCRATCH_PREFIX}live00`);
+    const dead = join(dir, `${SCRATCH_PREFIX}dead00`);
+    for (const d of [live, dead]) mkdirSync(d, { recursive: true });
+    markScratchOwner(live);            // this process, which is definitionally alive
+    markScratchOwner(dead, 0x7fffffff); // a pid nothing is going to be using
+    // Both are pushed well past the age gate: age must not be what decides.
+    age(live, MIN_SCRATCH_AGE_MS * 24);
+    age(dead, MIN_SCRATCH_AGE_MS * 24);
+
+    const { removed, kept } = sweepScratchDirs(dir);
+    if (existsSync(live) && !existsSync(dead)
+        && kept.length === 1 && removed.length === 1) {
+      pass('a live owner keeps its scratch past the age gate, a dead one does not save it');
+    } else {
+      fail(`liveness wrong: removed=${JSON.stringify(removed)} kept=${JSON.stringify(kept)} `
+        + `live exists=${existsSync(live)} dead exists=${existsSync(dead)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 10. An unreadable marker means "unknown", not "alive" ─────────────
+{
+  // Every leftover written before this marker existed has none, so treating an
+  // absent or unparseable marker as a live run would mean never sweeping again —
+  // the bug, restored through the mechanism meant to be careful about it.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-nomarker-'));
+  try {
+    const bare = join(dir, `${SCRATCH_PREFIX}bare00`);
+    const junk = join(dir, `${SCRATCH_PREFIX}junk00`);
+    mkdirSync(bare, { recursive: true });
+    mkdirSync(junk, { recursive: true });
+    writeFileSync(join(junk, '.owner-pid'), 'not-a-pid\n');
+
+    const unknown = !scratchOwnerAlive(bare) && !scratchOwnerAlive(junk);
+    age(bare);
+    age(junk);
+    const { removed } = sweepScratchDirs(dir);
+    if (unknown && removed.length === 2) {
+      pass('a missing or unparseable owner marker falls through to the age gate');
+    } else {
+      fail(`unknown-owner handling wrong: unknown=${unknown} removed=${JSON.stringify(removed)}`);
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/tests/scratch-dirs.test.mjs
+++ b/tests/scratch-dirs.test.mjs
@@ -222,8 +222,8 @@ const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
     } catch (err) {
       // Anything else that cannot make a link says so and moves on, rather than
       // throwing and silently deleting the sections below it from the run.
-      warn(`cannot create a link here (${err?.code ?? err?.message}) — the `
-        + 'symlink case did not run');
+      warn(`cannot create a link here (${err?.code ?? err?.message ?? String(err)}) `
+        + '— the symlink case did not run');
       linkable = false;
     }
     // The TARGET is backdated, not just the parent: a sweep that resolved the

--- a/tests/scratch-dirs.test.mjs
+++ b/tests/scratch-dirs.test.mjs
@@ -1,0 +1,223 @@
+/**
+ * scratch-dirs.test.mjs — a killed test run must not turn the next one red.
+ *
+ * `test-all.mjs` copies the checkout into a `.tmp-script-test-*` directory and
+ * removes it in a `finally` that an interrupted run never reaches. The leftover
+ * is gitignored and carries no `.git`, so neither `git status` nor
+ * `isNestedCheckout()` sees it, and every walker reads a second copy of the
+ * repository as source: 264 failures on a clean `main`, all naming correct
+ * files, none reproducible for anybody else (#3940).
+ *
+ * The assertions below run the real walk and the real sweep against real
+ * directories rather than checking that the prefix appears somewhere. What
+ * broke here was never the spelling of a string; it was that a directory
+ * nothing could see was being graded as source.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, relative, sep } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { SCRATCH_PREFIX, MIN_SCRATCH_AGE_MS, isScratchDir, sweepScratchDirs } from '../lib/scratch-dirs.mjs';
+import { collectMjsFiles } from '../lib/mjs-files.mjs';
+import { execFileSync } from 'child_process';
+
+console.log('\nscratch dirs — an interrupted run leaves no trap for the next one');
+
+// Backdate a directory past the age gate. Real mtimes rather than a stubbed
+// clock wherever the test is not about the clock itself: the gate reads the
+// filesystem, and a stub would let a wrong field (birthtime, ctime) pass.
+const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
+  const when = new Date(Date.now() - ms);
+  utimesSync(dir, when, when);
+};
+
+// ── 1. The predicate ──────────────────────────────────────────────────
+{
+  // mkdtemp appends six random characters, so the prefix is the entire signal.
+  const matches = isScratchDir(`${SCRATCH_PREFIX}OP9Bzd`) && isScratchDir(SCRATCH_PREFIX);
+  // Near misses that must NOT be swept: this function authorises a recursive
+  // delete, so a loose rule costs somebody their directory.
+  const spares = !isScratchDir('tests')
+    && !isScratchDir('.tmp-script-tes')
+    && !isScratchDir('tmp-script-test-x')
+    && !isScratchDir(`prefix-${SCRATCH_PREFIX}x`);
+  if (matches && spares) pass('isScratchDir matches the mkdtemp prefix and nothing adjacent to it');
+  else fail(`isScratchDir is wrong: matches=${matches} spares=${spares}`);
+}
+
+// ── 2. A leftover no longer reaches the walkers ───────────────────────
+{
+  // The reported failure, reproduced through the real walk: a scratch copy
+  // holding a suite, which every layout guard would grade as a suite living
+  // outside tests/.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-walk-'));
+  try {
+    mkdirSync(join(dir, 'tests'), { recursive: true });
+    writeFileSync(join(dir, 'tests', 'real.test.mjs'), 'export {};\n');
+    const scratch = join(dir, `${SCRATCH_PREFIX}OP9Bzd`, 'tests');
+    mkdirSync(scratch, { recursive: true });
+    writeFileSync(join(scratch, 'real.test.mjs'), 'export {};\n');
+
+    const found = collectMjsFiles(dir).map(f => relative(dir, f).split(sep).join('/'));
+    if (found.length === 1 && found[0] === 'tests/real.test.mjs') {
+      pass('collectMjsFiles skips a scratch copy and still returns the real tree');
+    } else {
+      fail(`collectMjsFiles returned ${JSON.stringify(found)}; expected only tests/real.test.mjs`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 3. The sweep removes leftovers, and only leftovers ────────────────
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-sweep-'));
+  try {
+    for (const name of [`${SCRATCH_PREFIX}aaaaaa`, `${SCRATCH_PREFIX}bbbbbb`]) {
+      mkdirSync(join(dir, name, 'tests'), { recursive: true });
+      age(join(dir, name));
+    }
+    mkdirSync(join(dir, 'tests'), { recursive: true });
+    writeFileSync(join(dir, `${SCRATCH_PREFIX}not-a-dir`), 'a file, not a scratch tree\n');
+
+    const { removed, failed } = sweepScratchDirs(dir);
+    const keptTheRepo = existsSync(join(dir, 'tests'));
+    // A FILE carrying the prefix is not a scratch copy, and the sweep deletes
+    // directories: matching it would delete something it never created.
+    const keptTheFile = existsSync(join(dir, `${SCRATCH_PREFIX}not-a-dir`));
+    const gone = [`${SCRATCH_PREFIX}aaaaaa`, `${SCRATCH_PREFIX}bbbbbb`]
+      .every(n => !existsSync(join(dir, n)));
+
+    if (gone && keptTheRepo && keptTheFile && failed.length === 0 && removed.length === 2) {
+      pass('sweepScratchDirs removes every stale scratch directory and touches nothing else');
+    } else {
+      fail(`sweep wrong: removed=${JSON.stringify(removed)} failed=${JSON.stringify(failed)} `
+        + `gone=${gone} keptTheRepo=${keptTheRepo} keptTheFile=${keptTheFile}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 4. An unremovable leftover is reported, not thrown ────────────────
+{
+  // Driven through the removal seam. A locked directory is a real case on
+  // Windows (a handle held by a just-exited child), and the sweep must not turn
+  // it into a crash at the top of the run: it is housekeeping in front of the
+  // real work, and the guards below still report the tree either way.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-locked-'));
+  try {
+    mkdirSync(join(dir, `${SCRATCH_PREFIX}locked`), { recursive: true });
+    age(join(dir, `${SCRATCH_PREFIX}locked`));
+    let result;
+    try {
+      result = sweepScratchDirs(dir, {
+        remove: () => { throw new Error('EPERM: operation not permitted'); },
+      });
+    } catch (err) {
+      fail(`sweepScratchDirs threw instead of reporting: ${err?.message ?? err}`);
+    }
+    if (result && result.removed.length === 0 && result.failed.length === 1
+        && /EPERM/.test(result.failed[0].error)) {
+      pass('a scratch directory that cannot be removed is reported, not thrown');
+    } else if (result) {
+      fail(`expected one reported failure, got ${JSON.stringify(result)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 5. .gitignore and SCRATCH_PREFIX cannot drift apart ───────────────
+{
+  // git is the only thing that can answer this. `.gitignore` cannot import the
+  // constant, so the two are a hand-maintained pair — and the invisibility that
+  // made #3940 hard to see is exactly what that rule provides. Asked as a
+  // question about behaviour: does git ignore a directory named from the
+  // constant? A grep for the rule's text would still pass if the rule stopped
+  // matching, which is the failure worth catching.
+  const probe = `${SCRATCH_PREFIX}gitignoreprobe/tests/probe.test.mjs`;
+  let ignored = false;
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--no-index', '--', probe],
+      { cwd: ROOT, stdio: 'ignore' });
+    ignored = true;
+  } catch {
+    ignored = false;
+  }
+  if (ignored) {
+    pass('.gitignore still ignores a directory named from SCRATCH_PREFIX');
+  } else {
+    fail(`.gitignore no longer covers ${SCRATCH_PREFIX}*/ — a leftover would show up as `
+      + 'untracked noise, or be committed');
+  }
+}
+
+// ── 6. A live run's scratch survives another run's startup sweep ──────
+{
+  // The sweep runs at the top of every `test-all.mjs`, and a second run in the
+  // same checkout has a scratch of its own that is minutes old. Deleting it
+  // crashes a run that was doing nothing wrong — trading #3940's false red for
+  // a real one. The age gate is what keeps this sweep off it.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-live-'));
+  try {
+    const live = join(dir, `${SCRATCH_PREFIX}live00`);
+    const stale = join(dir, `${SCRATCH_PREFIX}stale0`);
+    mkdirSync(live, { recursive: true });
+    mkdirSync(stale, { recursive: true });
+    age(stale);
+
+    const { removed, kept } = sweepScratchDirs(dir);
+    if (existsSync(live) && !existsSync(stale)
+        && kept.length === 1 && kept[0] === `${SCRATCH_PREFIX}live00`
+        && removed.length === 1 && removed[0] === `${SCRATCH_PREFIX}stale0`) {
+      pass("a concurrent run's fresh scratch is kept while the stale one is swept");
+    } else {
+      fail(`age gate wrong: removed=${JSON.stringify(removed)} kept=${JSON.stringify(kept)} `
+        + `live exists=${existsSync(live)} stale exists=${existsSync(stale)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 7. A symlink named like a scratch is never followed, never removed ─
+{
+  // This function authorises a recursive delete, so the one input that must
+  // never work is a link pointing somewhere else. It is safe today only because
+  // `entry.isDirectory()` is false for a symlink — an implicit property of
+  // `withFileTypes` that a future switch to `statSync().isDirectory()` would
+  // silently reverse. Measured with that switch applied: the link is removed.
+  // Its target survives, because `rmSync` on a symlink unlinks it rather than
+  // recursing through it — so the damage is the user's link, not the tree
+  // behind it. Smaller than it first looks, and still not this function's to
+  // delete.
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-symlink-'));
+  try {
+    const precious = join(dir, 'precious');
+    mkdirSync(join(precious, 'work'), { recursive: true });
+    writeFileSync(join(precious, 'work', 'important.txt'), 'not yours to delete\n');
+    const root = join(dir, 'root');
+    mkdirSync(root, { recursive: true });
+    const link = join(root, `${SCRATCH_PREFIX}symlink`);
+    symlinkSync(precious, link, 'dir');
+    // The TARGET is backdated, not just the parent: a sweep that resolved the
+    // link with statSync() would read this old mtime, judge the link stale, and
+    // act on it. Ageing only the parent would leave the link looking fresh and
+    // let a broken sweep pass this on a technicality.
+    age(precious);
+    age(root);
+
+    const { removed, kept, failed } = sweepScratchDirs(root);
+    const survived = existsSync(join(precious, 'work', 'important.txt'));
+    if (survived && removed.length === 0 && kept.length === 0 && failed.length === 0) {
+      pass('a symlink named like a scratch directory is neither followed nor removed');
+    } else {
+      fail(`symlink handling wrong: target survived=${survived} `
+        + `removed=${JSON.stringify(removed)} kept=${JSON.stringify(kept)} failed=${JSON.stringify(failed)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/tests/scratch-dirs.test.mjs
+++ b/tests/scratch-dirs.test.mjs
@@ -17,7 +17,7 @@
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, utimesSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, relative, sep } from 'path';
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, warn, ROOT } from './helpers.mjs';
 import {
   SCRATCH_PREFIX, MIN_SCRATCH_AGE_MS, MAX_SCRATCH_AGE_MS, isScratchDir,
   sweepScratchDirs, markScratchOwner, scratchOwnerAlive,
@@ -197,6 +197,7 @@ const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
   // behind it. Smaller than it first looks, and still not this function's to
   // delete.
   const dir = mkdtempSync(join(tmpdir(), 'co-scratch-symlink-'));
+  let linkable = true;
   try {
     const precious = join(dir, 'precious');
     mkdirSync(join(precious, 'work'), { recursive: true });
@@ -204,7 +205,27 @@ const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
     const root = join(dir, 'root');
     mkdirSync(root, { recursive: true });
     const link = join(root, `${SCRATCH_PREFIX}symlink`);
-    symlinkSync(precious, link, 'dir');
+    // A `dir` symlink needs SeCreateSymbolicLinkPrivilege on Windows, which a
+    // non-elevated shell without Developer Mode does not hold — the default box,
+    // and not what `windows-latest` reproduces. Measured there by @artemtrofymenko:
+    // this threw EPERM, the throw took the four sections after it with it, and CI
+    // stayed green so nothing said so.
+    //
+    // A junction needs no privilege and the target here is a directory, so it is
+    // a substitute rather than a weakening: `lstat` reports a junction as
+    // `isSymbolicLink() === true`, which is the property under test — it is what
+    // makes `entry.isDirectory()` false and sends the sweep down the branch this
+    // section exists to pin. Verified on that same box: the case passes for its
+    // own reason, target intact and all three result arrays empty.
+    try {
+      symlinkSync(precious, link, process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (err) {
+      // Anything else that cannot make a link says so and moves on, rather than
+      // throwing and silently deleting the sections below it from the run.
+      warn(`cannot create a link here (${err?.code ?? err?.message}) — the `
+        + 'symlink case did not run');
+      linkable = false;
+    }
     // The TARGET is backdated, not just the parent: a sweep that resolved the
     // link with statSync() would read this old mtime, judge the link stale, and
     // act on it. Ageing only the parent would leave the link looking fresh and
@@ -212,9 +233,13 @@ const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
     age(precious);
     age(root);
 
-    const { removed, kept, failed } = sweepScratchDirs(root);
+    const { removed, kept, failed } = linkable
+      ? sweepScratchDirs(root)
+      : { removed: [], kept: [], failed: [] };
     const survived = existsSync(join(precious, 'work', 'important.txt'));
-    if (survived && removed.length === 0 && kept.length === 0 && failed.length === 0) {
+    if (!linkable) {
+      // Already warned above. Not a pass: this section asserted nothing.
+    } else if (survived && removed.length === 0 && kept.length === 0 && failed.length === 0) {
       pass('a symlink named like a scratch directory is neither followed nor removed');
     } else {
       fail(`symlink handling wrong: target survived=${survived} `

--- a/tests/scratch-dirs.test.mjs
+++ b/tests/scratch-dirs.test.mjs
@@ -19,8 +19,8 @@ import { tmpdir } from 'os';
 import { join, relative, sep } from 'path';
 import { pass, fail, ROOT } from './helpers.mjs';
 import {
-  SCRATCH_PREFIX, MIN_SCRATCH_AGE_MS, isScratchDir, sweepScratchDirs,
-  markScratchOwner, scratchOwnerAlive,
+  SCRATCH_PREFIX, MIN_SCRATCH_AGE_MS, MAX_SCRATCH_AGE_MS, isScratchDir,
+  sweepScratchDirs, markScratchOwner, scratchOwnerAlive,
 } from '../lib/scratch-dirs.mjs';
 import { collectMjsFiles } from '../lib/mjs-files.mjs';
 import { execFileSync } from 'child_process';
@@ -299,6 +299,36 @@ const age = (dir, ms = MIN_SCRATCH_AGE_MS * 2) => {
       pass('a missing or unparseable owner marker falls through to the age gate');
     } else {
       fail(`unknown-owner handling wrong: unknown=${unknown} removed=${JSON.stringify(removed)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 11. A living-owner claim does not hold forever ────────────────────
+{
+  // `kill(pid, 0)` answers "is that pid running", not "is that pid the run that
+  // wrote this marker". A pid freed by a crash gets reused, and the marker then
+  // reads as alive for as long as the recycled process lives — so the claim
+  // needs a ceiling, or "never sweep a live run" becomes "never sweep".
+  const dir = mkdtempSync(join(tmpdir(), 'co-scratch-ceiling-'));
+  try {
+    const recent = join(dir, `${SCRATCH_PREFIX}recent`);
+    const forever = join(dir, `${SCRATCH_PREFIX}foreve`);
+    for (const d of [recent, forever]) {
+      mkdirSync(d, { recursive: true });
+      markScratchOwner(d);   // this process: alive by construction, for both
+    }
+    age(recent, MIN_SCRATCH_AGE_MS * 2);        // stale, but well under the ceiling
+    age(forever, MAX_SCRATCH_AGE_MS * 2);       // past it
+
+    const { removed, kept } = sweepScratchDirs(dir);
+    if (existsSync(recent) && !existsSync(forever)
+        && kept.length === 1 && removed.length === 1) {
+      pass('a living owner protects its scratch, but not past the ceiling');
+    } else {
+      fail(`ceiling wrong: removed=${JSON.stringify(removed)} kept=${JSON.stringify(kept)} `
+        + `recent exists=${existsSync(recent)} forever exists=${existsSync(forever)}`);
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -236,6 +236,7 @@ const SYSTEM_PATHS = [
   'lib/scan-summary-marker.mjs',
   'lib/is-main-module.mjs',
   'lib/mjs-files.mjs',
+  'lib/scratch-dirs.mjs',
   'lib/outcome-dir.mjs',
   'lib/outcome-types.mjs',
   'lib/latex-escape.mjs',


### PR DESCRIPTION
A `test-all.mjs` run that gets killed leaves a full copy of the checkout behind, and that copy turns the **next** run red: 264 failures locally against 0 in CI, on a clean `main`, every one of them naming a file that is in the right place.

Closes #3940

---

## Why it happens

Section 75 copies the whole checkout into a scratch directory so the script smoke tests can run against a tree they are free to damage, and removes it in a `finally`:

```js
const scriptTmp = mkdtempSync(join(ROOT, '.tmp-script-test-'));
try   { /* run the CLIs against the copy */ }
finally { rmSync(scriptTmp, { recursive: true, force: true }); }
```

A timeout, a Ctrl-C or a crash never reaches that `finally`, so the copy stays. Nothing then notices it, because both mechanisms that would have are blind to this particular directory:

| | why it misses the leftover |
|---|---|
| `git status` | `.gitignore` carries `.tmp-script-test-*/` |
| `isNestedCheckout()` | the copy excludes `.git`, so there is no marker to detect |

Every repo-walking guard therefore reads the copy as source. The loudest consumer is the layout guard, which requires each `*.test.mjs` to live under `tests/` — and a copied suite's path is `.tmp-script-test-OP9Bzd/tests/foo.test.mjs`, which does not start with `tests/`. One leftover, several hundred violations.

It also compounds: the copy loop did not exclude an existing scratch either, so each run wrapped the previous leftover inside its own — the nested `.tmp-script-test-OP9Bzd/.tmp-script-test-tBjFgy/…` in the report.

**Reproducing takes three commands, no crash required:**

```bash
mkdir -p .tmp-script-test-x/tests
cp tests/core-test-layout.test.mjs .tmp-script-test-x/tests/
node tests/core-test-layout.test.mjs
```

`all 377 *.test.mjs files live under tests/` becomes a red line per file, while `git status` stays empty throughout. That invisibility is most of the cost here: the run is red locally and green in CI, it points at correct files, nobody else can reproduce it, and the cause does not appear in any command you would think to run. For a first-time contributor it reads as "I changed nothing and the suite broke".

## The fix

`lib/scratch-dirs.mjs` (new) owns the prefix and the predicate. It was previously written twice — the `mkdtempSync` call and `.gitignore` — and had begun to drift: one of them knew the directory existed, the other did not.

Three consumers, with clearly separated jobs:

| layer | file | job |
|---|---|---|
| **1. Correctness** | `lib/mjs-files.mjs` | `collectMjsFiles` skips a scratch directory, so no guard ever reads one |
| **2. No compounding** | `test-all.mjs` (copy loop) | a stale scratch is never copied into the new one |
| **3. Housekeeping** | `test-all.mjs` (startup) | sweep old leftovers to reclaim the disk |

**Layer 1 is the fix.** The walk is the single entry point every guard shares, so excluding the directory once immunises all of them — a new guard inherits it instead of rediscovering the bug. Same shape as the nested worktree in #3499, different marker. This layer alone removes the 264 failures; the leftover may still sit on disk, but nothing grades it.

**Layer 3 only reclaims disk**, and that separation is what lets it be careful. Without care, a second `test-all.mjs` in the same checkout has its live scratch deleted underneath it — trading a false red for a real one. So the sweep asks two questions in order:

> **Is anybody using this?** A run writes its own pid into the scratch before filling it, and `kill(pid, 0)` answers. A directory with a living owner is not removed.
>
> **Failing that, how old is it?** For a leftover with no usable marker — everything predating this mechanism — an hour, against a full suite that takes ~4 minutes locally. The leftovers in the report were dated 7-aug and 15-aug.

Liveness comes first because age is only a proxy for it, and a wrong one in the direction that costs something: mtime stops advancing when the copy finishes, so a run that then blocks ages while it is alive. The pid claim is itself bounded at a week, since a pid freed by a crash can be reused and would otherwise protect a dead run's tree forever.

The sweep runs **before** the `--only` early exit, because the 264-failure run is exactly the one a developer then re-runs with `--only core-test-layout` to look closer.

### Files

| file | |
|---|---|
| `lib/scratch-dirs.mjs` | new — the prefix and predicate, the owner marker and its liveness check, the sweep |
| `lib/mjs-files.mjs` | +1 line in the walk |
| `test-all.mjs` | import, startup sweep, copy-loop exclusion, owner marker, `mkdtemp` uses the shared constant |
| `tests/scratch-dirs.test.mjs` | new — 11 assertions |
| `update-system.mjs` | +1 line registering the new library file in `SYSTEM_PATHS` |

## How it is verified

Full suite: **8701 passed, 0 failed**.

`main` measures 8687 in a fresh worktree, and the 14 between them is worth spelling out because two of the three parts are not this PR's assertions: 11 from the suite below, 2 from the syntax gate running over two added files, and 1 from `cv-sync-check.mjs`, which passes here and warns in a fresh worktree because that worktree has no user-layer data. The warning count moving 16 → 15 is the same event seen from the other side. A baseline taken in a different checkout is not a pinned comparison, so the number is only useful with that caveat attached.

| # | what it pins | negative control |
|---|---|---|
| 1 | `isScratchDir` matches the mkdtemp prefix and nothing adjacent to it | — |
| 2 | the walk skips a scratch copy and still returns the real tree | ✅ |
| 3 | the sweep removes every stale scratch and touches nothing else | — |
| 4 | a scratch that cannot be removed is reported, not thrown | — |
| 5 | `.gitignore` still ignores a directory named from the constant | ✅ |
| 6 | a concurrent run's fresh scratch is kept, the stale one swept | ✅ |
| 7 | a symlink named like a scratch is neither followed nor removed | ✅ |
| 8 | a FILE carrying the prefix stays in the walk; only the directory is skipped | ✅ |
| 9 | a live owner keeps its scratch past the age gate; a dead one does not | ✅ |
| 10 | a missing or unparseable owner marker falls through to the age gate | — |
| 11 | a living owner is believed, but not past the ceiling | ✅ |

Seven were checked against their own negative — the fix removed, the assertion watched to go red — rather than assumed to work. The two that matter most:

- **remove the walk's skip** → `collectMjsFiles returned [".tmp-script-test-OP9Bzd/tests/real.test.mjs","tests/real.test.mjs"]`, the source of the original 264
- **swap `entry.isDirectory()` for a link-following `statSync`** → `removed=[".tmp-script-test-symlink"]`

That last probe backdates the link's **target**, not just its parent: a fresh link clears the age gate, and a broken sweep would pass on that technicality instead of reaching the delete path. Measured blast radius, stated in the test rather than overclaimed — the link goes, its target survives, because `rmSync` unlinks a symlink rather than recursing through it.

Two deliberate choices in the test:

- **Ages are set with real `utimesSync`, not a stubbed clock.** The gate reads the filesystem; a stub would let an implementation reading the wrong field (`birthtime`, `ctime`) pass.
- **The `.gitignore` pairing asks git**, via `check-ignore`, rather than grepping for the rule's text. `.gitignore` cannot import the constant, so the two are a hand-maintained pair — and a grep would still pass on a rule that had stopped matching anything, which is the failure worth catching.

End to end, on the path a person actually takes: with a leftover present, `node test-all.mjs --only scratch-dirs` prints `🧹 removed a stale scratch copy from an interrupted run: …` and the directory is gone.

## Notes for review

1. **Overlap with #3908 and #3904 — bigger than I first said.** I originally wrote that the contended surface was a single line in `lib/mjs-files.mjs`. @artemtrofymenko measured it and that was wrong; I re-measured and got the same result:

   ```
   3968 x 3904 -> CONFLICT: tests/helpers.mjs, tests/mjs-files.test.mjs, tests/mojibake-canary.test.mjs
   3968 x 3908 -> CONFLICT: lib/mjs-files.mjs, test-all.mjs, update-system.mjs
   ```

   So #3908 overlaps in all three production files, not one line. Nothing here is a defect in any of the three branches — it is routine for work off one file — but it makes the ordering worth choosing deliberately rather than by arrival. I have no preference and will rebase onto whatever lands first; say the word and I will go after #3908 instead.

2. **The copy-loop exclusion has no direct automated test.** `copyDirSync` is inline in `test-all.mjs` and not importable, and extracting it felt like scope creep on a file two open PRs are already rewriting. It is also the second gate rather than the first — the startup sweep normally removes a leftover before the copy runs. Stating the gap rather than leaving it to be found.

3. **A flake in `update-system.mjs check`, now identified.** An earlier run reported one unexplained failure. It has since reproduced and named itself: `update-system.mjs check crashed (exit null, signal SIGTERM)` — the 30s script timeout firing on a check that reaches the network. It appeared three runs running during one window and has been green either side of it, on this branch and on `main`. Confirmed not to be from this change by running `main` and this branch alternately: `main` 8687/0, this branch 8701/0, same window. f4c28e6's message names the same flake, so it predates this PR.

4. **Windows.** The symlink section originally used a `dir` symlink, which needs a privilege a default non-elevated Windows box does not have — so it threw, took the four sections after it, and `windows-latest` never showed it. Fixed with a junction (28cc350), and link creation is no longer fatal to the rest of the file. That whole finding came from @artemtrofymenko running it on a real machine; CI could not have told me.

## One open question for the maintainer

The sweep believes a living-owner claim, but overrules it after seven days. Two review rounds asked for opposite things here and both were right about their own half:

Without the ceiling, kill(pid, 0) cannot tell a live owner from a recycled pid, so a crashed run's copy can be protected forever — an unbounded disk leak.
With the ceiling, a test-all.mjs run alive for more than seven days would lose its scratch to another run's sweep.

I kept the ceiling, because the first failure needs a crash plus a pid wrap (which happens on a busy machine over months) and the second needs a four-minute suite to stay alive for a week. Neither loses authored content; a scratch is a copy, so the cost is a failed run or reclaimable disk.

The principled fix is a non-reusable owner identity, and I could not find a cheap portable one: process start time has no cross-platform Node API, an open handle does not prevent unlink on POSIX, and a heartbeat stops when a debugger pauses the very run it is meant to protect. A platform-branching ps / tasklist probe would work — say the word if that is proportionate here and I will add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR prevents interrupted `test-all.mjs` runs from causing false layout failures in later runs.

## User-visible changes

- Repository scans skip scratch directories: `lib/mjs-files.mjs:176`.
- New scratch copies skip existing scratch directories: `test-all.mjs:479`.
- Startup cleanup removes stale scratch directories and preserves active runs: `test-all.mjs:226`, `lib/scratch-dirs.mjs:194`.
- Cleanup handles invalid markers, symlinks, and removal failures without stopping the test run.
- Tests cover detection, walking, cleanup, age handling, concurrency, process liveness, `.gitignore`, and symlinks: `tests/scratch-dirs.test.mjs`.

## Files touched

- `lib/mjs-files.mjs`
- `lib/scratch-dirs.mjs`
- `test-all.mjs`
- `tests/scratch-dirs.test.mjs`
- `update-system.mjs:239`: adds `lib/scratch-dirs.mjs` to `SYSTEM_PATHS`.

The requested system files were not changed: `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

## Validation

Full suite: 8697 passed, 0 failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->