### PR TITLE
fix(verify-cv-facts): stop reading a CV's own reworded prose as a tool claim

### DIFF
--- a/tests/nonmetric-fact-gate.test.mjs
+++ b/tests/nonmetric-fact-gate.test.mjs
@@ -323,6 +323,25 @@ try {
     fail(`#4004 a determiner-led sibling suppressed a claim that must block: ${JSON.stringify(mixedListFailClosed)}`);
   }
 
+  // The whole-clause drop is about PROSE triggers: a determiner after "using"
+  // or "worked with" says the trigger is ordinary English. A determiner after
+  // "Technologies:" says no such thing, because that trigger is a declaration
+  // whatever follows it, so there the determiner taints only its own fragment.
+  const declaredWithDeterminer = factClaims('Technologies: our playbook and React').filter(claim => claim.kind === 'tool');
+  if (declaredWithDeterminer.some(claim => claim.value === 'react')
+      && !declaredWithDeterminer.some(claim => claim.value.includes('playbook'))) {
+    pass('#4004 a determiner in a declared list does not discard the list');
+  } else {
+    fail(`#4004 a declared technology was lost to a determiner sibling: ${JSON.stringify(declaredWithDeterminer)}`);
+  }
+
+  const declaredFailClosed = factClaims('Tech stack: our stack and kubernetes').filter(claim => claim.kind === 'tool');
+  if (declaredFailClosed.some(claim => claim.value === 'kubernetes')) {
+    pass('#4004 a declared list still yields the claim the gate must block');
+  } else {
+    fail(`#4004 a determiner sibling suppressed a declared claim: ${JSON.stringify(declaredFailClosed)}`);
+  }
+
   // The other direction: an explicit declaration is still a declaration.
   const declaredTools = factClaims('Technologies: React, Postgres');
   if (declaredTools.some(claim => claim.kind === 'tool' && claim.value === 'react')

--- a/tests/nonmetric-fact-gate.test.mjs
+++ b/tests/nonmetric-fact-gate.test.mjs
@@ -249,6 +249,75 @@ try {
     fail(`a source-backed lowercase tool name was blocked: ${JSON.stringify(backedLowercaseTool)}`);
   }
 
+  // #4004 - `isLikelyTool()` accepts by default: a fragment that is neither
+  // tool-shaped nor an exact source match is still asserted as a tool unless
+  // one of its words happens to sit in `TOOL_PROSE_WORDS`. A tailoring run
+  // that rewords a "using" sentence out of the CV's own vocabulary therefore
+  // blocks the render of a document that asserts nothing false.
+  writeFileSync(source, [
+    'Regional Sales Manager at Northwind Supply.',
+    'Reported on campaign performance and on coverage of the pipeline every week.',
+    'Advised clients on solutions for print and digital channels.',
+    'Grew the account through a consultative approach to selling.',
+  ].join('\n'));
+  const rewordedProse = [
+    ['a reworded source phrase', 'Reported weekly using campaign performance and pipeline coverage.'],
+    ['a noun phrase reassembled from the source', 'Advised clients using digital solutions.'],
+    ['a gerund phrase from the source', 'Grew the account using consultative selling.'],
+  ];
+  for (const [label, target] of rewordedProse) {
+    const result = verifyFacts(target, { sourcePaths: [source], configPath: config });
+    if (result.verdict === 'pass' && !result.unsupportedFacts.some(claim => claim.kind === 'tool')) {
+      pass(`#4004 prose built from the source's own words is not a tool claim: ${label}`);
+    } else {
+      fail(`#4004 ordinary prose blocked a truthful document (${label}): ${JSON.stringify(result)}`);
+    }
+  }
+
+  // A name the source never mentions is still unverified, whatever its casing:
+  // the source-vocabulary test above must not become a way to smuggle one in.
+  const novelLowercaseTool = verifyFacts('Reported weekly using kubernetes.', {
+    sourcePaths: [source], configPath: config,
+  });
+  if (novelLowercaseTool.verdict === 'block'
+      && novelLowercaseTool.unsupportedFacts.some(claim => claim.kind === 'tool' && claim.value === 'kubernetes')) {
+    pass('#4004 a lowercase name absent from the source still blocks');
+  } else {
+    fail(`#4004 opened a bypass for an unbacked lowercase tool: ${JSON.stringify(novelLowercaseTool)}`);
+  }
+
+  // Determiners are a closed grammatical class, so this one needs no source:
+  // "that campaign" and "our playbook" are ordinary reference, not products.
+  const determinerCases = [
+    ['a demonstrative', 'Rebuilt the funnel using that campaign.'],
+    ['a possessive', 'Ran the quarterly review using our playbook.'],
+  ];
+  for (const [label, text] of determinerCases) {
+    const found = factClaims(text).filter(claim => claim.kind === 'tool');
+    if (found.length === 0) {
+      pass(`#4004 a determiner-led fragment is not a tool claim: ${label}`);
+    } else {
+      fail(`#4004 determiner-led prose was extracted as a tool (${label}): ${JSON.stringify(found)}`);
+    }
+  }
+
+  // The other direction: an explicit declaration is still a declaration.
+  const declaredTools = factClaims('Technologies: React, Postgres');
+  if (declaredTools.some(claim => claim.kind === 'tool' && claim.value === 'react')
+      && declaredTools.some(claim => claim.kind === 'tool' && claim.value === 'postgres')) {
+    pass('#4004 a Technologies: list is still extracted');
+  } else {
+    fail(`#4004 lost a declared technology list: ${JSON.stringify(declaredTools)}`);
+  }
+
+  const builtWithTools = factClaims('Built with Django and Redis.');
+  if (builtWithTools.some(claim => claim.kind === 'tool' && claim.value === 'django')
+      && builtWithTools.some(claim => claim.kind === 'tool' && claim.value === 'redis')) {
+    pass('#4004 a "built with" declaration is still extracted');
+  } else {
+    fail(`#4004 lost a "built with" declaration: ${JSON.stringify(builtWithTools)}`);
+  }
+
   const delegatedSource = [
     'Sourced and directed vendor Acme Interactive through the WebGL build of an in-store kiosk.',
     'Built the internal deployment pipeline using Node.js.',

--- a/tests/nonmetric-fact-gate.test.mjs
+++ b/tests/nonmetric-fact-gate.test.mjs
@@ -301,6 +301,28 @@ try {
     }
   }
 
+  // A determiner LATER in a list leads one fragment, not the whole capture.
+  // The check ran on the raw capture before the split, so "React and our
+  // playbook" lost React, and an unsupported "kubernetes" in that position
+  // stopped being blocked at all. A determiner immediately after the trigger
+  // is different and still drops the clause: that marks the trigger as
+  // ordinary English ("worked with the team in London"), which the prose guard
+  // above depends on.
+  const mixedList = factClaims('Built with React and our playbook.').filter(claim => claim.kind === 'tool');
+  if (mixedList.some(claim => claim.value === 'react')
+      && !mixedList.some(claim => claim.value.includes('playbook'))) {
+    pass('#4004 a determiner in one fragment does not discard its siblings');
+  } else {
+    fail(`#4004 a determiner-led fragment took the whole list with it: ${JSON.stringify(mixedList)}`);
+  }
+
+  const mixedListFailClosed = factClaims('Shipped it using kubernetes and our stack.').filter(claim => claim.kind === 'tool');
+  if (mixedListFailClosed.some(claim => claim.value === 'kubernetes')) {
+    pass('#4004 an unsupported name beside a determiner-led fragment is still claimed');
+  } else {
+    fail(`#4004 a determiner-led sibling suppressed a claim that must block: ${JSON.stringify(mixedListFailClosed)}`);
+  }
+
   // The other direction: an explicit declaration is still a declaration.
   const declaredTools = factClaims('Technologies: React, Postgres');
   if (declaredTools.some(claim => claim.kind === 'tool' && claim.value === 'react')

--- a/tests/nonmetric-fact-gate.test.mjs
+++ b/tests/nonmetric-fact-gate.test.mjs
@@ -323,6 +323,16 @@ try {
     fail(`#4004 a determiner-led sibling suppressed a claim that must block: ${JSON.stringify(mixedListFailClosed)}`);
   }
 
+  // A determiner can be the WHOLE fragment, not just its lead: the `for`
+  // lookahead ends the capture at "that", and the split can leave one standing
+  // alone. Requiring trailing whitespace missed both.
+  const bareDeterminer = factClaims('Built this using that for the migration.').filter(claim => claim.kind === 'tool');
+  if (bareDeterminer.length === 0) {
+    pass('#4004 a determiner standing alone is not a tool claim');
+  } else {
+    fail(`#4004 a bare determiner was extracted as a tool: ${JSON.stringify(bareDeterminer)}`);
+  }
+
   // The whole-clause drop is about PROSE triggers: a determiner after "using"
   // or "worked with" says the trigger is ordinary English. A determiner after
   // "Technologies:" says no such thing, because that trigger is a declaration

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -30,7 +30,7 @@ const TOOL_PROSE_WORDS = new Set([
 // that campaign", "using our playbook". The class is closed, so unlike
 // TOOL_PROSE_WORDS it cannot turn into a list that grows by one word per bug
 // report (#4004).
-const DETERMINER_LEAD_RE = /^(?:the|that|this|these|those|our|your|their|its|his|her|my)\s+/i;
+const DETERMINER_LEAD_RE = /^(?:the|that|this|these|those|our|your|their|its|his|her|my)(?:\s+|$)/i;
 const DECLARED_TOOL_TRIGGER_RE = /^(?:technologies?|tech stack)\s*:/i;
 const TOOL_PHRASE_PATTERN = /^(?=.{1,80}$)[\p{L}\p{N}.][\p{L}\p{N}+#./-]*(?:\s+[\p{L}\p{N}.][\p{L}\p{N}+#./-]*){0,2}$/u;
 const DELEGATED_PARTY_RE = /\b(?:vendors?|agenc(?:y|ies)|contractors?|consultanc(?:y|ies)|consultants?|external teams?|outsourc(?:ed|ing)|implementation partners?)\b/i;

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -31,6 +31,7 @@ const TOOL_PROSE_WORDS = new Set([
 // TOOL_PROSE_WORDS it cannot turn into a list that grows by one word per bug
 // report (#4004).
 const DETERMINER_LEAD_RE = /^(?:the|that|this|these|those|our|your|their|its|his|her|my)\s+/i;
+const DECLARED_TOOL_TRIGGER_RE = /^(?:technologies?|tech stack)\s*:/i;
 const TOOL_PHRASE_PATTERN = /^(?=.{1,80}$)[\p{L}\p{N}.][\p{L}\p{N}+#./-]*(?:\s+[\p{L}\p{N}.][\p{L}\p{N}+#./-]*){0,2}$/u;
 const DELEGATED_PARTY_RE = /\b(?:vendors?|agenc(?:y|ies)|contractors?|consultanc(?:y|ies)|consultants?|external teams?|outsourc(?:ed|ing)|implementation partners?)\b/i;
 const DELEGATION_RE = /\b(?:commissioned|coordinated|directed|engaged|hired|managed|oversaw|partnered with|supervised)\b/i;
@@ -391,13 +392,16 @@ export function factClaims(text, sourceNormalized = null) {
   for (const [kind, pattern] of patterns) {
     for (const match of clean.matchAll(pattern)) {
       const rawText = kind === 'tool' ? match[1].trim() : '';
+      // "Technologies:" and "tech stack:" declare a list whatever follows them.
+      // The prose triggers do not: a determiner straight after "using" or
+      // "worked with" means the trigger is ordinary English, so the whole clause
+      // is prose and "worked with the team in London" must not yield London.
+      const declaredList = kind === 'tool' && DECLARED_TOOL_TRIGGER_RE.test(match[0]);
       const rawValues = kind === 'tool'
-        // A determiner immediately after the trigger means the trigger is being
-        // used in its ordinary English sense, so the whole clause is prose:
-        // "worked with the team in London" must not yield London. A determiner
-        // LATER in the list taints only its own fragment, so filtering after the
-        // split keeps its siblings, including a name the gate has to block (#4004).
-        ? (DETERMINER_LEAD_RE.test(rawText)
+        // A determiner LATER in a list taints only its own fragment, so filter
+        // after the split and keep its siblings, including a name the gate has
+        // to block (#4004).
+        ? ((!declaredList && DETERMINER_LEAD_RE.test(rawText))
           ? []
           : rawText.split(/,|\band\b|\bwith\b|\bin\b/i).filter(raw => !DETERMINER_LEAD_RE.test(raw.trim())))
         : [match[1] || match[2]];

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -26,6 +26,11 @@ const TOOL_PROSE_WORDS = new Set([
   'improving', 'in', 'of', 'on', 'on-time', 'operations', 'production', 'project',
   'recurring', 'resolving', 'submission', 'team', 'the', 'to', 'using', 'with',
 ]);
+// A leading determiner marks ordinary reference, not a product list: "using
+// that campaign", "using our playbook". The class is closed, so unlike
+// TOOL_PROSE_WORDS it cannot turn into a list that grows by one word per bug
+// report (#4004).
+const DETERMINER_LEAD_RE = /^(?:the|that|this|these|those|our|your|their|its|his|her|my)\s+/i;
 const TOOL_PHRASE_PATTERN = /^(?=.{1,80}$)[\p{L}\p{N}.][\p{L}\p{N}+#./-]*(?:\s+[\p{L}\p{N}.][\p{L}\p{N}+#./-]*){0,2}$/u;
 const DELEGATED_PARTY_RE = /\b(?:vendors?|agenc(?:y|ies)|contractors?|consultanc(?:y|ies)|consultants?|external teams?|outsourc(?:ed|ing)|implementation partners?)\b/i;
 const DELEGATION_RE = /\b(?:commissioned|coordinated|directed|engaged|hired|managed|oversaw|partnered with|supervised)\b/i;
@@ -304,11 +309,16 @@ function looksToolShaped(rawValue) {
  * in cv.md must still pass, and rejecting it on casing alone would just trade
  * one false-positive class for another.
  *
- * A fragment that is neither tool-shaped nor source-backed is still retained
- * by default, preserving the gate's fail-closed behavior for lowercase names.
- * Only exact words observed as prose false positives are rejected through
- * `TOOL_PROSE_WORDS`; morphological suffixes are deliberately not used
- * because real products such as Spring, Unity, and Processing share them.
+ * A fragment whose every word already occurs in the source is dropped: that
+ * is the document's own vocabulary reworded, and tailoring rewords "using"
+ * sentences by design. A name the source never mentions is unaffected, so
+ * "kubernetes" in a CV that never says it stays fail-closed.
+ *
+ * Anything left is retained by default, preserving that fail-closed behavior
+ * for lowercase names. Only exact words observed as prose false positives are
+ * rejected through `TOOL_PROSE_WORDS`; morphological suffixes are deliberately
+ * not used because real products such as Spring, Unity, and Processing share
+ * them.
  */
 function isLikelyTool(value, sourceNormalized) {
   const normalized = normalizeFact(value);
@@ -317,6 +327,12 @@ function isLikelyTool(value, sourceNormalized) {
   if (!TOOL_PHRASE_PATTERN.test(value.trim())) return false;
   if (looksToolShaped(value)) return true;
   if (sourceNormalized != null && sourceContainsFact(sourceNormalized, normalized)) return true;
+  // Every word of the fragment already occurs in the source: this is the
+  // document's own vocabulary reworded, not a technology the source never
+  // mentions. Tailoring rewords "using" sentences by design, so without this
+  // the only thing between ordinary prose and a tool claim is
+  // TOOL_PROSE_WORDS (#4004).
+  if (sourceNormalized != null && words.every(word => sourceContainsFact(sourceNormalized, word))) return false;
   return !words.some(word => TOOL_PROSE_WORDS.has(word));
 }
 
@@ -376,7 +392,7 @@ export function factClaims(text, sourceNormalized = null) {
     for (const match of clean.matchAll(pattern)) {
       const rawText = kind === 'tool' ? match[1].trim() : '';
       const rawValues = kind === 'tool'
-        ? (/^the\s+/i.test(rawText) ? [] : rawText.split(/,|\band\b|\bwith\b|\bin\b/i))
+        ? (DETERMINER_LEAD_RE.test(rawText) ? [] : rawText.split(/,|\band\b|\bwith\b|\bin\b/i))
         : [match[1] || match[2]];
       for (const raw of rawValues) {
         const value = normalizeFact(raw);

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -392,7 +392,14 @@ export function factClaims(text, sourceNormalized = null) {
     for (const match of clean.matchAll(pattern)) {
       const rawText = kind === 'tool' ? match[1].trim() : '';
       const rawValues = kind === 'tool'
-        ? (DETERMINER_LEAD_RE.test(rawText) ? [] : rawText.split(/,|\band\b|\bwith\b|\bin\b/i))
+        // A determiner immediately after the trigger means the trigger is being
+        // used in its ordinary English sense, so the whole clause is prose:
+        // "worked with the team in London" must not yield London. A determiner
+        // LATER in the list taints only its own fragment, so filtering after the
+        // split keeps its siblings, including a name the gate has to block (#4004).
+        ? (DETERMINER_LEAD_RE.test(rawText)
+          ? []
+          : rawText.split(/,|\band\b|\bwith\b|\bin\b/i).filter(raw => !DETERMINER_LEAD_RE.test(raw.trim())))
         : [match[1] || match[2]];
       for (const raw of rawValues) {
         const value = normalizeFact(raw);


### PR DESCRIPTION
## What does this PR do?

`isLikelyTool()` accepted any short lowercase fragment by default, so ordinary "using" prose was asserted as a technology name and `assertFacts()` blocked the render of a CV that claimed nothing false. A fragment whose every word already occurs in the source is now dropped as the document's own vocabulary reworded, and the existing leading-article drop is widened to the rest of the determiner class.

## Related issue

Closes #4004

## Approach

#3643 added `looksToolShaped()` and the source-backed exemption. Both only add accept paths, so nothing rejected a fragment the function could not recognise and `TOOL_PROSE_WORDS` was left as the only thing between ordinary prose and a tool claim. That list holds the words that happened to appear in #3639, so any other word reopened the class: `pipeline coverage`, `digital solutions`, `consultative selling`, `that campaign`.

Two changes, neither of which adds a list anybody has to maintain:

1. **Source vocabulary is not a technology name.** A fragment that is neither tool-shaped nor an exact source match, but whose every word already occurs in the source, is the document's own wording rearranged. `pdf` mode rewords "using" sentences by design, so this is the common case, not an edge one. It uses evidence the function already receives (`sourceNormalized`), not a lexicon.

2. **Determiners are a closed grammatical class.** The extractor already dropped a capture beginning "the"; it now drops the rest of the determiners as well, which removes "that campaign" and "our playbook" on grammar alone, with no dependency on what the source happens to contain.

`TOOL_PROSE_WORDS` stays as the fallback for callers that pass no source, so the #3639 cases keep their coverage there.

## What still blocks, deliberately

- A name the source never mentions, whatever its casing. A sales CV that never says "kubernetes" still blocks `using kubernetes`, so the fail-closed behaviour #3643 was protecting is intact.
- A Title-Cased or version-bearing fabrication, which `looksToolShaped()` accepts as a claim before any of this runs.
- The two-argument shape means `factClaims(text)` with no source is unchanged: with nothing to compare against there is no evidence to reason from. `verifyFacts()` and `assertFacts()` always pass a source, so the gate itself is fixed while direct library callers keep the old behaviour.

## Known limit

A reworded phrase that introduces a word the CV never uses is still extracted, and still blocks. That is the gate speaking up about vocabulary the source does not support, which is the direction it should fail in, but it means this narrows the class rather than closing it completely.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Test plan

Five new cases in `tests/nonmetric-fact-gate.test.mjs`, each confirmed failing on `main` before the change and passing after:

- a reworded source phrase (`using campaign performance and pipeline coverage`) no longer blocks
- a noun phrase reassembled from the source (`using digital solutions`) no longer blocks
- a gerund phrase from the source (`using consultative selling`) no longer blocks
- a demonstrative (`using that campaign`) is not a tool claim
- a possessive (`using our playbook`) is not a tool claim

Plus three guards that pass in both directions, so the fix cannot quietly widen: a lowercase name absent from the source still blocks, `Technologies: React, Postgres` is still extracted, and `Built with Django and Redis.` is still extracted.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`verify-cv-facts.mjs:324-337` now rejects source-derived prose as tool claims. `verify-cv-facts.mjs:396-410` filters determiner-led prose while preserving valid tools in mixed lists.

From the user's point of view: truthful CV sentences after “using” no longer block PDF rendering. Unsupported tool names still block rendering. Explicit declarations such as `Technologies: React, Postgres` and `Built with Django and Redis` remain supported.

Regression coverage includes reworded phrases, noun and gerund phrases, demonstratives, possessives, mixed lists, real tools, and unsupported tools: `tests/nonmetric-fact-gate.test.mjs:252-359`.

Touched files: `verify-cv-facts.mjs`, `tests/nonmetric-fact-gate.test.mjs`.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->