### PR TITLE
fix(pdf): drop optional sections that arrive as a bare header

### DIFF
--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -174,10 +174,13 @@ export function stripEmptySections(template, payload, format) {
 // A section's own title is present whether or not the section has content, so
 // it must not count as content. This matches the shipped templates'
 // `<div class="section-title">`, or a plain heading tag for a custom template
-// that uses one, and is applied once — a later heading inside a populated body
+// that uses one. Either quote style, matching generate-pdf.mjs's own
+// SECTION_TITLE_RE: a hand-written or third-party template may use single
+// quotes, and reading its title as content would keep every empty section.
+// Applied once — a later heading inside a populated body
 // keeps its text and correctly reads as content.
 const SECTION_HEADING_RE = new RegExp(
-  String.raw`<(div|h[1-6])\b[^>]*class="[^"]*\bsection-title\b[^"]*"[^>]*>[\s\S]*?<\/\1>` +
+  String.raw`<(div|h[1-6])\b[^>]*class=["'][^"']*\bsection-title\b[^"']*["'][^>]*>[\s\S]*?<\/\1>` +
   String.raw`|<(h[1-6])\b[^>]*>[\s\S]*?<\/\2>`,
   'i',
 );

--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -156,3 +156,58 @@ export function stripEmptySections(template, payload, format) {
   }
   return out;
 }
+
+// ── Content-driven emptiness, for callers holding rendered HTML ──────────────
+//
+// isEmptySection answers from the payload the template was filled from. The
+// web pdf path has no payload to ask: since #2185 the agent emits finished
+// HTML and the backend writes it straight to disk, so neither builder — and
+// therefore neither stripEmptySections call site — is on that path, and every
+// optional section the agent left empty reaches the renderer as a bare header.
+//
+// The two exports below answer the same question from the rendered document
+// instead. They read the section body back out with the PATTERNS.html entry
+// that stripEmptySections removes with, so a marker or boundary change moves
+// both halves together and there is still one definition of where a section
+// starts and ends.
+
+// A section's own title is present whether or not the section has content, so
+// it must not count as content. This matches the shipped templates'
+// `<div class="section-title">`, or a plain heading tag for a custom template
+// that uses one, and is applied once — a later heading inside a populated body
+// keeps its text and correctly reads as content.
+const SECTION_HEADING_RE = new RegExp(
+  String.raw`<(div|h[1-6])\b[^>]*class="[^"]*\bsection-title\b[^"]*"[^>]*>[\s\S]*?<\/\1>` +
+  String.raw`|<(h[1-6])\b[^>]*>[\s\S]*?<\/\2>`,
+  'i',
+);
+
+// Does this section render as a bare header — a title and nothing under it?
+//
+// False when the format has no pattern for the section, and false when the
+// document has no such section at all: both mean there is nothing to strip,
+// and reporting "empty" for a section that is simply absent would invite a
+// caller to act on markup that was never there.
+export function isEmptyRenderedSection(html, section) {
+  const pattern = PATTERNS.html[section];
+  if (!pattern) return false;
+  const block = html.match(pattern);
+  if (!block) return false;
+  const text = block[0]
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(SECTION_HEADING_RE, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;|\u00a0/g, ' ');
+  return text.trim() === '';
+}
+
+// Remove every optional section that rendered as a bare header. The emptiness
+// map is derived from the document as it arrives, before anything is removed,
+// so one strip cannot change the verdict on the next.
+export function stripEmptyRenderedSections(html) {
+  const derived = {};
+  for (const section of OPTIONAL_SECTIONS) {
+    derived[section] = isEmptyRenderedSection(html, section) ? [] : [section];
+  }
+  return stripEmptySections(html, derived, 'html');
+}

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -43,6 +43,7 @@ import { getCareerOpsRoot } from './path-resolver.mjs';
 import { readStyleTokens, injectThemeStyle, readCvSectionOrder } from './theme-style.mjs';
 import { resolvePdfIndexPath, resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
+import { stripEmptyRenderedSections } from './cv-sections-core.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const trackerPath = resolveTrackerPath(getCareerOpsRoot());
@@ -1316,6 +1317,15 @@ async function generatePDF() {
   } catch (err) {
     if (err?.code !== 'ENOENT') throw err;
   }
+  // Drop the optional sections that came in as a bare header — a title with
+  // nothing under it (#3986). The builders already strip these from the payload
+  // side, but neither builder is on every path here: the web pdf flow has the
+  // agent emit finished HTML, which reaches this script with the empty wrappers
+  // still in place. Deciding from the rendered content covers both, and running
+  // it before the reorder and the guard means they judge the document that will
+  // actually be printed. A CV with nothing empty comes through unchanged.
+  html = stripEmptyRenderedSections(html);
+
   // Apply the user's declared section order (config/profile.yml `cv.sections`)
   // before the guard runs, so the guard judges the document that will be
   // printed. Anchored to workspaceRoot, NOT __dirname: readStyleTokens() reads
@@ -1485,9 +1495,11 @@ async function runBatchFromManifest(manifestPath, globals) {
       }
 
       let html = await readFile(entryInput, 'utf-8');
-      // Same order as the single render: reorder first so the guard judges the
-      // document that will actually be printed. Without this the batch path
-      // rendered N CVs with cv.sections silently inert.
+      // Same order as the single render: strip the bare-header sections, then
+      // reorder, so the guard judges the document that will actually be
+      // printed. Without this the batch path rendered N CVs with cv.sections
+      // silently inert.
+      html = stripEmptyRenderedSections(html);
       html = reorderCvSections(html, cvSectionOrder);
       validateCvSectionOrder(html, cvMarkdown, { allowReorder: globals.allowReorder });
       html = normalizeTextForATS(html).html;

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -42,7 +42,7 @@
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { pass, fail, ROOT } from './helpers.mjs';
-import { stripEmptySections } from '../cv-sections-core.mjs';
+import { stripEmptySections, isEmptyRenderedSection, stripEmptyRenderedSections } from '../cv-sections-core.mjs';
 
 console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
 
@@ -487,3 +487,74 @@ check('an absent projects key is treated as empty',
 let threw = false;
 try { stripEmptySections('x', EMPTY, 'pdf'); } catch { threw = true; }
 check('an unknown template format throws', threw, true);
+
+// --- Rendered HTML: the same strip, driven by content instead of a payload --
+// The web pdf path has no payload. Since #2185 the agent emits finished HTML
+// and the backend writes it straight to disk, so neither builder runs and an
+// optional section the agent left empty reaches the renderer as a bare header
+// (#3986). isEmptyRenderedSection reads the verdict back out of the document
+// with the same PATTERNS.html entry that removes the section, so these cases
+// also pin that the two halves agree on where a section starts and ends.
+
+// A CV as the agent emits one: the shipped template with every placeholder
+// resolved, projects/awards/interests left with nothing under their headers.
+// Built from the template on disk rather than a hand-written excerpt, so a
+// markup change to a real section is exercised here too.
+const AGENT_FILLED = {
+  COMPETENCIES: '<span class="tag">Rust</span>',
+  EXPERIENCE: '<div class="job"><div class="job-title">Engineer</div></div>',
+  PROJECTS: '',
+  EDUCATION: '<div class="edu">BSc, 2015</div>',
+  CERTIFICATIONS: '<div class="cert">AWS SA</div>',
+  AWARDS: '',
+  INTERESTS: '',
+  SKILLS: '<div class="skill">Languages: Rust, Go</div>',
+};
+const agentHtml = readFileSync(join(ROOT, 'templates/cv-template.html'), 'utf-8')
+  .replace(/\{\{([A-Z_]+)\}\}/g, (whole, key) => {
+    if (Object.hasOwn(AGENT_FILLED, key)) return AGENT_FILLED[key];
+    // Every other placeholder is a scalar (name, title, a section heading);
+    // the heading ones must stay non-empty or an empty section would look
+    // empty for the wrong reason and the assertions below would pass vacuously.
+    return key.startsWith('SECTION_') ? key.slice('SECTION_'.length) : 'x';
+  });
+
+for (const section of ['projects', 'awards', 'interests']) {
+  check(`isEmptyRenderedSection: an agent-emitted ${section} section with nothing under its header reads empty`,
+    isEmptyRenderedSection(agentHtml, section), true);
+}
+for (const section of ['competencies', 'experience', 'education', 'certifications', 'skills']) {
+  check(`isEmptyRenderedSection: a populated ${section} section does not read empty`,
+    isEmptyRenderedSection(agentHtml, section), false);
+}
+
+// The section title is present either way, so counting it as content would
+// make every section look populated — the guard that fails first if the
+// heading stops being recognised.
+check('isEmptyRenderedSection: the section title alone is not content',
+  isEmptyRenderedSection('<!-- PROJECTS -->\n<div class="section"><div class="section-title">Projects</div></div>\n<!-- EDUCATION -->', 'projects'), true);
+check('isEmptyRenderedSection: a plain heading tag alone is not content',
+  isEmptyRenderedSection('<!-- PROJECTS -->\n<section><h2>Projects</h2></section>\n<!-- EDUCATION -->', 'projects'), true);
+check('isEmptyRenderedSection: text under the heading is content',
+  isEmptyRenderedSection('<!-- PROJECTS -->\n<section><h2>Projects</h2><p>Rescued a CLI</p></section>\n<!-- EDUCATION -->', 'projects'), false);
+// A section the document does not contain is not "empty" — there is nothing
+// to strip, and saying otherwise invites a caller to act on markup that was
+// never there.
+check('isEmptyRenderedSection: an absent section does not read empty',
+  isEmptyRenderedSection('<!-- EDUCATION -->\n<div>Education</div>\n<!-- END -->', 'projects'), false);
+
+const strippedRendered = stripEmptyRenderedSections(agentHtml);
+for (const marker of ['<!-- PROJECTS -->', '<!-- AWARDS -->', '<!-- INTERESTS -->']) {
+  check(`stripEmptyRenderedSections: ${marker} is removed from an agent-emitted CV`,
+    strippedRendered.includes(marker), false);
+}
+for (const marker of ['<!-- CORE COMPETENCIES -->', '<!-- WORK EXPERIENCE -->', '<!-- EDUCATION -->', '<!-- CERTIFICATIONS -->', '<!-- SKILLS -->']) {
+  check(`stripEmptyRenderedSections: ${marker} survives with its content`,
+    strippedRendered.includes(marker), true);
+}
+check('stripEmptyRenderedSections: the populated sections keep their bodies',
+  ['Rust</span>', 'Engineer', 'BSc, 2015', 'AWS SA', 'Languages: Rust, Go'].every((t) => strippedRendered.includes(t)), true);
+check('stripEmptyRenderedSections: the closing document skeleton survives',
+  strippedRendered.includes('</body>\n</html>'), true);
+check('stripEmptyRenderedSections: a CV with nothing empty comes out byte-identical',
+  stripEmptyRenderedSections(strippedRendered), strippedRendered);

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -533,6 +533,8 @@ for (const section of ['competencies', 'experience', 'education', 'certification
 // heading stops being recognised.
 check('isEmptyRenderedSection: the section title alone is not content',
   isEmptyRenderedSection('<!-- PROJECTS -->\n<div class="section"><div class="section-title">Projects</div></div>\n<!-- EDUCATION -->', 'projects'), true);
+check('isEmptyRenderedSection: a single-quoted section title alone is not content',
+  isEmptyRenderedSection("<!-- PROJECTS -->\n<div class='section'><div class='section-title'>Projects</div></div>\n<!-- EDUCATION -->", 'projects'), true);
 check('isEmptyRenderedSection: a plain heading tag alone is not content',
   isEmptyRenderedSection('<!-- PROJECTS -->\n<section><h2>Projects</h2></section>\n<!-- EDUCATION -->', 'projects'), true);
 check('isEmptyRenderedSection: text under the heading is content',

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -1000,6 +1000,7 @@ ${sections.join('\n')}</div>
     for (const f of [
       'generate-pdf.mjs', 'theme-style.mjs', 'tracker-utils.mjs',
       'tracker-parse.mjs', 'tracker-aliases.json', 'pipeline-lock.mjs',
+      'cv-sections-core.mjs',
     ]) {
       copyFileSync(join(ROOT, f), join(sandbox, f));
     }
@@ -1137,6 +1138,7 @@ export const chromium = {
     for (const f of [
       'generate-pdf.mjs', 'theme-style.mjs', 'tracker-utils.mjs',
       'tracker-parse.mjs', 'tracker-aliases.json', 'pipeline-lock.mjs',
+      'cv-sections-core.mjs',
     ]) {
       copyFileSync(join(ROOT, f), join(sandbox, f));
     }

--- a/tests/generate-pdf-batch.test.mjs
+++ b/tests/generate-pdf-batch.test.mjs
@@ -49,6 +49,9 @@ copyFileSync(join(ROOT, 'tracker-utils.mjs'), join(sandbox, 'tracker-utils.mjs')
 copyFileSync(join(ROOT, 'tracker-parse.mjs'), join(sandbox, 'tracker-parse.mjs'));
 copyFileSync(join(ROOT, 'tracker-aliases.json'), join(sandbox, 'tracker-aliases.json'));
 copyFileSync(join(ROOT, 'pipeline-lock.mjs'), join(sandbox, 'pipeline-lock.mjs'));
+// ...and it strips the optional sections that rendered as a bare header via
+// ./cv-sections-core.mjs (#3986), another local sibling this sandbox needs.
+copyFileSync(join(ROOT, 'cv-sections-core.mjs'), join(sandbox, 'cv-sections-core.mjs'));
 // generate-pdf.mjs resolves user-layer paths via path-resolver.mjs
 // (CAREER_OPS_ROOT), so the fixture carries that too.
 copyFileSync(join(ROOT, 'path-resolver.mjs'), join(sandbox, 'path-resolver.mjs'));

--- a/tests/generate-pdf-page-budget.test.mjs
+++ b/tests/generate-pdf-page-budget.test.mjs
@@ -47,6 +47,9 @@ copyFileSync(join(ROOT, 'tracker-utils.mjs'), join(sandbox, 'tracker-utils.mjs')
 copyFileSync(join(ROOT, 'tracker-parse.mjs'), join(sandbox, 'tracker-parse.mjs'));
 copyFileSync(join(ROOT, 'tracker-aliases.json'), join(sandbox, 'tracker-aliases.json'));
 copyFileSync(join(ROOT, 'pipeline-lock.mjs'), join(sandbox, 'pipeline-lock.mjs'));
+// ...and it strips the optional sections that rendered as a bare header via
+// ./cv-sections-core.mjs (#3986), another local sibling this sandbox needs.
+copyFileSync(join(ROOT, 'cv-sections-core.mjs'), join(sandbox, 'cv-sections-core.mjs'));
 // ...and generate-pdf resolves user-layer paths via path-resolver.mjs
 // (CAREER_OPS_ROOT), so the fixture carries that too.
 copyFileSync(join(ROOT, 'path-resolver.mjs'), join(sandbox, 'path-resolver.mjs'));
@@ -68,7 +71,7 @@ writeFileSync(join(playwrightStub, 'package.json'), JSON.stringify({
   exports: './index.js',
 }), 'utf-8');
 writeFileSync(join(playwrightStub, 'index.js'), `
-import { readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 
 const twoPagePdf = Buffer.from(\`%PDF-1.7
 1 0 obj
@@ -117,6 +120,10 @@ export const chromium = {
         return {
           async goto(url) {
             const html = await readFile(new URL(url), 'utf-8');
+            // Keep the document that actually reached the renderer, after every
+            // transform generate-pdf.mjs applies to it. Written to the sandbox
+            // (the spawned script's cwd) so a case can assert on it.
+            await writeFile('.rendered.html', html, 'utf-8');
             renderedPdf = html.includes('THREE_PAGE_FIXTURE') ? threePagePdf : twoPagePdf;
           },
           async evaluate() {},
@@ -371,6 +378,55 @@ try {
     pass('renderHtmlToPdf keeps an external baseDir temporary file inside the workspace');
   } else {
     fail(`renderHtmlToPdf placed its temporary file outside the workspace: ${observedTempPath}`);
+  }
+  // --- Optional sections that arrived as a bare header (#3986) -------------
+  // The builders strip these from the payload before filling a template, but
+  // neither builder runs on the web pdf path: the agent emits finished HTML,
+  // which reaches this script with the empty wrappers intact. Assert on the
+  // document the renderer actually received, so removing the call in
+  // generate-pdf.mjs fails here and not only in the unit suite for the module.
+  const bareHeaderInput = join(sandbox, 'bare-header-sections.html');
+  writeFileSync(bareHeaderInput, `<!doctype html>
+<html>
+  <body>
+    <!-- WORK EXPERIENCE -->
+    <div class="section">
+      <div class="section-title">Work Experience</div>
+      <div class="job">Staff Engineer, Acme</div>
+    </div>
+
+    <!-- PROJECTS -->
+    <div class="section">
+      <div class="section-title">Projects</div>
+    </div>
+
+    <!-- EDUCATION -->
+    <div class="section">
+      <div class="section-title">Education</div>
+      <div class="edu">BSc, 2015</div>
+    </div>
+
+    <!-- END -->
+  </body>
+</html>
+`, 'utf-8');
+  const bareHeaderPdf = join(sandbox, 'bare-header-sections.pdf');
+  const bareHeaderRun = runPdf([bareHeaderInput, bareHeaderPdf]);
+  const renderedHtml = existsSync(join(sandbox, '.rendered.html'))
+    ? readFileSync(join(sandbox, '.rendered.html'), 'utf-8')
+    : '';
+  if (
+    bareHeaderRun.status === 0 &&
+    renderedHtml !== '' &&
+    !renderedHtml.includes('<!-- PROJECTS -->') &&
+    renderedHtml.includes('<!-- WORK EXPERIENCE -->') &&
+    renderedHtml.includes('Staff Engineer, Acme') &&
+    renderedHtml.includes('<!-- EDUCATION -->') &&
+    renderedHtml.includes('BSc, 2015')
+  ) {
+    pass('generate-pdf drops a section that arrived as a bare header and keeps the populated ones');
+  } else {
+    fail(`generate-pdf did not strip the empty Projects section from the rendered document: ${bareHeaderRun.output.trim()}`);
   }
 } finally {
   rmSync(sandbox, { recursive: true, force: true });


### PR DESCRIPTION
## What does this PR do?

Removes the optional CV sections that reach the renderer as a bare header, so the web pdf path stops printing a section title and rule with nothing under it. `cv-sections-core.mjs` gains a content-driven counterpart to `isEmptySection`, and `generate-pdf.mjs` applies it on both its single and batch paths.

## Related issue

Closes #3986

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

### The shape of the fix

`stripEmptySections` cannot be called on the web path as it stands, because `isEmptySection(payload, section)` reads a payload that path never builds. So the predicate is what gets a second implementation, not the removal:

- `isEmptyRenderedSection(html, section)` reads the section body back out of the rendered document with the same `PATTERNS.html` entry `stripEmptySections` removes with, discards the section's own title, and asks whether anything is left.
- `stripEmptyRenderedSections(html)` derives the map for every optional section up front, from the document as it arrives, then hands it to `stripEmptySections` so the vetted boundaries still perform the removal.

That is the shape offered in the issue: one definition of where a section starts and ends, two ways to ask whether it is empty. The Skills sentinel behaviour, the marker matching and the fail-safe no-op are all untouched, because none of that code changed.

The title has to be discarded explicitly, because it is present whether or not the section has content. That is the single assertion most likely to rot, so it is pinned twice: `<div class="section-title">` as the shipped templates write it, and a plain heading tag for a custom template that uses one.

### Why it is applied in generate-pdf.mjs and not pdf-render.mjs

The issue comment proposed composing it in the web path. That does not build.

`web/next.config.ts` pins the Turbopack root to the app: `turbopack: { root: import.meta.dirname }`, with a comment explaining why (two lockfiles exist, and inferring the repo root sends the Windows postcss workers into a respawn loop). A static import of a repo-root module from `web/src/lib/pdf-render.mjs` is therefore outside the filesystem root. I wrote it that way first and `next build` rejected it:

```
Module not found: Can't resolve '../../../cv-sections-core.mjs'
  ./src/lib/pdf-render.mjs
  ./src/app/api/run/route.ts
```

The `web typecheck + build` job would have caught it in CI. The escape hatch `web/src/lib/core/tracker-lock.ts` uses for the same problem, a runtime `import(pathToFileURL(join(careerOpsRoot(), ...)))` with `webpackIgnore`, is available, but it makes the loader async and `writeCvHtml` is called from inside a synchronous `child.on("close")` handler that sequences `close()` by hand. Turning that async is a change to the least-tested part of the route to fix a cosmetic bug.

`generate-pdf.mjs` is where the two flows converge, and fixing it there is both smaller and wider:

| Path | HTML arrives | Effect |
|---|---|---|
| CLI, via `build-cv-html.mjs` | already stripped from the payload | no-op, byte-identical |
| Web pdf (#2185) | finished HTML from the agent, wrappers intact | empty sections removed |
| `--batch` | same as whichever produced each entry | same, and it had the identical gap |

It runs before `reorderCvSections` and `validateCvSectionOrder` so both judge the document that will actually print, matching the reason the reorder already runs before the guard. Removing sections cannot make the guard fire: it compares only sections present on both sides, and returns early below two comparable ones.

### Verified behaviour

On a CV built from `templates/cv-template.html` with projects, awards and interests left empty, exactly those three markers are removed and competencies, work experience, education, certifications and skills survive with their bodies, as does the closing document skeleton. Re-running on the result is byte-identical.

### Test evidence

`tests/cv-optional-sections.test.mjs` gains 24 cases for the two new exports, built by resolving the shipped template's placeholders rather than from a hand-written excerpt, so a markup change to a real section is exercised too.

`tests/generate-pdf-page-budget.test.mjs` gains one end-to-end case. Its Playwright stub now also writes the document it was handed, so the assertion is on what actually reached the renderer after every transform, not on the module in isolation. Without it, deleting the call in `generate-pdf.mjs` would leave the whole suite green.

Mutation-checked:

| Mutation | Result |
|---|---|
| Stop discarding the section title | RED, 8 cases: every empty section reads as populated |
| Match only a double-quoted `section-title` | RED, the single-quoted case |
| Remove the call from the single-render path | RED, the end-to-end case only |

Four test sandboxes copy `generate-pdf.mjs`'s siblings into a temp workspace by name and now carry `cv-sections-core.mjs` too. Two of them (`tests/cv-section-order.test.mjs`) failed with `ERR_MODULE_NOT_FOUND` on the first full run and are fixed here rather than worked around.

`node test-all.mjs`: 8712 passed, 0 failed.
