### PR TITLE
Add JSON output support for set-status, with tests  issue #3855

### DIFF
--- a/set-status.mjs
+++ b/set-status.mjs
@@ -235,7 +235,9 @@ const failWith = makeCliFailWith(flags.json);
 function failUsage(message) {
   const msg = message ?? 'Expected 2 arguments: <report#|company> <state>';
   if (rawArgs.includes('--json')) {
+     // JSON must be the last thing written to stdout; machine callers parse stdout as one JSON document.
     console.log(JSON.stringify({ error: msg, code: 'usage' }));
+    // consol.log("end")  # simulate failure case
     console.error(`❌ ${msg}`);
   } else {
     if (message) console.error(`❌ ${message}\n`);
@@ -649,7 +651,11 @@ const result = {
 };
 
 if (flags.json) {
+  // JSON must be the last thing written to stdout; machine callers parse stdout as one JSON document.
   console.log(JSON.stringify(result, null, 2));
+  //console.log("done")  //simulate failure case
+  //console.log("      ")     whitespace test case
+  //console.log("      ")     new line test case
 } else {
   const verb = flags.dryRun ? 'would set' : changed ? 'set' : 'already';
   console.log(`✅ #${target.num} ${target.company} — ${target.role}: ${verb} ${oldStatus} → ${newStatus}${note ? ` (note: ${note})` : ''}`);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -237,7 +237,6 @@ function failUsage(message) {
   if (rawArgs.includes('--json')) {
      // JSON must be the last thing written to stdout; machine callers parse stdout as one JSON document.
     console.log(JSON.stringify({ error: msg, code: 'usage' }));
-    // consol.log("end")  # simulate failure case
     console.error(`❌ ${msg}`);
   } else {
     if (message) console.error(`❌ ${message}\n`);
@@ -653,9 +652,6 @@ const result = {
 if (flags.json) {
   // JSON must be the last thing written to stdout; machine callers parse stdout as one JSON document.
   console.log(JSON.stringify(result, null, 2));
-  //console.log("done")  //simulate failure case
-  //console.log("      ")     whitespace test case
-  //console.log("      ")     new line test case
 } else {
   const verb = flags.dryRun ? 'would set' : changed ? 'set' : 'already';
   console.log(`✅ #${target.num} ${target.company} — ${target.role}: ${verb} ${oldStatus} → ${newStatus}${note ? ` (note: ${note})` : ''}`);

--- a/tests/set-status-json-output.test.mjs
+++ b/tests/set-status-json-output.test.mjs
@@ -1,0 +1,159 @@
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nset-status.mjs — JSON result must be the final stdout output #3855');
+
+const work = mkdtempSync(join(tmpdir(), 'cops-set-status-'));
+const tracker = join(work, 'data', 'applications.md');
+
+function parseFinalJson(stdout, label) {
+  try {
+    const result = JSON.parse(stdout);
+
+    // JSON.parse() already rejects any non-whitespace after the JSON document.
+    // This additionally makes the "closing brace + optional whitespace" rule explicit.
+    if (!/}\s*$/.test(stdout)) {
+      fail(`${label} JSON is not the final stdout output`);
+      return null;
+    }
+
+    pass(`${label} JSON is the final stdout output`);
+    return result;
+  } catch {
+    fail(`${label} stdout is not one JSON document: ${JSON.stringify(stdout)}`);
+    return null;
+  }
+}
+
+try {
+  mkdirSync(join(work, 'data'), { recursive: true });
+
+  writeFileSync(
+    tracker,
+    [
+      '# Applications Tracker',
+      '',
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+      '|---|------|---------|------|-------|--------|-----|--------|-------|',
+      '| 1 | 2026-09-08 | Acme | Python Developer | 4.5/5 | Evaluated | — | — | — |',
+      '',
+    ].join('\n'),
+  );
+
+  const env = {
+    ...process.env,
+    CAREER_OPS_ROOT: work,
+    CAREER_OPS_TRACKER: tracker,
+  };
+
+  // SUCCESS CASE
+
+  const success = spawnSync(
+    NODE,
+    [
+      join(ROOT, 'set-status.mjs'),
+      '--row',
+      '1',
+      'Interview',
+      '--json',
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env,
+    },
+  );
+
+  const successStdout = success.stdout || '';
+
+  if (success.status === 0) {
+    pass('successful set-status command exits 0');
+  } else {
+    fail(
+      `successful set-status command should exit 0, got ${success.status}: ` +
+      JSON.stringify(successStdout),
+    );
+  }
+
+  const successResult = parseFinalJson(successStdout, 'success');
+
+  if (
+    successResult &&
+    successResult.changed === true &&
+    successResult.newStatus === 'Interview'
+  ) {
+    pass('success stdout contains the expected JSON result');
+  } else if (successResult) {
+    fail(`unexpected success JSON: ${JSON.stringify(successResult)}`);
+  }
+
+  const trackerAfterSuccess = readFileSync(tracker, 'utf-8');
+
+  if (
+    trackerAfterSuccess.includes(
+      '| 1 | 2026-09-08 | Acme | Python Developer | 4.5/5 | Interview |',
+    )
+  ) {
+    pass('success case actually updates applications.md');
+  } else {
+    fail('success case did not update applications.md to Interview');
+  }
+
+  if (existsSync(join(work, 'data', 'status-log.tsv'))) {
+    pass('success case writes status-log.tsv');
+  } else {
+    fail('success case did not create status-log.tsv');
+  }
+
+  // FAILURE CASE
+
+  const failure = spawnSync(
+    NODE,
+    [
+      join(ROOT, 'set-status.mjs'),
+      '--row',
+      '1',
+      'NotARealStatus',
+      '--json',
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env,
+    },
+  );
+
+  const failureStdout = failure.stdout || '';
+
+  if (failure.status !== 0) {
+    pass('failed set-status command exits non-zero');
+  } else {
+    fail('failed set-status command should exit non-zero');
+  }
+
+  const failureResult = parseFinalJson(failureStdout, 'failure');
+
+  if (
+    failureResult &&
+    failureResult.error &&
+    failureResult.code === 'invalid-state'
+  ) {
+    pass('failure stdout contains the expected JSON error');
+  } else if (failureResult) {
+    fail(`unexpected failure JSON: ${JSON.stringify(failureResult)}`);
+  }
+
+} finally {
+  console.log(`Temporary test directory: ${work}`);
+  // rmSync(work, { recursive: true, force: true });    uncomment it for auto cleanup of files
+}

--- a/tests/set-status-json-output.test.mjs
+++ b/tests/set-status-json-output.test.mjs
@@ -154,6 +154,5 @@ try {
   }
 
 } finally {
-  console.log(`Temporary test directory: ${work}`);
-  // rmSync(work, { recursive: true, force: true });    uncomment it for auto cleanup of files
+  rmSync(work, { recursive: true, force: true });
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds regression test cases for issue #3855 to verify the set-status.mjs JSON stdout contract.

The tests verify that when --json is used:

    The successful command returns a valid JSON document on stdout.
    The failed command returns a valid JSON error on stdout.
    The JSON document is the final content written to stdout.
    Whitespace, tabs, and newlines after the JSON are allowed.
    Any non-whitespace output after the JSON causes the test to fail.
    The success case updates applications.md and creates status-log.tsv.

These tests ensure that future output such as console.log("done") after the JSON result cannot be introduced without the regression test catching it.

## Related issue

Fixes #3855

## Type of change

Regression tests for existing behavior

Add Test cases for issue #3855

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds regression coverage for the `set-status.mjs --json` stdout contract.

## User impact

The JSON result must be the final stdout content. Extra output can make the web client report an error after a status update succeeds.

## Changes

: Adds success and failure integration tests in `tests/set-status-json-output.test.mjs`.
: Verifies JSON fields, exit codes, tracker updates, `status-log.tsv` creation, and trailing-output rules.
: Documents the contract near `set-status.mjs:238` and `set-status.mjs:652`.
: Preserves existing `set-status.mjs` behavior.

## System files touched

Not touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->