### PR TITLE
fix(batch): parse scores locale-independently in batch-runner

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -1069,8 +1069,10 @@ process_offer() {
     fi
 
     # Check min-score gate
-    if is_decimal_number "$score" && awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
-      if awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
+    if is_decimal_number "$score" && LC_ALL=C awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
+      # LC_ALL=C: under a non-English locale awk parses "4.5" as 4, so the
+      # MIN_SCORE comparison would silently run on truncated integers.
+      if LC_ALL=C awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
         update_state_retrying "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries" || true
         release_report_num "$report_num"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
@@ -1125,7 +1127,7 @@ print_summary() {
     case "$sstatus" in
       completed) completed=$((completed + 1))
         if is_decimal_number "$sscore"; then
-          score_sum=$(awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}' 2>/dev/null || echo "$score_sum")
+          score_sum=$(LC_ALL=C awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}' 2>/dev/null || echo "$score_sum")
           score_count=$((score_count + 1))
         fi
         ;;
@@ -1139,7 +1141,9 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}' 2>/dev/null || echo "N/A")
+    # LC_ALL=C: under e.g. a German locale awk formats "%.1f" as "4,5"
+    # instead of "4.5", and a decimal comma breaks every downstream parser.
+    avg=$(LC_ALL=C awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}' 2>/dev/null || echo "N/A")
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 
@@ -1176,7 +1180,7 @@ print_status_table() {
       completed)
         completed=$((completed + 1))
         if is_decimal_number "$sscore"; then
-          score_sum=$(awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}' 2>/dev/null || echo "$score_sum")
+          score_sum=$(LC_ALL=C awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}' 2>/dev/null || echo "$score_sum")
           score_count=$((score_count + 1))
         fi
         ;;
@@ -1193,7 +1197,9 @@ print_status_table() {
   echo "Total: $total | Completed: $completed | Processing: $processing | Failed: $failed | Pending: $pending | Skipped: $skipped | Rate Limited: $rate_limited | Paused: $paused_rate_limit"
   if (( score_count > 0 )); then
     local avg
-    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}' 2>/dev/null || echo "N/A")
+    # LC_ALL=C: under e.g. a German locale awk formats "%.1f" as "4,5"
+    # instead of "4.5", and a decimal comma breaks every downstream parser.
+    avg=$(LC_ALL=C awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}' 2>/dev/null || echo "N/A")
     echo "Average score: $avg/5 ($score_count scored)"
   fi
   echo ""


### PR DESCRIPTION
## Problem

Under a non-English locale `awk` parses `4.5` as `4`. `batch/batch-runner.sh` passes scores to `awk` in five places, so on such a system:

- `--status` prints `Average score: 4,5/5` — a decimal comma that breaks any downstream parser reading that output.
- More seriously, the **`MIN_SCORE` gate compares truncated integers**. A 4.5 and a 4.0 become indistinguishable to the filter, so postings can be skipped or kept for the wrong reason without any visible error.

Found while running a batch on a German-locale machine.

## Fix

Prefix the numeric `awk` calls with `LC_ALL=C`.

`LC_ALL` rather than `LC_NUMERIC`: when `LC_ALL` is set in the environment it overrides `LC_NUMERIC`, so the narrower variable would leave the bug in place for exactly the users who hit it. I had it as `LC_NUMERIC=C` first and the reproduction below still failed — that is what surfaced the distinction.

## Reproduce

```bash
mkdir -p /tmp/t/batch && cd /tmp/t
printf 'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n1\thttps://example.com/one\tcompleted\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t001\t4.5\t-\t0\n' > batch/batch-state.tsv
cp <repo>/batch/batch-runner.sh batch/
LC_ALL=de_DE.UTF-8 bash batch/batch-runner.sh --status | grep Average
```

| | Output |
|---|---|
| before | `Average score: 4,5/5 (1 scored)` |
| after | `Average score: 4.5/5 (1 scored)` |

## Note on test coverage

The existing `--status` assertion in `test-all.mjs` does not catch this, because CI runs under the default C/en locale. I did not add a regression test that sets `LC_ALL=de_DE.UTF-8`, since that locale is not guaranteed to be generated on every runner and the test would be flaky. Happy to add one guarded by a `locale -a` check if you would prefer coverage here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`batch/batch-runner.sh:1155`: Uses `LC_ALL=C` for score filtering and score calculations.

`batch/batch-runner.sh:1229`: Keeps status averages in dot-decimal format, such as `4.5/5`, across locales.

`tests/batch-runner-score-locale.test.mjs:46`: Adds static checks and conditional locale coverage for numeric `awk` calls.

System files touched: none of `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->