### PR TITLE
fix(analyze-patterns): validate threshold and vendor flags

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -1678,6 +1678,28 @@ if (isMainModule(import.meta.url)) {
     requireOperand: true,
   });
 
+  const validateIntegerFlag = (flag, raw, { positive }) => {
+    const requirement = positive ? 'a positive integer' : 'a non-negative integer';
+    const valid = raw !== undefined
+      && /^\d+$/.test(String(raw))
+      && Number.isSafeInteger(Number(raw))
+      && (!positive || Number(raw) > 0);
+    if (!valid) {
+      console.error(`Error: ${flag} requires ${requirement}, got "${raw}"`);
+      process.exit(2);
+    }
+  };
+
+  const rawMinThreshold = flagValue(args, '--min-threshold');
+  if (rawMinThreshold !== undefined) {
+    validateIntegerFlag('--min-threshold', rawMinThreshold, { positive: false });
+  }
+
+  const rawMinVendorN = flagValue(args, '--min-vendor-n');
+  if (rawMinVendorN !== undefined) {
+    validateIntegerFlag('--min-vendor-n', rawMinVendorN, { positive: true });
+  }
+
   if (args.includes('--self-test')) {
     runSelfTest();
   }

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -147,6 +147,36 @@ test('fix-slugs rejects missing --file values (bare, empty, or next-is-flag)', (
   assert.doesNotMatch(rShortFlagEq.all, /no portals file at/i);
 });
 
+// --- analyze-patterns specific: numeric value flags must be strict ----------
+for (const [form, args] of [
+  ['space-separated', ['--min-threshold', 'abc']],
+  ['negative', ['--min-threshold', '-5']],
+  ['decimal', ['--min-threshold', '1.5']],
+  ['extra characters', ['--min-threshold', '10abc']],
+  ['unsafe integer', ['--min-threshold=9007199254740992']],
+]) {
+  test(`analyze-patterns rejects ${form} threshold values`, () => {
+    const r = runScript('analyze-patterns.mjs', ...args);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+    assert.match(r.all, /--min-threshold requires a non-negative integer, got/);
+  });
+}
+
+for (const [form, args] of [
+  ['space-separated', ['--min-vendor-n', 'abc']],
+  ['zero', ['--min-vendor-n', '0']],
+  ['negative', ['--min-vendor-n=-1']],
+  ['decimal', ['--min-vendor-n=1.5']],
+  ['unsafe integer', ['--min-vendor-n', '9007199254740992']],
+]) {
+  test(`analyze-patterns rejects ${form} vendor sample values`, () => {
+    const r = runScript('analyze-patterns.mjs', ...args);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+    assert.match(r.all, /--min-vendor-n requires a positive integer, got/);
+  });
+}
+
+
 // --- missing operand for a RECOGNIZED value-taking flag (#3087) ------------
 //
 // A different defect than an unrecognized flag: the flag is spelled right,

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -176,6 +176,18 @@ for (const [form, args] of [
   });
 }
 
+test('analyze-patterns rejects a trailing --min-threshold without an operand', () => {
+  const r = runScript('analyze-patterns.mjs', '--min-threshold');
+  assert.equal(r.status, 1, `exited ${r.status}, want 1`);
+  assert.match(r.all, /--min-threshold requires a value/);
+});
+
+test('analyze-patterns rejects a trailing --min-vendor-n without an operand', () => {
+  const r = runScript('analyze-patterns.mjs', '--min-vendor-n');
+  assert.equal(r.status, 1, `exited ${r.status}, want 1`);
+  assert.match(r.all, /--min-vendor-n requires a value/);
+});
+
 
 // --- missing operand for a RECOGNIZED value-taking flag (#3087) ------------
 //


### PR DESCRIPTION
Closes #3113

### Summary of Changes
- Added flag value validation for `--min-threshold` and `--min-vendor-n` in `analyze-patterns.mjs`.
- `--min-threshold` is validated as a non-negative integer (>= 0).
- `--min-vendor-n` is validated as a positive integer (>= 1).
- Preserved both `--flag <val>` and `--flag=<val>` syntaxes.
- Missing operands continue to be rejected via `validateFlags()` (`requireOperand: true`).
- Added comprehensive regression tests in `tests/cli-flag-validation.test.mjs`.

### Validation Behavior
- Supplied values for `--min-threshold` that are non-integers, negative, or invalid strings (e.g. `abc`, `-1`, `3.5`, `7abc`) output `Error: --min-threshold requires a non-negative integer, got "<val>"` and exit with CLI validation exit code `2`.
- Supplied values for `--min-vendor-n` that are non-integers, non-positive, or invalid strings (e.g. `abc`, `0`, `-1`, `3.5`, `7abc`) output `Error: --min-vendor-n requires a positive integer, got "<val>"` and exit with CLI validation exit code `2`.
- Valid inputs (`--min-threshold 0`, `--min-threshold 5`, `--min-vendor-n 1`, `--min-vendor-n 8`, `--min-threshold=5`, `--min-vendor-n=8`) and defaults (`5` for threshold, `8` for vendor-n) behave as expected.

### Safety of `validateFlags()` Placement
`validateFlags()` and flag value validation are guarded inside `if (isMainModule(import.meta.url))`. This ensures that when `analyze-patterns.mjs` is imported in-process by test runners (such as `tests/analyze-patterns-outcomes.test.mjs`), CLI validation is not executed against the test runner process's `process.argv`.

### Tests Run & Results
- `node --test tests/cli-flag-validation.test.mjs` (41/41 passing)
- `node --test tests/analyze-patterns-cli-flags.test.mjs` (4/4 passing)
- `node --test tests/analyze-patterns-outcomes.test.mjs` (1/1 passing with all subtests)
- `node analyze-patterns.mjs --self-test` (OK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User impact

- Users can pass `--min-threshold` as a non-negative safe integer.
- Users can pass `--min-vendor-n` as a positive safe integer.
- Invalid or missing values fail with flag-specific errors and exit status `1` (`analyze-patterns.mjs:1667-1692`).
- Spaced and equals-sign syntax remain supported.
- Imported modules retain default values because CLI parsing runs only in the main-module guard (`analyze-patterns.mjs:83-86,1666-1668`).

## Files changed

- `analyze-patterns.mjs:23,1667-1692`: adds flag validation and guarded numeric parsing.
- `tests/cli-flag-validation.test.mjs:208-246`: adds regression tests for invalid, unsafe, and missing values.
- `AGENTS.md`: not changed.
- `modes/`: not changed.
- `update-system.mjs`: not changed.
- `DATA_CONTRACT.md`: not changed.
- `providers/`: not changed.
- `.github/`: not changed.

Test results are not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->