### PR TITLE
fix(web): validate the saved cliId against what is installed before a run

### DIFF
--- a/SIGNATURES.md
+++ b/SIGNATURES.md
@@ -161,3 +161,4 @@ public commit with a stated reason.
 - @mortee | 2026-09-04 | id:338540 | src:https://github.com/career-ops-hq/career-ops/discussions/3827 | n:113
 - @adityap | Aditya Poddar | 2026-09-07 | id:7117191 | src:https://github.com/career-ops-hq/career-ops/discussions/3970 | n:114
 - @cooldashing24 | Vishnu | 2026-09-07 | "May the Force be with us all" | id:4034728 | src:https://github.com/career-ops-hq/career-ops/discussions/3977 | n:115
+- @infosolutiondmdc | EnggNbs | 2026-09-08 | id:242919430 | src:https://github.com/career-ops-hq/career-ops/discussions/4021 | n:116

--- a/web/src/components/jobs/job-store.tsx
+++ b/web/src/components/jobs/job-store.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { scoreTone } from "@/lib/format";
-import { readSavedCliId, resolveCliId } from "@/lib/saved-cli";
+import { resolveCliId } from "@/lib/saved-cli";
 
 export type JobStep = { kind: "tool" | "status"; label: string; ts: number };
 export type JobResult = { score: number | null; summary: string; tone: "good" | "warn" | "bad" | "muted" };
@@ -109,7 +109,10 @@ export function JobsProvider({ children }: { children: React.ReactNode }) {
       setJobs((js) => [job, ...js]);
 
       (async () => {
-        const cliId = readSavedCliId() || (await resolveCliId());
+        // resolveCliId() validates the saved id against what is installed; a
+        // bare readSavedCliId() here would short-circuit that check and launch
+        // a run against an uninstalled CLI (#4012).
+        const cliId = await resolveCliId();
         if (!cliId) {
           patch(id, (j) => ({
             ...j,

--- a/web/src/lib/saved-cli.ts
+++ b/web/src/lib/saved-cli.ts
@@ -30,18 +30,33 @@ export function pickSoleInstalled(
   return installed.length === 1 ? installed[0].id : null;
 }
 
-/** Saved Config cliId, or the only installed CLI (and persist that pick). */
+/**
+ * Saved Config cliId if it is still installed, otherwise the only installed CLI
+ * (and persist that pick). Returns null when neither resolves — the caller then
+ * shows the "open Config" message rather than launching a run that 404s.
+ *
+ * The saved id is validated against /api/clis, not trusted blind: an install
+ * swapped from one CLI to another leaves a stale id in localStorage, and
+ * `resolveCli()` on the server returns null for it, so every run fails with
+ * `CLI '<id>' not found` until Config is reopened (#4012).
+ */
 export async function resolveCliId(): Promise<string | null> {
   const saved = readSavedCliId();
-  if (saved) return saved;
+  let clis: { id: string; installed?: boolean }[] | undefined;
   try {
     const r = await fetch("/api/clis");
     const d = (await r.json()) as { clis?: { id: string; installed?: boolean }[] };
-    const sole = pickSoleInstalled(d.clis);
-    if (!sole) return null;
-    persistCliId(sole);
-    return sole;
+    clis = d.clis;
   } catch {
-    return null;
+    // /api/clis unreachable — can't check. Trust the saved id rather than
+    // stranding a working setup on a transient fetch failure.
+    return saved;
   }
+  if (saved && (clis || []).some((c) => c.id === saved && c.installed)) {
+    return saved;
+  }
+  const sole = pickSoleInstalled(clis);
+  if (!sole) return null;
+  persistCliId(sole);
+  return sole;
 }

--- a/web/src/lib/saved-cli.ts
+++ b/web/src/lib/saved-cli.ts
@@ -45,14 +45,19 @@ export async function resolveCliId(): Promise<string | null> {
   let clis: { id: string; installed?: boolean }[] | undefined;
   try {
     const r = await fetch("/api/clis");
-    const d = (await r.json()) as { clis?: { id: string; installed?: boolean }[] };
-    clis = d.clis;
+    if (r.ok) {
+      const d = (await r.json()) as { clis?: { id: string; installed?: boolean }[] };
+      clis = d.clis;
+    }
   } catch {
-    // /api/clis unreachable — can't check. Trust the saved id rather than
-    // stranding a working setup on a transient fetch failure.
+    // network error — fall through to the not-an-array guard below
+  }
+  if (!Array.isArray(clis)) {
+    // /api/clis unreachable, errored, or malformed — can't check. Trust the
+    // saved id rather than stranding a working setup on a transient failure.
     return saved;
   }
-  if (saved && (clis || []).some((c) => c.id === saved && c.installed)) {
+  if (saved && clis.some((c) => c.id === saved && c.installed)) {
     return saved;
   }
   const sole = pickSoleInstalled(clis);

--- a/web/tests/lib/saved-cli-resolve.test.mjs
+++ b/web/tests/lib/saved-cli-resolve.test.mjs
@@ -17,7 +17,7 @@ const CONFIG_KEY = "career-ops:config";
 
 // Install fake localStorage + fetch and return the backing store so a test can
 // assert what got persisted.
-function stubEnv({ saved, clis, fetchThrows } = {}) {
+function stubEnv({ saved, clis, fetchThrows, httpError } = {}) {
   const store = new Map();
   if (saved !== undefined) {
     store.set(CONFIG_KEY, JSON.stringify({ mode: "cli", cliId: saved }));
@@ -30,7 +30,8 @@ function stubEnv({ saved, clis, fetchThrows } = {}) {
   globalThis.fetch = async (url) => {
     assert.equal(url, "/api/clis");
     if (fetchThrows) throw new Error("network down");
-    return { json: async () => ({ clis }) };
+    if (httpError) return { ok: false, status: 500, json: async () => ({ error: "boom" }) };
+    return { ok: true, status: 200, json: async () => ({ clis }) };
   };
   return store;
 }
@@ -88,5 +89,10 @@ test("no saved id still picks the sole installed CLI", async () => {
 
 test("an unreachable /api/clis trusts the saved id rather than stranding a working setup", async () => {
   stubEnv({ saved: "claude", fetchThrows: true });
+  assert.equal(await resolveCliId(), "claude");
+});
+
+test("a non-2xx /api/clis response trusts the saved id, not a null 'no CLI' verdict", async () => {
+  stubEnv({ saved: "claude", httpError: true });
   assert.equal(await resolveCliId(), "claude");
 });

--- a/web/tests/lib/saved-cli-resolve.test.mjs
+++ b/web/tests/lib/saved-cli-resolve.test.mjs
@@ -1,0 +1,92 @@
+// Executes the REAL resolveCliId() from saved-cli.ts. The module is client-safe
+// (localStorage + fetch, no node imports) and uses only strippable type syntax,
+// so node --test imports the .ts directly, the way explore-ai-dedup.test.mjs does.
+//
+// Covers #4012: a saved cliId that is no longer installed was returned
+// unchecked, so every run 404'd ("CLI '<id>' not found") with nothing on screen
+// connecting the failure to a stale setting.
+//
+// Run:  node --test tests/lib/saved-cli-resolve.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { resolveCliId } = await import("../../src/lib/saved-cli.ts");
+
+const CONFIG_KEY = "career-ops:config";
+
+// Install fake localStorage + fetch and return the backing store so a test can
+// assert what got persisted.
+function stubEnv({ saved, clis, fetchThrows } = {}) {
+  const store = new Map();
+  if (saved !== undefined) {
+    store.set(CONFIG_KEY, JSON.stringify({ mode: "cli", cliId: saved }));
+  }
+  globalThis.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  };
+  globalThis.fetch = async (url) => {
+    assert.equal(url, "/api/clis");
+    if (fetchThrows) throw new Error("network down");
+    return { json: async () => ({ clis }) };
+  };
+  return store;
+}
+
+const savedCliId = (store) => JSON.parse(store.get(CONFIG_KEY) || "{}").cliId;
+
+test("a saved id that is still installed is returned", async () => {
+  const store = stubEnv({
+    saved: "claude",
+    clis: [
+      { id: "claude", installed: true },
+      { id: "opencode", installed: false },
+    ],
+  });
+  assert.equal(await resolveCliId(), "claude");
+  assert.equal(savedCliId(store), "claude");
+});
+
+test("a saved id that is no longer installed falls through to the sole installed CLI and persists it", async () => {
+  const store = stubEnv({
+    saved: "opencode",
+    clis: [
+      { id: "claude", installed: true },
+      { id: "opencode", installed: false },
+    ],
+  });
+  assert.equal(await resolveCliId(), "claude");
+  assert.equal(savedCliId(store), "claude", "the stale pick should be replaced");
+});
+
+test("a saved id that is no longer installed, with no sole pick, resolves to null", async () => {
+  stubEnv({
+    saved: "opencode",
+    clis: [
+      { id: "claude", installed: true },
+      { id: "codex", installed: true },
+      { id: "opencode", installed: false },
+    ],
+  });
+  // null is what routes the caller to the existing "open Config" message
+  // instead of a 404 on every run.
+  assert.equal(await resolveCliId(), null);
+});
+
+test("no saved id still picks the sole installed CLI", async () => {
+  const store = stubEnv({
+    clis: [
+      { id: "claude", installed: false },
+      { id: "opencode", installed: true },
+    ],
+  });
+  assert.equal(await resolveCliId(), "opencode");
+  assert.equal(savedCliId(store), "opencode");
+});
+
+test("an unreachable /api/clis trusts the saved id rather than stranding a working setup", async () => {
+  stubEnv({ saved: "claude", fetchThrows: true });
+  assert.equal(await resolveCliId(), "claude");
+});


### PR DESCRIPTION
## What & why

`resolveCliId()` returned the `localStorage` `cliId` without checking it, and `job-store.tsx` short-circuited on `readSavedCliId()` before `resolveCliId()` was even reached. When an install is swapped from one CLI to another, the saved id goes stale: `resolveCli()` on the server returns `null` for it, so every run 404s with `CLI '<id>' not found` — which reads as an unrecognised id rather than a stale setting — and the UI offers no way out except knowing to reopen Config and pick again.

The asymmetry was the bug: `resolveCliId()` already knew about installed-ness and `/api/clis` already reports it, but that knowledge was applied only to the branch the function computes itself, never to the branch it trusts from `localStorage`.

## The fix

- `resolveCliId()` now fetches `/api/clis` and returns the saved id **only when that id is still installed**. Otherwise it falls through to the existing sole-installed pick (persisting it), or returns `null` so the caller surfaces its existing `No CLI configured — open Config and click Save config` message instead of launching a doomed run.
- A `/api/clis` fetch failure returns the saved id rather than stranding a working setup on a transient error.
- `job-store.tsx` calls `resolveCliId()` directly, so the validation can't be short-circuited.

## Tests

`web/tests/lib/saved-cli-resolve.test.mjs` executes the **real** `resolveCliId()` — `node --test` imports the `.ts` directly, the way `explore-ai-dedup.test.mjs` does — covering: saved-and-installed, saved-but-uninstalled with a sole fallback, saved-but-uninstalled with no fallback (→ `null`), no-saved-id, and an unreachable `/api/clis`. The two stale-id cases were verified failing before the change.

- `npm test` (web) → 507 pass, 1 skipped (pre-existing)
- `npx tsc --noEmit` → clean
- `npm run build` → clean

Closes #4012


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can continue runs after changing or uninstalling a CLI.

- `web/src/lib/saved-cli.ts:54-77`: Validates the saved `cliId` against `/api/clis`.
- `web/src/lib/saved-cli.ts:74-77`: Selects and saves the sole installed CLI when the saved CLI is stale.
- `web/src/lib/saved-cli.ts:66-69`: Preserves the saved ID when the check fails or returns malformed data.
- `web/src/components/jobs/job-store.tsx:111-123`: Uses `resolveCliId()` directly and shows the existing Config guidance when no CLI is available.
- `web/tests/lib/saved-cli-resolve.test.mjs:41-108`: Covers installed, stale, missing, fallback, malformed-data, and fetch-failure cases.
- `web/package.json:13-15`: Requires Node.js `>=22.18.0`.

Without this change, runs could repeatedly fail with `CLI '<id>' not found` after the selected CLI was uninstalled.

The system files `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are present but were not changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->