### PR TITLE
fix(analyze-patterns): an empty tracker is a new user, not a failed command

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -1250,7 +1250,9 @@ function analyze() {
   const entries = parseTracker();
 
   if (entries.length === 0) {
-    return { error: 'No applications found in tracker.' };
+    // noData marks this as the empty-tracker case rather than a failure, so the
+    // exit status below does not have to match on the message text.
+    return { error: 'No applications found in tracker.', noData: true };
   }
 
   // Enrich entries with report data and classification
@@ -1690,5 +1692,16 @@ if (isMainModule(import.meta.url)) {
     console.log(JSON.stringify(result, null, 2));
   }
 
-  if (result.error) process.exit(1);
+  // "No applications found" is the state of a NEW USER, not a failure. Every
+  // other analysis script over the same tracker — stats, upskill, salary-gap,
+  // process-quality, rejection-latency, detect-reposts, company-history,
+  // calibrate, funnel-velocity, tracker-sync-check — reports it and exits 0.
+  // This one exited 1, which breaks `&&` chaining and makes the batch runners
+  // treat an empty tracker as a broken command.
+  //
+  // Still non-zero for a genuine failure: the check is on the KIND of error, so
+  // a future `result.error` that is not "no data" keeps its exit 1. Written as
+  // an allowlist of no-data codes rather than a message match, so the exit
+  // status does not depend on prose.
+  if (result.error && !result.noData) process.exit(1);
 }

--- a/tests/empty-tracker-exit-code.test.mjs
+++ b/tests/empty-tracker-exit-code.test.mjs
@@ -1,0 +1,119 @@
+// tests/empty-tracker-exit-code.test.mjs — an empty tracker is the state of a
+// NEW USER, not a failed command.
+//
+// Eleven analysis scripts read the same tracker. Ten reported "no data yet" and
+// exited 0; analyze-patterns.mjs exited 1 for the same condition, which breaks
+// `&&` chaining and makes the batch runners treat a fresh install as a broken
+// command.
+//
+// Asserted as AGREEMENT across the set rather than against a hardcoded exit
+// code for one script, so this keeps holding if the convention itself is ever
+// revisited — and so a new analysis script joining the family is measured
+// against its siblings rather than against a number in a test.
+//
+// Every required input EXISTS and is empty. That distinction is the whole
+// measurement: a MISSING input file is a legitimate non-zero (the caller has to
+// create it), and an earlier version of this comparison was wrong because it
+// left negotiation-roi without a story bank at all and read the resulting exit 1
+// as an exit-code inconsistency. It was a path bug, fixed separately in #3985.
+//
+// Run:  node --test tests/empty-tracker-exit-code.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// Scripts that read the tracker and report on it. negotiation-roi is left out:
+// it reads the story bank rather than the tracker, so "empty tracker" is not a
+// condition it has an opinion about.
+const ANALYSIS_SCRIPTS = [
+  'stats.mjs', 'upskill.mjs', 'salary-gap.mjs', 'process-quality.mjs',
+  'rejection-latency.mjs', 'detect-reposts.mjs', 'company-history.mjs',
+  'calibrate.mjs', 'funnel-velocity.mjs', 'tracker-sync-check.mjs',
+  'analyze-patterns.mjs',
+];
+
+function emptyButValid() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-emptytracker-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  // A real header and separator with no rows — a tracker that parses and holds
+  // nothing, which is exactly what a new user has.
+  writeFileSync(join(dir, 'data', 'applications.md'), [
+    '# Applications Tracker',
+    '',
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|---|---|---|---|---|---|---|---|',
+    '',
+  ].join('\n'));
+  return dir;
+}
+
+function exitCodes(dir) {
+  const out = {};
+  for (const script of ANALYSIS_SCRIPTS) {
+    const r = spawnSync(process.execPath, [join(ROOT, script), '--summary'], {
+      cwd: dir, encoding: 'utf-8', timeout: 60_000,
+      env: { ...process.env, CAREER_OPS_ROOT: dir, CAREER_OPS_DATA_DIR: '' },
+    });
+    assert.equal(r.error, undefined, `${script} failed to spawn: ${r.error?.message}`);
+    out[script] = r.status;
+  }
+  return out;
+}
+
+test('every analysis script agrees on what an empty tracker means', () => {
+  const dir = emptyButValid();
+  try {
+    const codes = exitCodes(dir);
+    const distinct = [...new Set(Object.values(codes))];
+    assert.equal(
+      distinct.length,
+      1,
+      'the analysis scripts disagree on the exit code for an empty tracker, so `&&` chaining and the '
+      + `batch runners see a fresh install as a broken command:\n${
+        Object.entries(codes).map(([s, c]) => `  ${s}: exit ${c}`).join('\n')}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('and that shared meaning is success', () => {
+  // The agreement above could in principle be reached by making all eleven exit
+  // 1. It should not be: "you have not evaluated anything yet" is the normal
+  // first state of the tool, and AGENTS.md tells users to run these before they
+  // have data.
+  const dir = emptyButValid();
+  try {
+    for (const [script, code] of Object.entries(exitCodes(dir))) {
+      assert.equal(code, 0, `${script} exits ${code} on an empty tracker`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('a real failure still exits non-zero', () => {
+  // The guard on the fix: analyze-patterns now checks the KIND of error, so
+  // only the no-data case is excused. An unreadable tracker must still fail, or
+  // this change would have bought consistency by never reporting anything.
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-badtracker-'));
+  try {
+    mkdirSync(join(dir, 'data'), { recursive: true });
+    // A directory where the tracker file belongs: unreadable, not empty.
+    mkdirSync(join(dir, 'data', 'applications.md'), { recursive: true });
+    const r = spawnSync(process.execPath, [join(ROOT, 'analyze-patterns.mjs'), '--summary'], {
+      cwd: dir, encoding: 'utf-8', timeout: 60_000,
+      env: { ...process.env, CAREER_OPS_ROOT: dir, CAREER_OPS_DATA_DIR: '' },
+    });
+    assert.notEqual(r.status, 0, 'an unreadable tracker was reported as success');
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});


### PR DESCRIPTION
Eleven analysis scripts read the same tracker. With every required input present and empty:

```
exit 0   stats  upskill  salary-gap  process-quality  rejection-latency
         detect-reposts  company-history  calibrate  funnel-velocity
         tracker-sync-check
exit 1   analyze-patterns          <-- same condition
```

An empty tracker is the state of a new user — `AGENTS.md` tells them to run these before they have data. Exiting 1 breaks `&&` chaining and makes the batch runners treat a fresh install as a broken command.

## On the kind of error, not the message

`analyze()` marks the empty-tracker return with `noData: true`, and the exit stays non-zero for anything else. Matching on `'No applications found in tracker.'` would have tied the exit status to prose that is free to change.

## A scope correction I made along the way

My first measurement had `negotiation-roi` in this set as a second outlier. It was not: its exit 1 came from resolving `story-bank.md` off the **code** root and never finding the fixture at all — a path bug, fixed separately in #3985. My fixture had left it without a story bank, which is a *missing input*, and a missing input is a legitimate non-zero.

Re-measured with every required input present and empty, it exits 0 like the rest. The test excludes it on the honest grounds: it reads the story bank, not the tracker, so "empty tracker" is not a condition it has an opinion about.

## Tests

Asserted as **agreement** across the eleven rather than a hardcoded 0 for one script, so it keeps holding if the convention is ever revisited and a new analysis script is measured against its siblings instead of a number in a test.

Two guards: the shared answer must be *success* (agreement could also be reached by making all eleven exit 1), and an unreadable tracker must still fail — otherwise this would buy consistency by never reporting anything.

Reverting the one-line change reddens 2 of 3; the failure guard stays green. Full suite green at 8686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can run `analyze-patterns` with an empty tracker and receive a successful result. The command reports `noData: true` instead of failing because no applications exist.

Other tracker errors remain non-zero. Unreadable trackers still fail.

The new test checks consistent exit codes across the eleven tracker-based analysis scripts and verifies unreadable tracker handling: `tests/empty-tracker-exit-code.test.mjs:1`.

Changed files: `analyze-patterns.mjs`, `tests/empty-tracker-exit-code.test.mjs`.

The requested system files were not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->