### PR TITLE
fix(pipeline): preserve unknown scores when reconciling reports

### DIFF
--- a/reconcile-pipeline.mjs
+++ b/reconcile-pipeline.mjs
@@ -151,7 +151,7 @@ function resolveScore(stateScore, reportFile) {
     const denominator = rep.match(/\/[ \t]*(\d+(?:\.\d+)?)/);
     if (denominator) {
       const tail = rep.slice(denominator.index + denominator[0].length);
-      if (Number(denominator[1]) !== 5 || (tail && !/^[\s*_`,;(—–-]/.test(tail))) return 'N/A';
+      if (Number(denominator[1]) !== 5 || (tail && !/^[\s*_`,;:.()\]—–-]/.test(tail))) return 'N/A';
     } else if (/^[*_`]*[ \t]*\//.test(rep.slice(score[0].length))) {
       return 'N/A'; // An explicit but unreadable scale is not a bare score.
     }

--- a/reconcile-pipeline.mjs
+++ b/reconcile-pipeline.mjs
@@ -127,19 +127,35 @@ function readReportField(reportFile, field) {
   if (!reportFile) return null;
   try {
     const txt = readFileSync(join(REPORTS_DIR, reportFile), 'utf-8');
-    const m = txt.match(new RegExp(`^\\*\\*${field}:\\*\\*\\s*(.+)$`, 'm'));
+    // An empty header is unknown; never borrow the following URL/PDF line.
+    const m = txt.match(new RegExp(`^\\*\\*${field}:\\*\\*([^\\r\\n]*)$`, 'm'));
     return m ? m[1].trim() : null;
   } catch { return null; }
 }
 
-// State score is authoritative when numeric; otherwise fall back to the report.
+function formatScore(value) {
+  return /^\d+(?:\.\d+)?$/.test(value) && Number(value) <= 5 ? `${value}/5` : null;
+}
+
+// A valid numeric state score is authoritative; otherwise fall back to the report.
 function resolveScore(stateScore, reportFile) {
-  if (/^\d+(?:\.\d+)?$/.test(stateScore)) return `${stateScore}/5`;
+  const state = formatScore(stateScore);
+  if (state) return state;
   const rep = readReportField(reportFile, 'Score');
   if (rep) {
-    const num = rep.match(/(\d+(?:\.\d+)?)/);
-    if (num) return `${num[1]}/5`;
-    if (/n\/?a/i.test(rep)) return 'N/A';
+    // Scores may have Markdown decoration or trailing prose. The first
+    // denominator is authoritative even when an annotation precedes it,
+    // matching evaluator score cells: "4.2 (strong fit)/10" is not 4.2/5.
+    const score = rep.match(/^[*_`]*(\d+(?:\.\d+)?)(?=$|[\s*_`/,(—–-])/);
+    if (!score) return 'N/A';
+    const denominator = rep.match(/\/[ \t]*(\d+(?:\.\d+)?)/);
+    if (denominator) {
+      const tail = rep.slice(denominator.index + denominator[0].length);
+      if (Number(denominator[1]) !== 5 || (tail && !/^[\s*_`,;(—–-]/.test(tail))) return 'N/A';
+    } else if (/^[*_`]*[ \t]*\//.test(rep.slice(score[0].length))) {
+      return 'N/A'; // An explicit but unreadable scale is not a bare score.
+    }
+    return formatScore(score[1]) || 'N/A';
   }
   return 'N/A';
 }

--- a/tests/reconcile-pipeline-scores.test.mjs
+++ b/tests/reconcile-pipeline-scores.test.mjs
@@ -23,7 +23,7 @@ function fixture(t, { report, stateScore = '-', stateStatus = 'completed', langu
     `id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n1\t${URL}\t${stateStatus}\t2026-09-01\t2026-09-01\t42\t${stateScore}\t\t0\n`);
   writeFileSync(join(root, 'reports', '042-example-2026-09-01.md'), report);
   const run = (...args) => {
-    const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    const result = spawnSync(process.execPath, [SCRIPT, '--pipeline', pipeline, '--state', join(root, 'batch', 'batch-state.tsv'), ...args], {
       cwd: root,
       env: { ...process.env, CAREER_OPS_ROOT: root, CAREER_OPS_DATA_DIR: root, CAREER_OPS_TRACKER: '' },
       encoding: 'utf8',
@@ -66,6 +66,10 @@ const cases = [
   ['bare numeric report score', '**Score:** 4.2', '4.2/5'],
   ['annotated score', '**Score:** 4.2/5 (strong match)', '4.2/5'],
   ['comma after denominator', '**Score:** 4.2/5, strong match', '4.2/5'],
+  ['period after denominator', '**Score:** 4.2/5.', '4.2/5'],
+  ['colon after denominator', '**Score:** 4.2/5: strong match', '4.2/5'],
+  ['closing punctuation after denominator', '**Score:** 4.2/5)', '4.2/5'],
+  ['closing bracket after denominator', '**Score:** 4.2/5]', '4.2/5'],
   ['annotated bare score', '**Score:** 4.2 (strong fit)', '4.2/5'],
   ['final score annotation', '**Score:** 4.2 (final)', '4.2/5'],
   ['internal score annotation', '**Score:** 4.2 (internal)', '4.2/5'],

--- a/tests/reconcile-pipeline-scores.test.mjs
+++ b/tests/reconcile-pipeline-scores.test.mjs
@@ -1,0 +1,134 @@
+// Exercise the real CLI and its written pipeline rows, using only synthetic data.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(dirname(dirname(fileURLToPath(import.meta.url))), 'reconcile-pipeline.mjs');
+const URL = 'https://jobs.example.test/4521';
+
+function fixture(t, { report, stateScore = '-', stateStatus = 'completed', language = 'en' }) {
+  const root = mkdtempSync(join(tmpdir(), 'career-ops-reconcile-score-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  for (const dir of ['data', 'batch', 'reports']) mkdirSync(join(root, dir));
+  const pipeline = join(root, 'data', 'pipeline.md');
+  const pending = language === 'es' ? 'Pendientes' : 'Pending';
+  const processed = language === 'es' ? 'Procesadas' : 'Processed';
+  const original = `# Pipeline\n\n## ${pending}\n\n- [ ] ${URL} | Example | Engineer\n- [ ] https://jobs.example.test/pending | Other | Analyst\n\n## ${processed}\n\n`;
+  writeFileSync(pipeline, original);
+  writeFileSync(join(root, 'batch', 'batch-state.tsv'),
+    `id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n1\t${URL}\t${stateStatus}\t2026-09-01\t2026-09-01\t42\t${stateScore}\t\t0\n`);
+  writeFileSync(join(root, 'reports', '042-example-2026-09-01.md'), report);
+  const run = (...args) => {
+    const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+      cwd: root,
+      env: { ...process.env, CAREER_OPS_ROOT: root, CAREER_OPS_DATA_DIR: root, CAREER_OPS_TRACKER: '' },
+      encoding: 'utf8',
+      timeout: 15_000,
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    return result;
+  };
+  return { pipeline, original, run };
+}
+
+function processedRow(pipeline) {
+  const rows = readFileSync(pipeline, 'utf8').split('\n').filter(line => line.startsWith('- [x]'));
+  assert.equal(rows.length, 1);
+  const fields = rows[0].split('|').map(field => field.trim());
+  assert.equal(fields[1], URL);
+  assert.match(fields[0], /\[42\]\(\.\.\/reports\/042-example-2026-09-01\.md\)/);
+  return { score: fields[4], pdf: fields[5] };
+}
+
+const cases = [
+  ['empty Score before URL', '**Score:**\n**URL:** https://jobs.example.test/4521', 'N/A'],
+  ['empty Score before PDF', '**Score:** \t\n**PDF:** output/042-cv.pdf', 'N/A'],
+  ['empty Score with CRLF', '**Score:**\t\r\n**URL:** https://jobs.example.test/4521', 'N/A'],
+  ['first empty Score before a later score', '**Score:**\n\n## Notes\n**Score:** 4.9/5', 'N/A'],
+  ['missing Score', '**URL:** https://jobs.example.test/4521', 'N/A'],
+  ['N/A with a posting ID', '**Score:** N/A (posting 4521 unavailable)', 'N/A'],
+  ['prose containing a number', '**Score:** unavailable after 2 attempts', 'N/A'],
+  ['negative report score', '**Score:** -1/5', 'N/A'],
+  ['out-of-range report score', '**Score:** 6/5', 'N/A'],
+  ['different denominator', '**Score:** 4.2/10', 'N/A'],
+  ['denominator prefix', '**Score:** 4.2/50', 'N/A'],
+  ['decimal denominator', '**Score:** 4.2/5.5', 'N/A'],
+  ['denominator followed by a word', '**Score:** 4.2/5th', 'N/A'],
+  ['unreadable denominator', '**Score:** 4.2/unknown', 'N/A'],
+  ['percentage', '**Score:** 4.2%', 'N/A'],
+  ['unverified comparison score', '**Score:** pending — compare with 3/5 baseline', 'N/A'],
+  ['decimal score', '**Score:** 4.2/5', '4.2/5'],
+  ['bare numeric report score', '**Score:** 4.2', '4.2/5'],
+  ['annotated score', '**Score:** 4.2/5 (strong match)', '4.2/5'],
+  ['comma after denominator', '**Score:** 4.2/5, strong match', '4.2/5'],
+  ['annotated bare score', '**Score:** 4.2 (strong fit)', '4.2/5'],
+  ['final score annotation', '**Score:** 4.2 (final)', '4.2/5'],
+  ['internal score annotation', '**Score:** 4.2 (internal)', '4.2/5'],
+  ['dash after bare score', '**Score:** 4.5 - strong signal', '4.5/5'],
+  ['N/A in score annotation', '**Score:** 4.2 (N/A noted)', '4.2/5'],
+  ['annotation before denominator', '**Score:** 4.2 (strong fit)/5', '4.2/5'],
+  ['annotation before wrong denominator', '**Score:** 4.2 (strong fit)/10', 'N/A'],
+  ['first fraction before denominator', '**Score:** 4.2 (fit 3/4 axes)/5', 'N/A'],
+  ['first fraction without denominator', '**Score:** 4.2 (fit 3/4 axes)', 'N/A'],
+  ['bold score', '**Score:** **4.2/5** — strong match', '4.2/5'],
+  ['code-wrapped bare score', '**Score:** `4.2`', '4.2/5'],
+  ['zero score', '**Score:** 0/5', '0/5'],
+  ['maximum score', '**Score:** 5/5', '5/5'],
+  ['spaced score with CRLF', '**Score:**\t4.2 / 5\r\n**URL:** https://jobs.example.test/4521', '4.2/5'],
+];
+
+for (const [name, report, expected] of cases) {
+  test(`reconciliation writes the expected score for ${name}`, t => {
+    const f = fixture(t, { report });
+    f.run();
+    assert.equal(processedRow(f.pipeline).score, expected);
+  });
+}
+
+for (const [name, stateScore, expected] of [
+  ['authoritative numeric batch score', '4.7', '4.7/5'],
+  ['zero batch score', '0', '0/5'],
+  ['out-of-range batch falls back to report', '4521', '4.2/5'],
+]) {
+  test(name, t => {
+    const f = fixture(t, { report: '**Score:** 4.2/5', stateScore });
+    f.run();
+    assert.equal(processedRow(f.pipeline).score, expected);
+  });
+}
+
+test('an empty PDF field does not consume the next header', t => {
+  const f = fixture(t, { report: '**Score:** 4.2/5\n**PDF:**\n**URL:** https://jobs.example.test/4521' });
+  f.run();
+  assert.deepEqual(processedRow(f.pipeline), { score: '4.2/5', pdf: 'PDF ❌' });
+});
+
+for (const [pdf, expected] of [['Not generated', 'PDF ❌'], ['output/042-cv.pdf', 'PDF ✅']]) {
+  test(`a skipped batch entry preserves PDF field: ${pdf}`, t => {
+    const f = fixture(t, { report: `**Score:** 2.5/5\n**PDF:** ${pdf}`, stateStatus: 'skipped' });
+    f.run();
+    assert.deepEqual(processedRow(f.pipeline), { score: '2.5/5', pdf: expected });
+  });
+}
+
+test('dry-run, backup and repeated reconciliation preserve the Spanish pipeline', t => {
+  const f = fixture(t, { report: '**Score:**\n**URL:** https://jobs.example.test/4521', language: 'es' });
+  const dryRun = f.run('--dry-run');
+  assert.match(dryRun.stdout, /\(N\/A\)/);
+  assert.equal(readFileSync(f.pipeline, 'utf8'), f.original);
+  assert.equal(existsSync(`${f.pipeline}.pre-reconcile.bak`), false);
+  f.run();
+  const written = readFileSync(f.pipeline, 'utf8');
+  assert.match(written, /^## Procesadas$/m);
+  assert.match(written, /^- \[ \] https:\/\/jobs\.example\.test\/pending \| Other \| Analyst$/m);
+  assert.equal(processedRow(f.pipeline).score, 'N/A');
+  assert.equal(readFileSync(`${f.pipeline}.pre-reconcile.bak`, 'utf8'), f.original);
+  f.run();
+  assert.equal(readFileSync(f.pipeline, 'utf8'), written);
+  assert.equal(readFileSync(`${f.pipeline}.pre-reconcile.bak`, 'utf8'), f.original);
+});


### PR DESCRIPTION
An empty `**Score:**` followed by a URL containing `4521` became `4521/5`. Numbers in `N/A` explanations could become scores too, and an empty `**PDF:**` could mark a PDF as generated from the next header.

Read each header on its own line and accept only scores from 0 to 5 on the five-point scale. Valid batch scores take precedence; bare numbers, Markdown formatting and trailing explanations remain supported.

Validation:

- 54 CLI tests pass, including 45 new cases covering rejected scores, PDF flags, dry-run, backup and repeat runs. Six mutants fail as expected.
- Full suite: 8689 passed, 0 failed with `CAREER_OPS_GIT_TIMEOUT_MS=2000 CAREER_OPS_GIT_FETCH_TIMEOUT_MS=5000 node test-all.mjs`. These bound the existing updater network timeout in the smoke fixture; CI runs with defaults.
- `npm run lint` and `git diff --check` pass.
