### PR TITLE
docs(workday): pin the locationMainGroup nested-facet trap with a fixture

### DIFF
--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -106,7 +106,12 @@ function resolveMaxPages(entry) {
 // unfaceted crawl, and a board it could not finish keeps the workdayTruncated
 // tag rather than being reported as complete.
 
-/** Sum one facet's value counts; null when none of its values carry a count. */
+/**
+ * Sum one facet's value counts; null when none of its values carry a count.
+ *
+ * Reads a facet's own `values` only. Nested children are deliberately not
+ * summed — see the trap documented on `chooseSplitFacet()` (#3875).
+ */
 function facetCoverage(facet) {
   const values = Array.isArray(facet?.values) ? facet.values : [];
   let sum = 0;
@@ -152,6 +157,20 @@ export function trueTotalFromFacets(facets) {
  *
  * `exclude` carries the facet parameters already applied further up the split,
  * without which re-splitting a slice would keep re-deriving the same partition.
+ *
+ * Descending into those id-less headers' nested children looks like a free
+ * improvement — more values, a finer partition — and is a trap. On
+ * dickssportinggoods|wd1|dsg (measured 2026-08-28) `locationMainGroup` carries
+ * 2 group parents whose 938 nested children sum to 16,732 against a board of
+ * ~8,366: almost exactly 2.00x, because a requisition open in several locations
+ * is counted once per location. Every other counted facet on that board agrees
+ * within 0.9% and errs downward. Since `trueTotalFromFacets()` takes the
+ * maximum, recursing would double the true total, make every healthy board
+ * compare its honest `total` against it and read as offset-clamped, and hand
+ * `workdayTruncated` to boards that were complete — a silent failure that looks
+ * like success. The `id` filter below is what keeps that shut; it is
+ * load-bearing, not tidiness. See #3875; pinned by the nested-shape fixture in
+ * tests/providers/workday-facet-split.test.mjs.
  *
  * Exported for the test suite.
  */

--- a/tests/providers/workday-facet-split.test.mjs
+++ b/tests/providers/workday-facet-split.test.mjs
@@ -58,6 +58,51 @@ const DSG_FACETS = [
   },
 ];
 
+// The same board with `locationMainGroup` in the fuller shape a live tenant
+// ships (page 0, 2026-08-28): the id-less group parents above, each carrying
+// nested children that *do* have their own ids and counts.
+//
+// Those children double-count. A requisition open in several locations is
+// counted once per location, so the live facet's 938 children summed to 16,732
+// against a board of ~8,366 — almost exactly 2.00x — while every other counted
+// facet on the board agreed within 0.9% and erred downward. The children below
+// are collapsed from 938 to 4 with that sum preserved, since the sum is the
+// property under test.
+//
+// Neither function should reach them: `facetCoverage()` sums a facet's own
+// `values`, and `chooseSplitFacet()` filters on a string `id`. Recursing into
+// `values[].values` looks like a free improvement — more values, a finer
+// partition — and would instead double the true total, so every healthy board
+// would compare its honest `total` against it and read as offset-clamped. The
+// two assertions below go red if that refactor ever lands. See #3875.
+const DSG_NESTED_FACETS = [
+  ...DSG_FACETS.filter((f) => f.facetParameter !== 'locationMainGroup'),
+  {
+    facetParameter: 'locationMainGroup',
+    descriptor: null,
+    values: [
+      {
+        id: null,
+        descriptor: 'Location - State',
+        count: null,
+        values: [
+          { id: 'loc-pa', descriptor: 'Pennsylvania', count: 4183 },
+          { id: 'loc-ny', descriptor: 'New York', count: 4183 },
+        ],
+      },
+      {
+        id: null,
+        descriptor: 'Locations',
+        count: null,
+        values: [
+          { id: 'loc-pgh', descriptor: 'Pittsburgh', count: 4183 },
+          { id: 'loc-nyc', descriptor: 'New York City', count: 4183 },
+        ],
+      },
+    ],
+  },
+];
+
 try {
   const workdayModule = await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href);
   const workday = workdayModule.default;
@@ -90,6 +135,19 @@ try {
     pass('trueTotalFromFacets() ignores facets whose values carry no usable counts');
   } else {
     fail(`trueTotalFromFacets(uncounted) returned ${uncounted}, expected null`);
+  }
+
+  // The board size must not move when the nested children are present. An
+  // implementation that summed them would return 16,732 and, because this
+  // function takes the maximum, every healthy tenant would then read as clamped.
+  const nestedTrue = trueTotalFromFacets(DSG_NESTED_FACETS);
+  if (nestedTrue === 8425) {
+    pass('trueTotalFromFacets() ignores nested facet children — locationMainGroup cannot double the board');
+  } else {
+    fail(
+      `trueTotalFromFacets(DSG_NESTED) returned ${nestedTrue}, expected 8425` +
+        ' — 16732 means the nested children were summed (#3875)',
+    );
   }
 
   // ── chooseSplitFacet ──────────────────────────────────────────────
@@ -134,6 +192,17 @@ try {
     pass('chooseSplitFacet() rejects facets whose values have no id (id-less group headers)');
   } else {
     fail('chooseSplitFacet() should reject id-less facet values');
+  }
+
+  // Same rejection, but against the shape that makes descending tempting: the
+  // parents are still id-less, yet their children carry usable ids and counts.
+  const nestedChosen = chooseSplitFacet(DSG_NESTED_FACETS);
+  if (nestedChosen && nestedChosen.facetParameter === 'jobFamily') {
+    pass('chooseSplitFacet() never picks a nested group facet, even when its children carry ids and counts');
+  } else {
+    fail(
+      `chooseSplitFacet(DSG_NESTED) chose ${JSON.stringify(nestedChosen?.facetParameter)}, expected "jobFamily" (#3875)`,
+    );
   }
 
   const locationFirst = chooseSplitFacet([


### PR DESCRIPTION
Closes #3875. Landed in the shape you scoped: a comment naming `locationMainGroup` and the 2.00x, plus a fixture asserting the nested facet is never chosen. **No behavior change.**

## The trap

On `dickssportinggoods|wd1|dsg` (page 0, 2026-08-28) `locationMainGroup` carries 2 id-less group parents whose 938 nested children sum to **16,732** against a board of ~8,366 — almost exactly **2.00x**, because a requisition open in several locations is counted once per location. Every other counted facet on that board agrees within 0.9% and errs downward.

Both functions exclude it today by accident of shape rather than by an explicit check: `facetCoverage()` finds no `count` on the parents, `chooseSplitFacet()` finds no `id`. Descending into the children looks like a free improvement — more values, a finer partition — and would instead double `trueTotalFromFacets()` (it takes the maximum), make every healthy board compare its honest `total` against the doubled figure and read as offset-clamped, and hand `workdayTruncated` to boards that were complete. Silent, and it looks like success.

## What's here

- **`providers/workday.mjs`** — the reasoning recorded on `chooseSplitFacet()`'s doc block, so the `id` filter reads as load-bearing rather than tidiness. One-line pointer on `facetCoverage()`, since the doubling reaches `trueTotalFromFacets()` through it.
- **`tests/providers/workday-facet-split.test.mjs`** — `DSG_NESTED_FACETS`, the same board with `locationMainGroup` in the shape a live tenant ships: id-less parents carrying children that *do* have ids and counts. Children collapsed from 938 to 4 with the 16,732 sum preserved, since the sum is the property under test. Two assertions, each in its existing section:
  - `trueTotalFromFacets(DSG_NESTED_FACETS) === 8425` — not 16,732.
  - `chooseSplitFacet(DSG_NESTED_FACETS)` still picks `jobFamily`.

## Verification

Beyond the suite passing, I simulated the refactor — flattened `values[].values` in both functions — and confirmed the fixture actually catches it:

```
❌ trueTotalFromFacets(DSG_NESTED) returned 16732, expected 8425 — 16732 means the nested children were summed (#3875)
❌ chooseSplitFacet(DSG_NESTED) chose "locationMainGroup", expected "jobFamily" (#3875)
```

Exactly those two fail and nothing else, so the fixture adds coverage rather than restating checks that already existed. Reverted before committing.

`workday-facet-split` 34 passing / 0 failing (was 32), `workday.test.mjs` 0 failing, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNd8V4nj7XJYoAYLCVfwtg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User impact

Workday facet totals remain correct when `locationMainGroup` contains id-less nested groups. The nested child counts are ignored, so `trueTotalFromFacets()` returns `8425` instead of `16732`. `chooseSplitFacet()` continues to select `jobFamily`.

The change adds comments that explain why facet values must have IDs and why nested values are excluded. It adds the `DSG_NESTED_FACETS` regression fixture and related tests.

## Files changed

- `providers/workday.mjs`: Documents the existing facet exclusions.
- `tests/providers/workday-facet-split.test.mjs`: Adds nested-facet regression coverage.

No behavior changes. No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->