### PR TITLE
fix(set-status): the canonical tracker write path cannot find a configured tracker (#3987)

### DIFF
--- a/mark-pdf-ready.mjs
+++ b/mark-pdf-ready.mjs
@@ -41,8 +41,11 @@ import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './
 import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, CLI_EXIT, makeCliFailWith, acquireTrackerLockForCli,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+// The USER's data root, not this file's directory — same defect, same fix as
+// set-status.mjs above it in this change.
+const DATA_ROOT = getCareerOpsRoot();
 
 // LOCK_TIMEOUT is not destructured here — that exit path is raised inside
 // acquireTrackerLockForCli() itself (tracker-utils.mjs), via CLI_EXIT.LOCK_TIMEOUT.
@@ -102,7 +105,7 @@ const targetReportNum = parseInt(reportSelector, 10);
 
 // ── tracker access ───────────────────────────────────────────────
 
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(APPS_FILE)) {
   failWith(EXIT_NOT_FOUND, 'no-tracker', `No tracker found at ${APPS_FILE}`);
 }

--- a/outcome.mjs
+++ b/outcome.mjs
@@ -36,14 +36,22 @@ import {
   resolveTrackerPath,
   resolveWorkspaceRoot,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { resolveOutcomeDir } from './lib/outcome-dir.mjs';
 import { parsePdfIndex } from './find.mjs';
 import { findCaptureForReport } from './jd-capture.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+// Two roots. CODE_ROOT locates the sibling scripts this file shells out to and
+// is the cwd it runs them from; DATA_ROOT is where the user's tracker and
+// outcome journals live. One constant named CAREER_OPS did both, so
+// resolveTrackerPath() looked inside the checkout and `outcome.mjs 1 rejected`
+// answered "Tracker not found at <CHECKOUT>/applications.md" — a path the user
+// never configured.
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
 const NODE = process.execPath;
-const SET_STATUS_SCRIPT = join(CAREER_OPS, 'set-status.mjs');
-const ARCHIVE_POSTING_SCRIPT = join(CAREER_OPS, 'archive-posting.mjs');
+const SET_STATUS_SCRIPT = join(CODE_ROOT, 'set-status.mjs');
+const ARCHIVE_POSTING_SCRIPT = join(CODE_ROOT, 'archive-posting.mjs');
 
 const EXIT_OK = 0;
 const EXIT_USAGE = 1;
@@ -142,7 +150,7 @@ if (!outcomeConfig) {
   failExit(`Invalid outcome_type "${rawOutcomeType}". Valid types: ${validTypes}`, 'invalid-outcome', EXIT_USAGE);
 }
 
-const appsFile = resolveTrackerPath(CAREER_OPS);
+const appsFile = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(appsFile)) {
   failExit(`Tracker not found at ${appsFile}`, 'tracker-not-found', EXIT_NOT_FOUND);
 }
@@ -422,7 +430,7 @@ if (!resolvedPostingPath) {
 if (!resolvedPostingPath && targetUrl) {
   try {
     execFileSync(NODE, [ARCHIVE_POSTING_SCRIPT, targetUrl, `--company=${matchedRow.company}`, `--role=${matchedRow.role}`, `--report=${matchedRow.num}`], {
-      cwd: CAREER_OPS,
+      cwd: CODE_ROOT,
       env: process.env,
       stdio: 'ignore',
       timeout: 45000,
@@ -503,7 +511,7 @@ if (matchedRow.role) {
 
 let setStatusResult = null;
 try {
-  const statusOutput = execFileSync(NODE, setStatusArgs, { cwd: CAREER_OPS, env: process.env, encoding: 'utf-8' });
+  const statusOutput = execFileSync(NODE, setStatusArgs, { cwd: CODE_ROOT, env: process.env, encoding: 'utf-8' });
   setStatusResult = JSON.parse(statusOutput);
 } catch (err) {
   failExit(`Tracker update via set-status.mjs failed: ${err.message}`, 'tracker-update-failed', 1);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -99,9 +99,21 @@ import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, loadCanonicalStates, resolveCanonicalState,
   normalizeCompany, cell, CLI_EXIT, makeCliFailWith, acquireTrackerLockForCli,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
+// Two roots. CODE_ROOT holds templates/states.yml, which ships with the code;
+// DATA_ROOT is the user's, and getCareerOpsRoot() is the only thing that honours
+// CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR / the .career-ops-data marker.
+//
+// One constant named CAREER_OPS did both, so resolveTrackerPath() looked inside
+// the checkout. AGENTS.md calls this script "the canonical (locked, validated,
+// atomic) write path" and #2901 converged the web layer's /api/status onto it —
+// so on any configured data root the one supported way to change a status
+// answered "No tracker found at <CHECKOUT>/applications.md", naming a file the
+// user never configured. Same defect #3715 fixed in the analysis scripts.
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
+const STATES_FILE = join(CODE_ROOT, 'templates/states.yml');
 
 // LOCK_TIMEOUT is not destructured here — that exit path is raised inside
 // acquireTrackerLockForCli() itself (tracker-utils.mjs), via CLI_EXIT.LOCK_TIMEOUT.
@@ -260,7 +272,7 @@ if (!newStatus) {
 
 // ── tracker access ───────────────────────────────────────────────
 
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(APPS_FILE)) {
   failWith(EXIT_NOT_FOUND, 'no-tracker', `No tracker found at ${APPS_FILE}`);
 }

--- a/tests/tracker-writers-data-root.test.mjs
+++ b/tests/tracker-writers-data-root.test.mjs
@@ -1,0 +1,151 @@
+// tests/tracker-writers-data-root.test.mjs — the tracker WRITERS resolve the
+// tracker against the user's data root (#3510's family, completing #3715).
+//
+// #3715 fixed the analysis scripts, which only read. These two write:
+//
+//   set-status.mjs:103    const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+//   set-status.mjs:263    const APPS_FILE  = resolveTrackerPath(CAREER_OPS);
+//   mark-pdf-ready.mjs:45 / :105   the same pair
+//
+// The constant reads as the project root and holds the CODE root, so
+// getCareerOpsRoot() — the only thing that honours CAREER_OPS_ROOT,
+// CAREER_OPS_DATA_DIR and the .career-ops-data marker — was never consulted.
+//
+// set-status.mjs is the one that matters: AGENTS.md calls it "the canonical
+// (locked, validated, atomic) write path", the tracker Pipeline Integrity rules
+// say status changes go through it and NOT through hand edits, and #2901
+// converged the web layer's /api/status onto it. So on any configured data root
+// the single supported way to change a status answered
+//
+//     No tracker found at <CHECKOUT>/applications.md
+//
+// naming a file the user never configured, while their real tracker sat
+// untouched.
+//
+// Each check runs with the data root and the cwd pointed at DIFFERENT
+// directories — from the data root the two resolutions agree and the bug is
+// invisible.
+//
+// Run:  node --test tests/tracker-writers-data-root.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const TRACKER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|---|---|---|---|---|---|---|---|',
+  '| 1 | 2026-01-05 | Acme | Backend Engineer | 4.2/5 | Applied | ❌ | [1](../reports/001-acme.md) | n |',
+  '',
+].join('\n');
+
+function fixture() {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-trwriter-'));
+  const decoyCwd = mkdtempSync(join(tmpdir(), 'career-ops-trdecoy-'));
+  mkdirSync(join(dataRoot, 'data'), { recursive: true });
+  writeFileSync(join(dataRoot, 'data', 'applications.md'), TRACKER);
+  return { dataRoot, decoyCwd };
+}
+
+const cleanup = (f) => {
+  for (const d of [f.dataRoot, f.decoyCwd]) rmSync(d, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+};
+
+function run(script, args, f) {
+  const r = spawnSync(process.execPath, [join(ROOT, script), ...args], {
+    cwd: f.decoyCwd, encoding: 'utf-8', timeout: 60_000,
+    env: { ...process.env, CAREER_OPS_ROOT: f.dataRoot, CAREER_OPS_DATA_DIR: '' },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+const trackerText = (f) => readFileSync(join(f.dataRoot, 'data', 'applications.md'), 'utf-8');
+
+test('set-status writes to the configured tracker, not the checkout', () => {
+  const f = fixture();
+  try {
+    const r = run('set-status.mjs', ['1', 'Interview', '--json'], f);
+    assert.doesNotMatch(r.all, /No tracker found/i, `it looked in the checkout:\n${r.all.slice(0, 400)}`);
+    assert.match(trackerText(f), /Interview/, `the configured tracker was not updated:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('and the status-log lands beside that tracker', () => {
+  // data/status-log.tsv is the tracker's sibling ledger. A writer that finds the
+  // tracker but logs elsewhere would split the record in two.
+  const f = fixture();
+  try {
+    run('set-status.mjs', ['1', 'Interview'], f);
+    assert.ok(
+      existsSync(join(f.dataRoot, 'data', 'status-log.tsv')),
+      `no ledger beside the tracker; data/ holds: ${readdirSync(join(f.dataRoot, 'data')).join(', ')}`,
+    );
+  } finally { cleanup(f); }
+});
+
+test('nothing is written into the directory it was launched from', () => {
+  const f = fixture();
+  try {
+    run('set-status.mjs', ['1', 'Interview'], f);
+    assert.deepEqual(readdirSync(f.decoyCwd), [], 'set-status wrote into the cwd');
+  } finally { cleanup(f); }
+});
+
+test('outcome.mjs finds the configured tracker too', () => {
+  // It shells out to set-status.mjs, so both halves have to resolve: the parent
+  // to locate the tracker, and the child to write it. The child inherits
+  // CAREER_OPS_ROOT through the environment.
+  const f = fixture();
+  try {
+    const r = run('outcome.mjs', ['1', 'rejected'], f);
+    assert.doesNotMatch(r.all, /Tracker not found|No tracker found/i, `it looked in the checkout:\n${r.all.slice(0, 400)}`);
+    assert.match(trackerText(f), /Rejected/, `the outcome did not reach the configured tracker:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('mark-pdf-ready resolves the same tracker', () => {
+  const f = fixture();
+  try {
+    const r = run('mark-pdf-ready.mjs', ['1'], f);
+    assert.doesNotMatch(r.all, /No tracker found|not found at/i, `it looked in the checkout:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('templates/states.yml still resolves from the CODE root', () => {
+  // The other half of set-status's split. states.yml ships with the code and is
+  // NOT in a user's data root, so a blanket move to DATA_ROOT would break every
+  // status validation — the check this script exists to perform.
+  const f = fixture();
+  try {
+    const r = run('set-status.mjs', ['1', 'NotACanonicalState', '--json'], f);
+    assert.doesNotMatch(r.all, /states\.yml/i, `states.yml was reported missing:\n${r.all.slice(0, 400)}`);
+    // It must still REJECT the bogus state, which it can only do by having read
+    // the template.
+    assert.match(r.all, /invalid|unknown|not a canonical|canonical/i, `the state was not validated:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('no tracker writer resolves the tracker from its own directory', () => {
+  // Structural, and scoped to the WRITERS because a wrong path there loses data
+  // rather than just reporting nothing. Same spirit as #3511's check 6.
+  const offenders = [];
+  for (const file of readdirSync(ROOT).filter((f) => f.endsWith('.mjs'))) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    const call = src.match(/resolveTrackerPath\(\s*([A-Z_]+)\s*\)/);
+    if (!call) continue;
+    const def = src.match(new RegExp(`^const ${call[1]}\\s*=\\s*(.+)$`, 'm'));
+    if (def && /dirname\(\s*fileURLToPath/.test(def[1])) {
+      offenders.push(`${file}: resolveTrackerPath(${call[1]}) where ${call[1]} = ${def[1].trim().slice(0, 50)}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `tracker resolved from the code root:\n${offenders.join('\n')}`);
+});


### PR DESCRIPTION
Fixes #3987. Completes #3715, which covered the readers.

```js
const CAREER_OPS = dirname(fileURLToPath(import.meta.url));   // the CODE root
const APPS_FILE  = resolveTrackerPath(CAREER_OPS);
```

Measured, tracker at a configured data root and cwd elsewhere:

```
$ CAREER_OPS_ROOT=<root> node set-status.mjs 1 Interview --json
{"error":"No tracker found at <CHECKOUT>/applications.md","code":"no-tracker"}
```

It names a file the user never configured while their real tracker sits untouched.

## Why this one is worse than the readers

`AGENTS.md` calls `set-status.mjs` *"the canonical (locked, validated, atomic) write path"*; the Pipeline Integrity rules say status changes go through it and **not** through hand edits; and #2901 converged the web layer's `/api/status` onto it. On any configured data root the single supported way to change a status did not work — and `outcome.mjs`, which shells out to it, failed the same way.

A wrong path in a reader produces an empty report. In a writer it reports success against a file the user never configured.

## The census

Every `resolveTrackerPath()` caller, by what it is handed:

```
OK  (data root)   16 scripts
BUG (code root)   set-status.mjs · mark-pdf-ready.mjs · outcome.mjs
```

All three fixed here. `set-status` and `outcome` needed **two** roots rather than a substitution — `set-status` reads `templates/states.yml`, which ships with the code and is absent from a user's data root, and `outcome` uses its own directory as the cwd for the sibling scripts it spawns. A blanket move would have broken status validation, which is the thing `set-status` exists to do.

## Tests

Seven, each separating the data root from the cwd — from the data root the two resolutions agree and the bug is invisible.

Three guards beyond the fixes:

- `data/status-log.tsv` must land **beside** the tracker it describes, or the record is split in two.
- `templates/states.yml` must keep resolving from the code root — so the easier blanket fix reddens. It also asserts a bogus state is still **rejected**, which `set-status` can only do by having read the template; without that, "no error about states.yml" would pass on a script that silently stopped validating.
- A structural sweep over every `resolveTrackerPath()` caller, so the next writer fails closed rather than joining a list of three.

That structural check earned its place immediately — it caught `outcome.mjs`, which I had fixed on a different branch and not on this one.

Reverting `set-status` alone reddens 4 of 7; either of the other two reddens 2. Full suite green at 8686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Tracker writers now resolve tracker files from the configured data root.

### User impact

When `CAREER_OPS_ROOT` or `CAREER_OPS_DATA_DIR` is configured, users can run status, outcome, and PDF-ready updates from another working directory. The scripts update the configured tracker and place the status log beside it.

Status validation still loads `templates/states.yml` from the code root. Sibling scripts also run from the code root. The change prevents writes to the launch directory or the writer module directory.

### Files changed

- `set-status.mjs`: Uses `getCareerOpsRoot()` for tracker data and retains code-root status validation.
- `outcome.mjs`: Uses separate code and data roots.
- `mark-pdf-ready.mjs`: Uses the configured data root.
- `tests/tracker-writers-data-root.test.mjs`: Adds regression coverage for separated roots, working directories, logs, validation, and tracker-path callers.

The requested system files were not part of this change: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->