### PR TITLE
test(harness): raise tracker-columns-tests.mjs to the outlier budget

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -365,7 +365,23 @@ const scripts = [
   { name: 'invite-match.mjs --self-test', expectExit: 0 },
   { name: 'tracker-sync-check.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
-  { name: 'tracker-columns-tests.mjs', expectExit: 0 },
+  // The second outlier, on the same grounds as tracker-writer-lock-tests.mjs
+  // below and measured the same way. It spawns five node subprocesses
+  // (merge-tracker, verify-pipeline) against throwaway mkdtempSync trees, and
+  // that cost is the behaviour under test rather than slack to be trimmed.
+  //
+  // Measured on windows-latest across six green runs: 10.9s, 11.7s, 11.9s,
+  // 12.0s, 12.4s, 13.8s, which makes it the SLOWEST script in this section
+  // there, a hair above tracker-writer-lock-tests.mjs at 11.6s on the same run.
+  // A seventh run ran past the 30s default and was killed mid-suite
+  // (`exit null, signal SIGTERM`) while ubuntu, macos and every other check on
+  // that commit passed (#4010, same shape as #2906). Locally on an idle box it
+  // is 4.2s, so the spread is Windows process creation under runner load.
+  //
+  // SLOW_SCRIPT_WARN_FRACTION could not have given notice: at a typical 12s of
+  // 30s this never reaches the 75% warning, so it goes from silent to killed
+  // with nothing in between. The ceiling is the only signal it has.
+  { name: 'tracker-columns-tests.mjs', expectExit: 0, timeoutMs: 180_000 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },
   { name: 'followup-seed-tests.mjs', expectExit: 0 },
   { name: 'paste-reply-tests.mjs', expectExit: 0 },


### PR DESCRIPTION
## What does this PR do?

Gives `tracker-columns-tests.mjs` the `timeoutMs: 180_000` its list-neighbour `tracker-writer-lock-tests.mjs` already has. It runs on the shared 30s default today and is killed on `windows-latest` often enough to redden PRs that do not touch it.

## Related issue

Closes #4010

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Evidence

The failure is a kill, not an assertion:

```
❌ tracker-columns-tests.mjs crashed (exit null, signal SIGTERM)
  stdout: PASS merge into 10-col tracker exits 0
```

It had already passed its first case. The log entry before it lands at `19:24:47.595` and the kill at `19:25:17.611`, exactly 30.0s, which is `DEFAULT_SCRIPT_TIMEOUT_MS` (`tests/helpers.mjs:37`). This was on #4008, a three-file change under `web/`; `ubuntu-latest`, `macos-latest` and every other check passed on that commit, and a retrigger with byte-identical content turned the leg green.

Elapsed on `windows-latest`, measured as the delta between the previous suite's `runs OK` line and this suite's, so it includes this suite's own setup:

| Run | Branch | Elapsed |
|---|---|---|
| 34154514034 | dev/4004-tool-claim-prose | 10.90s |
| 34148068976 | feat/personio-tenant-pin | 11.71s |
| 34157015801 | dev/4003 (the retrigger) | 11.88s |
| 34154539119 | fix/analyze-patterns-flag-validation | 12.01s |
| 34154934619 | feat/verdict-lead-block | 12.39s |
| 34147993447 | feat/bwi-provider | 13.80s |
| 34155386224 | dev/4003 (the kill) | > 30.0s, SIGTERM |

It is the slowest script in that section on Windows. Slowest ten on the green run:

```
 11.88s  tracker-columns-tests.mjs
 11.64s  tracker-writer-lock-tests.mjs
  8.70s  set-status-tests.mjs
  7.61s  agent-inbox-tests.mjs
  3.79s  update-system.mjs check
  3.48s  followup-seed-tests.mjs
  1.17s  updater-migration-tests.mjs
  0.74s  paste-reply-tests.mjs
  0.40s  img-to-pdf.mjs --self-test
  0.39s  archive-posting.mjs --help
```

Two suites at 11.88s and 11.64s on the same run, one budgeted at 180s and the other at 30s. The second one just got caught first. Locally on an idle macOS box it is 4.1s to 4.4s over three runs, so the spread is Windows process creation under runner load: the suite spawns five node subprocesses (`merge-tracker.mjs`, `verify-pipeline.mjs`) against throwaway `mkdtempSync` trees.

## Why the existing warning could not catch it

`SLOW_SCRIPT_WARN_FRACTION` is 0.75, so the "close to being killed for time" warning fires above 22.5s. At a typical 12s this suite never warns. It is not creeping toward the ceiling, it is spiking past it, so it goes from completely silent to killed with nothing in between. The ceiling is the only signal it has, which is why the ceiling is what this changes.

## Scope

Raised on the entry, not in `run()`'s default, so the policy stated at `test-all.mjs:382-386` holds unchanged: every other script keeps the 30s bound, and a new script that starts taking half a minute still fails loudly instead of inheriting a budget sized for these two.

`set-status-tests.mjs` (8.70s) and `agent-inbox-tests.mjs` (7.61s) are deliberately untouched. Neither has been killed, and both sit far enough below the line that raising them would be pre-emptive rather than evidenced.

## One thing to decide, flagged rather than assumed

#3736 proposes moving five root `*-tests.mjs` suites into `tests/`, and this is one of the five. It also records why `tracker-writer-lock-tests.mjs` stays put: the discovery path has no timeout mechanism, so moving a suite that carries a tuned budget trades a tuned budget for none.

This change puts `tracker-columns-tests.mjs` in that same position, so #3736 becomes four that can move rather than five, unless the per-suite budget in `runDiscovered` that #3736 itself suggests lands first.

I do not think that should block this: the 30s budget is wrong today and is reddening unrelated PRs today, and the alternative is leaving a known flake in place while a larger refactor is scoped. But the ordering is yours to choose, and I would rather surface it now than have it turn up after the merge.

## Verification

`node test-all.mjs --quick`: 8686 passed, 0 failed, 16 warnings, exit 0. `npm run lint` clean. The entry still satisfies the `timeoutMs` validation at `test-all.mjs:495` and does not touch the default that section 59c guards.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `test-all.mjs:368-384`: Adds Windows runner context and assigns `tracker-columns-tests.mjs` a `180_000` ms timeout.
- Other scripts keep the shared 30-second timeout.
- This reduces intermittent `SIGTERM` failures caused by Windows subprocess startup time.
- `tracker-writer-lock-tests.mjs` keeps its existing 180-second timeout.
- `set-status-tests.mjs` and `agent-inbox-tests.mjs` remain unchanged.

## Files

Touched: `test-all.mjs`

Not touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, `.github/`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->