### PR TITLE
fix(outcome,tracker): stamp the local calendar day, not the UTC one (#3989)

### DIFF
--- a/mark-pdf-ready.mjs
+++ b/mark-pdf-ready.mjs
@@ -41,8 +41,11 @@ import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './
 import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, CLI_EXIT, makeCliFailWith, acquireTrackerLockForCli,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+// The USER's data root, not this file's directory — same defect, same fix as
+// set-status.mjs above it in this change.
+const DATA_ROOT = getCareerOpsRoot();
 
 // LOCK_TIMEOUT is not destructured here — that exit path is raised inside
 // acquireTrackerLockForCli() itself (tracker-utils.mjs), via CLI_EXIT.LOCK_TIMEOUT.
@@ -102,7 +105,7 @@ const targetReportNum = parseInt(reportSelector, 10);
 
 // ── tracker access ───────────────────────────────────────────────
 
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(APPS_FILE)) {
   failWith(EXIT_NOT_FOUND, 'no-tracker', `No tracker found at ${APPS_FILE}`);
 }

--- a/outcome.mjs
+++ b/outcome.mjs
@@ -36,14 +36,22 @@ import {
   resolveTrackerPath,
   resolveWorkspaceRoot,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { resolveOutcomeDir } from './lib/outcome-dir.mjs';
 import { parsePdfIndex } from './find.mjs';
 import { findCaptureForReport } from './jd-capture.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+// Two roots. CODE_ROOT locates the sibling scripts this file shells out to and
+// is the cwd it runs them from; DATA_ROOT is where the user's tracker and
+// outcome journals live. One constant named CAREER_OPS did both, so
+// resolveTrackerPath() looked inside the checkout and `outcome.mjs 1 rejected`
+// answered "Tracker not found at <CHECKOUT>/applications.md" — a path the user
+// never configured.
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
 const NODE = process.execPath;
-const SET_STATUS_SCRIPT = join(CAREER_OPS, 'set-status.mjs');
-const ARCHIVE_POSTING_SCRIPT = join(CAREER_OPS, 'archive-posting.mjs');
+const SET_STATUS_SCRIPT = join(CODE_ROOT, 'set-status.mjs');
+const ARCHIVE_POSTING_SCRIPT = join(CODE_ROOT, 'archive-posting.mjs');
 
 const EXIT_OK = 0;
 const EXIT_USAGE = 1;
@@ -142,7 +150,7 @@ if (!outcomeConfig) {
   failExit(`Invalid outcome_type "${rawOutcomeType}". Valid types: ${validTypes}`, 'invalid-outcome', EXIT_USAGE);
 }
 
-const appsFile = resolveTrackerPath(CAREER_OPS);
+const appsFile = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(appsFile)) {
   failExit(`Tracker not found at ${appsFile}`, 'tracker-not-found', EXIT_NOT_FOUND);
 }
@@ -422,7 +430,7 @@ if (!resolvedPostingPath) {
 if (!resolvedPostingPath && targetUrl) {
   try {
     execFileSync(NODE, [ARCHIVE_POSTING_SCRIPT, targetUrl, `--company=${matchedRow.company}`, `--role=${matchedRow.role}`, `--report=${matchedRow.num}`], {
-      cwd: CAREER_OPS,
+      cwd: CODE_ROOT,
       env: process.env,
       stdio: 'ignore',
       timeout: 45000,
@@ -503,7 +511,7 @@ if (matchedRow.role) {
 
 let setStatusResult = null;
 try {
-  const statusOutput = execFileSync(NODE, setStatusArgs, { cwd: CAREER_OPS, env: process.env, encoding: 'utf-8' });
+  const statusOutput = execFileSync(NODE, setStatusArgs, { cwd: CODE_ROOT, env: process.env, encoding: 'utf-8' });
   setStatusResult = JSON.parse(statusOutput);
 } catch (err) {
   failExit(`Tracker update via set-status.mjs failed: ${err.message}`, 'tracker-update-failed', 1);

--- a/outcome.mjs
+++ b/outcome.mjs
@@ -37,6 +37,7 @@ import {
   resolveWorkspaceRoot,
 } from './tracker-utils.mjs';
 import { getCareerOpsRoot } from './path-resolver.mjs';
+import { localToday } from './lib/local-today.mjs';
 import { resolveOutcomeDir } from './lib/outcome-dir.mjs';
 import { parsePdfIndex } from './find.mjs';
 import { findCaptureForReport } from './jd-capture.mjs';
@@ -67,8 +68,17 @@ function slugify(text) {
     .slice(0, 60) || 'unknown';
 }
 
+// LOCAL calendar day, not the UTC one (#3070). This stamps the outcome journal
+// under data/outcomes/ — the `## Entry:` header and `**Date**:` — which
+// calibrate.mjs and funnel-velocity.mjs then read.
+//
+// tests/local-today-gates.test.mjs already covers assessment-log.mjs for
+// exactly this reason ("the date written into a user's assessments.tsv row").
+// This is the same kind of date, in an append-only file, and it was the UTC
+// one: an outcome recorded on a Sunday evening anywhere in the Americas was
+// journaled as Monday, moving it into the next week and the next funnel bucket.
 function today() {
-  return new Date().toISOString().split('T')[0];
+  return localToday();
 }
 
 

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -99,9 +99,21 @@ import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, loadCanonicalStates, resolveCanonicalState,
   normalizeCompany, cell, CLI_EXIT, makeCliFailWith, acquireTrackerLockForCli,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
+// Two roots. CODE_ROOT holds templates/states.yml, which ships with the code;
+// DATA_ROOT is the user's, and getCareerOpsRoot() is the only thing that honours
+// CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR / the .career-ops-data marker.
+//
+// One constant named CAREER_OPS did both, so resolveTrackerPath() looked inside
+// the checkout. AGENTS.md calls this script "the canonical (locked, validated,
+// atomic) write path" and #2901 converged the web layer's /api/status onto it —
+// so on any configured data root the one supported way to change a status
+// answered "No tracker found at <CHECKOUT>/applications.md", naming a file the
+// user never configured. Same defect #3715 fixed in the analysis scripts.
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
+const STATES_FILE = join(CODE_ROOT, 'templates/states.yml');
 
 // LOCK_TIMEOUT is not destructured here — that exit path is raised inside
 // acquireTrackerLockForCli() itself (tracker-utils.mjs), via CLI_EXIT.LOCK_TIMEOUT.
@@ -260,7 +272,7 @@ if (!newStatus) {
 
 // ── tracker access ───────────────────────────────────────────────
 
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(APPS_FILE)) {
   failWith(EXIT_NOT_FOUND, 'no-tracker', `No tracker found at ${APPS_FILE}`);
 }

--- a/tests/outcome-tracker-local-dates.test.mjs
+++ b/tests/outcome-tracker-local-dates.test.mjs
@@ -1,0 +1,168 @@
+// tests/outcome-tracker-local-dates.test.mjs — the outcome journal and the
+// tracker's status-event table stamp the LOCAL calendar day, not the UTC one
+// (#3070).
+//
+// tests/local-today-gates.test.mjs scoped itself to places that "GATE a
+// decision rather than stamping a filename", and included assessment-log.mjs
+// for "the date written into a user's assessments.tsv row". These two write
+// exactly that kind of date and were both on `new Date().toISOString()`:
+//
+//   outcome.mjs:62    the `## Entry:` header and `**Date**:` in data/outcomes/,
+//                     which calibrate.mjs and funnel-velocity.mjs then read
+//   tracker.mjs:552   the date on a row in the SQLite status_events table
+//
+// The tracker one sticks: the index is derived and rebuildable, but its own
+// comment says events "persist across rebuilds, keyed by id", so a wrong day is
+// written once and never corrected by a resync.
+//
+// FROZEN INSTANT, not the wall clock — the same discipline as the gate file, and
+// for the same reason it records: the window where the UTC day and the local day
+// disagree exists for only part of the UTC day, so a test reading `new Date()`
+// passes for most of the day whether the bug is present or not.
+//
+// Run:  node --test tests/outcome-tracker-local-dates.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// 01:30 UTC on the 18th is still the 17th everywhere west of Greenwich.
+const INSTANT = '2026-08-18T01:30:00Z';
+const UTC_DAY = '2026-08-18';
+const NY_DAY = '2026-08-17';
+
+const TRACKER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|---|---|---|---|---|---|---|---|',
+  '| 1 | 2026-01-05 | Acme | Backend Engineer | 4.2/5 | Applied | ✅ | [1](reports/001-acme-2026-01-05.md) | n |',
+  '',
+].join('\n');
+
+// A --import preload that freezes Date, then the real script as the entry
+// point. tests/scan-ats-full-outage-checkpoint.test.mjs uses the same shape.
+//
+// --import rather than a wrapper that imports the target: isMainModule()
+// compares import.meta.url against the process entry path, so a wrapper entry
+// makes every one of these scripts decide it is a library and skip its CLI body
+// — a silent exit 0 that looks like the command ran and did nothing. With
+// --import the preload runs first and the script is still argv[1].
+function freezeFile(dir) {
+  const file = join(dir, 'freeze-clock.mjs');
+  writeFileSync(file, `
+const RealDate = Date;
+const FROZEN = new RealDate(${JSON.stringify(INSTANT)});
+globalThis.Date = class extends RealDate {
+  constructor(...a) { if (a.length === 0) { super(FROZEN.getTime()); } else { super(...a); } }
+  static now() { return FROZEN.getTime(); }
+};
+`);
+  return pathToFileURL(file).href;
+}
+
+function runFrozen(dir, scriptRel, args, dataRoot) {
+  const r = spawnSync(process.execPath, ['--import', freezeFile(dir), join(ROOT, scriptRel), ...args], {
+    cwd: dataRoot, encoding: 'utf-8', timeout: 60_000,
+    env: {
+      ...process.env,
+      TZ: 'America/New_York',
+      CAREER_OPS_ROOT: dataRoot,
+      CAREER_OPS_DATA_DIR: '',
+    },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+function sandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-localdate-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  mkdirSync(join(dir, 'reports'), { recursive: true });
+  writeFileSync(join(dir, 'data', 'applications.md'), TRACKER);
+  writeFileSync(join(dir, 'reports', '001-acme-2026-01-05.md'), '# Acme\n\n**Score:** 4.2/5\n');
+  return dir;
+}
+
+test('the premise: at this instant the UTC day and the New York day differ', () => {
+  // Without this the rest measures nothing — it is the whole reason the instant
+  // is pinned rather than read from the clock.
+  assert.notEqual(UTC_DAY, NY_DAY);
+});
+
+test('outcome.mjs journals the local day', () => {
+  const dir = sandbox();
+  try {
+    const r = runFrozen(dir, 'outcome.mjs', ['1', 'rejected'], dir);
+    const outcomesDir = join(dir, 'data', 'outcomes');
+    assert.ok(existsSync(outcomesDir), `no outcome journal was written:\n${r.all.slice(0, 500)}`);
+    // outcome.mjs writes data/outcomes/<slug>/outcome.md — a directory per
+    // outcome, not loose files — so collect one level down.
+    const journals = readdirSync(outcomesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .flatMap((e) => readdirSync(join(outcomesDir, e.name))
+        .filter((f) => f.endsWith('.md'))
+        .map((f) => join(outcomesDir, e.name, f)));
+    assert.ok(journals.length > 0, `outcomes/ holds no journal:\n${r.all.slice(0, 500)}`);
+    const text = journals.map((f) => readFileSync(f, 'utf-8')).join('\n');
+    assert.ok(
+      text.includes(NY_DAY),
+      `the journal carries the UTC day, not the local one. Expected ${NY_DAY}, got:\n${text.slice(0, 400)}`,
+    );
+    assert.ok(
+      !text.includes(UTC_DAY),
+      `the UTC day ${UTC_DAY} still appears in the journal:\n${text.slice(0, 400)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('tracker.mjs dates its status events with the local day', async () => {
+  // node:sqlite needs Node >= 22.5; skip rather than fail on an older runtime,
+  // the way test-all does for the tracker index suites. Probed in-process, so
+  // this file contains no process.exit literal — tests/main-guard-convention
+  // greps discovered suites for one and does not care that it is inside a
+  // subprocess argument.
+  try {
+    await import('node:sqlite');
+  } catch {
+    return;   // node:sqlite unavailable
+  }
+
+  const dir = sandbox();
+  try {
+    // TWO syncs with a status change between them. `today` is only reached on a
+    // TRANSITION — a first sync dates the event from the row's own Date column
+    // (`DATE_RE.test(a.date) ? a.date : today`), so a single sync never touches
+    // the clock and a test built on one measures nothing. That is exactly how
+    // the first draft of this passed with the fix reverted.
+    runFrozen(dir, 'tracker.mjs', ['sync'], dir);
+    writeFileSync(join(dir, 'data', 'applications.md'), TRACKER.replace('| Applied |', '| Interview |'));
+    const r = runFrozen(dir, 'tracker.mjs', ['sync'], dir);
+    const dbPath = join(dir, 'data', 'applications.db');
+    assert.ok(existsSync(dbPath), `no index was built:\n${r.all.slice(0, 500)}`);
+
+    const q = spawnSync(process.execPath, ['--no-warnings', '--input-type=module', '-e', `
+      const { DatabaseSync } = await import('node:sqlite');
+      const db = new DatabaseSync(${JSON.stringify(dbPath)});
+      const rows = db.prepare('SELECT date FROM status_events').all();
+      process.stdout.write(JSON.stringify(rows.map(r => r.date)));
+    `], { encoding: 'utf-8', timeout: 30_000 });
+    assert.equal(q.status, 0, `could not read status_events: ${q.stderr}`);
+    const dates = JSON.parse(q.stdout);
+    assert.ok(
+      !dates.includes(UTC_DAY),
+      `a status event was dated with the UTC day (${UTC_DAY}): ${JSON.stringify(dates)}. `
+      + 'These persist across rebuilds keyed by id, so a wrong day is written once and sticks.',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});

--- a/tests/tracker-writers-data-root.test.mjs
+++ b/tests/tracker-writers-data-root.test.mjs
@@ -1,0 +1,151 @@
+// tests/tracker-writers-data-root.test.mjs — the tracker WRITERS resolve the
+// tracker against the user's data root (#3510's family, completing #3715).
+//
+// #3715 fixed the analysis scripts, which only read. These two write:
+//
+//   set-status.mjs:103    const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+//   set-status.mjs:263    const APPS_FILE  = resolveTrackerPath(CAREER_OPS);
+//   mark-pdf-ready.mjs:45 / :105   the same pair
+//
+// The constant reads as the project root and holds the CODE root, so
+// getCareerOpsRoot() — the only thing that honours CAREER_OPS_ROOT,
+// CAREER_OPS_DATA_DIR and the .career-ops-data marker — was never consulted.
+//
+// set-status.mjs is the one that matters: AGENTS.md calls it "the canonical
+// (locked, validated, atomic) write path", the tracker Pipeline Integrity rules
+// say status changes go through it and NOT through hand edits, and #2901
+// converged the web layer's /api/status onto it. So on any configured data root
+// the single supported way to change a status answered
+//
+//     No tracker found at <CHECKOUT>/applications.md
+//
+// naming a file the user never configured, while their real tracker sat
+// untouched.
+//
+// Each check runs with the data root and the cwd pointed at DIFFERENT
+// directories — from the data root the two resolutions agree and the bug is
+// invisible.
+//
+// Run:  node --test tests/tracker-writers-data-root.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const TRACKER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|---|---|---|---|---|---|---|---|',
+  '| 1 | 2026-01-05 | Acme | Backend Engineer | 4.2/5 | Applied | ❌ | [1](../reports/001-acme.md) | n |',
+  '',
+].join('\n');
+
+function fixture() {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-trwriter-'));
+  const decoyCwd = mkdtempSync(join(tmpdir(), 'career-ops-trdecoy-'));
+  mkdirSync(join(dataRoot, 'data'), { recursive: true });
+  writeFileSync(join(dataRoot, 'data', 'applications.md'), TRACKER);
+  return { dataRoot, decoyCwd };
+}
+
+const cleanup = (f) => {
+  for (const d of [f.dataRoot, f.decoyCwd]) rmSync(d, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+};
+
+function run(script, args, f) {
+  const r = spawnSync(process.execPath, [join(ROOT, script), ...args], {
+    cwd: f.decoyCwd, encoding: 'utf-8', timeout: 60_000,
+    env: { ...process.env, CAREER_OPS_ROOT: f.dataRoot, CAREER_OPS_DATA_DIR: '' },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+const trackerText = (f) => readFileSync(join(f.dataRoot, 'data', 'applications.md'), 'utf-8');
+
+test('set-status writes to the configured tracker, not the checkout', () => {
+  const f = fixture();
+  try {
+    const r = run('set-status.mjs', ['1', 'Interview', '--json'], f);
+    assert.doesNotMatch(r.all, /No tracker found/i, `it looked in the checkout:\n${r.all.slice(0, 400)}`);
+    assert.match(trackerText(f), /Interview/, `the configured tracker was not updated:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('and the status-log lands beside that tracker', () => {
+  // data/status-log.tsv is the tracker's sibling ledger. A writer that finds the
+  // tracker but logs elsewhere would split the record in two.
+  const f = fixture();
+  try {
+    run('set-status.mjs', ['1', 'Interview'], f);
+    assert.ok(
+      existsSync(join(f.dataRoot, 'data', 'status-log.tsv')),
+      `no ledger beside the tracker; data/ holds: ${readdirSync(join(f.dataRoot, 'data')).join(', ')}`,
+    );
+  } finally { cleanup(f); }
+});
+
+test('nothing is written into the directory it was launched from', () => {
+  const f = fixture();
+  try {
+    run('set-status.mjs', ['1', 'Interview'], f);
+    assert.deepEqual(readdirSync(f.decoyCwd), [], 'set-status wrote into the cwd');
+  } finally { cleanup(f); }
+});
+
+test('outcome.mjs finds the configured tracker too', () => {
+  // It shells out to set-status.mjs, so both halves have to resolve: the parent
+  // to locate the tracker, and the child to write it. The child inherits
+  // CAREER_OPS_ROOT through the environment.
+  const f = fixture();
+  try {
+    const r = run('outcome.mjs', ['1', 'rejected'], f);
+    assert.doesNotMatch(r.all, /Tracker not found|No tracker found/i, `it looked in the checkout:\n${r.all.slice(0, 400)}`);
+    assert.match(trackerText(f), /Rejected/, `the outcome did not reach the configured tracker:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('mark-pdf-ready resolves the same tracker', () => {
+  const f = fixture();
+  try {
+    const r = run('mark-pdf-ready.mjs', ['1'], f);
+    assert.doesNotMatch(r.all, /No tracker found|not found at/i, `it looked in the checkout:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('templates/states.yml still resolves from the CODE root', () => {
+  // The other half of set-status's split. states.yml ships with the code and is
+  // NOT in a user's data root, so a blanket move to DATA_ROOT would break every
+  // status validation — the check this script exists to perform.
+  const f = fixture();
+  try {
+    const r = run('set-status.mjs', ['1', 'NotACanonicalState', '--json'], f);
+    assert.doesNotMatch(r.all, /states\.yml/i, `states.yml was reported missing:\n${r.all.slice(0, 400)}`);
+    // It must still REJECT the bogus state, which it can only do by having read
+    // the template.
+    assert.match(r.all, /invalid|unknown|not a canonical|canonical/i, `the state was not validated:\n${r.all.slice(0, 400)}`);
+  } finally { cleanup(f); }
+});
+
+test('no tracker writer resolves the tracker from its own directory', () => {
+  // Structural, and scoped to the WRITERS because a wrong path there loses data
+  // rather than just reporting nothing. Same spirit as #3511's check 6.
+  const offenders = [];
+  for (const file of readdirSync(ROOT).filter((f) => f.endsWith('.mjs'))) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    const call = src.match(/resolveTrackerPath\(\s*([A-Z_]+)\s*\)/);
+    if (!call) continue;
+    const def = src.match(new RegExp(`^const ${call[1]}\\s*=\\s*(.+)$`, 'm'));
+    if (def && /dirname\(\s*fileURLToPath/.test(def[1])) {
+      offenders.push(`${file}: resolveTrackerPath(${call[1]}) where ${call[1]} = ${def[1].trim().slice(0, 50)}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `tracker resolved from the code root:\n${offenders.join('\n')}`);
+});

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -40,6 +40,7 @@ import { createHash } from 'crypto';
 import { dirname, resolve, join, basename } from 'path';
 import { pathToFileURL, fileURLToPath } from 'url';
 import { getCareerOpsRoot, resolveTrackerPath } from './path-resolver.mjs';
+import { localToday } from './lib/local-today.mjs';
 import * as yaml from 'js-yaml';
 import {
   resolveColumns, detectColumns, isHeaderRow, isSeparatorRow, LEGACY_COLMAP,
@@ -549,7 +550,11 @@ function reportDiagnostics(diag) {
 
 function syncIndex(db, states) {
   const { apps, diag, layout } = parseTracker(states);
-  const today = new Date().toISOString().slice(0, 10);
+  // LOCAL calendar day (#3070). This dates a row in the status_events table,
+  // and that table is the one part of the index a resync does NOT rebuild
+  // identically — the comment below says events "persist across rebuilds, keyed
+  // by id", so a wrong day is written once and then sticks.
+  const today = localToday();
 
   db.exec('BEGIN');
   db.exec('PRAGMA defer_foreign_keys = ON'); // full rebuild — FKs settle at commit


### PR DESCRIPTION
Fixes #3989.

> **Stacked on #3988.** The outcome test cannot run without it — `outcome.mjs` could not find a configured tracker at all. Review #3988 first; this branch shows only its own two commits once that lands.

`tests/local-today-gates.test.mjs` scoped itself to places that *"GATE a decision rather than stamping a filename"*, and included `assessment-log.mjs` for *"the date written into a user's assessments.tsv row"*. These two write exactly that kind of date:

```js
outcome.mjs:62    return new Date().toISOString().split('T')[0];
tracker.mjs:552   const today = new Date().toISOString().slice(0, 10);
```

An outcome recorded on a Sunday evening anywhere in the Americas was journaled as Monday, moving it into the next week and the next funnel bucket — and `calibrate.mjs` and `funnel-velocity.mjs` read that journal.

The tracker one sticks. The index is derived and rebuildable, except that `status_events` is the one part a resync does **not** rebuild identically — the comment right below says events *"persist across rebuilds, keyed by id"*.

## Two things the tests had to get right

Both found the useful way: by reverting the fix and watching the test still pass.

**The tracker case needs two syncs with a status change between them.** `today` is only reached on a *transition* — a first sync dates the event from the row's own Date column (`DATE_RE.test(a.date) ? a.date : today`) — so a single-sync test never touches the clock and measures nothing.

**The clock is frozen via `--import`, not a wrapper that imports the target.** `isMainModule()` compares against the process entry path, so a wrapper entry makes these scripts decide they are libraries and skip their CLI bodies entirely: a silent exit 0 that looks like the command ran and did nothing. `--import` runs the preload first and leaves the script as the entry point — which also keeps this file clear of `process.argv[1]`, the convention `tests/main-guard-convention.test.mjs` enforces. It caught my first attempt.

The instant is pinned rather than read from the wall clock, for the reason the gate file records: the window where the UTC day and the local day disagree exists for only part of the UTC day, so a test reading `new Date()` passes for most of the day whether the bug is there or not.

Reverting either fix reddens exactly its own check. Full suite green at 8688.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users now get local-calendar dates for outcome entries and tracker status events. Sunday-evening entries in the Americas no longer move into Monday’s weekly or funnel calculations.

The change also supports configured data roots:

- `outcome.mjs:62`: Uses the local date for journal headers and `Date` fields.
- `tracker.mjs:552`: Uses the local date for new `status_events` records.
- `outcome.mjs`, `set-status.mjs`, `mark-pdf-ready.mjs`: Resolve tracker data from the configured root.
- `outcome.mjs`, `set-status.mjs`: Continue loading templates and scripts from the code root.
- `tests/outcome-tracker-local-dates.test.mjs`: Adds frozen-clock regression tests.
- `tests/tracker-writers-data-root.test.mjs`: Verifies configured-root resolution, status-log placement, and template loading.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->