### PR TITLE
fix(web): surface a successful render's warnings instead of dropping them

### DIFF
--- a/web/src/lib/pdf-render.mjs
+++ b/web/src/lib/pdf-render.mjs
@@ -172,7 +172,7 @@ export function cleanupPdfScratch(scratchDir, prefix) {
 /**
  * @typedef {Object} RenderedResult
  * @property {"rendered"} kind
- * @property {string[]} warnings - Non-fatal issues to surface to the user (e.g. a tracker row that was not marked).
+ * @property {string[]} warnings - Non-fatal issues to surface to the user (e.g. a renderer advisory, or a tracker row that was not marked).
  */
 /** @typedef {RenderFailedResult | RenderedResult} RenderResult */
 
@@ -196,6 +196,18 @@ export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, form
 
   if (!render.ok) {
     return { kind: "render-failed", error: render.stderr || "PDF rendering failed." };
+  }
+
+  // A render that exits 0 can still have written advisories to stderr, and two
+  // of them matter to whoever asked for this PDF: the page-budget overflow
+  // (warning-only unless --strict-pages) and the CV fact check's advisory
+  // phrases. Reading render.stderr only in the failure branch above collected
+  // both and dropped them, so on the web path an unsupported claim the fact
+  // gate flagged reached nobody. One warning per line, blank lines skipped, so
+  // a clean render still reports none.
+  for (const line of render.stderr.split("\n")) {
+    const text = line.trim();
+    if (text) warnings.push(text);
   }
 
   // The PDF is the real deliverable and it already rendered successfully — a

--- a/web/tests/lib/pdf-render.test.mjs
+++ b/web/tests/lib/pdf-render.test.mjs
@@ -322,6 +322,58 @@ test("renderAndMarkPdf: render succeeds but mark-pdf-ready fails with no parseab
   }
 });
 
+test("renderAndMarkPdf: successful render with stderr -> that stderr is surfaced as warnings", async () => {
+  // Given generate-pdf.mjs exits cleanly but wrote advisories to stderr — the
+  // page-budget overflow and the CV fact check both warn on that channel
+  const dir = makeScratchDir();
+  const pdfPaths = makePdfPaths(dir, "6");
+  writeFileSync(pdfPaths.html, "<html></html>");
+  const stderr = [
+    "\u26a0\ufe0f  CV is 3 pages; the allowed maximum is 2 pages.",
+    "\u26a0\ufe0f  CV fact check warning: cv-web-6.html",
+    "  - advisory phrase: world-class",
+  ].join("\n");
+  const { spawnFn } = makeRouterSpawn({
+    "generate-pdf.mjs": { exitCode: 0, stderr },
+    "mark-pdf-ready.mjs": { exitCode: 0, stdout: JSON.stringify({ changed: true }) },
+  });
+  try {
+    // When rendering and marking
+    const result = await renderAndMarkPdf({ spawnFn, execPath: "node", root: "/root", pdfPaths, format: "letter", reportNum: "6" });
+
+    // Then the PDF is reported rendered and every stderr line reaches the caller,
+    // one warning per line, rather than being collected and dropped
+    assert.equal(result.kind, "rendered");
+    assert.equal(result.warnings.length, 3);
+    assert.match(result.warnings[0], /CV is 3 pages/);
+    assert.match(result.warnings[1], /fact check warning/);
+    assert.match(result.warnings[2], /advisory phrase: world-class/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("renderAndMarkPdf: successful render with empty stderr -> no warnings invented", async () => {
+  // Given generate-pdf.mjs exits cleanly having written nothing to stderr
+  const dir = makeScratchDir();
+  const pdfPaths = makePdfPaths(dir, "7");
+  writeFileSync(pdfPaths.html, "<html></html>");
+  const { spawnFn } = makeRouterSpawn({
+    "generate-pdf.mjs": { exitCode: 0, stderr: "" },
+    "mark-pdf-ready.mjs": { exitCode: 0, stdout: JSON.stringify({ changed: true }) },
+  });
+  try {
+    // When rendering and marking
+    const result = await renderAndMarkPdf({ spawnFn, execPath: "node", root: "/root", pdfPaths, format: "letter", reportNum: "7" });
+
+    // Then a clean run still reports zero warnings — blank lines must not
+    // become empty warnings the user has to read past
+    assert.deepEqual(result, { kind: "rendered", warnings: [] });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ── writeCvHtml (#2185) ──
 //
 // The agent no longer writes the tailored CV — it emits it through the


### PR DESCRIPTION
## What does this PR do?

`renderAndMarkPdf` now passes a successful render's stderr through as warnings instead of discarding it. `spawnGeneratePdf` resolves `{ ok, stderr }` for every run, but `render.stderr` was read only inside the `!render.ok` branch, so on a clean exit the collected stderr went nowhere.

## Related issue

Closes #3984

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

### What was being dropped

Two advisories ride that channel, and both are written by a run that exits 0:

| Source | Written by | Condition |
|---|---|---|
| `enforcePageBudget` (`generate-pdf.mjs:1019`) | `console.warn` at line 1038 | CV exceeds `maxPages` (default 2) and `--strict-pages` was not passed, so overflow is warning-only |
| `assertFacts` (`generate-pdf.mjs:1355`) | `console.warn` at line 1359, one line per advisory phrase | the fact gate returns `warn` |

The second is why this is worth fixing rather than logging. `pdf` mode is where an agent rewrites CV content, so the check that flags an unsupported claim is aimed at the person who is about to send that CV. On the web path it was collected into `render.stderr` and then never read.

### The fix

The stderr is split on newlines and pushed into the `warnings` array `renderAndMarkPdf` already returns; the route already streams that array through `sendWarnings`. Blank lines are skipped, so a clean render with empty stderr still produces zero warnings rather than one empty one.

Nothing about exit codes changes. A non-zero exit still returns `render-failed` with the same message, ahead of this block.

### Test evidence

Two cases added to `web/tests/lib/pdf-render.test.mjs`, one per direction, both mutation-checked:

| Mutation | Result |
|---|---|
| Revert the change (read stderr only on failure) | RED on the non-empty case (0 warnings, 3 expected) |
| Drop the blank-line guard (`warnings.push(text)` unconditionally) | RED on the empty case |

`node test-all.mjs`: 8687 passed, 0 failed. `web/`: 499 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Successful web PDF renders now show renderer advisories to users. `renderAndMarkPdf` splits non-empty `stderr` lines into warnings at `web/src/lib/pdf-render.mjs:201-210`.

Failed renders keep the existing `render-failed` behavior at `web/src/lib/pdf-render.mjs:198`. Empty `stderr` produces no warnings.

## Tests

`web/tests/lib/pdf-render.test.mjs:325-371` verifies:

- Successful renders expose each stderr line as a warning.
- Empty stderr does not create warnings.

## Files changed

- `web/src/lib/pdf-render.mjs`
- `web/tests/lib/pdf-render.test.mjs`

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->