### PR TITLE
fix(followup-cadence): emit cadenceDefaults when the tracker is empty

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -795,7 +795,12 @@ export function computeNextFollowupDate(status, appDate, lastFollowupDate, follo
 export function analyzeFromContent(trackerContent, followupsContent = '') {
   const apps = parseTrackerContent(trackerContent);
   if (apps.length === 0) {
-    return { error: 'No applications found in tracker.' };
+    // cadenceDefaults rides along on the error. It is a constant, so it is just
+    // as valid with no applications as with a hundred, and this is the ONE
+    // state where a consumer cannot do without it: on a first run the web
+    // cadence form has no profile overrides to fall back on either, so
+    // withholding it renders six empty fields with nothing to type back in.
+    return { error: 'No applications found in tracker.', cadenceDefaults: DEFAULT_CADENCE };
   }
 
   const followups = parseFollowups(followupsContent);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -15938,9 +15938,13 @@ try {
       '',
     );
     const emptyDefaults = emptyEmitted?.cadenceDefaults;
+    // Value equality, not just shape. Returning CADENCE here (defaults PLUS the
+    // user's profile overrides) would satisfy every structural check while
+    // handing the form one of the user's own overrides as the baseline they
+    // would be reverting to, which is the #2369 mistake exactly.
     const emptyOk = emptyDefaults && typeof emptyDefaults === 'object'
-      && cadKeys.every((k) => Number.isInteger(emptyDefaults[k]) && emptyDefaults[k] >= 0)
-      && Object.keys(emptyDefaults).length === cadKeys.length;
+      && Object.keys(emptyDefaults).length === cadKeys.length
+      && cadKeys.every((k) => Number.isInteger(emptyDefaults[k]) && emptyDefaults[k] === DEFAULT_CADENCE[k]);
     if (emptyOk) {
       pass('followup-cadence emits cadenceDefaults even when the tracker is empty (#4005)');
     } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -15946,6 +15946,14 @@ try {
     } else {
       fail(`an empty tracker withholds cadenceDefaults, so a first-run web cadence form renders blank (#4005): ${JSON.stringify(emptyEmitted)}`);
     }
+    // The error must SURVIVE alongside the defaults: stats.mjs short-circuits on
+    // result.error before it reads entries, so dropping it while adding the
+    // defaults would hand that caller a payload with no entries to iterate.
+    if (emptyEmitted?.error === 'No applications found in tracker.') {
+      pass('the empty-tracker payload still reports its error alongside the defaults (#4005)');
+    } else {
+      fail(`the empty-tracker error was lost, so callers that branch on result.error now fall through (#4005): ${JSON.stringify(emptyEmitted)}`);
+    }
     const webFollowups = join(ROOT, 'web', 'src', 'lib', 'followups.ts');
     if (existsSync(webFollowups)) {
       const webSrc = readFileSync(webFollowups, 'utf-8');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -15928,6 +15928,24 @@ try {
     } else {
       fail('the web _days key mapping no longer lines up with the core cadenceDefaults keys (#2369)');
     }
+    // The defaults are a CONSTANT, so an empty tracker must not withhold them.
+    // That is the first-run state (onboarding creates a header-only tracker),
+    // and it is precisely when the web form has no profile overrides to fall
+    // back on, so a missing baseline leaves every field blank (#4005).
+    const emptyEmitted = analyzeFromContent(
+      '# Applications Tracker\n\n| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n',
+      '',
+    );
+    const emptyDefaults = emptyEmitted?.cadenceDefaults;
+    const emptyOk = emptyDefaults && typeof emptyDefaults === 'object'
+      && cadKeys.every((k) => Number.isInteger(emptyDefaults[k]) && emptyDefaults[k] >= 0)
+      && Object.keys(emptyDefaults).length === cadKeys.length;
+    if (emptyOk) {
+      pass('followup-cadence emits cadenceDefaults even when the tracker is empty (#4005)');
+    } else {
+      fail(`an empty tracker withholds cadenceDefaults, so a first-run web cadence form renders blank (#4005): ${JSON.stringify(emptyEmitted)}`);
+    }
     const webFollowups = join(ROOT, 'web', 'src', 'lib', 'followups.ts');
     if (existsSync(webFollowups)) {
       const webSrc = readFileSync(webFollowups, 'utf-8');


### PR DESCRIPTION
## What does this PR do?

`analyzeFromContent()` returns early when the tracker has no rows, and that payload carried only the error. `cadenceDefaults` is a constant that does not depend on tracker contents, so it now rides along on the early return too.

## Related issue

Closes #4005

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Why it matters

`readCoreDefaults()` in `web/src/app/api/followups/cadence/route.ts` requires `cadenceDefaults` and returns null without it, so `GET /api/followups/cadence` responds with an empty `effective`. `cadence-settings.tsx` maps that onto its inputs and renders `""` for every key the core did not supply, so all six fields on the Config page come up blank and Save is then rejected on the first empty one, with nothing on the page stating what the defaults were.

This lands on a first run specifically. Onboarding creates a header-only tracker, and a user with no applications yet also has no `followup_cadence:` block in `config/profile.yml` to fall back on, so both sources of a baseline are missing at once.

#3862 fixed the other half of this path by adding `--json` to `KNOWN_FLAGS`, and `tests/web-core-argv-contract.test.mjs` pins the argv. That covers which flags the core accepts, not what the payload contains, so the invocation succeeded while the response was still missing the key the route needs.

Exit 1 is unchanged, since the analysis genuinely produced no entries. `stats.mjs` is the only other consumer and short-circuits on `result.error` before touching `entries`, so the extra key is inert there.

## Verification

Reproduced on `main` at 8a20e491 before the change, with a positive control on the same import to prove the check was not vacuous:

```
empty tracker (header row only) : {"error":"No applications found in tracker."}   assertion FAIL
one tracker row                 : cadenceDefaults present                          control OK
```

After the change, the same empty tracker through the real CLI:

```
$ CAREER_OPS_ROOT=/tmp/new node followup-cadence.mjs --json
{
  "error": "No applications found in tracker.",
  "cadenceDefaults": {
    "applied_first": 7,
    "applied_subsequent": 7,
    "applied_max_followups": 2,
    "responded_initial": 1,
    "responded_subsequent": 3,
    "interview_thankyou": 1
  }
}
$ echo $?
1
```

The test goes in `test-all.mjs` section 55.3c, beside the existing #2369 payload assertions, which only ever exercised a populated tracker. That is the gap that let this through: the contract was already asserted, just never on the empty path.

`node test-all.mjs`: 8688 passed, 0 failed, 16 warnings.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

When the tracker is empty, `analyzeFromContent()` includes `cadenceDefaults` with the existing error response at `followup-cadence.mjs:803`. The CLI still returns exit code 1.

Users with a new header-only tracker can now see all six default cadence values in the web settings form. The form can save without requiring users to enter missing defaults.

Regression coverage at `test-all.mjs:15935` validates the defaults and the existing error. The full suite passes: 8,689 tests.

Changed files: `followup-cadence.mjs`, `test-all.mjs`.

No changes to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->