### PR TITLE
docs(agents): twelve market mode sets ship and were undocumented (#3992)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,18 @@ Default modes are in `modes/` (English). Market-specific mode sets (each include
 | Japanese (Japan) | `modes/ja/` | `kyujin` / `oubo` | 正社員, 賞与, みなし残業, 年俸制, 36協定 |
 | Turkish (Turkey) | `modes/tr/` | `is-ilani` / `basvuru` | SGK, kıdem tazminatı, brüt/net maaş, BES |
 | Hindi (India) | `modes/hi/` | `naukri` / `aavedan` | CTC vs. in-hand, PF/EPF, Notice period/buyout, ESOPs |
+| Spanish (ES/LatAm) | `modes/es/` | `oferta` / `aplicar` | Contrato indefinido, convenio, pagas extra, Seguridad Social |
+| Portuguese (BR/PT) | `modes/pt/` | `oferta` / `aplicar` | CLT, PJ, FGTS, 13º, férias, vale-refeição |
+| Italian (Italy) | `modes/it/` | `annuncio` / `candidarsi` | CCNL, tempo indeterminato, tredicesima |
+| Dutch (NL/BE) | `modes/nl/` | `vacature` / `solliciteren` | vakantiegeld, proeftijd, opzegtermijn, pensioen |
+| Polish (Poland) | `modes/pl/` | `oferta` / `aplikuj` | Umowa o pracę, B2B, ZUS, okres wypowiedzenia, urlop |
+| Danish (Denmark) | `modes/da/` | `oferta` / `apply` | løn, opsigelsesvarsel, ferie, overenskomst, A-kasse |
+| Russian | `modes/ru/` | `oferta` / `apply` | ТК РФ, оклад, испытательный срок, самозанятый, ДМС |
+| Ukrainian (Ukraine) | `modes/ua/` | `oferta` / `apply` | ФОП, КЗпП, оклад, випробувальний термін |
+| Chinese, Simplified | `modes/zh/` | `oferta` / `apply` | 五险一金, 试用期, 年终奖, 劳动合同, 竞业 |
+| Chinese, Traditional | `modes/zh-TW/` | `oferta` / `apply` | 勞保, 試用期, 年終獎金, 勞動契約, 特休 |
+| Korean (South Korea) | `modes/ko/` | `gonggo` / `jiwon` | 정규직, 계약직, 퇴직금, 연봉 |
+| Indonesian (Indonesia) | `modes/id/` | `lowongan` / `melamar` | THR, BPJS, PKWT, pesangon, UMR |
 
 ### Output Language vs Market Modes
 

--- a/tests/market-modes-documented.test.mjs
+++ b/tests/market-modes-documented.test.mjs
@@ -1,0 +1,71 @@
+// tests/market-modes-documented.test.mjs — every market mode set that ships is
+// listed in AGENTS.md's market table.
+//
+// The table is not a nicety. AGENTS.md is loaded into every agent session, and
+// its own rule for choosing a set reads:
+//
+//     "you detect a JD written in that language -> suggest switching"
+//
+// driven by that table. A set the table does not name is a set the agent cannot
+// route to, whatever is on disk. Eighteen complete sets shipped and six were
+// listed, so twelve full localizations — es, pt, it, nl, pl, da, ru, ua, zh,
+// zh-TW, ko, id — were invisible to the system that would have used them.
+//
+// A set is "shipped" when it has _shared.md, which is what makes it a market
+// set rather than a subdirectory like modes/interview/ or modes/pdf/.
+//
+// Run:  node --test tests/market-modes-documented.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const AGENTS = readFileSync(join(ROOT, 'AGENTS.md'), 'utf-8');
+
+/** Market mode sets on disk: a modes/ subdirectory carrying _shared.md. */
+function shippedSets() {
+  return readdirSync(join(ROOT, 'modes'), { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(ROOT, 'modes', e.name, '_shared.md')))
+    .map((e) => e.name)
+    .sort();
+}
+
+/** Dirs the market table names, e.g. `modes/de/`. */
+function documentedSets() {
+  return [...new Set([...AGENTS.matchAll(/\|\s*`modes\/([a-zA-Z-]+)\/`\s*\|/g)].map((m) => m[1]))].sort();
+}
+
+test('every shipped market mode set is in the market table', () => {
+  const missing = shippedSets().filter((d) => !documentedSets().includes(d));
+  assert.deepEqual(
+    missing,
+    [],
+    `${missing.length} market mode set(s) ship and are undocumented: ${missing.join(', ')}. `
+    + 'AGENTS.md is what routes JD-language detection to a set, so an unlisted set is unreachable.',
+  );
+});
+
+test('and the table names no set that does not ship', () => {
+  // The other direction: a row for a deleted set sends the agent at a directory
+  // that is not there, which costs a tool call every session it tries.
+  const ghosts = documentedSets().filter((d) => !shippedSets().includes(d));
+  assert.deepEqual(ghosts, [], `the market table names non-existent set(s): ${ghosts.join(', ')}`);
+});
+
+test('every evaluation and apply mode the table names exists on disk', () => {
+  // The mode NAMES are what a user types and what the agent looks for. A row
+  // with the right directory and a wrong filename is still a dead route.
+  const rows = [...AGENTS.matchAll(/\|\s*`modes\/([a-zA-Z-]+)\/`\s*\|\s*`([a-z-]+)`\s*\/\s*`([a-z-]+)`\s*\|/g)];
+  assert.ok(rows.length >= 18, `only ${rows.length} market rows parsed — the table format changed`);
+  const missing = [];
+  for (const [, dir, evalMode, applyMode] of rows) {
+    for (const mode of [evalMode, applyMode]) {
+      const path = join('modes', dir, `${mode}.md`);
+      if (!existsSync(join(ROOT, path))) missing.push(path);
+    }
+  }
+  assert.deepEqual(missing, [], `the market table names mode file(s) that do not exist:\n${missing.join('\n')}`);
+});


### PR DESCRIPTION
Fixes #3992.

Eighteen complete market mode sets ship. The market table listed six.

```
on disk      ar da de es fr hi id it ja ko nl pl pt ru tr ua zh zh-TW   (18)
documented   ar de fr hi ja tr                                          (6)
```

`AGENTS.md` is loaded into every agent session, and its own rule for choosing a set — *"you detect a JD written in that language → suggest switching"* — is driven by that table. A set the table does not name is a set the agent cannot route to, whatever is on disk. A Spanish JD could not reach `modes/es/`, a Brazilian one could not reach `modes/pt/`, and so on for twelve complete localizations.

## Every cell is verified, not remembered

The directory and both mode filenames come from the filesystem. The **Local vocabulary** terms were each confirmed to appear in that market's own files (`grep -rF` over `modes/{dir}/`) rather than supplied from general knowledge of the market:

```
es     Contrato indefinido, convenio, pagas extra, Seguridad Social
pl     Umowa o pracę, B2B, ZUS, okres wypowiedzenia, urlop
ru     ТК РФ, оклад, испытательный срок, самозанятый, ДМС
zh     五险一金, 试用期, 年终奖, 劳动合同, 竞业
...
```

Where a term could not be confirmed in the files it is not listed. This table is read as instruction, so a short honest row beats a fuller invented one — and the repo's own rule is that keywords get reformulated, never fabricated.

I originally tried to derive the column mechanically from `_shared.md`, which turned out to be the translated scoring guidance rather than employment vocabulary; the market terms live in the evaluation modes and READMEs. Grepping the whole market directory is what made each term checkable.

## Guard, in both directions

- a shipped set missing from the table reddens
- a row naming a set **or a mode file** that does not exist reddens

The second direction matters because a dead row is not harmless: it costs the agent a tool call every session it tries to follow it. Verified by deleting the twelve rows (reddens) and by adding a `modes/tlh/` row (reddens).

Full suite green at 8686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added 12 market mode entries to `AGENTS.md: market modes table`.
- Agents can now route job descriptions for Spanish, Portuguese, Italian, Dutch, Polish, Danish, Russian, Ukrainian, Simplified Chinese, Traditional Chinese, Korean, and Indonesian.
- Added filesystem-verified directories, evaluation modes, apply modes, and local vocabulary examples.
- Added bidirectional validation in `tests/market-modes-documented.test.mjs:1-71`. The tests detect undocumented shipped sets and invalid table references.

## Files touched

- `AGENTS.md`
- `tests/market-modes-documented.test.mjs`

The following system files were not touched: `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->