### PR TITLE
feat(validate-profile): config/profile.yml is never validated, so a misspelled key silently does nothing (#3981)

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -14,6 +14,7 @@ import * as yaml from 'js-yaml';
 import dotenv from 'dotenv';
 import { discoverPlugins, pluginRoots, pluginStatus } from './plugins/_engine.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
+import { validateProfile, EXAMPLE_PATH } from './validate-profile.mjs';
 import { resolveExtractorMode } from './browser-extract.mjs';
 import { parseConfigByExtension } from './jsonc-parse.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
@@ -640,6 +641,34 @@ function checkPlugins(root) {
   return fixes.length ? { warn: true, label, fix: fixes } : { pass: true, label };
 }
 
+// profile.yml steers scoring targets, output language, spend tier, CV format and
+// location policy — and the existence check above is all that ever looked at it.
+// Every reader does `profile?.language?.output` and takes the fallback when the
+// key is missing, which is indistinguishable from the key being MISSPELLED. So
+// `langauge: {output: ja}` produces English output and no signal anywhere.
+//
+// WARN, never FAIL, like the plugin check below it: an unknown key is a typo,
+// not a broken install, and refusing to run would be a worse answer than naming
+// it.
+function checkProfileShape(root) {
+  const profilePath = process.env.CAREER_OPS_PROFILE || join(root, 'config', 'profile.yml');
+  if (!existsSync(profilePath)) return null;   // the prereq check owns "absent"
+  let findings;
+  try {
+    const example = existsSync(EXAMPLE_PATH) ? readFileSync(EXAMPLE_PATH, 'utf-8') : '';
+    findings = validateProfile(readFileSync(profilePath, 'utf-8'), example).findings;
+  } catch (err) {
+    return { warn: true, label: `config/profile.yml could not be read (${err.message})` };
+  }
+  const actionable = findings.filter((f) => f.level !== 'info');
+  if (actionable.length === 0) return { pass: true, label: 'config/profile.yml: shape OK' };
+  return {
+    warn: true,
+    label: `config/profile.yml: ${actionable.length} issue${actionable.length === 1 ? '' : 's'} — settings under an unrecognized key have no effect`,
+    fix: actionable.map((f) => f.message),
+  };
+}
+
 async function main() {
   console.log('\ncareer-ops doctor');
   console.log('================\n');
@@ -660,6 +689,7 @@ async function main() {
     ...USER_LAYER_PREREQS.map(checkPrereq),
     checkFonts(),
     checkPersonalization(projectRoot),
+    checkProfileShape(projectRoot),
     checkAutoDir('data'),
     checkPipelineFile(),
     checkAutoDir('output'),

--- a/profile-language.mjs
+++ b/profile-language.mjs
@@ -11,14 +11,49 @@ function normalizeOutputLanguage(value) {
   return language;
 }
 
-/** Parse language.output from profile YAML, falling back to English. */
-export function parseOutputLanguage(profileYaml) {
+/**
+ * language.output, plus WHY that is the answer.
+ *
+ * The catch below folds three different situations into `en`: no profile, no
+ * language key, and a profile that does not parse. The first two are correct —
+ * English is the documented default. The third is not something the caller
+ * should be unable to distinguish: a user who set `output: ja` and has a YAML
+ * typo elsewhere in the file gets every report, cover letter and outreach
+ * message in English, and the only signal is noticing the wrong language in
+ * finished work.
+ *
+ * `source` makes that inspectable without changing what any existing caller
+ * receives. `doctor.mjs` is the primary signal now (checkProfileShape reports
+ * an unparseable profile on the first message of every session); this is for a
+ * caller that wants to say so at generation time.
+ *
+ * @param {string} profileYaml
+ * @returns {{language: string, source: 'configured'|'default'|'unparseable'}}
+ */
+export function describeOutputLanguage(profileYaml) {
+  let profile;
   try {
-    const profile = yaml.load(String(profileYaml ?? '')) || {};
-    return normalizeOutputLanguage(profile?.language?.output);
+    profile = yaml.load(String(profileYaml ?? '')) || {};
   } catch {
-    return DEFAULT_OUTPUT_LANGUAGE;
+    return { language: DEFAULT_OUTPUT_LANGUAGE, source: 'unparseable' };
   }
+  const raw = profile?.language?.output;
+  const language = normalizeOutputLanguage(raw);
+  // 'configured' only when the file actually asked for what it got — a value
+  // that normalizes away (too long, embedded newline) is a default, not a
+  // setting the user made.
+  const configured = typeof raw === 'string' && raw.trim() === language;
+  return { language, source: configured ? 'configured' : 'default' };
+}
+
+/**
+ * Parse language.output from profile YAML, falling back to English.
+ *
+ * Contract unchanged — returns the language string. Use describeOutputLanguage
+ * when the reason matters.
+ */
+export function parseOutputLanguage(profileYaml) {
+  return describeOutputLanguage(profileYaml).language;
 }
 
 /** Build the canonical output-language rule injected into every model prompt. */

--- a/tests/profile-schema-validation.test.mjs
+++ b/tests/profile-schema-validation.test.mjs
@@ -1,0 +1,124 @@
+// tests/profile-schema-validation.test.mjs — config/profile.yml is the one
+// config file nothing checked the shape of.
+//
+// It steers scoring targets, output language, spend tier, CV format and
+// location policy. doctor.mjs checked that it EXISTS; every reader then does
+// `profile?.language?.output` and takes the fallback when the key is absent —
+// which is indistinguishable from the key being MISSPELLED:
+//
+//     langauge:          # <- parses cleanly, validates nowhere
+//       output: ja
+//     spend_teir: premium
+//
+// English output at the default tier, no signal anywhere. The user's only clue
+// is noticing the wrong language in finished work.
+//
+// portals.yml has validate-portals.mjs and the plugin registry has
+// validate-plugin-registry.mjs; this is the same family for the file that had
+// none.
+//
+// Run:  node --test tests/profile-schema-validation.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const { validateProfile, knownKeysFromExample, UNDOCUMENTED_KEYS, EXAMPLE_PATH } =
+  await import(pathToFileURL(join(ROOT, 'validate-profile.mjs')).href);
+
+const EXAMPLE = existsSync(EXAMPLE_PATH) ? readFileSync(EXAMPLE_PATH, 'utf-8') : '';
+
+test('a misspelled key is named, with the key it was probably meant to be', () => {
+  const { findings } = validateProfile('langauge:\n  output: ja\nspend_teir: premium\n', EXAMPLE);
+  const unknown = findings.filter((f) => f.code === 'unknown-key');
+  assert.equal(unknown.length, 2, `expected both typos: ${JSON.stringify(findings)}`);
+  assert.equal(unknown.find((f) => f.key === 'langauge')?.suggestion, 'language');
+  assert.equal(unknown.find((f) => f.key === 'spend_teir')?.suggestion, 'spend_tier');
+});
+
+test('the real shipped example validates clean against itself', () => {
+  // The strongest guard available: if the example a user is told to copy would
+  // itself warn, the check is wrong, not the user.
+  assert.ok(EXAMPLE.trim(), 'config/profile.example.yml is missing or empty');
+  assert.deepEqual(validateProfile(EXAMPLE, EXAMPLE).findings, []);
+});
+
+test('keys the code reads but the example omits are not called unknown', () => {
+  // rejection_latency, table_freshness and scan have real readers. Warning on
+  // them would flag a correct profile — the failure mode that makes a validator
+  // something users learn to ignore.
+  for (const key of Object.keys(UNDOCUMENTED_KEYS)) {
+    const { findings } = validateProfile(`${key}:\n  x: 1\n`, EXAMPLE);
+    assert.ok(
+      !findings.some((f) => f.code === 'unknown-key'),
+      `${key} was reported unknown despite having a reader: ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test('and their absence from the example is reported rather than hidden', () => {
+  const { findings } = validateProfile('rejection_latency:\n  courtesy_days: 45\n', EXAMPLE);
+  const undoc = findings.find((f) => f.code === 'undocumented-key');
+  assert.ok(undoc, 'the doc gap was swallowed');
+  assert.match(undoc.message, /rejection-latency\.mjs/, 'the finding does not name the reader');
+});
+
+test('the known-key set is derived from the example, not hardcoded here', () => {
+  // A key added to config/profile.example.yml must be understood on the same
+  // commit. A hardcoded roster can only chase the example, and drifts.
+  const widened = `${EXAMPLE}\nbrand_new_section:\n  x: 0\n`;
+  assert.deepEqual(validateProfile('brand_new_section:\n  x: 1\n', widened).findings, []);
+  assert.ok(knownKeysFromExample(widened).includes('brand_new_section'));
+});
+
+test('empty, comment-only and absent profiles are not errors', () => {
+  // Legitimate starting states. doctor's existence check owns "not set up yet";
+  // this one must not double-report it as a shape problem.
+  for (const text of ['', '\n', '# nothing here yet\n']) {
+    assert.deepEqual(validateProfile(text, EXAMPLE).findings, [], `"${text}" was reported`);
+  }
+});
+
+test('a malformed or non-mapping profile is reported as such', () => {
+  assert.equal(validateProfile('\tbroken: tab\n', EXAMPLE).findings[0]?.code, 'unparseable');
+  assert.equal(validateProfile('just a string\n', EXAMPLE).findings[0]?.code, 'not-a-mapping');
+});
+
+test('doctor surfaces it as a warning, and does not fail the run', () => {
+  // WARN not FAIL: an unknown key is a typo, not a broken install. Refusing to
+  // run would be a worse answer than naming it.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-profile-shape-'));
+  try {
+    mkdirSync(join(dir, 'config'), { recursive: true });
+    writeFileSync(join(dir, 'config', 'profile.yml'), 'langauge:\n  output: ja\n');
+    const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--target', dir], {
+      cwd: dir, encoding: 'utf-8', timeout: 60_000,
+      env: { ...process.env, CAREER_OPS_ROOT: dir, CAREER_OPS_DATA_DIR: '' },
+    });
+    const all = `${r.stdout}${r.stderr}`;
+    assert.match(all, /config\/profile\.yml: 1 issue/, `doctor did not report the typo:\n${all.slice(0, 600)}`);
+    assert.match(all, /did you mean "language"/, 'doctor did not carry the suggestion through');
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('a clean profile adds no doctor noise', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-profile-clean-'));
+  try {
+    mkdirSync(join(dir, 'config'), { recursive: true });
+    writeFileSync(join(dir, 'config', 'profile.yml'), 'language:\n  output: ja\n');
+    const r = spawnSync(process.execPath, [join(ROOT, 'doctor.mjs'), '--target', dir], {
+      cwd: dir, encoding: 'utf-8', timeout: 60_000,
+      env: { ...process.env, CAREER_OPS_ROOT: dir, CAREER_OPS_DATA_DIR: '' },
+    });
+    assert.doesNotMatch(`${r.stdout}${r.stderr}`, /profile\.yml: \d+ issue/, 'a correct profile was warned about');
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -349,6 +349,7 @@ const SYSTEM_PATHS = [
   'tracker-writer-lock-tests.mjs',
   'agent-inbox-tests.mjs',
   'validate-portals.mjs',
+  'validate-profile.mjs',
   'verify-portals.mjs',
   'audit-portals.mjs',
   'fix-slugs.mjs',

--- a/validate-profile.mjs
+++ b/validate-profile.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * validate-profile.mjs — structural check for config/profile.yml.
+ *
+ * profile.yml steers scoring targets, output language, spend tier, CV format
+ * and location policy, and nothing checked its shape. `doctor.mjs` checks that
+ * the file EXISTS; every reader then does `profile?.language?.output` and takes
+ * the fallback when the key is missing — which is indistinguishable from the
+ * key being misspelled. A profile reading
+ *
+ *     langauge:
+ *       output: ja
+ *     spend_teir: premium
+ *
+ * parses cleanly, validates nowhere, and silently produces English output at
+ * the default tier. The user's only signal is noticing the wrong language in
+ * finished work.
+ *
+ * WARN, never FAIL. career-ops is meant to work out of the box and an unknown
+ * key is not a broken install — it is almost always a typo, and the right
+ * response is to name it, not to refuse to run. `portals.yml` gets
+ * validate-portals.mjs and the plugin registry gets validate-plugin-registry.mjs;
+ * this is the same family for the one file that had none.
+ *
+ * The known-key set is DERIVED from config/profile.example.yml rather than
+ * hardcoded, so a key added to the example is understood here on the same
+ * commit. Keys the code reads but the example does not document are listed
+ * explicitly below, each naming its reader — a hardcoded list can only ever
+ * chase reality, and that list is short and auditable.
+ *
+ * Usage:
+ *   node validate-profile.mjs [--profile <path>] [--json] [--self-test]
+ *
+ * Exit codes:
+ *   0  clean, or findings (they are warnings)
+ *   1  usage error
+ *   2  the profile exists and does not parse
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import * as yaml from 'js-yaml';
+import { getCareerOpsRoot } from './path-resolver.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
+
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
+
+export const EXAMPLE_PATH = join(CODE_ROOT, 'config', 'profile.example.yml');
+export const DEFAULT_PROFILE_PATH = process.env.CAREER_OPS_PROFILE
+  || join(DATA_ROOT, 'config', 'profile.yml');
+
+/**
+ * Top-level keys the code reads that config/profile.example.yml does not show.
+ *
+ * Each is a real reader, so treating them as unknown would warn on a correct
+ * profile. They are listed here rather than added to the example silently
+ * because the example is the file a user learns the schema from — see the
+ * `undocumented` finding below, which reports the gap instead of hiding it.
+ */
+export const UNDOCUMENTED_KEYS = {
+  rejection_latency: 'rejection-latency.mjs (courtesy_days)',
+  table_freshness: 'check-table-freshness.mjs (max_age_months)',
+  scan: 'browser-extract.mjs / doctor.mjs (extractor)',
+};
+
+/** Top-level keys from the shipped example — the documented schema. */
+export function knownKeysFromExample(exampleText) {
+  const doc = yaml.load(String(exampleText ?? '')) || {};
+  if (typeof doc !== 'object' || Array.isArray(doc)) return [];
+  return Object.keys(doc);
+}
+
+/**
+ * Edit distance, capped — only used to turn "unknown key" into "did you mean".
+ * A typo is the case this check exists for, so naming the intended key is most
+ * of its value; without it the user is told `langauge` is unknown and still has
+ * to spot the transposition themselves.
+ */
+export function nearestKey(key, candidates, maxDistance = 3) {
+  let best = null;
+  let bestD = Infinity;
+  for (const c of candidates) {
+    const d = editDistance(key.toLowerCase(), c.toLowerCase());
+    if (d < bestD) { bestD = d; best = c; }
+  }
+  return bestD <= maxDistance ? best : null;
+}
+
+function editDistance(a, b) {
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const tmp = prev[j];
+      prev[j] = Math.min(prev[j] + 1, prev[j - 1] + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1));
+      diag = tmp;
+    }
+  }
+  return prev[b.length];
+}
+
+/**
+ * @param {string} profileText - Raw profile.yml.
+ * @param {string} exampleText - Raw config/profile.example.yml.
+ * @returns {{findings: object[], parsed: object|null}}
+ */
+export function validateProfile(profileText, exampleText) {
+  const findings = [];
+  let parsed;
+  try {
+    parsed = yaml.load(String(profileText ?? ''));
+  } catch (err) {
+    return {
+      parsed: null,
+      findings: [{
+        level: 'error',
+        code: 'unparseable',
+        message: `config/profile.yml is not valid YAML: ${String(err.message).split('\n')[0]}`,
+      }],
+    };
+  }
+  // An empty or comment-only profile is a legitimate starting state, not an
+  // error — doctor's existence check is what covers "you have not set this up".
+  if (parsed == null) return { parsed: null, findings };
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      parsed: null,
+      findings: [{ level: 'error', code: 'not-a-mapping', message: 'config/profile.yml does not contain a YAML mapping.' }],
+    };
+  }
+
+  const documented = knownKeysFromExample(exampleText);
+  const known = new Set([...documented, ...Object.keys(UNDOCUMENTED_KEYS)]);
+
+  for (const key of Object.keys(parsed)) {
+    if (known.has(key)) continue;
+    const suggestion = nearestKey(key, [...known]);
+    findings.push({
+      level: 'warn',
+      code: 'unknown-key',
+      key,
+      suggestion,
+      message: suggestion
+        ? `Unknown top-level key "${key}" — did you mean "${suggestion}"? It is being ignored, so whatever you set under it has no effect.`
+        : `Unknown top-level key "${key}". It is being ignored, so whatever you set under it has no effect.`,
+    });
+  }
+
+  // Reported, not silently tolerated: a key the code reads and the example does
+  // not show is a schema a user cannot learn from the file they are pointed at.
+  for (const [key, reader] of Object.entries(UNDOCUMENTED_KEYS)) {
+    if (key in parsed && !documented.includes(key)) {
+      findings.push({
+        level: 'info',
+        code: 'undocumented-key',
+        key,
+        message: `"${key}" is read by ${reader} but is not in config/profile.example.yml, so it is undiscoverable.`,
+      });
+    }
+  }
+
+  return { parsed, findings };
+}
+
+// --- self-test ---------------------------------------------------------
+function runSelfTest() {
+  let pass = 0; let fail = 0;
+  const check = (cond, label) => { if (cond) { pass++; } else { fail++; console.error(`  ✗ ${label}`); } };
+  const EXAMPLE = 'candidate:\n  full_name: x\nlanguage:\n  output: en\nspend_tier: standard\ncv:\n  output_format: html\n';
+
+  const typo = validateProfile('langauge:\n  output: ja\nspend_teir: premium\n', EXAMPLE);
+  check(typo.findings.filter(f => f.code === 'unknown-key').length === 2, 'two typo keys are reported');
+  check(typo.findings.some(f => f.key === 'langauge' && f.suggestion === 'language'), 'langauge suggests language');
+  check(typo.findings.some(f => f.key === 'spend_teir' && f.suggestion === 'spend_tier'), 'spend_teir suggests spend_tier');
+
+  const clean = validateProfile('candidate:\n  full_name: x\nlanguage:\n  output: ja\n', EXAMPLE);
+  check(clean.findings.length === 0, 'a correct profile produces no findings');
+
+  const extra = validateProfile('rejection_latency:\n  courtesy_days: 45\n', EXAMPLE);
+  check(extra.findings.every(f => f.code !== 'unknown-key'), 'a code-read key is not reported as unknown');
+  check(extra.findings.some(f => f.code === 'undocumented-key'), 'and its absence from the example is reported');
+
+  check(validateProfile('', EXAMPLE).findings.length === 0, 'an empty profile is not an error');
+  check(validateProfile('# just a comment\n', EXAMPLE).findings.length === 0, 'a comment-only profile is not an error');
+  check(validateProfile('\tbroken: tab\n', EXAMPLE).findings[0]?.code === 'unparseable', 'malformed YAML is reported as unparseable');
+  check(validateProfile('just a string\n', EXAMPLE).findings[0]?.code === 'not-a-mapping', 'a scalar profile is reported');
+
+  // Derivation, not a hardcoded list: a key added to the example is accepted
+  // here with no edit to this file.
+  const widened = validateProfile('brand_new_section:\n  x: 1\n', `${EXAMPLE}brand_new_section:\n  x: 0\n`);
+  check(widened.findings.length === 0, 'a key added to the example is understood without editing this file');
+
+  console.log(`\n  validate-profile self-test: ${pass} passed, ${fail} failed\n`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+if (isMainModule(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args.includes('--self-test')) runSelfTest();
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log('Usage: node validate-profile.mjs [--profile <path>] [--json] [--self-test]');
+    process.exit(0);
+  }
+  const pi = args.indexOf('--profile');
+  const profilePath = pi !== -1 && args[pi + 1] ? args[pi + 1] : DEFAULT_PROFILE_PATH;
+  if (!existsSync(profilePath)) {
+    console.log(`No profile at ${profilePath} — nothing to validate.`);
+    process.exit(0);
+  }
+  const example = existsSync(EXAMPLE_PATH) ? readFileSync(EXAMPLE_PATH, 'utf-8') : '';
+  const { findings } = validateProfile(readFileSync(profilePath, 'utf-8'), example);
+  if (args.includes('--json')) {
+    console.log(JSON.stringify({ profile: profilePath, findings }, null, 2));
+  } else if (findings.length === 0) {
+    console.log(`✓ ${profilePath}: no structural problems.`);
+  } else {
+    for (const f of findings) console.log(`  ${f.level === 'error' ? '✗' : '⚠'} ${f.message}`);
+  }
+  process.exit(findings.some(f => f.code === 'unparseable' || f.code === 'not-a-mapping') ? 2 : 0);
+}

--- a/validate-profile.mjs
+++ b/validate-profile.mjs
@@ -109,6 +109,19 @@ function editDistance(a, b) {
  */
 export function validateProfile(profileText, exampleText) {
   const findings = [];
+  // Emptiness is decided from the TEXT, before parsing, because the parsers
+  // disagree about it: js-yaml 4 returns undefined for an empty or comment-only
+  // document, js-yaml 5 throws "expected a document, but the input is empty".
+  // package.json asks for ^5.3.0 and there is no root lockfile, so which major a
+  // given checkout has is not fixed — inferring "empty" from what the parser
+  // does would report a blank profile as malformed on one and not the other.
+  // The identical hazard bit #3593 in plugins.mjs; same answer here.
+  const hasContent = String(profileText ?? '').split('\n').some((line) => {
+    const t = line.trim();
+    return t !== '' && !t.startsWith('#');
+  });
+  if (!hasContent) return { parsed: null, findings };
+
   let parsed;
   try {
     parsed = yaml.load(String(profileText ?? ''));


### PR DESCRIPTION
Fixes #3981.

`config/profile.yml` steers scoring targets, output language, spend tier, CV format and location policy. `doctor.mjs` checked that it exists; every reader then does `profile?.language?.output` and takes the fallback when the key is absent — indistinguishable from the key being **misspelled**.

```yaml
langauge:            # parses cleanly, validates nowhere
  output: ja
spend_teir: premium
```

English output at the default tier, no signal anywhere. `portals.yml` has `validate-portals.mjs` and the plugin registry has `validate-plugin-registry.mjs`; this is the same family for the one config file that had none.

## Derived, not hardcoded

The known-key set comes from `config/profile.example.yml`, so a key added there is understood on the same commit — a hardcoded roster can only chase the example and drifts.

Three keys needed care: `rejection_latency`, `table_freshness` and `scan` are read by code and are **not** in the example, so a naive derivation would warn on a *correct* profile — the failure mode that teaches users to ignore a validator. They are listed explicitly, each naming its reader, and their absence from the example is reported as its own informational finding rather than papered over. A schema you cannot learn from the file you were told to copy is a real gap.

Unknown keys carry a did-you-mean, because a typo is the whole point: *"langauge is unknown"* still leaves the user to spot the transposition.

## WARN, never FAIL

An unknown key is a typo, not a broken install. The check returns `null` when the profile is absent, so the existing prereq check keeps sole ownership of "you have not set this up yet" and the two cannot double-report. Only actionable findings reach the doctor label — the undocumented-key finding is informational and would otherwise warn users about the repo's own doc gap.

## The English fallback now says why

`parseOutputLanguage` folded three situations into `en`: no profile, no language key, and *a profile that does not parse*. The first two are correct. The third means a YAML typo anywhere in the file silently produces English in every report, cover letter and outreach message.

`describeOutputLanguage` returns `{language, source}` — `configured` / `default` / `unparseable`. `parseOutputLanguage` delegates and keeps its exact contract, so no caller changes. `configured` only when the file asked for what it got: a value that normalizes away (over 64 chars, embedded newline) is a default, not a setting, and calling it configured would be the same false confidence one level down.

## Tests

Nine, and the load-bearing one is that **the shipped `config/profile.example.yml` validates clean against itself**. If the file a user is told to copy would warn, the check is wrong rather than the user, and every other assertion is worth less.

Also pinned: a key added to the example is accepted with no edit to the validator; empty/comment-only profiles are not errors; and a clean profile adds no doctor noise.

Full suite green at 8687.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can validate `config/profile.yml` before misspelled keys silently trigger defaults.

- `validate-profile.mjs`: Validates profile keys against `config/profile.example.yml` and suggests corrections for unknown keys.
- `doctor.mjs`: Reports invalid profiles as warnings without failing checks.
- `profile-language.mjs`: Distinguishes configured, default, and unparseable output languages while preserving `parseOutputLanguage`.
- `tests/profile-schema-validation.test.mjs`: Covers validation, typo suggestions, malformed and empty profiles, doctor warnings, and clean profiles.
- `update-system.mjs`: Adds `validate-profile.mjs` to the system update manifest.

From the user’s point of view: misspelled keys no longer fail silently. Malformed profiles are distinct from missing language settings. Clean profiles continue to work without warnings.

System files touched from the requested list: `update-system.mjs`. No changes were made to `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->