### PR TITLE
fix(web): read the whole of modes/_profile.md, not just the managed block

### DIFF
--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -11,6 +11,10 @@ import { resolvePdfIndexPath } from "@/lib/core/pdf-index";
 // don't drift into two different definitions of "which report does this
 // index row belong to" (#2599, #2008 review).
 import { pdfIndexEntryForReport } from "@/lib/apply/cv-selection.mjs";
+// The managed-block markers and the profile read live together in one plain
+// module, so rememberFact() (the block's only WRITER) and readMemory() (its
+// reader) cannot drift apart, and so the read rule is testable from web/tests.
+import { NOTES_START, NOTES_END, profilePath as profileMemoryPath, readProfileMemory } from "@/lib/profile-memory.mjs";
 
 /**
  * Resolve the career-ops "home" — the directory holding the user's sibling
@@ -382,29 +386,13 @@ export function findApplication(n: string): Application | null {
  *  web assistant learns go HERE (single source of truth) inside a managed marker
  *  block — so the CLI sees them too. No web-only memory store (that would drift). */
 export function profilePath(): string {
-  return path.join(careerOpsRoot(), "modes", "_profile.md");
+  return profileMemoryPath(careerOpsRoot());
 }
 
-const NOTES_START = "<!-- co-web-notes:start -->";
-const NOTES_END = "<!-- co-web-notes:end -->";
-
-/** Read back ONLY the web-assistant managed notes from modes/_profile.md (small,
- *  focused — the agent reads the rest of the canonical files itself). Falls back
- *  to the legacy web-only memory file for back-compat. */
+/** Read modes/_profile.md back for injection into a prompt. profile-memory.mjs
+ *  owns the rule and is where it is tested. */
 export function readMemory(): string {
-  try {
-    const md = fs.readFileSync(profilePath(), "utf8");
-    const i = md.indexOf(NOTES_START);
-    const j = md.indexOf(NOTES_END);
-    if (i !== -1 && j !== -1 && j > i) return md.slice(i + NOTES_START.length, j).trim();
-  } catch {
-    /* no _profile.md yet */
-  }
-  try {
-    return fs.readFileSync(path.join(careerOpsRoot(), ".career-ops-web", "memory.md"), "utf8").trim();
-  } catch {
-    return "";
-  }
+  return readProfileMemory(careerOpsRoot());
 }
 
 /** Append a durable fact to the canonical modes/_profile.md (creating the file +

--- a/web/src/lib/profile-memory.mjs
+++ b/web/src/lib/profile-memory.mjs
@@ -1,0 +1,57 @@
+/**
+ * profile-memory.mjs: how modes/_profile.md is read back into a prompt.
+ *
+ * Lives in a plain .mjs, taking the root as a parameter, for the same reason
+ * pdf-paths.mjs does. web/tests runs bare `node --test`, which cannot resolve
+ * career-ops.ts through the `@/` alias, and this is logic that has to be
+ * asserted on as a VALUE. career-ops.ts keeps readMemory() as its entry point
+ * and calls in here with careerOpsRoot().
+ *
+ * The marker constants are exported rather than duplicated. rememberFact() in
+ * career-ops.ts is the only WRITER of the managed block and needs them to know
+ * where to append and how to dedupe: one definition, two consumers.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+export const NOTES_START = "<!-- co-web-notes:start -->";
+export const NOTES_END = "<!-- co-web-notes:end -->";
+
+/** The CANONICAL user-customization file the CLI/TUI reads. */
+export function profilePath(root) {
+  return path.join(root, "modes", "_profile.md");
+}
+
+/**
+ * Everything modes/_profile.md says about the user, for injection into a prompt.
+ *
+ * The whole file, NOT the co-web-notes block. That block is a write-time
+ * construct: rememberFact() needs it to know where to append and how to dedupe.
+ * It used to double as the read filter, so the reader returned only the bullets
+ * the assistant had written about the user and discarded everything the user
+ * had written themselves. With no block present, which is the state every
+ * install starts in (_profile.template.md ships without one, and rememberFact()
+ * is the only thing that ever creates it), the read returned the empty string,
+ * and buildPrompt() omits the notes section entirely for an empty memory. A run
+ * with no guardrails was byte-indistinguishable from a run that never needed
+ * any (#4003).
+ *
+ * The legacy .career-ops-web/memory.md still answers when modes/_profile.md is
+ * missing or empty, so installs predating the move keep working.
+ *
+ * @param {string} root career-ops home, i.e. careerOpsRoot()
+ * @returns {string}
+ */
+export function readProfileMemory(root) {
+  try {
+    const md = fs.readFileSync(profilePath(root), "utf8").trim();
+    if (md) return md;
+  } catch {
+    /* no _profile.md yet */
+  }
+  try {
+    return fs.readFileSync(path.join(root, ".career-ops-web", "memory.md"), "utf8").trim();
+  } catch {
+    return "";
+  }
+}

--- a/web/tests/lib/profile-memory.test.mjs
+++ b/web/tests/lib/profile-memory.test.mjs
@@ -1,0 +1,121 @@
+// Tests for readProfileMemory(): what modes/_profile.md actually contributes to
+// a prompt (#4003).
+//
+// The failure this file exists to stop is a silent one: when the read returns
+// "", buildPrompt() drops the whole "Durable notes about the user" section
+// rather than emitting an empty one, so a run with no guardrails is
+// byte-indistinguishable from a run that never had any. Nothing errors, nothing
+// is logged, and the output looks exactly like correctly constrained output.
+// That is why the last test here asserts on the built PROMPT and not only on
+// this function's return value.
+//
+// Run:  node --test tests/lib/profile-memory.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readProfileMemory, NOTES_START, NOTES_END } from "../../src/lib/profile-memory.mjs";
+import { buildPrompt } from "../../src/lib/run-prompts.mjs";
+
+// Synthetic, and deliberately of the KIND users really put in this file: the
+// rules that keep generated CVs and form answers honest.
+const HANDWRITTEN = `# Profile customization
+
+## Archetypes
+- Staff platform engineer at a mid-size SaaS company
+
+## Never claim
+- I contributed to the billing migration, I did not lead it.
+- The 40% latency figure covers one service, not the whole platform.
+`;
+
+const ROOTS = [];
+
+function makeRoot({ profile, legacy } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "co-profile-mem-"));
+  ROOTS.push(root);
+  if (profile !== undefined) {
+    mkdirSync(join(root, "modes"), { recursive: true });
+    writeFileSync(join(root, "modes", "_profile.md"), profile);
+  }
+  if (legacy !== undefined) {
+    mkdirSync(join(root, ".career-ops-web"), { recursive: true });
+    writeFileSync(join(root, ".career-ops-web", "memory.md"), legacy);
+  }
+  return root;
+}
+
+test.after(() => {
+  for (const r of ROOTS) rmSync(r, { recursive: true, force: true });
+});
+
+test("a profile with no managed block still reaches the prompt", () => {
+  // Given: the DEFAULT state of an install. modes/_profile.template.md ships
+  // with no co-web-notes markers, doctor.mjs auto-copies it, and rememberFact()
+  // is the only thing that ever creates the block, so until the web assistant
+  // happens to remember something, every personalized profile looks like this.
+  const root = makeRoot({ profile: HANDWRITTEN });
+
+  const memory = readProfileMemory(root);
+
+  assert.match(memory, /I contributed to the billing migration/);
+  assert.match(memory, /Staff platform engineer/);
+});
+
+test("a managed block does not displace the content around it", () => {
+  // Given: the state after the assistant has remembered one fact. The block now
+  // exists, and the marker slice used to return ONLY its bullets, silently
+  // dropping everything the user hand-wrote in the same file.
+  const root = makeRoot({
+    profile: `${HANDWRITTEN}
+## Notes from the web assistant
+${NOTES_START}
+- Prefers fully remote roles.
+${NOTES_END}
+`,
+  });
+
+  const memory = readProfileMemory(root);
+
+  assert.match(memory, /Prefers fully remote roles/);
+  assert.match(memory, /I contributed to the billing migration/);
+});
+
+test("the legacy .career-ops-web/memory.md is still read when there is no profile", () => {
+  // Given: an install that predates modes/_profile.md as the memory store.
+  // Deleting the second fs read in readProfileMemory() is what fails this.
+  const root = makeRoot({ legacy: "- Wants roles in the EU only.\n" });
+
+  assert.equal(readProfileMemory(root), "- Wants roles in the EU only.");
+});
+
+test("an empty profile falls through to the legacy store rather than shadowing it", () => {
+  // Given: doctor.mjs created modes/_profile.md but nothing has been written to
+  // it. An existing file must not win over a legacy store that has content.
+  const root = makeRoot({ profile: "\n\n  \n", legacy: "- Wants roles in the EU only.\n" });
+
+  assert.equal(readProfileMemory(root), "- Wants roles in the EU only.");
+});
+
+test("nothing on disk reads as no memory, not as an error", () => {
+  assert.equal(readProfileMemory(makeRoot()), "");
+});
+
+test("the profile lands in the prompt buildPrompt() actually sends", () => {
+  // The whole point. buildPrompt() omits the notes section entirely for an empty
+  // memory, so asserting on readProfileMemory()'s return value alone would not
+  // catch a break between the two.
+  const root = makeRoot({ profile: HANDWRITTEN });
+
+  const prompt = buildPrompt({
+    kind: "evaluate",
+    input: "https://example.com/jobs/1",
+    memory: readProfileMemory(root),
+    today: "2026-09-07",
+  });
+
+  assert.match(prompt, /Durable notes about the user/);
+  assert.match(prompt, /I contributed to the billing migration, I did not lead it\./);
+});


### PR DESCRIPTION
## What does this PR do?

`readMemory()` returned only the text between the `co-web-notes` markers in `modes/_profile.md`, so the anti-fabrication guardrails a user hand-writes in that file never reached the model on a web-triggered run. It now returns the whole file. The markers stay in `rememberFact()`, which is the only thing that needs them.

## Related issue

Closes #4003

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The bug

Two failure states, both ordinary installs.

**No markers, which is where every install starts.** `modes/_profile.template.md` ships without them, `doctor.mjs` auto-copies it, and `rememberFact()` is the only thing that ever creates the block. Until a user happens to trigger the assistant's remember path, a fully written `modes/_profile.md` fell through to `.career-ops-web/memory.md` and returned `""`, permanently.

**Markers present.** The read returned only the bullets the assistant had written about the user, and silently dropped everything the user had written in the same file.

`buildPrompt()` omits the entire `Durable notes about the user` section for an empty memory rather than emitting an empty one, so the built prompt carried no trace that anything was meant to be there. A run with no guardrails was byte-indistinguishable from a run that never needed any. Of the five call sites, only `/api/run` kind `evaluate` tells the agent to read `modes/_profile.md` itself; `pdf`, `/api/apply/prefill`, `/api/assistant` and `/api/explore/ai` have no other path to that file, and the first two are the ones whose output reaches a real employer.

## The fix

The managed block was doing two jobs. `rememberFact()` genuinely needs it, to know where to append and how to dedupe. As a read filter it had no reason to exist, and it was throwing away the file it had just read successfully.

```js
export function readProfileMemory(root) {
  try {
    const md = fs.readFileSync(profilePath(root), "utf8").trim();
    if (md) return md;
  } catch { /* no _profile.md yet */ }
  try {
    return fs.readFileSync(path.join(root, ".career-ops-web", "memory.md"), "utf8").trim();
  } catch { return ""; }
}
```

The legacy `.career-ops-web/memory.md` still answers when `modes/_profile.md` is missing or empty, so installs on the old store are unaffected. `NOTES_START` and `NOTES_END` are exported from the new module and imported by `rememberFact()`, so there is still exactly one definition of them.

I deliberately did not narrow this to "fall back to the whole file only when the markers are absent". That version reintroduces the same failure with a delay: guardrails are injected until the assistant remembers its first fact, at which point the block appears and the hand-written content silently disappears again.

I also did not add the `doctor.mjs` warning discussed in the issue. Once the whole file is read, having no managed block is an ordinary state rather than a fault, so warning about it would be a false alarm on most installs, and `doctor.mjs` already flags an unpersonalized `modes/_profile.md`. Happy to add it if you would rather have both.

## Why a new module

`web/tests` runs bare `node --test`, which cannot resolve `career-ops.ts` through the `@/` alias, so the read rule was not testable where it was. It moves to `web/src/lib/profile-memory.mjs` taking the root as a parameter, the same shape as `pdf-paths.mjs` and `report-files.mjs`. `readMemory()` stays the exported entry point and calls in with `careerOpsRoot()`. The move itself is byte-for-byte behavior-preserving; the behavior change is the four-line reader above.

## Tests

`web/tests/lib/profile-memory.test.mjs`, six cases. The last one asserts on the built prompt rather than only on the return value, because the silent part of this bug is `buildPrompt()` dropping the section entirely.

Verified failing against the old reader first:

```
not ok 1 - a profile with no managed block still reaches the prompt
not ok 2 - a managed block does not displace the content around it
ok 3 - the legacy .career-ops-web/memory.md is still read when there is no profile
ok 4 - an empty profile falls through to the legacy store rather than shadowing it
ok 5 - nothing on disk reads as no memory, not as an error
not ok 6 - the profile lands in the prompt buildPrompt() actually sends
# pass 3
# fail 3
```

3, 4 and 5 are regression guards on behavior this change must not break, so they are green before and after. I checked they can fail rather than assuming it: deleting the second `fs.readFileSync` reds 3 and 4, and changing `if (md) return md` to `return md` reds 4.

After the fix, all six pass, and:

- `web`: `npm test` 503 passed / 0 failed, `npx tsc --noEmit` clean, `npm run build` clean
- root: `npm run lint` clean, `node test-all.mjs --quick` 8688 passed / 0 failed

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can now write guardrails and notes anywhere in `modes/_profile.md`. Web-triggered model runs receive the full profile, including content outside the managed `co-web-notes` block.

If `modes/_profile.md` is missing or empty, `readMemory()` uses `.career-ops-web/memory.md` as a fallback. Managed markers remain write-time logic in `rememberFact()`.

## Testing

Added six tests for profile content, managed notes, fallback behavior, missing files, and prompt construction: `web/tests/lib/profile-memory.test.mjs`.

## Files changed

- `web/src/lib/profile-memory.mjs`: Added shared profile reading and path helpers.
- `web/src/lib/career-ops.ts`: Delegated `readMemory()` and profile path handling to the shared module.
- `web/tests/lib/profile-memory.test.mjs`: Added direct reader tests.

`AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` were not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->