### PR TITLE
fix(i18n): route zh/zh-TW pipeline report numbering through reserve-report-num.mjs

### DIFF
--- a/modes/zh-TW/pipeline.md
+++ b/modes/zh-TW/pipeline.md
@@ -6,7 +6,7 @@
 
 1. **讀取資料**：分析 `data/pipeline.md`，找出 "Pending" 區塊下所有標記為 `- [ ]` 的待處理項目。
 2. **逐一處理**：對每一個未處理的 URL：
-   a. **計算新報告編號**：掃描 `reports/` 目錄，找出目前最大的三位數字前綴並加 1，作為 `REPORT_NUM`。
+   a. **領取新報告編號**：執行 `node reserve-report-num.mjs` 原子地佔用下一個順序編號作為 `REPORT_NUM`；報告寫入後執行 `node reserve-report-num.mjs --release <num>` 釋放佔位。切勿自行掃描 `reports/` 取最大值加 1 —— 並行時多個 worker 會算出同一個編號（#749）。
    b. **擷取職缺描述 (JD)**：首選 Playwright（透過 `browser_navigate` + `browser_snapshot`）渲染網頁擷取；次選 `WebFetch` 抓取靜態文字；最後以 `WebSearch` 搜尋同名職缺的快照。
    c. **例外處理**：若連結因權限、失效等原因完全打不開，將該項標記為 `- [!]`，附上錯誤描述，然後繼續處理下一個。
    d. **執行一鍵管線評估**：跑 A–F 各維度評估 → 存成報告 `.md` → 依設定產生履歷 PDF（若評分達門檻）→ 自動登錄至 tracker。

--- a/modes/zh/pipeline.md
+++ b/modes/zh/pipeline.md
@@ -6,7 +6,7 @@
 
 1. **读取数据**：分析 `data/pipeline.md` 文件，找出 "Pending" 模块下所有标记为 `- [ ]` 的待处理项目。
 2. **循环遍历处理**：对每一个未处理的 URL：
-   a. **计算新报告编号**：扫描 `reports/` 目录，找出当前最大的三位数字前缀并加 1，作为 `REPORT_NUM`。
+   a. **领取新报告编号**：运行 `node reserve-report-num.mjs` 原子地占用下一个顺序编号作为 `REPORT_NUM`；报告写入后运行 `node reserve-report-num.mjs --release <num>` 释放占位。切勿自己扫描 `reports/` 取最大值加 1 —— 并发时多个 worker 会算出同一个编号（#749）。
    b. **抓取职位描述 (JD)**：首选 Playwright (通过 `browser_navigate` + `browser_snapshot`) 渲染网页抓取，备选 `WebFetch` 提取静态文本，最后使用 `WebSearch` 搜索同名岗位快照。
    c. **异常处理**：若链接因权限、失效等原因完全无法打开，将该项标记为 `- [!]`，附加错误描述，并继续处理下一个。
    d. **执行一键管道评估**：运行 A-F 维度评估 → 保存为报告 `.md` 文件 → 根据设定生成简历 PDF（若评分达到阈值）→ 自动记录至 tracker。


### PR DESCRIPTION
Routes the report-number step in both Chinese `pipeline.md` modes through `reserve-report-num.mjs` instead of a hand-rolled `max+1` scan.

Closes #3980

## What changed

- `modes/zh/pipeline.md:9` and `modes/zh-TW/pipeline.md:9` — claim the number with `node reserve-report-num.mjs`, release the sentinel with `--release <num>` after the report is written, mirroring the English `modes/pipeline.md:36`.
- Each line also states why, inline: `切勿自己扫描 reports/ 取最大值加 1 —— 并发时多个 worker 会算出同一个编号（#749）`. The surrounding mode files put the reason next to the instruction, and it is what stops the next translator reintroducing this.

Two lines total; no other content in either file is touched.

## Why this is a restoration, not a change

The English mode already read `node reserve-report-num.mjs` at 207f9600, the commit that introduced these translations, so this puts back what the source said rather than proposing new behaviour. The English was internally consistent at the time: an unconditional 3+ fan-out is safe *because* the number is reserved atomically. The translation dropped the reservation and kept the fan-out.

## Scope — what this PR deliberately does not do

- **`modes/ar/pipeline.md:11` carries the same defect and is left unfixed.** I do not write Arabic and would rather leave it to someone who does than machine-translate the replacement.
- **The Playwright-serial rule is still missing from these files.** English `modes/pipeline.md:43` requires browser-backed extraction to be processed one at a time, because workers sharing a Playwright session cross-contaminate. That rule is absent from **all 17** localized `pipeline.md` files, so after this PR both Chinese modes still recommend 3+ parallel subagents with Playwright as the preferred extractor. That is a separate, systemic propagation gap of the same family as #3828 and #3168, and folding it in here would mean writing the rule into 17 languages I mostly cannot check.

Flagging both explicitly so the merged file is not read as fully aligned with English.

## Suggested follow-up (not in this PR)

A parity assertion in `test-all.mjs` requiring every `modes/*/pipeline.md` to reference `reserve-report-num.mjs` — same shape as the existing `#1449 Phase 2b` extractor check at `test-all.mjs:4800`. Adding it now would go red on `ar`, which would amount to using CI to force a machine translation. It belongs in the PR that fixes `ar`.

## Verification

- Re-read `modes/pipeline.md` at `ref=207f9600` via the API to confirm the English was already correct when these files landed.
- Walked all 18 `modes/*/pipeline.md`: 15 already route through the reserver (`da de es fr hi id it ja ko nl pl pt ru tr ua`), 3 did not (`ar`, `zh-TW`, `zh`).
- Confirmed `--release` exists by running `node reserve-report-num.mjs --help`.
- Confirmed each Chinese file mentions report numbering in exactly one place, so one line per file is the whole fix. (The English `## Automatic numbering` section has no counterpart in either localized file — pre-existing, not introduced here.)
- `node test-all.mjs`: **8687 passed, 0 failed** on `origin/main` and with this change. The existing language-parity assertion (`all 18 language pipeline mirrors wire the opt-in extractor`) still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `modes/zh/pipeline.md:9` and `modes/zh-TW/pipeline.md:9`: Reserve report numbers atomically with `node reserve-report-num.mjs`.
- Release each reservation after writing the report.
- Do not calculate `max+1`; parallel workers could select the same number and overwrite reports.

Only `modes/` changed. `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` were not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->