### PR TITLE
fix(update-system): never prune a file upstream has not shipped

### DIFF
--- a/tests/updater-never-shipped-prune.test.mjs
+++ b/tests/updater-never-shipped-prune.test.mjs
@@ -28,6 +28,13 @@ const historyContaining = (...paths) => (...args) => {
   return paths.includes(file) ? 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' : '';
 };
 
+// The decision `apply()` actually makes, mirroring its call site:
+//   if (!wasEverShippedUpstream(f, ref)) { keep; continue; }
+// Tests assert through this rather than the bare return value — a helper named
+// for the SHIPPED state is easy to read with the wrong polarity at the point
+// where it decides a DELETE.
+const wouldPrune = (file, revList) => wasEverShippedUpstream(file, 'FETCH_HEAD', revList);
+
 // ── 1. a file upstream never shipped is kept ────────────────────────────────
 {
   // The real incident: a fork's own provider, spelled exactly like a shipped
@@ -66,14 +73,29 @@ const historyContaining = (...paths) => (...args) => {
 
 // ── 4. an unusable history keeps the file (fail safe) ───────────────────────
 {
-  // Shallow clone, or a rev walk that errors. History cannot prove the file was
-  // never shipped, and deleting a fork's source is not recoverable from the
-  // update itself, while keeping a retired file is cosmetic.
+  // A rev walk that errors (broken ref, git unavailable) proves nothing. The
+  // caller prunes only on a TRUE return, so the safe answer is false: pruning
+  // requires positive proof the file was shipped. Asserted through
+  // `wouldPrune` rather than the raw return value, because reading the
+  // polarity backwards here is exactly how the inverted fallback got written
+  // and then confirmed by its own test.
   const revListThrows = () => { throw new Error('fatal: bad object FETCH_HEAD'); };
-  if (wasEverShippedUpstream('providers/acme.mjs', 'FETCH_HEAD', revListThrows)) {
-    pass('an errored rev walk keeps the file rather than pruning on no evidence');
+  if (wouldPrune('providers/acme.mjs', revListThrows)) {
+    fail('an errored rev walk pruned the file — a broken ref would delete fork-local code');
   } else {
-    fail('an errored rev walk pruned the file — a shallow clone would delete fork-local code');
+    pass('an errored rev walk keeps the file rather than pruning on no evidence');
+  }
+}
+
+// ── 4b. a shallow clone keeps the file too ──────────────────────────────────
+{
+  // Truncated history does not throw; the walk simply finds nothing. Same
+  // verdict as the error case, reached by a different route.
+  const revListEmpty = () => '';
+  if (wouldPrune('modes/retired-mode.md', revListEmpty)) {
+    fail('a shallow clone pruned a file whose history it cannot see');
+  } else {
+    pass('a shallow clone keeps the file rather than pruning on truncated history');
   }
 }
 

--- a/tests/updater-never-shipped-prune.test.mjs
+++ b/tests/updater-never-shipped-prune.test.mjs
@@ -28,6 +28,21 @@ const historyContaining = (...paths) => (...args) => {
   return paths.includes(file) ? 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' : '';
 };
 
+// A fake that models git's PATHSPEC behaviour: without --literal-pathspecs a
+// candidate containing glob metacharacters matches a different upstream path.
+// '*' is modelled as "matches any run of characters", which is enough to show
+// the difference the flag makes.
+const globbingHistory = (...paths) => (...args) => {
+  const file = args[args.length - 1];
+  const literal = args.includes('--literal-pathspecs');
+  const star = file.indexOf('*');
+  const matches = (p) => {
+    if (literal || star === -1) return p === file;
+    return p.startsWith(file.slice(0, star)) && p.endsWith(file.slice(star + 1));
+  };
+  return paths.some(matches) ? 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' : '';
+};
+
 // The decision `apply()` actually makes, mirroring its call site:
 //   if (!wasEverShippedUpstream(f, ref)) { keep; continue; }
 // Tests assert through this rather than the bare return value — a helper named
@@ -106,5 +121,28 @@ const wouldPrune = (file, revList) => wasEverShippedUpstream(file, 'FETCH_HEAD',
     fail('an empty candidate path was reported as shipped');
   } else {
     pass('an empty candidate path is rejected without consulting history');
+  }
+}
+
+// ── 6. a filename with glob metacharacters is matched literally ─────────────
+{
+  // `-- <path>` is a pathspec. A fork-local `modes/_share[a-z].md` would match
+  // upstream's `modes/_shared.md`, read as "shipped", and be pruned — the very
+  // deletion this function exists to prevent. --literal-pathspecs stops it.
+  const revList = globbingHistory('modes/_shared.md');
+  if (wouldPrune('modes/_share*.md', revList)) {
+    fail('a fork-local filename with a glob was matched as a pattern and would be pruned');
+  } else {
+    pass('a candidate path with glob metacharacters is matched literally, not as a pattern');
+  }
+}
+
+// ── 7. the literal flag does not break ordinary paths ───────────────────────
+{
+  const revList = globbingHistory('modes/_shared.md');
+  if (wouldPrune('modes/_shared.md', revList)) {
+    pass('an ordinary path still resolves under --literal-pathspecs');
+  } else {
+    fail('--literal-pathspecs broke the ordinary lookup — retired files would stop pruning');
   }
 }

--- a/tests/updater-never-shipped-prune.test.mjs
+++ b/tests/updater-never-shipped-prune.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * updater-never-shipped-prune.test.mjs — the stale-file prune must not delete a
+ * file upstream has NEVER shipped.
+ *
+ * `staleSystemFiles()` selects on "absent from upstream's current tree", which
+ * cannot distinguish a file upstream retired from a file upstream never
+ * carried. Under the ~50 directory-prefix SYSTEM_PATHS entries (`providers/`,
+ * `tests/`, `templates/`, `docs/`, `modes/<lang>/`, ...) that second case is any
+ * file a fork or contributor added, and `apply()` deleted it on every update
+ * (#3971 — same root cause as #3636 / #3696, on a surface where no USER_PATHS
+ * carve-out applies and no filename shape distinguishes the file).
+ *
+ * `wasEverShippedUpstream()` settles it from upstream's history, which
+ * `apply()` has already fetched. These tests pin the four behaviours that
+ * matter: never-shipped is kept, retired-upstream still prunes, a moved file
+ * still prunes via its old path, and an unusable history keeps the file.
+ */
+
+import { pass, fail } from './helpers.mjs';
+import { wasEverShippedUpstream } from '../update-system.mjs';
+
+console.log('\n🧪 Testing never-shipped vs. retired-upstream prune discrimination...');
+
+// A fake `git rev-list`: non-empty output means the path exists somewhere in
+// the ref's history, which is exactly what the real command reports.
+const historyContaining = (...paths) => (...args) => {
+  const file = args[args.length - 1];
+  return paths.includes(file) ? 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' : '';
+};
+
+// ── 1. a file upstream never shipped is kept ────────────────────────────────
+{
+  // The real incident: a fork's own provider, spelled exactly like a shipped
+  // one, absent from upstream's tree because it was never there to begin with.
+  const revList = historyContaining('providers/greenhouse.mjs');
+  if (wasEverShippedUpstream('providers/acme.mjs', 'FETCH_HEAD', revList)) {
+    fail('a provider absent from upstream history was reported as shipped — it would be pruned');
+  } else {
+    pass('a file absent from upstream history is not treated as shipped (kept)');
+  }
+}
+
+// ── 2. a file upstream really did retire still prunes ───────────────────────
+{
+  // Guards against "fix" by blanket-disabling the prune, which would reopen
+  // #2532 (retired files persisting on installs forever).
+  const revList = historyContaining('modes/retired-mode.md');
+  if (wasEverShippedUpstream('modes/retired-mode.md', 'FETCH_HEAD', revList)) {
+    pass('a file present in upstream history is still prunable when the current tree drops it');
+  } else {
+    fail('a genuinely retired upstream file was kept — the prune step is now a no-op');
+  }
+}
+
+// ── 3. a file upstream MOVED still prunes at its old path ───────────────────
+{
+  // lib/context-budget.test.mjs -> tests/context-budget.test.mjs was a real
+  // v1.32.0 move; the old path must not survive as a stale duplicate.
+  const revList = historyContaining('lib/context-budget.test.mjs');
+  if (wasEverShippedUpstream('lib/context-budget.test.mjs', 'FETCH_HEAD', revList)) {
+    pass('a moved file still prunes at its old path (the old path is in history)');
+  } else {
+    fail('a moved file was kept at its old path, leaving a stale duplicate behind');
+  }
+}
+
+// ── 4. an unusable history keeps the file (fail safe) ───────────────────────
+{
+  // Shallow clone, or a rev walk that errors. History cannot prove the file was
+  // never shipped, and deleting a fork's source is not recoverable from the
+  // update itself, while keeping a retired file is cosmetic.
+  const revListThrows = () => { throw new Error('fatal: bad object FETCH_HEAD'); };
+  if (wasEverShippedUpstream('providers/acme.mjs', 'FETCH_HEAD', revListThrows)) {
+    pass('an errored rev walk keeps the file rather than pruning on no evidence');
+  } else {
+    fail('an errored rev walk pruned the file — a shallow clone would delete fork-local code');
+  }
+}
+
+// ── 5. an empty path is not treated as shipped ──────────────────────────────
+{
+  const revList = historyContaining('');
+  if (wasEverShippedUpstream('', 'FETCH_HEAD', revList)) {
+    fail('an empty candidate path was reported as shipped');
+  } else {
+    pass('an empty candidate path is rejected without consulting history');
+  }
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1028,7 +1028,11 @@ export function wasEverShippedUpstream(candidatePath, ref = 'FETCH_HEAD', revLis
   const file = normalizeRepoPath(candidatePath);
   if (!file) return false;
   try {
-    return revList('rev-list', '--max-count=1', ref, '--', file) !== '';
+    // --literal-pathspecs: `-- <path>` is a PATHSPEC, so a tracked filename
+    // containing glob metacharacters would be matched as a pattern. A local
+    // `modes/_share[a-z].md` matches upstream's `modes/_shared.md`, reads as
+    // "shipped", and is pruned — the exact deletion this function prevents.
+    return revList('--literal-pathspecs', 'rev-list', '--max-count=1', ref, '--', file) !== '';
   } catch {
     // No evidence either way. The caller prunes only on a TRUE return, so
     // false is the safe answer: pruning requires positive proof the file was

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1019,8 +1019,9 @@ export function isReferencedByPreservedFile(candidatePath, preservedPaths, readF
 // the case of a file upstream MOVED (its old path is in history), which is why
 // this does not simply disable the feature.
 //
-// Fails safe in both directions that matter: on a shallow clone, or if the rev
-// walk errors, history cannot prove the file was ever shipped, so it is kept.
+// Fails safe: pruning requires positive proof the file was shipped. On a
+// shallow clone the walk returns empty, and on a broken ref it throws; both
+// answer "not proven", so the file is kept.
 // Keeping a retired file is a cosmetic regression (#2532); deleting a fork's
 // source file is not recoverable from the update itself.
 export function wasEverShippedUpstream(candidatePath, ref = 'FETCH_HEAD', revList = (...args) => gitQuiet(...args)) {
@@ -1029,7 +1030,10 @@ export function wasEverShippedUpstream(candidatePath, ref = 'FETCH_HEAD', revLis
   try {
     return revList('rev-list', '--max-count=1', ref, '--', file) !== '';
   } catch {
-    return true; // Cannot prove it was never shipped -> keep it.
+    // No evidence either way. The caller prunes only on a TRUE return, so
+    // false is the safe answer: pruning requires positive proof the file was
+    // shipped, never the mere absence of a usable answer.
+    return false;
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1001,6 +1001,38 @@ export function isReferencedByPreservedFile(candidatePath, preservedPaths, readF
   });
 }
 
+// A stale-file prune candidate may never have been an upstream file at all.
+// `staleSystemFiles()` selects on "absent from upstream's CURRENT tree", which
+// cannot tell a file upstream retired from a file upstream never carried — a
+// provider, test or registry entry a fork added under one of the ~50
+// directory-prefix SYSTEM_PATHS entries (`providers/`, `tests/`, `templates/`,
+// `docs/`, `modes/*/`, ...). Both are "local, not in the new tree", and the
+// prune deleted both (#3971; same root cause as #3636 and #3696 on a third
+// surface, where no USER_PATHS carve-out applies because the file genuinely IS
+// system-layer, and no filename shape distinguishes it — a fork's
+// `providers/acme.mjs` is spelled exactly like a shipped provider).
+//
+// Upstream's HISTORY settles it, and `apply()` already fetched it: a path that
+// appears in no commit reachable from the fetched ref was never shipped, so its
+// absence from the current tree is not evidence of anything. A path that DOES
+// appear there, but is gone now, is a real removal and still prunes — including
+// the case of a file upstream MOVED (its old path is in history), which is why
+// this does not simply disable the feature.
+//
+// Fails safe in both directions that matter: on a shallow clone, or if the rev
+// walk errors, history cannot prove the file was ever shipped, so it is kept.
+// Keeping a retired file is a cosmetic regression (#2532); deleting a fork's
+// source file is not recoverable from the update itself.
+export function wasEverShippedUpstream(candidatePath, ref = 'FETCH_HEAD', revList = (...args) => gitQuiet(...args)) {
+  const file = normalizeRepoPath(candidatePath);
+  if (!file) return false;
+  try {
+    return revList('rev-list', '--max-count=1', ref, '--', file) !== '';
+  } catch {
+    return true; // Cannot prove it was never shipped -> keep it.
+  }
+}
+
 // Files the self-reexec stage must check out so the TARGET update-system.mjs
 // loads without a missing-module crash. Today this is the entry plus its only
 // local import; resolveReexecCheckout derives the real set from the fetched
@@ -2291,6 +2323,10 @@ async function apply() {
         for (const f of staleCandidates) {
           if (isReferencedByPreservedFile(f, preservedPaths)) {
             console.log(`Kept stale asset still referenced by a preserved file: ${f}`);
+            continue;
+          }
+          if (!wasEverShippedUpstream(f, 'FETCH_HEAD')) {
+            console.log(`Kept local file upstream has never shipped: ${f}`);
             continue;
           }
           try {


### PR DESCRIPTION
## What does this PR do?

Stops `update-system.mjs apply()`'s stale-file prune from deleting files upstream has **never shipped** — fork-local providers, tests and registry entries under the directory-prefix `SYSTEM_PATHS` entries. It discriminates on upstream's history (already fetched by `apply()`) instead of on the current tree alone, so genuinely retired files still prune.

## Related issue

Closes #3971

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The bug

`staleSystemFiles()` selects local files that are absent from upstream's **current** tree, matched by a `SYSTEM_PATHS` entry, and not matched by a `USER_PATHS` entry. `pathMatchesManifest()` matches directory entries by `startsWith`, so everything under the ~50 directory-prefix entries (`providers/`, `tests/`, `templates/`, `docs/`, `modes/<lang>/`, `dashboard/`, ...) is in scope.

"Absent from the current tree" reads as "upstream removed it", but for a file upstream never carried the absence means nothing. The two are indistinguishable from the current tree alone, and the prune deleted both — silently, and committed by the update's own commit step. On my fork this recurred at v1.12.0, v1.28.0 and v1.32.0; the v1.32.0 run pruned 11 files.

This is the root cause @santifer described in #3636 — *"the discriminator has to be 'shipped by us' … never the directory"* — on a third surface. It can't be fixed the way #3638 and #3700 fix theirs: there's no correct `USER_PATHS` carve-out (the file genuinely **is** system-layer), and no filename shape to key on, since a fork's `providers/acme.mjs` is spelled exactly like a shipped provider.

## The fix

`wasEverShippedUpstream()` asks `git rev-list --max-count=1 <ref> -- <path>`. A path reachable from no commit in the fetched ref was never shipped, so its absence proves nothing → keep. A path in history but gone now is a real removal → prune.

Three properties worth checking in review:

- **#2532 does not reopen.** Retired files still prune. That issue and this one are the same missing signal read in opposite directions.
- **Moves still prune.** A file upstream relocated keeps its old path in history, so the stale copy is still removed. This is real, not hypothetical — v1.32.0 moved `lib/context-budget.test.mjs` to `tests/context-budget.test.mjs`, and I verified this fix still prunes the old path.
- **Fails safe.** Pruning requires positive proof the file was shipped upstream. A shallow clone returns empty and a broken ref throws; both mean "not proven", so the file is kept. Keeping a retired file is cosmetic; deleting a fork's source file isn't recoverable from the update itself. (The first push had this fallback inverted — caught in review, fixed in cd29f128, and the test that missed it now asserts through the call site's actual decision.)

Cost is one `rev-list` per prune candidate, and candidates are typically 0–15.

## Alternative considered

Version tags would give a cleaner "previous shipped tree", but tagging stopped at `v1.6.0` upstream, so no recent version is reachable that way. A recorded manifest of what each `apply()` wrote would also work and would survive shallow clones, at the cost of new on-disk state and a one-cycle bootstrap where nothing prunes. Happy to switch to that if you'd prefer it.

## Verification

- New suite `tests/updater-never-shipped-prune.test.mjs` (5 cases): never-shipped kept, retired still prunes, moved still prunes at the old path, errored rev walk keeps, empty path rejected.
- `node test-all.mjs` on this branch: **8680 passed, 0 failed**.
- Also exercised against real history rather than only the injected fake: `providers/vcstack.mjs` → false, `lib/context-budget.test.mjs` → true, `modes/_shared.md` → true.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`update-system.mjs:1027` adds `wasEverShippedUpstream()`. `apply()` uses it at `update-system.mjs:2336` to keep files that upstream never shipped.

Previously shipped files still prune, including files moved to new upstream paths. Failed or shallow history checks keep the file. `--literal-pathspecs` prevents false matches for filenames with Git pathspec characters at `update-system.mjs:1035`.

`tests/updater-never-shipped-prune.test.mjs:51` adds regression coverage for these decisions.

From the user's point of view: updates no longer delete fork-local files under `providers/`, `tests/`, or `plugins-registry/`. Retired upstream files continue to prune.

Named system paths: `update-system.mjs` is touched. `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

