### PR TITLE
fix(cli): --help was discarded, so the script ran instead

### DIFF
--- a/calibrate.mjs
+++ b/calibrate.mjs
@@ -436,7 +436,24 @@ function selfTest() {
 // against the real tracker inside the test process.
 import { isMainModule } from './lib/is-main-module.mjs';
 
+// Derived from the flags this file actually accepts, so `--help` cannot
+// describe an option that does not exist.
+const USAGE = `Usage:
+  node calibrate.mjs [--json] [--min-band-n <n>] [--self-test]
+
+  --json           full JSON to stdout
+  --min-band-n <n> per-band sample floor (default 5)
+  --self-test      run the built-in checks
+  --help, -h   print this and exit`;
+
 if (isMainModule(import.meta.url)) {
+  // BEFORE any work. Unhandled, `--help` fell through to the analysis: this
+  // script printed a full report for it, which is not what the flag asks for
+  // and hides that it was never recognised.
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
   const argv = process.argv.slice(2);
   if (argv.includes('--self-test')) selfTest();
 

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -814,7 +814,23 @@ Maintained the internal Fabrikam-SDK build.
 
 // ── Main ─────────────────────────────────────────────────────────────
 
+// Derived from the flags this file actually accepts, so `--help` cannot
+// describe an option that does not exist.
+const USAGE = `Usage:
+  node jd-skill-gap.mjs <jd-file> [--summary] [--self-test]
+
+  --summary    human-readable output instead of JSON
+  --self-test  run the built-in checks
+  --help, -h   print this and exit`;
+
 if (isMainModule(import.meta.url)) {
+  // BEFORE any work. Unhandled, `--help` fell through to the analysis: this
+  // script printed a full report for it, which is not what the flag asks for
+  // and hides that it was never recognised.
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
 if (selfTestMode) {
   runSelfTest();
 } else {

--- a/negotiation-roi.mjs
+++ b/negotiation-roi.mjs
@@ -702,6 +702,25 @@ function main() {
   }
 }
 
+// Derived from the flags this file actually accepts, so `--help` cannot
+// describe an option that does not exist.
+const USAGE = `Usage:
+  node negotiation-roi.mjs [--summary] [--wage <n>] [--frequency <unit>] [--occurrences <n>] [--self-test]
+
+  --summary             human-readable output instead of JSON
+  --wage <n>            wage used for the annualized estimate
+  --frequency <unit>    daily|weekly|biweekly|monthly|quarterly|annually|yearly
+  --occurrences <n>     occurrences per year, instead of --frequency
+  --self-test           run the built-in checks
+  --help, -h   print this and exit`;
+
 if (isMainModule(import.meta.url)) {
+  // BEFORE any work. Unhandled, `--help` fell through to the analysis: this
+  // script printed a full report for it, which is not what the flag asks for
+  // and hides that it was never recognised.
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
   main();
 }

--- a/salary-gap.mjs
+++ b/salary-gap.mjs
@@ -758,6 +758,23 @@ function main() {
   }
 }
 
+// Derived from the flags this file actually accepts, so `--help` cannot
+// describe an option that does not exist.
+const USAGE = `Usage:
+  node salary-gap.mjs [--summary] [--stated-for <role>] [--self-test]
+
+  --summary            human-readable table instead of JSON
+  --stated-for <role>  compare against a stated target for one role
+  --self-test          run the built-in checks
+  --help, -h   print this and exit`;
+
 if (isMainModule(import.meta.url)) {
+  // BEFORE any work. Unhandled, `--help` fell through to the analysis: this
+  // script printed a full report for it, which is not what the flag asks for
+  // and hides that it was never recognised.
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
   main();
 }

--- a/story-provenance-check.mjs
+++ b/story-provenance-check.mjs
@@ -789,7 +789,25 @@ Brings 15 years of unrelated professional background in adult education prior to
 
 // ── Main ─────────────────────────────────────────────────────────────
 
+// Derived from the flags this file actually accepts, so `--help` cannot
+// describe an option that does not exist.
+const USAGE = `Usage:
+  node story-provenance-check.mjs [--summary] [--story-bank <path>] [--cv <path>] [--self-test]
+
+  --summary            human-readable table instead of JSON
+  --story-bank <path>  override the story-bank path
+  --cv <path>          override the cv.md path
+  --self-test          run the built-in checks
+  --help, -h   print this and exit`;
+
 if (isMainModule(import.meta.url)) {
+  // BEFORE any work. Unhandled, `--help` fell through to the analysis: this
+  // script printed a full report for it, which is not what the flag asks for
+  // and hides that it was never recognised.
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
   if (selfTestMode) {
     runSelfTest();
   } else {

--- a/tests/help-flag-handled.test.mjs
+++ b/tests/help-flag-handled.test.mjs
@@ -1,0 +1,119 @@
+// tests/help-flag-handled.test.mjs — `--help` prints help, on every CLI that
+// has one.
+//
+// Six scripts did not recognise the flag, and an unrecognised flag was simply
+// discarded — so `--help` fell through to the analysis and the script RAN:
+//
+//   calibrate.mjs --help              printed a full calibration report
+//   salary-gap.mjs --help             printed JSON
+//   tracker-sync-check.mjs --help     printed JSON
+//   story-provenance-check.mjs --help printed JSON
+//
+// Nothing errored, which is the problem: the user asked what the flags are and
+// got output that answers a different question, with no sign the flag was never
+// read. For a script that writes, the same silent-discard would run the write.
+//
+// Two invariants, because either alone is satisfiable the wrong way: help must
+// be PRINTED (not just exit 0), and the work must NOT have run.
+//
+// Run:  node --test tests/help-flag-handled.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const FIXED = [
+  'calibrate.mjs', 'salary-gap.mjs', 'tracker-sync-check.mjs',
+  'story-provenance-check.mjs', 'negotiation-roi.mjs', 'jd-skill-gap.mjs',
+];
+
+function help(script) {
+  const r = spawnSync(process.execPath, [join(ROOT, script), '--help'], {
+    cwd: ROOT, encoding: 'utf-8', timeout: 60_000,
+  });
+  assert.equal(r.error, undefined, `${script} failed to spawn: ${r.error?.message}`);
+  return r;
+}
+
+for (const script of FIXED) {
+  test(`${script} --help prints usage and exits 0`, () => {
+    const r = help(script);
+    assert.equal(r.status, 0, `exited ${r.status}: ${r.stderr.slice(0, 200)}`);
+    assert.match(r.stdout, /^Usage:/m, `no usage block:\n${r.stdout.slice(0, 200)}`);
+  });
+
+  test(`${script} --help does not run the script`, () => {
+    // The half that matters. Exiting 0 with a usage block would still be wrong
+    // if the analysis had also run — the original bug produced output too.
+    const r = help(script);
+    assert.doesNotMatch(r.stdout, /^\s*\{/, `it printed JSON as well as usage:\n${r.stdout.slice(0, 200)}`);
+    assert.ok(r.stdout.split('\n').length < 40, `output is too long to be usage alone (${r.stdout.split('\n').length} lines)`);
+  });
+
+  test(`${script} --help names only flags it accepts`, () => {
+    // Usage that lists an option the script ignores is worse than none — it
+    // sends the user to write a flag that silently does nothing.
+    const src = readFileSync(join(ROOT, script), 'utf-8');
+    const documented = [...help(script).stdout.matchAll(/^\s+(--[a-z-]+)/gm)].map((m) => m[1]);
+    assert.ok(documented.length > 0, 'the usage block lists no flags');
+    const phantom = documented.filter((f) => f !== '--help' && !src.includes(`'${f}'`));
+    assert.deepEqual(phantom, [], `${script} documents flag(s) it does not accept: ${phantom.join(', ')}`);
+  });
+}
+
+test('-h is accepted wherever --help is', () => {
+  // Every script in the repo that offers one offers both; a CLI that answers
+  // --help and silently runs on -h has the original bug for half its users.
+  for (const script of FIXED) {
+    const r = spawnSync(process.execPath, [join(ROOT, script), '-h'], { cwd: ROOT, encoding: 'utf-8', timeout: 60_000 });
+    assert.equal(r.status, 0, `${script} -h exited ${r.status}`);
+    assert.match(r.stdout, /^Usage:/m, `${script} -h did not print usage`);
+  }
+});
+
+// CLIs that still discard --help. A SHRINKING ALLOWLIST, in the style this repo
+// already uses for coverage ratchets: the point is not that this list is empty
+// today — nineteen entries is far more than one change should touch — but that
+// it can only get shorter. A new CLI cannot join it, and removing an entry
+// requires actually fixing that script.
+//
+// Each of these has the same defect the six fixed here had: an unrecognised
+// flag is discarded, so `--help` falls through and the script runs.
+const KNOWN_WITHOUT_HELP = new Set([
+  'batch-evaluate-gemini.mjs', 'cv-templates.mjs', 'fetch-jd.mjs', 'followup-seed.mjs',
+  'generate-cover-letter.mjs', 'generate-latex.mjs', 'generate-pdf.mjs', 'intake.mjs',
+  'match-star.mjs', 'normalize-statuses.mjs', 'openrouter-runner.mjs', 'plugins.mjs',
+  'scan-hn.mjs', 'scan-interamt.mjs', 'seed-fixture.mjs', 'tracker.mjs',
+  'validate-plugin-registry.mjs', 'validate-untrusted-content-coverage.mjs',
+  'verify-portals.mjs',
+]);
+
+test('no NEW CLI silently swallows --help, and the allowlist only shrinks', () => {
+  const offenders = [];
+  const fixed = [];
+  for (const file of readdirSync(ROOT).filter((f) => f.endsWith('.mjs'))) {
+    if (/-tests\.mjs$|^test-|^playwright/.test(file)) continue;
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    if (!src.includes('isMainModule(import.meta.url)')) continue;   // not a CLI
+    const handles = /'--help'|"--help"/.test(src);
+    if (!handles && !KNOWN_WITHOUT_HELP.has(file)) offenders.push(file);
+    if (handles && KNOWN_WITHOUT_HELP.has(file)) fixed.push(file);
+  }
+  assert.deepEqual(
+    offenders.sort(),
+    [],
+    `these CLIs discard --help, so the flag falls through and the script runs instead:\n  ${offenders.join('\n  ')}`,
+  );
+  // The ratchet's other end: a fixed script must leave the list, or the list
+  // stops describing anything and quietly rots.
+  assert.deepEqual(
+    fixed.sort(),
+    [],
+    `these now handle --help and should be removed from KNOWN_WITHOUT_HELP:\n  ${fixed.join('\n  ')}`,
+  );
+});

--- a/tracker-sync-check.mjs
+++ b/tracker-sync-check.mjs
@@ -764,7 +764,26 @@ function runSelfTest() {
 }
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
+// Derived from the flags this file actually accepts, so `--help` cannot
+// describe an option that does not exist.
+const USAGE = `Usage:
+  node tracker-sync-check.mjs [--summary] [--porcelain] [--apps-file <path>] [--interviews-file <path>] [--self-test]
+
+  --summary                 human-readable table instead of JSON
+  --porcelain               machine-readable lines
+  --apps-file <path>        override the tracker path
+  --interviews-file <path>  override the active-interviews path
+  --self-test               run the built-in checks
+  --help, -h   print this and exit`;
+
 if (isMainModule(import.meta.url)) {
+  // BEFORE any work. Unhandled, `--help` fell through to the analysis: this
+  // script printed a full report for it, which is not what the flag asks for
+  // and hides that it was never recognised.
+  if (process.argv.slice(2).some((a) => a === '--help' || a === '-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
   if (selfTestMode) {
     runSelfTest();
   }


### PR DESCRIPTION
Six scripts did not recognise the flag, and an unrecognised flag is simply discarded — so `--help` fell through to the work:

```
calibrate.mjs --help               printed a full calibration report
salary-gap.mjs --help              printed JSON
tracker-sync-check.mjs --help      printed JSON
story-provenance-check.mjs --help  printed JSON
```

Nothing errored, which is the problem. The user asked what the flags are and got output answering a different question, with no sign the flag was never read. On a script that writes, the same silent discard would run the write.

## Usage derived, not remembered

None of the six had a `USAGE` const, and only two documented usage in their header. The text is built from the flags each file **actually accepts**, because a usage block naming an option the script ignores is worse than none — it sends the user to write a flag that silently does nothing. A test asserts that correspondence rather than trusting me to have got it right.

## Two invariants per script

Either alone is satisfiable the wrong way:

- help must be **printed**
- the work must **not** have run

Exiting 0 with a usage block would still be wrong if the analysis also ran — the original bug produced output too.

## The other nineteen

The census that found these six turned up nineteen more CLIs with the same defect (`generate-pdf`, `tracker`, `plugins`, `intake`, …). That is far more than one change should touch, so it is a **shrinking allowlist**, in the style this repo already uses for coverage ratchets:

- a **new** CLI cannot join the list — it must handle `--help`
- a script that gets fixed must be **removed** from the list, or the test says so

Verified both directions: adding `calibrate.mjs` back to the list reddens with *"these now handle --help and should be removed"*, and reverting one fix reddens 4 of 20.

I'd rather hand you a ratchet that describes the real state than an assertion that nineteen scripts are fine when they are not. Happy to work the list down in follow-ups.

Full suite green at 8686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User impact

- Users can run `--help` or `-h` for six CLI scripts and receive usage information.
- Each script exits before normal analysis, checks, or report generation starts.
- Usage text lists the flags accepted by each script.
- Tests detect new CLIs that silently discard `--help`.
- The allowlist contains the remaining affected CLIs and shrinks when a CLI is fixed.

## Files changed

- `calibrate.mjs`: Adds usage output and early help handling.
- `jd-skill-gap.mjs`: Adds usage output and early help handling.
- `negotiation-roi.mjs`: Adds usage output and early help handling.
- `salary-gap.mjs`: Adds usage output and early help handling.
- `story-provenance-check.mjs`: Adds usage output and early help handling.
- `tracker-sync-check.mjs`: Adds usage output and early help handling.
- `tests/help-flag-handled.test.mjs`: Verifies help output, successful exit, prevented execution, flag correspondence, and the shrinking allowlist.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->