### PR TITLE
fix(doctor): report malformed setup YAML

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -466,11 +466,33 @@ function prereqPresent(root, path) {
   return existsSync(join(root, ...path.split('/')));
 }
 
-function checkPrereq({ path, fix }) {
-  if (prereqPresent(projectRoot, path)) {
-    return { pass: true, label: `${path} found` };
+function checkPrereq(root, { path, fix }) {
+  if (!prereqPresent(root, path)) {
+    return { warn: true, label: `${path} not found (user setup required)`, fix };
   }
-  return { warn: true, label: `${path} not found (user setup required)`, fix };
+  if (path.endsWith('.yml')) {
+    let source;
+    try {
+      source = readFileSync(join(root, ...path.split('/')), 'utf8');
+    } catch {
+      return { pass: false, label: `${path}: YAML file could not be read` };
+    }
+    try {
+      // load() rejects empty/comment-only input in js-yaml 5. Allow an empty
+      // configuration while keeping the runtime's single-document contract.
+      if (yaml.loadAll(source).length > 1) {
+        return { pass: false, label: `${path}: invalid YAML (expected a single document)` };
+      }
+    } catch (err) {
+      // Parser messages, reasons and snippets can expose profile values (even
+      // an unknown alias/tag name). Only report fixed text and numeric positions.
+      const { line, column } = err?.mark || {};
+      const position = Number.isInteger(line) && line >= 0 && Number.isInteger(column) && column >= 0
+        ? ` (line ${line + 1}, column ${column + 1})` : '';
+      return { pass: false, label: `${path}: invalid YAML${position}` };
+    }
+  }
+  return { pass: true, label: `${path} found` };
 }
 
 function checkFonts() {
@@ -645,6 +667,7 @@ async function main() {
   console.log('================\n');
 
   const { cli: activeCli, source: cliSource, warning: cliWarning } = resolveActiveCli();
+  const prereqChecks = new Map(USER_LAYER_PREREQS.map((prereq) => [prereq.path, checkPrereq(projectRoot, prereq)]));
 
   const checks = [
     checkNodeVersion(),
@@ -656,8 +679,10 @@ async function main() {
     checkTrackedBakFiles(projectRoot),
     await checkPlaywright(),
     checkPlaywrightMcp(projectRoot, activeCli),
-    checkScanExtractor(projectRoot),
-    ...USER_LAYER_PREREQS.map(checkPrereq),
+    // An unreadable profile falls back to MCP in the runtime loader; that is
+    // not a successful configuration check when diagnosing a broken file.
+    prereqChecks.get('config/profile.yml').pass !== false && checkScanExtractor(projectRoot),
+    ...prereqChecks.values(),
     checkFonts(),
     checkPersonalization(projectRoot),
     checkAutoDir('data'),
@@ -668,7 +693,7 @@ async function main() {
   ].filter(Boolean);
 
   // Network-bound portals.yml reachability probe — only under --strict.
-  if (STRICT) {
+  if (STRICT && prereqChecks.get('portals.yml').pass !== false) {
     checks.push(await checkPortalSlugs(projectRoot));
   }
 
@@ -822,10 +847,12 @@ function onboardingState(root) {
   const mcpCheck = checkPlaywrightMcp(root, activeCli);
   const unpersonalized = unpersonalizedFiles(root);
   const bakCheck = checkTrackedBakFiles(root);
+  const prereqChecks = USER_LAYER_PREREQS.map((prereq) => checkPrereq(root, prereq));
   const warnings = [
     ...(cliWarning ? [cliWarning] : []),
     ...(mcpCheck?.warn ? [`${mcpCheck.label}\n→ ${[].concat(mcpCheck.fix || []).join('\n  ')}`] : []),
     ...(bakCheck.warn ? [`${bakCheck.label}\n→ ${[].concat(bakCheck.fix || []).join('\n  ')}`] : []),
+    ...prereqChecks.filter((check) => check.pass === false).map((check) => check.label),
     ...unpersonalized.map((u) => `${u.path} ${u.reason} — ${u.impact}\n→ Personalize it from cv.md before running evaluations.`),
   ];
 

--- a/tests/doctor-invalid-yaml.test.mjs
+++ b/tests/doctor-invalid-yaml.test.mjs
@@ -62,7 +62,11 @@ function runDoctor(root, { json = true, target = root, cwd = root, env = {}, ext
   const result = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--cli', 'codex',
     ...(json ? ['--json'] : []), ...(target ? ['--target', target] : []), ...extra], {
     cwd, encoding: 'utf8', timeout: 60_000,
-    env: { ...process.env, HOME: root, USERPROFILE: root, CAREER_OPS_ROOT: '', CAREER_OPS_DATA_DIR: '', ...env },
+    env: {
+      ...process.env, HOME: root, USERPROFILE: root, CAREER_OPS_ROOT: '', CAREER_OPS_DATA_DIR: '', ...env,
+      // Keep YAML checks independent of installed browsers, including Windows' LOCALAPPDATA cache.
+      PLAYWRIGHT_BROWSERS_PATH: join(root, 'playwright-browsers'),
+    },
   });
   assert.equal(result.error, undefined, result.error?.message);
   assert.equal(result.stderr, '');
@@ -112,7 +116,7 @@ for (const source of ['scan:\n  extractor: cli\n', '', '# Empty configuration is
     const human = runDoctor(root, { json: false });
     for (const path of YAML_PATHS) assert.ok(human.stdout.includes(`✓ ${path} found`), human.stdout);
     assert.ok(human.stdout.includes(`✓ Scan extractor: ${source.startsWith('scan:') ? 'cli' : 'mcp'}`), human.stdout);
-    // Other prerequisites (e.g. installed Chromium) depend on the host.
+    // These cases check YAML; unrelated prerequisites may still fail.
     assert.ok(!human.stdout.includes('invalid YAML'), human.stdout);
   });
 }

--- a/tests/doctor-invalid-yaml.test.mjs
+++ b/tests/doctor-invalid-yaml.test.mjs
@@ -1,0 +1,182 @@
+// Real CLI coverage: broken setup YAML must be visible without exposing its contents.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isNestedCheckout } from '../lib/mjs-files.mjs';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const YAML_PATHS = ['config/profile.yml', 'portals.yml'];
+const PRIVATE_MARKER = 'SYNTHETIC_PRIVATE_YAML_VALUE';
+const INVALID = `scan:\n  extractor: cli\nprivate: [${PRIVATE_MARKER}\n`;
+const INVALID_LABEL = (path) => `${path}: invalid YAML (line 4, column 1)`;
+const yamlWarnings = (state) => state.warnings.filter((warning) => YAML_PATHS.some((path) => warning.startsWith(`${path}:`)));
+
+function fixture(t, overrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'career-ops-doctor-yaml-'));
+  t.after(() => rmSync(root, { recursive: true, force: true, maxRetries: 10 }));
+  for (const dir of ['config', 'modes', 'data', 'output', 'reports', 'node_modules']) {
+    mkdirSync(join(root, dir));
+  }
+  const files = {
+    'cv.md': '# Example Candidate\n',
+    'config/profile.yml': 'scan:\n  extractor: cli\n',
+    'portals.yml': 'tracked_companies: []\njob_boards: []\n',
+    'modes/_profile.md': '# Backend targeting\n',
+    'modes/_custom.md': '# House rules\n',
+    'modes/_brief.md': '# Backend brief\n',
+    'voice-dna.md': '# Plain language\n',
+    'data/pipeline.md': '# Existing pipeline\n',
+    'browser-extract.mjs': '// Presence check only.\n',
+    ...overrides,
+  };
+  for (const [path, text] of Object.entries(files)) {
+    if (text !== null) writeFileSync(join(root, path), text);
+  }
+  return root;
+}
+
+function contents(root) {
+  const entries = [];
+  for (const entry of readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (isNestedCheckout(path)) {
+        entries.push([entry.name, null]);
+        continue;
+      }
+      entries.push([entry.name, contents(path)]);
+    } else {
+      entries.push([entry.name, readFileSync(path, 'utf8')]);
+    }
+  }
+  return entries;
+}
+
+function runDoctor(root, { json = true, target = root, cwd = root, env = {}, extra = [] } = {}) {
+  const before = contents(root);
+  const beforeCwd = cwd === root ? null : contents(cwd);
+  const result = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--cli', 'codex',
+    ...(json ? ['--json'] : []), ...(target ? ['--target', target] : []), ...extra], {
+    cwd, encoding: 'utf8', timeout: 60_000,
+    env: { ...process.env, HOME: root, USERPROFILE: root, CAREER_OPS_ROOT: '', CAREER_OPS_DATA_DIR: '', ...env },
+  });
+  assert.equal(result.error, undefined, result.error?.message);
+  assert.equal(result.stderr, '');
+  assert.ok(!result.stdout.includes(PRIVATE_MARKER), 'doctor exposed YAML contents');
+  assert.deepEqual(contents(root), before, 'diagnostics changed the user files');
+  if (beforeCwd) assert.deepEqual(contents(cwd), beforeCwd, 'diagnostics changed the working directory');
+  if (json) {
+    assert.equal(result.status, 0, result.stdout);
+    return JSON.parse(result.stdout);
+  }
+  return result;
+}
+
+function expectErrors(root, labels, options = {}) {
+  const state = runDoctor(root, options);
+  assert.deepEqual(state.missing, []);
+  assert.equal(state.onboardingNeeded, false);
+  assert.deepEqual(state.autoCopied, []);
+  assert.deepEqual(yamlWarnings(state), labels);
+  const human = runDoctor(root, { ...options, json: false });
+  assert.equal(human.status, 1);
+  for (const label of labels) {
+    assert.ok(human.stdout.includes(`✗ ${label}`), human.stdout);
+    assert.ok(!human.stdout.includes(`${label.split(':')[0]} found`), human.stdout);
+  }
+  assert.ok(!human.stdout.includes('All checks passed'), human.stdout);
+  if (labels.some((label) => label.startsWith('config/profile.yml:'))) {
+    assert.ok(!human.stdout.includes('Scan extractor:'), human.stdout);
+  }
+  return human;
+}
+
+for (const paths of [['config/profile.yml'], ['portals.yml'], YAML_PATHS]) {
+  test(`invalid YAML is reported in JSON and human output: ${paths.join(', ')}`, (t) => {
+    const root = fixture(t, Object.fromEntries(paths.map((path) => [path, INVALID])));
+    expectErrors(root, paths.map(INVALID_LABEL));
+  });
+}
+
+for (const source of ['scan:\n  extractor: cli\n', '', '# Empty configuration is valid YAML.\n']) {
+  test(`valid YAML remains accepted: ${source || '(empty)'}`, (t) => {
+    const root = fixture(t, Object.fromEntries(YAML_PATHS.map((path) => [path, source])));
+    const state = runDoctor(root);
+    assert.deepEqual(state.missing, []);
+    assert.equal(state.onboardingNeeded, false);
+    assert.deepEqual(yamlWarnings(state), []);
+    const human = runDoctor(root, { json: false });
+    for (const path of YAML_PATHS) assert.ok(human.stdout.includes(`✓ ${path} found`), human.stdout);
+    assert.ok(human.stdout.includes(`✓ Scan extractor: ${source.startsWith('scan:') ? 'cli' : 'mcp'}`), human.stdout);
+    // Other prerequisites (e.g. installed Chromium) depend on the host.
+    assert.ok(!human.stdout.includes('invalid YAML'), human.stdout);
+  });
+}
+
+test('missing YAML keeps onboarding and warning semantics', (t) => {
+  const root = fixture(t, Object.fromEntries(YAML_PATHS.map((path) => [path, null])));
+  const state = runDoctor(root);
+  assert.deepEqual(state.missing, YAML_PATHS);
+  assert.equal(state.onboardingNeeded, true);
+  assert.deepEqual(yamlWarnings(state), []);
+  const human = runDoctor(root, { json: false });
+  for (const path of YAML_PATHS) {
+    assert.ok(human.stdout.includes(`⚠ ${path} not found (user setup required)`), human.stdout);
+  }
+  assert.ok(!human.stdout.includes('invalid YAML'), human.stdout);
+});
+
+for (const path of YAML_PATHS) {
+  test(`a YAML path that cannot be read as a file is diagnosed: ${path}`, (t) => {
+    const root = fixture(t, { [path]: null });
+    mkdirSync(join(root, path));
+    expectErrors(root, [`${path}: YAML file could not be read`]);
+  });
+}
+
+for (const value of [`*${PRIVATE_MARKER}`, `!${PRIVATE_MARKER} value`]) {
+  test(`parser diagnostics never expose ${value[0] === '*' ? 'alias' : 'tag'} names`, (t) => {
+    const root = fixture(t, { 'config/profile.yml': `private: ${value}\n` });
+    const state = runDoctor(root);
+    assert.equal(state.onboardingNeeded, false);
+    assert.deepEqual(state.missing, []);
+    const warnings = yamlWarnings(state);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /^config\/profile\.yml: invalid YAML \(line 1, column \d+\)$/);
+    const human = runDoctor(root, { json: false });
+    assert.equal(human.status, 1);
+    assert.ok(human.stdout.includes(`✗ ${warnings[0]}`), human.stdout);
+  });
+}
+
+test('--strict does not pass malformed portals to the live probe or expose its exception', (t) => {
+  const root = fixture(t, { 'portals.yml': INVALID });
+  const human = expectErrors(root, [INVALID_LABEL('portals.yml')], { extra: ['--strict'] });
+  assert.ok(!human.stdout.includes('Portal entry check skipped:'), human.stdout);
+  assert.ok(!human.stdout.includes('All portals.yml entries resolve'), human.stdout);
+});
+
+test('multiple YAML documents are not accepted as a single configuration', (t) => {
+  const root = fixture(t, Object.fromEntries(YAML_PATHS.map((path) => [path, 'scan: {}\n---\nscan: {}\n'])));
+  expectErrors(root, YAML_PATHS.map((path) => `${path}: invalid YAML (expected a single document)`));
+});
+
+for (const variable of ['CAREER_OPS_ROOT', 'CAREER_OPS_DATA_DIR']) {
+  test(`YAML diagnostics use the configured Data Root: ${variable}`, (t) => {
+    const root = fixture(t, { 'config/profile.yml': INVALID });
+    const decoy = fixture(t);
+    expectErrors(root, [INVALID_LABEL('config/profile.yml')], { target: null, cwd: decoy, env: { [variable]: root } });
+  });
+}
+
+test('--target takes precedence over the configured Data Root', (t) => {
+  const root = fixture(t, { 'portals.yml': INVALID });
+  const other = fixture(t);
+  const before = contents(other);
+  expectErrors(root, [INVALID_LABEL('portals.yml')], { env: { CAREER_OPS_ROOT: other, CAREER_OPS_DATA_DIR: other } });
+  assert.deepEqual(contents(other), before);
+});


### PR DESCRIPTION
Doctor marks malformed `config/profile.yml` and `portals.yml` as found. A broken profile also produces a successful default-MCP extractor check.

Validate both YAML prerequisites and report the filename and line/column without exposing file contents. Human output fails; `--json` adds diagnostics to `warnings`, preserving its exit status and missing-file/onboarding fields. Skip the extractor check or `--strict` portal probe when its configuration is invalid. No YAML files are rewritten.

Real CLI tests cover both outputs, target selection, empty/missing files, and diagnostic privacy. Four regression mutants fail.

Validation: `CAREER_OPS_GIT_TIMEOUT_MS=2000 CAREER_OPS_GIT_FETCH_TIMEOUT_MS=5000 node test-all.mjs` (8689 passed, 0 failed, 16 warnings); `npm run lint`.
