### PR TITLE
fix(web): read external data without redirecting core scripts

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -19,8 +19,10 @@ npm ci
 npm run dev
 ```
 
-Open http://localhost:3000. The app reads the career-ops checkout it lives in
-(the parent directory) — your existing CV, pipeline and reports appear as-is.
+Open http://localhost:3000. The app reads the same Data Root as the CLI — your
+existing CV, pipeline and reports appear as-is. By default this is the parent
+checkout; `CAREER_OPS_DATA_DIR` or its `.career-ops-data` marker can select a
+separate directory for user files.
 
 ## What works today
 
@@ -61,8 +63,24 @@ npx tsc --noEmit     # typecheck
 npm run build        # production build
 ```
 
-Set `CAREER_OPS_ROOT=/path/to/checkout` in `web/.env.local` to point the app at
-a different career-ops directory (useful for testing against sample data).
+Workspace settings can be placed in `web/.env.local`:
+
+- `CAREER_OPS_ROOT=/path/to/checkout` preserves the web's existing behavior:
+  select another checkout for both user files and core scripts.
+- Otherwise, `CAREER_OPS_DATA_DIR=/path/to/data` selects user files while core
+  scripts, templates and modes stay in the checkout hosting `web/`.
+- With neither variable set, `.career-ops-data` in the hosting checkout selects
+  the user directory. An empty or absent marker uses the checkout itself.
+
+Relative paths are resolved from the hosting checkout, not `web/`.
+`CAREER_OPS_ROOT` takes precedence over `CAREER_OPS_DATA_DIR` and the marker.
+An unreadable marker is an error; the web does not silently switch workspaces.
+
+Separate user directories work for viewing and configuration. AI evaluation,
+CV/PDF generation and portal repair still require a complete selected workspace
+with user files and core together: their prompts and renderer use one working
+directory. The existing run guard reports a missing mode or script before
+starting the agent.
 
 `/api` is gated by the same-origin + loopback guard in `src/lib/origin-guard.mjs`.
 Two opt-ins widen it, both unset by default and both in `web/.env.local`:

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -1,6 +1,6 @@
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import { resolveCli } from "@/lib/clis";
-import { careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, readMemory, doctorState } from "@/lib/career-ops";
 
 export const runtime = "nodejs"; // child_process (spawn) requires the Node runtime
 export const dynamic = "force-dynamic";
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
       ]
     : spec.args(prompt);
 
-  const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+  const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: careerOpsEnv() });
 
   const encoder = new TextEncoder();
   // `closed` + kill timer in the OUTER scope so cancel() can flip `closed` before

--- a/web/src/app/api/cv/ingest/route.ts
+++ b/web/src/app/api/cv/ingest/route.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { resolveCli } from "@/lib/clis";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsCodeRoot, careerOpsRoot } from "@/lib/career-ops";
 
 // Parse a CV (pasted text or an uploaded PDF) into clean cv.md markdown by running
 // the USER'S OWN CLI headless — the web never ships a heavyweight parser, and the
@@ -19,7 +19,7 @@ export const maxDuration = 300;
 // (exactly how the explore route handles a missing discover.md).
 function readCanonicalMode(): string | null {
   try {
-    return fs.readFileSync(path.join(careerOpsRoot(), "modes", "cv-ingest.md"), "utf8");
+    return fs.readFileSync(path.join(careerOpsCodeRoot(), "modes", "cv-ingest.md"), "utf8");
   } catch {
     return null;
   }
@@ -119,7 +119,7 @@ export async function POST(req: Request) {
 
   let child;
   try {
-    child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+    child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: careerOpsEnv() });
   } catch (e) {
     if (tempFile) cleanupTemp(tempFile); // never leak the CV temp if spawn throws sync
     return Response.json({ error: e instanceof Error ? e.message : "failed to start the CLI" }, { status: 500 });

--- a/web/src/app/api/doctor/route.ts
+++ b/web/src/app/api/doctor/route.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, rootScript } from "@/lib/career-ops";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -15,7 +15,7 @@ export async function GET() {
     return Response.json({ available: false, onboardingNeeded: false, missing: [], warnings: [] });
   }
   const stdout = await new Promise<string>((resolve) => {
-    execFile("node", [doctor, "--json"], { cwd: root, timeout: 10_000 }, (_err, out) => resolve(out || ""));
+    execFile("node", [doctor, "--json"], { cwd: root, env: careerOpsEnv(), timeout: 10_000 }, (_err, out) => resolve(out || ""));
   });
   try {
     const last = stdout.trim().split("\n").pop() || "{}";

--- a/web/src/app/api/explore/ai/route.ts
+++ b/web/src/app/api/explore/ai/route.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { resolveCli } from "@/lib/clis";
-import { careerOpsRoot, readMemory } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsCodeRoot, careerOpsRoot, readMemory } from "@/lib/career-ops";
 import { assembleDedupContext } from "@/lib/core/discover";
 
 // AI search orchestrates modes/discover.md by running the USER'S configured CLI
@@ -149,7 +149,7 @@ export async function POST(req: Request) {
   // homegrown prompt. Missing (older core) → graceful 400 so the Scan tab stays usable.
   let mode: string;
   try {
-    mode = fs.readFileSync(path.join(careerOpsRoot(), "modes", "discover.md"), "utf8");
+    mode = fs.readFileSync(path.join(careerOpsCodeRoot(), "modes", "discover.md"), "utf8");
   } catch {
     return Response.json({ code: "MODE_MISSING", error: "AI search needs a newer career-ops — update to enable it." }, { status: 400 });
   }
@@ -242,7 +242,7 @@ export async function POST(req: Request) {
 
   const child = spawnHeadlessCli(binPath, args, {
     cwd: childCwd,
-    env: process.env,
+    env: careerOpsEnv(),
     detached: useCodexProcessGroup,
   });
 

--- a/web/src/app/api/followups/cadence/route.ts
+++ b/web/src/app/api/followups/cadence/route.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsCodeRoot, careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
 import { PROFILE_CADENCE_KEYS, type ProfileCadenceKey } from "@/lib/followups";
 
@@ -39,7 +39,7 @@ async function readCoreDefaults(): Promise<Partial<Record<ProfileCadenceKey, num
   const script = rootScript("followup-cadence");
   if (!fs.existsSync(script)) return null;
   const stdout = await new Promise<string>((resolve) => {
-    execFile("node", [script, "--json"], { cwd: careerOpsRoot(), timeout: 12_000 }, (_e, out) => resolve(out || ""));
+    execFile("node", [script, "--json"], { cwd: careerOpsRoot(), env: careerOpsEnv(), timeout: 12_000 }, (_e, out) => resolve(out || ""));
   });
   try {
     const start = stdout.indexOf("{");
@@ -115,7 +115,7 @@ export async function POST(req: Request) {
   if (!fs.existsSync(file)) {
     // First create: seed from the example so we never leave a cadence-only profile.
     try {
-      const seeded = yaml.load(fs.readFileSync(path.join(root, "config", "profile.example.yml"), "utf8"));
+      const seeded = yaml.load(fs.readFileSync(path.join(careerOpsCodeRoot(), "config", "profile.example.yml"), "utf8"));
       base = isObj(seeded) ? seeded : {};
     } catch {
       base = {};

--- a/web/src/app/api/followups/log/route.ts
+++ b/web/src/app/api/followups/log/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
 
   const file = followupsLogPath();
   try {
-    return await withFollowupsWrite(() => {
+    return await withFollowupsWrite(file, () => {
       fs.mkdirSync(path.dirname(file), { recursive: true });
       let existing = "";
       if (fs.existsSync(file)) existing = fs.readFileSync(file, "utf8");
@@ -121,7 +121,7 @@ export async function DELETE(req: Request) {
   const file = followupsLogPath();
   if (!fs.existsSync(file)) return Response.json({ error: "no follow-up log" }, { status: 404 });
   try {
-    return await withFollowupsWrite(() => {
+    return await withFollowupsWrite(file, () => {
       const lines = fs.readFileSync(file, "utf8").split("\n");
       const idx = lines.findIndex((line) => {
         if (!line.startsWith("|")) return false;

--- a/web/src/app/api/followups/override/route.ts
+++ b/web/src/app/api/followups/override/route.ts
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
 
   const file = followupsLogPath();
   try {
-    return await withFollowupsWrite(() => {
+    return await withFollowupsWrite(file, () => {
       fs.mkdirSync(path.dirname(file), { recursive: true });
       let existing = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "# Follow-ups\n\n";
       // Supersede: drop any previous pin lines for this application (the parser
@@ -67,7 +67,7 @@ export async function DELETE(req: Request) {
   const file = followupsLogPath();
   if (!fs.existsSync(file)) return Response.json({ error: "no follow-up log" }, { status: 404 });
   try {
-    return await withFollowupsWrite(() => {
+    return await withFollowupsWrite(file, () => {
       const lines = fs.readFileSync(file, "utf8").split("\n");
       const kept = lines.filter((line) => !pinRe(appNum).test(line));
       if (kept.length === lines.length) {

--- a/web/src/app/api/followups/route.ts
+++ b/web/src/app/api/followups/route.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { selectDueFollowups, pickNextUpcoming } from "@/lib/core/followup-view.mjs";
 
 export const runtime = "nodejs";
@@ -16,7 +16,7 @@ export async function GET(req: Request) {
   const script = rootScript("followup-cadence");
   if (!fs.existsSync(script)) return Response.json({ available: false, metadata: null, entries: [], nextUpcoming: null });
   const stdout = await new Promise<string>((resolve) => {
-    execFile("node", [script, "--json"], { cwd: careerOpsRoot(), timeout: 12_000 }, (err, out) => resolve(err ? "" : out || ""));
+    execFile("node", [script, "--json"], { cwd: careerOpsRoot(), env: careerOpsEnv(), timeout: 12_000 }, (err, out) => resolve(err ? "" : out || ""));
   });
   try {
     const start = stdout.indexOf("{");

--- a/web/src/app/api/portals/route.ts
+++ b/web/src/app/api/portals/route.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import * as yaml from "js-yaml";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsCodeRoot, careerOpsRoot } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
 import { loadPortalsDocument, mergePortalFilters, PortalsConfigError } from "@/lib/portals-config.mjs";
 
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
   const file = path.join(root, "portals.yml");
   let doc: Record<string, unknown>;
   try {
-    ({ doc } = loadPortalsDocument(file, path.join(root, "templates", "portals.example.yml")));
+    ({ doc } = loadPortalsDocument(file, path.join(careerOpsCodeRoot(), "templates", "portals.example.yml")));
   } catch (error) {
     const invalidUserConfig = error instanceof PortalsConfigError && error.kind === "invalid-user-config";
     return Response.json(

--- a/web/src/app/api/portals/verify/route.ts
+++ b/web/src/app/api/portals/verify/route.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, rootScript } from "@/lib/career-ops";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,7 +32,7 @@ export async function GET() {
     execFile(
       "node",
       [verifyPortals],
-      { cwd: root, timeout: 110_000, maxBuffer: 4 * 1024 * 1024 },
+      { cwd: root, env: careerOpsEnv(), timeout: 110_000, maxBuffer: 4 * 1024 * 1024 },
       (_e, out, err) => resolve((out || "") + (err || "")),
     );
   });

--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsCodeRoot, careerOpsRoot } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
 
 export const runtime = "nodejs";
@@ -74,7 +74,7 @@ export async function POST(req: Request) {
   // malformed" (NEVER overwrite — that would silently destroy the user's data).
   if (!fs.existsSync(file)) {
     try {
-      base = (yaml.load(fs.readFileSync(path.join(root, "config", "profile.example.yml"), "utf8")) as Record<string, unknown>) || {};
+      base = (yaml.load(fs.readFileSync(path.join(careerOpsCodeRoot(), "config", "profile.example.yml"), "utf8")) as Record<string, unknown>) || {};
       seeded = Object.keys(base).length > 0;
     } catch {
       base = {};

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr, killMsForKind, timeoutMessage } from "@/lib/run-cli-support.mjs";
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
-import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates, readLanguageConfig } from "@/lib/career-ops";
+import { careerOpsEnv, readMemory, findReportFile, readInbox, readScanDates, readLanguageConfig } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf, writeCvHtml, pdfRunOutcome } from "@/lib/pdf-render.mjs";
 import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
@@ -39,24 +39,29 @@ export async function POST(req: Request) {
     });
   }
   const { spec, binPath } = resolved;
+  // A marker may change while the agent runs. Keep paths, children and the
+  // eventual tracker update on the workspace selected for this request.
+  const env = careerOpsEnv();
+  const root = env.CAREER_OPS_ROOT;
 
   // These run the REAL core (modes/scripts), not just data — fail clearly if the
-  // root is incomplete instead of faking it.
+  // selected data workspace is incomplete instead of faking it. These prompts
+  // and the PDF renderer still need data and core together in one cwd.
   // The precondition must check the file the prompt will actually read. Pinning
   // it to modes/oferta.md meant a configured market passed a check on a file the
   // run never opens, and would have missed a market dir with no evaluation mode.
   const lang = readLanguageConfig();
   const needsScript: Record<string, string> = { evaluate: lang.evalModeFile, "fix-portal": "verify-portals.mjs", pdf: "generate-pdf.mjs" };
   const required = needsScript[kind];
-  // CAREER_OPS_ROOT is runtime user data, not a build input. Tracing this
+  // The selected Data Root is runtime user data, not a build input. Tracing this
   // dynamic path would copy the whole web project into every server bundle.
   const requiredPath = required
-    ? path.join(/* turbopackIgnore: true */ careerOpsRoot(), required)
+    ? path.join(/* turbopackIgnore: true */ root, required)
     : "";
   if (required && !fs.existsSync(/* turbopackIgnore: true */ requiredPath)) {
     return new Response(
       JSON.stringify({
-        error: `This needs a complete career-ops checkout (${required}). CAREER_OPS_ROOT has data only — point it at a full checkout.`,
+        error: `This AI run needs a complete career-ops checkout. The selected data workspace is missing ${required}; keep user files and core together to run it.`,
       }),
       { status: 400, headers: { "Content-Type": "application/json" } },
     );
@@ -75,7 +80,7 @@ export async function POST(req: Request) {
 
   // An A–F score is meaningless without a CV to score against — the CLI would
   // hallucinate a fit narrative and still emit a VERDICT. Require cv.md first.
-  if ((kind === "evaluate" || kind === "pdf") && !fs.existsSync(path.join(careerOpsRoot(), "cv.md"))) {
+  if ((kind === "evaluate" || kind === "pdf") && !fs.existsSync(path.join(root, "cv.md"))) {
     return new Response(
       JSON.stringify({ error: "Add your CV first so I can score this against you — drop it on the home page." }),
       { status: 400, headers: { "Content-Type": "application/json" } },
@@ -91,7 +96,7 @@ export async function POST(req: Request) {
   // no longer told these paths, so a stale file cannot survive into a render.
   let pdfPaths: PdfPaths | undefined;
   if (kind === "pdf") {
-    const pathsResult = resolvePdfPaths(input, today, careerOpsRoot(), findReportFile);
+    const pathsResult = resolvePdfPaths(input, today, root, findReportFile);
     if (!pathsResult.ok) {
       return new Response(JSON.stringify({ error: pathsResult.error }), {
         status: 400,
@@ -134,7 +139,7 @@ export async function POST(req: Request) {
   // Names, not a count: reserving a number writes reports/NNN-RESERVED.md and the
   // final report REPLACES it, so the `.md` count is unchanged and a count-delta
   // gate reported "didn't save a report" for an evaluation that saved fine (#2085).
-  const reportsDir = path.join(careerOpsRoot(), "reports");
+  const reportsDir = path.join(root, "reports");
   const reportEntries = () => {
     try {
       return fs.readdirSync(reportsDir);
@@ -156,7 +161,7 @@ export async function POST(req: Request) {
   // every CLI-invoking route (assistant, explore/ai, cv/ingest, the apply planners),
   // which had the identical bug, and puts it behind one tested helper so it cannot
   // drift back in on any single call site.
-  const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+  const child = spawnHeadlessCli(binPath, args, { cwd: root, env });
   // Decode once on the stream, not per chunk. Buffer#toString() decodes each chunk
   // independently, so a chunk boundary falling inside a multi-byte UTF-8 sequence
   // yields a replacement character and mis-decodes the bytes after it. Those bytes
@@ -381,7 +386,8 @@ export async function POST(req: Request) {
           const result = await renderAndMarkPdf({
             spawnFn: spawn,
             execPath: process.execPath,
-            root: careerOpsRoot(),
+            root: root,
+            env,
             pdfPaths: paths,
             format,
             reportNum: input,

--- a/web/src/app/api/status/route.ts
+++ b/web/src/app/api/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { execFile } from "node:child_process";
 import fs from "node:fs";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { canonicalizeStatus } from "@/lib/core/states";
 import { parseCliJson, trackerRowArg, clientErrorMessage } from "@/lib/status-cli.mjs";
 
@@ -76,7 +76,7 @@ function runSetStatus(args: string[]): Promise<CliResult> {
       {
         cwd: careerOpsRoot(),
         timeout: SET_STATUS_TIMEOUT_MS,
-        env: { ...process.env, ...boundedLockWait() },
+        env: { ...careerOpsEnv(), ...boundedLockWait() },
       },
       (err, stdout, stderr) => {
         // execFile reports three different things through one error object: a

--- a/web/src/app/api/tracker/delete/route.ts
+++ b/web/src/app/api/tracker/delete/route.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { careerOpsRoot, rootScript, trackerCanDelete } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, rootScript, trackerCanDelete } from "@/lib/career-ops";
 import { isTrackerWriting } from "@/lib/core/run-registry";
 
 export const runtime = "nodejs";
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
       let err = "";
       let child;
       try {
-        child = spawn(process.execPath, args, { cwd: careerOpsRoot(), env: process.env });
+        child = spawn(process.execPath, args, { cwd: careerOpsRoot(), env: careerOpsEnv() });
       } catch (e) {
         resolve({ code: 1, err: e instanceof Error ? e.message : "failed to start tracker.mjs" });
         return;

--- a/web/src/lib/apply/agent-interpret.ts
+++ b/web/src/lib/apply/agent-interpret.ts
@@ -1,7 +1,7 @@
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import type { Frame } from "playwright-core";
 import { resolveCli } from "@/lib/clis";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot } from "@/lib/career-ops";
 import type { ApplyField } from "./extract";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -82,7 +82,7 @@ Return ONLY a JSON array, no prose, no code fence:
 function runPlanner(binPath: string, isClaude: boolean, argsFor: (p: string) => string[], prompt: string): Promise<string> {
   const args = isClaude ? ["-p", prompt, "--permission-mode", "acceptEdits", "--strict-mcp-config", "--allowedTools", "Read", "--disallowedTools", "Bash,Write,Edit,NotebookEdit,Task,WebFetch,WebSearch"] : argsFor(prompt);
   return new Promise((resolve) => {
-    const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+    const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: careerOpsEnv() });
     let buf = "";
     child.stdout.on("data", (d: Buffer) => (buf += d.toString()));
     child.stderr.on("data", () => {});

--- a/web/src/lib/apply/drive.ts
+++ b/web/src/lib/apply/drive.ts
@@ -1,7 +1,7 @@
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import type { Page, Frame } from "playwright-core";
 import { resolveCli } from "@/lib/clis";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot } from "@/lib/career-ops";
 import { dropNewTabs } from "./diagnose";
 import type { DriveStep } from "./issue";
 
@@ -59,7 +59,7 @@ function plannerTurn(binPath: string, prompt: string, resumeId: string | null): 
   const base = resumeId ? ["-p", "--resume", resumeId, prompt] : ["-p", prompt];
   const args = [...base, "--output-format", "json", "--strict-mcp-config", "--disallowedTools", "Bash,Read,Write,Edit,NotebookEdit,Task,WebFetch,WebSearch,Glob,Grep"];
   return new Promise((resolve) => {
-    const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+    const child = spawnHeadlessCli(binPath, args, { cwd: careerOpsRoot(), env: careerOpsEnv() });
     let buf = "";
     child.stdout.on("data", (d: Buffer) => (buf += d.toString()));
     child.stderr.on("data", () => {});

--- a/web/src/lib/apply/planner.ts
+++ b/web/src/lib/apply/planner.ts
@@ -1,5 +1,6 @@
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
 import type { CliSpec } from "@/lib/clis";
+import { careerOpsEnv } from "@/lib/career-ops";
 
 /**
  * planner.ts - spawn the read-only planner CLI and collect what it wrote.
@@ -63,7 +64,7 @@ export function runPlanner(opts: {
   return new Promise<PlannerRun>((resolve) => {
     // spawnHeadlessCli closes stdin right after spawning, so the CLI doesn't
     // wait on piped input that will never arrive.
-    const child = spawnHeadlessCli(binPath, args, { cwd, env: process.env });
+    const child = spawnHeadlessCli(binPath, args, { cwd, env: careerOpsEnv() });
     let buf = "";
     let firstByteAt = 0;
     const hb = setInterval(() => {

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import * as yaml from "js-yaml";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { parseApplications } from "@/lib/tracker-table.mjs";
+import { resolveWorkspacePaths } from "@/lib/workspace-paths.mjs";
 // One definition of the `{n}-RESERVED.md` convention, shared with
 // run-cli-support.mjs — see report-files.mjs for why it lives there.
 import { isReservedReportFile } from "@/lib/report-files.mjs";
@@ -12,17 +13,28 @@ import { resolvePdfIndexPath } from "@/lib/core/pdf-index";
 // index row belong to" (#2599, #2008 review).
 import { pdfIndexEntryForReport } from "@/lib/apply/cv-selection.mjs";
 
-/**
- * Resolve the career-ops "home" — the directory holding the user's sibling
- * files (cv.md, data/, reports/). In production the web/ app lives inside the
- * career-ops checkout, so the home is its parent (..). Dev overrides via
- * CAREER_OPS_ROOT to read the user's real (gitignored) data from a separate
- * checkout — see web/.env.local.
- */
+/** User files (cv.md, data/, reports/), using the core's Data Root precedence. */
 export function careerOpsRoot(): string {
-  const env = process.env.CAREER_OPS_ROOT?.trim();
-  if (env) return env;
-  return path.resolve(process.cwd(), "..");
+  return resolveWorkspacePaths().dataRoot;
+}
+
+/** Runtime core checkout; a separate Data Root never supplies executable code. */
+export function careerOpsCodeRoot(): string {
+  return resolveWorkspacePaths().codeRoot;
+}
+
+/** Keep child processes on the same absolute Data Root after changing cwd or
+ *  loading a core from another checkout. Preserve all other explicit overrides. */
+export function careerOpsEnv(): NodeJS.ProcessEnv & { CAREER_OPS_ROOT: string } {
+  const { codeRoot, dataRoot } = resolveWorkspacePaths();
+  const env: NodeJS.ProcessEnv & { CAREER_OPS_ROOT: string } = { ...process.env, CAREER_OPS_ROOT: dataRoot };
+  // Older core writers resolve their default tracker from the script directory.
+  // Pin them to the same canonical file readApplications() displays, or a status
+  // change could update a different workspace's row with the same number.
+  if (codeRoot !== dataRoot && !env.CAREER_OPS_TRACKER?.trim()) {
+    env.CAREER_OPS_TRACKER = path.join(dataRoot, "data", "applications.md");
+  }
+  return env;
 }
 
 /**
@@ -34,7 +46,7 @@ export function careerOpsRoot(): string {
 export function rootScript(nameNoExt: string): string {
   // The core checkout is selected at runtime and must not be bundled into the
   // web server output when Turbopack sees this dynamic script path.
-  return path.join(/* turbopackIgnore: true */ careerOpsRoot(), `${nameNoExt}.mjs`);
+  return path.join(/* turbopackIgnore: true */ careerOpsCodeRoot(), `${nameNoExt}.mjs`);
 }
 
 // Feature-detect the core's `tracker.mjs delete --num` row-delete (#1200) by probing
@@ -49,8 +61,9 @@ export function trackerCanDelete(): boolean {
 }
 
 function read(rel: string): string | null {
+  const root = careerOpsRoot();
   try {
-    return fs.readFileSync(path.join(careerOpsRoot(), rel), "utf8");
+    return fs.readFileSync(path.join(root, rel), "utf8");
   } catch {
     return null;
   }
@@ -155,7 +168,7 @@ export type Application = {
 export function readApplications(): Application[] {
   const md = read("data/applications.md");
   if (!md) return [];
-  return parseApplications(md, careerOpsRoot());
+  return parseApplications(md, careerOpsCodeRoot());
 }
 
 /** Resolve the report-number cell in data/pdf-index.tsv for a given report id.
@@ -254,9 +267,10 @@ export function doctorState(): {
   hasCv: boolean;
   hasData: boolean;
 } {
+  const root = careerOpsRoot();
   const has = (rel: string) => {
     try {
-      return fs.existsSync(path.join(careerOpsRoot(), rel));
+      return fs.existsSync(path.join(root, rel));
     } catch {
       return false;
     }
@@ -392,8 +406,10 @@ const NOTES_END = "<!-- co-web-notes:end -->";
  *  focused — the agent reads the rest of the canonical files itself). Falls back
  *  to the legacy web-only memory file for back-compat. */
 export function readMemory(): string {
+  const file = profilePath();
+  const legacyFile = path.join(careerOpsRoot(), ".career-ops-web", "memory.md");
   try {
-    const md = fs.readFileSync(profilePath(), "utf8");
+    const md = fs.readFileSync(file, "utf8");
     const i = md.indexOf(NOTES_START);
     const j = md.indexOf(NOTES_END);
     if (i !== -1 && j !== -1 && j > i) return md.slice(i + NOTES_START.length, j).trim();
@@ -401,7 +417,7 @@ export function readMemory(): string {
     /* no _profile.md yet */
   }
   try {
-    return fs.readFileSync(path.join(careerOpsRoot(), ".career-ops-web", "memory.md"), "utf8").trim();
+    return fs.readFileSync(legacyFile, "utf8").trim();
   } catch {
     return "";
   }
@@ -534,5 +550,5 @@ export function readLanguageConfig(): LanguageConfig {
   } catch {
     /* no profile yet, or malformed — defaults are correct */
   }
-  return { output, modesDir, evalModeFile: resolveEvalModeFile(root, modesDir) };
+  return { output, modesDir, evalModeFile: resolveEvalModeFile(careerOpsCodeRoot(), modesDir) };
 }

--- a/web/src/lib/core/followups-lock.ts
+++ b/web/src/lib/core/followups-lock.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsCodeRoot } from "@/lib/career-ops";
 
 /**
  * ACL for the core's follow-ups file lock (`followup-seed.mjs`).
@@ -47,12 +47,11 @@ type CoreWithFollowupsLock = (
  *  newly-installed checkout is picked up on the next request. */
 const modCache = new Map<string, CoreWithFollowupsLock>();
 
-/** Resolve the core export, or null when this root has data but no scripts.
- *  A data-only root cannot host the seeder either, so there is nothing to
- *  exclude cross-process and the in-process queue alone is correct — see
- *  `withFollowupsLock` below. */
+/** Resolve the lock from the selected core, even when user files live elsewhere.
+ *  Retain the legacy data-only CAREER_OPS_ROOT fallback when that selected
+ *  checkout has no seeder. */
 async function loadCoreLock(): Promise<CoreWithFollowupsLock | null> {
-  const file = path.join(careerOpsRoot(), "followup-seed.mjs");
+  const file = path.join(careerOpsCodeRoot(), "followup-seed.mjs");
   const cached = modCache.get(file);
   if (cached) return cached;
   if (!fs.existsSync(file)) return null;
@@ -76,7 +75,7 @@ export class FollowupsBusyError extends Error {
 /**
  * Run `fn` holding the core's follow-ups lock, releasing it on EVERY path.
  *
- * When the core scripts are absent (data-only root), runs `fn` with no file
+ * When the selected core has no seeder (legacy data-only CAREER_OPS_ROOT), runs `fn` with no file
  * lock: without the core there is no seeder to race, and `withLogLock` still
  * serializes this process. When the lock is contended past the web timeout,
  * throws `FollowupsBusyError` so the route can answer 409 rather than hang.

--- a/web/src/lib/core/pdf-index.ts
+++ b/web/src/lib/core/pdf-index.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsRoot, careerOpsCodeRoot } from "@/lib/career-ops";
 
 /**
  * ACL for the core's `resolvePdfIndexPath`/`resolveTrackerPath` (tracker-utils.mjs)
@@ -15,7 +15,7 @@ import { careerOpsRoot } from "@/lib/career-ops";
  * `CAREER_OPS_PDF_INDEX` override, for every reader.
  *
  * We can't `import` it statically: the core lives in the USER's checkout,
- * resolved at runtime via careerOpsRoot(), and is not a build dependency of this
+ * resolved at runtime via careerOpsCodeRoot(), and is not a build dependency of this
  * app. So we import it dynamically per resolved root and cache the module —
  * keyed by path, and NEVER caching a failure (the lesson from #2590, where a
  * cached fallback pinned stale definitions for the process lifetime).
@@ -36,7 +36,7 @@ let warned = false;
  *  callers must treat null as "can't resolve" rather than guessing a path. */
 export async function resolvePdfIndexPath(): Promise<string | null> {
   const root = careerOpsRoot();
-  const file = path.join(root, "tracker-utils.mjs");
+  const file = path.join(careerOpsCodeRoot(), "tracker-utils.mjs");
   const hit = modCache.get(file);
   if (hit) return hit.resolvePdfIndexPath(hit.resolveTrackerPath(root));
   try {

--- a/web/src/lib/core/pipeline.ts
+++ b/web/src/lib/core/pipeline.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsCodeRoot, careerOpsRoot, rootScript } from "@/lib/career-ops";
 import type { DiscoveredOffer } from "./scan";
 
 /**
@@ -41,7 +41,7 @@ export function addOffersToPipeline(offers: DiscoveredOffer[]): Promise<AddResul
   }
 
   const scanUrl = pathToFileURL(rootScript("scan")).href;
-  const localTodayUrl = pathToFileURL(path.join(careerOpsRoot(), "lib", "local-today.mjs")).href;
+  const localTodayUrl = pathToFileURL(path.join(careerOpsCodeRoot(), "lib", "local-today.mjs")).href;
   const code = `
 import { appendToPipeline, appendToScanHistory } from ${JSON.stringify(scanUrl)};
 import { localToday } from ${JSON.stringify(localTodayUrl)};
@@ -67,7 +67,7 @@ process.stdin.on("end", async () => {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, ["--input-type=module", "-e", code], {
       cwd: careerOpsRoot(),
-      env: process.env,
+      env: careerOpsEnv(),
     });
     let out = "";
     let err = "";

--- a/web/src/lib/core/scan.ts
+++ b/web/src/lib/core/scan.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import { careerOpsRoot, rootScript } from "@/lib/career-ops";
+import { careerOpsEnv, careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { writeTempPortals, cleanupTempPortals } from "./portals";
 import { ATS_SOURCES, type DiscoveredOffer, type ExploreFilters, type ScanEvent } from "@/lib/explore";
 
@@ -99,7 +99,7 @@ export function runDiscovery(filters: ExploreFilters, onEvent: (e: ScanEvent) =>
 
     const child = spawn(process.execPath, args, {
       cwd: careerOpsRoot(),
-      env: { ...process.env, CAREER_OPS_PORTALS: tempPortals },
+      env: { ...careerOpsEnv(), CAREER_OPS_PORTALS: tempPortals },
     });
 
     const offers: DiscoveredOffer[] = [];

--- a/web/src/lib/core/states.ts
+++ b/web/src/lib/core/states.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsCodeRoot } from "@/lib/career-ops";
 import { CANONICAL_STATES } from "@/lib/format";
 
 /**
@@ -54,7 +54,7 @@ const FALLBACK: CanonicalState[] = CANONICAL_STATES.map((label) => ({
 const statesCache = new Map<string, { mtimeMs: number; size: number; states: CanonicalState[] }>();
 
 export function readCanonicalStates(): CanonicalState[] {
-  const file = path.join(careerOpsRoot(), "templates", "states.yml");
+  const file = path.join(careerOpsCodeRoot(), "templates", "states.yml");
   try {
     const { mtimeMs, size } = fs.statSync(file);
     const cached = statesCache.get(file);

--- a/web/src/lib/core/text-key.ts
+++ b/web/src/lib/core/text-key.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsCodeRoot } from "@/lib/career-ops";
 import { normalizeTextKey as fallbackKey } from "./normalize-text-key.mjs";
 
 /**
@@ -14,7 +14,7 @@ import { normalizeTextKey as fallbackKey } from "./normalize-text-key.mjs";
  * evaluated" — a job the user never saw, with no signal.
  *
  * We can't `import` it statically: the core lives in the USER's checkout,
- * resolved at runtime via careerOpsRoot(), and is not a build dependency of this
+ * resolved at runtime via careerOpsCodeRoot(), and is not a build dependency of this
  * app. So we import it dynamically per resolved root and cache the module —
  * keyed by path, and NEVER caching a failure (the lesson from #2590, where a
  * cached fallback pinned stale definitions for the process lifetime).
@@ -36,7 +36,7 @@ let warned = false;
 
 /** Resolve the core's normalizeTextKey for the current root, or the fallback. */
 export async function getNormalizeTextKey(): Promise<NormalizeTextKey> {
-  const file = path.join(careerOpsRoot(), "tracker-parse.mjs");
+  const file = path.join(careerOpsCodeRoot(), "tracker-parse.mjs");
   const hit = modCache.get(file);
   if (hit) return hit;
   try {

--- a/web/src/lib/core/tracker-lock.ts
+++ b/web/src/lib/core/tracker-lock.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { careerOpsRoot } from "@/lib/career-ops";
+import { careerOpsCodeRoot } from "@/lib/career-ops";
 
 /**
  * ACL for the core's tracker lock (`tracker-utils.mjs`).
@@ -41,7 +41,7 @@ type LockDirFn = (trackerPath: string) => string;
 const modCache = new Map<string, { acquire: AcquireFn; lockDirFor: LockDirFn }>();
 
 async function loadCoreLock() {
-  const file = path.join(careerOpsRoot(), "tracker-utils.mjs");
+  const file = path.join(careerOpsCodeRoot(), "tracker-utils.mjs");
   const cached = modCache.get(file);
   if (cached) return cached;
   const mod = await import(/* webpackIgnore: true */ pathToFileURL(file).href);

--- a/web/src/lib/followups-server.ts
+++ b/web/src/lib/followups-server.ts
@@ -48,8 +48,10 @@ export function withLogLock<T>(fn: () => T | Promise<T>): Promise<T> {
 // eats the timeout and a 409 — for a race the free in-process queue already
 // resolves. Every followups writer goes through here so no call site can get
 // the nesting wrong.
-export function withFollowupsWrite<T>(fn: () => T | Promise<T>): Promise<T> {
-  return withLogLock(() => withFollowupsLock(followupsLogPath(), fn));
+// Lock the same captured file the callback writes, even if the workspace
+// marker changes while this request waits in the queue.
+export function withFollowupsWrite<T>(file: string, fn: () => T | Promise<T>): Promise<T> {
+  return withLogLock(() => withFollowupsLock(file, fn));
 }
 
 // Map a throw from withFollowupsWrite onto an HTTP response, consistently across

--- a/web/src/lib/pdf-render.mjs
+++ b/web/src/lib/pdf-render.mjs
@@ -90,10 +90,10 @@ export function writeCvHtml({ pdfPaths, html }) {
 
 /**
  * Spawn generate-pdf.mjs as a plain child process and resolve once it exits.
- * @param {{spawnFn: Function, execPath: string, root: string, html: string, finalPdf: string, format: "letter"|"a4", reportNum: string}} args
+ * @param {{spawnFn: Function, execPath: string, root: string, env?: Record<string, string | undefined>, html: string, finalPdf: string, format: "letter"|"a4", reportNum: string}} args
  * @returns {Promise<{ok: boolean, stderr: string}>}
  */
-export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, format, reportNum }) {
+export function spawnGeneratePdf({ spawnFn, execPath, root, env = process.env, html, finalPdf, format, reportNum }) {
   return new Promise((resolve) => {
     const child = spawnFn(
       execPath,
@@ -102,7 +102,7 @@ export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, form
       // hard-fail every web-triggered render — same bypass a human already
       // applies manually via the CLI when this diverges.
       [path.join(root, "generate-pdf.mjs"), html, finalPdf, `--format=${format}`, `--report=${reportNum}`, "--allow-reorder"],
-      { cwd: root },
+      { cwd: root, env },
     );
     let stderr = "";
     child.stderr.on("data", (d) => { stderr += d.toString(); });
@@ -116,12 +116,12 @@ export function spawnGeneratePdf({ spawnFn, execPath, root, html, finalPdf, form
  * JSON stdout when present (mark-pdf-ready.mjs prints a JSON payload even on
  * a failure exit when --json is passed) so a caller can surface the specific
  * reason (not-found / ambiguous / lock-timeout / ...) rather than raw stderr.
- * @param {{spawnFn: Function, execPath: string, root: string, reportNum: string}} args
+ * @param {{spawnFn: Function, execPath: string, root: string, env?: Record<string, string | undefined>, reportNum: string}} args
  * @returns {Promise<{ok: boolean, data: object | null, stderr: string}>}
  */
-export function markTrackerReady({ spawnFn, execPath, root, reportNum }) {
+export function markTrackerReady({ spawnFn, execPath, root, env = process.env, reportNum }) {
   return new Promise((resolve) => {
-    const child = spawnFn(execPath, [path.join(root, "mark-pdf-ready.mjs"), reportNum, "--json"], { cwd: root });
+    const child = spawnFn(execPath, [path.join(root, "mark-pdf-ready.mjs"), reportNum, "--json"], { cwd: root, env });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => { stdout += d.toString(); });
@@ -185,13 +185,13 @@ export function cleanupPdfScratch(scratchDir, prefix) {
  * Call after writeCvHtml for the same pdfPaths — this reads the HTML that
  * function wrote. `format` is passed in rather than read back off disk, so the two
  * no longer share a file and the only coupling left is the HTML itself.
- * @param {{spawnFn: Function, execPath: string, root: string, pdfPaths: {html: string, finalPdf: string}, format: "letter"|"a4", reportNum: string}} args
+ * @param {{spawnFn: Function, execPath: string, root: string, env?: Record<string, string | undefined>, pdfPaths: {html: string, finalPdf: string}, format: "letter"|"a4", reportNum: string}} args
  * @returns {Promise<RenderResult>}
  */
-export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, format, reportNum }) {
+export async function renderAndMarkPdf({ spawnFn, execPath, root, env = process.env, pdfPaths, format, reportNum }) {
   const warnings = [];
 
-  const render = await spawnGeneratePdf({ spawnFn, execPath, root, html: pdfPaths.html, finalPdf: pdfPaths.finalPdf, format, reportNum });
+  const render = await spawnGeneratePdf({ spawnFn, execPath, root, env, html: pdfPaths.html, finalPdf: pdfPaths.finalPdf, format, reportNum });
   cleanupPdfScratch(path.dirname(pdfPaths.html), `cv-web-${reportNum}.`);
 
   if (!render.ok) {
@@ -202,7 +202,7 @@ export async function renderAndMarkPdf({ spawnFn, execPath, root, pdfPaths, form
   // tracker-sync miss (e.g. the row was edited away mid-flight) doesn't fail
   // the whole job, but it must still be visible to whoever is watching this
   // run, not just a server-side log nobody sees.
-  const mark = await markTrackerReady({ spawnFn, execPath, root, reportNum });
+  const mark = await markTrackerReady({ spawnFn, execPath, root, env, reportNum });
   if (!mark.ok) {
     console.error(`mark-pdf-ready.mjs failed for report #${reportNum}: ${mark.data?.error ?? mark.stderr}`);
     warnings.push(

--- a/web/src/lib/tracker-table.mjs
+++ b/web/src/lib/tracker-table.mjs
@@ -44,7 +44,7 @@ const aliasCache = new Map();
  * table — no header row is then detected and parseApplications falls back to
  * the legacy fixed column order — and the cache entry is cleared so a later
  * recovered file is loaded immediately.
- * @param {string} rootDir - career-ops root (careerOpsRoot() on the web side).
+ * @param {string} rootDir - core checkout (careerOpsCodeRoot() on the web side).
  * @returns {Record<string, string>}
  */
 export function loadHeaderAliases(rootDir) {

--- a/web/src/lib/workspace-paths.mjs
+++ b/web/src/lib/workspace-paths.mjs
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolve the web's runtime checkout and user files. CAREER_OPS_ROOT retains
+ * its web meaning: select another checkout, including its core. DATA_DIR and
+ * the marker move only user files. Keep valid-path behavior in parity with
+ * the selected checkout's path-resolver.mjs; never cache a marker read.
+ *
+ * @param {{ cwd?: string, env?: Record<string, string | undefined> }} [options]
+ * @returns {{ codeRoot: string, dataRoot: string }}
+ */
+export function resolveWorkspacePaths({ cwd = process.cwd(), env = process.env } = {}) {
+  const hostingRoot = path.resolve(cwd, "..");
+  const rootOverride = env.CAREER_OPS_ROOT?.trim();
+  if (rootOverride) {
+    const codeRoot = path.resolve(hostingRoot, rootOverride);
+    return { codeRoot, dataRoot: codeRoot };
+  }
+
+  const dataOverride = env.CAREER_OPS_DATA_DIR?.trim();
+  if (dataOverride) {
+    return { codeRoot: hostingRoot, dataRoot: path.resolve(hostingRoot, dataOverride) };
+  }
+
+  let marker;
+  try {
+    // User configuration is read at runtime, outside the web build graph.
+    marker = fs.readFileSync(/* turbopackIgnore: true */ path.join(hostingRoot, ".career-ops-data"), "utf8").trim();
+  } catch (error) {
+    // A broken marker must not redirect reads or writes to the checkout.
+    if (error === null || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") throw error;
+  }
+  return { codeRoot: hostingRoot, dataRoot: marker ? path.resolve(hostingRoot, marker) : hostingRoot };
+}

--- a/web/tests/lib/pipeline-local-today.test.mjs
+++ b/web/tests/lib/pipeline-local-today.test.mjs
@@ -85,11 +85,11 @@ test("localToday is imported into the spawned child from lib/local-today.mjs", (
   );
 });
 
-test("localTodayUrl is built the same way scanUrl is: an absolute file:// URL under careerOpsRoot()", () => {
+test("localTodayUrl is built the same way scanUrl is: an absolute file:// URL under careerOpsCodeRoot()", () => {
   assert.match(
     src,
-    /const localTodayUrl = pathToFileURL\(path\.join\(careerOpsRoot\(\),\s*["']lib["'],\s*["']local-today\.mjs["']\)\)\.href;/,
-    `${SRC}: localTodayUrl must resolve lib/local-today.mjs under careerOpsRoot(), so the import ` +
+    /const localTodayUrl = pathToFileURL\(path\.join\(careerOpsCodeRoot\(\),\s*["']lib["'],\s*["']local-today\.mjs["']\)\)\.href;/,
+    `${SRC}: localTodayUrl must resolve lib/local-today.mjs under careerOpsCodeRoot(), so the import ` +
       `works regardless of the checkout the web dashboard is pointed at.`,
   );
 });

--- a/web/tests/lib/workspace-data-root.test.mjs
+++ b/web/tests/lib/workspace-data-root.test.mjs
@@ -1,0 +1,248 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { register } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import * as yaml from 'js-yaml';
+
+const webSrc = fileURLToPath(new URL('../../src/', import.meta.url));
+const coreRoot = fileURLToPath(new URL('../../../', import.meta.url));
+// The same test-only alias loader used by apply-cv-resolver.test.mjs.
+register('data:text/javascript,' + encodeURIComponent(`
+  import fs from 'node:fs';
+  import path from 'node:path';
+  import { pathToFileURL } from 'node:url';
+  export async function resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) {
+      const base = path.join(${JSON.stringify(webSrc)}, specifier.slice(2));
+      for (const ext of ['.ts', '.tsx', '.mjs', '.js', '.mts', '']) {
+        if (fs.existsSync(base + ext)) return { url: pathToFileURL(base + ext).href, shortCircuit: true };
+      }
+    }
+    return nextResolve(specifier, context);
+  }
+`), pathToFileURL(webSrc));
+
+const data = await import('../../src/lib/career-ops.ts');
+const { POST: saveProfile } = await import('../../src/app/api/profile/route.ts');
+const { POST: savePortals } = await import('../../src/app/api/portals/route.ts');
+const { readCanonicalStates } = await import('../../src/lib/core/states.ts');
+const { getNormalizeTextKey } = await import('../../src/lib/core/text-key.ts');
+const { resolvePdfIndexPath } = await import('../../src/lib/core/pdf-index.ts');
+const { withTrackerLock } = await import('../../src/lib/core/tracker-lock.ts');
+const { withFollowupsLock } = await import('../../src/lib/core/followups-lock.ts');
+const { POST: runAgent } = await import('../../src/app/api/run/route.ts');
+const { renderAndMarkPdf } = await import('../../src/lib/pdf-render.mjs');
+
+function put(root, rel, body) {
+  const file = path.join(root, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, body);
+}
+
+function request(body) {
+  return new Request('http://localhost/api/test', {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+  });
+}
+
+// These tests mutate cwd/env only inside this node:test worker. Subtests are
+// awaited serially, and every value is restored even when an assertion fails.
+test('a separate Data Root retains the pipeline and access to its core', async (t) => {
+  const sandbox = fs.realpathSync(fs.mkdtempSync(path.join(tmpdir(), 'co-web-data-')));
+  const code = path.join(sandbox, 'checkout');
+  const user = path.join(sandbox, 'user data');
+  const oldCwd = process.cwd();
+  const envKeys = ['CAREER_OPS_ROOT', 'CAREER_OPS_DATA_DIR', 'CAREER_OPS_TRACKER', 'CAREER_OPS_PDF_INDEX', 'PATH'];
+  const oldEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  try {
+    fs.mkdirSync(path.join(code, 'web'), { recursive: true });
+    put(code, 'cv.md', '# Wrong workspace\n');
+    put(code, 'tracker-aliases.json', fs.readFileSync(path.join(coreRoot, 'tracker-aliases.json')));
+    put(code, 'templates/states.yml', fs.readFileSync(path.join(coreRoot, 'templates/states.yml')));
+    put(code, 'modes/de/angebot.md', '# Evaluation A-F\n');
+    put(code, 'config/profile.example.yml', 'language:\n  output: en\ncandidate:\n  full_name: Template Person\n');
+    put(code, 'templates/portals.example.yml', 'tracked_companies:\n  - name: Fixture Employer\n    ats: greenhouse\n    board: fixture\n');
+    put(code, 'doctor.mjs', 'process.stdout.write("core-script-ran");\n');
+    // Exercise the real core in an isolated checkout. Web CI installs only
+    // web/node_modules, so copy the dependency closure and its own YAML package
+    // rather than importing back into a root checkout with missing dependencies.
+    for (const relative of ['set-status.mjs', 'tracker-utils.mjs', 'tracker-parse.mjs',
+      'path-resolver.mjs', 'pipeline-lock.mjs', 'role-matcher.mjs', 'followup-seed.mjs',
+      'followup-cadence.mjs', 'lib/local-today.mjs', 'lib/cli-flags.mjs', 'lib/is-main-module.mjs']) {
+      put(code, relative, fs.readFileSync(path.join(coreRoot, relative)));
+    }
+    fs.cpSync(new URL('../../node_modules/js-yaml', import.meta.url), path.join(code, 'node_modules/js-yaml'), { recursive: true });
+    put(user, 'cv.md', '# Synthetic Candidate\n');
+    put(user, 'config/profile.yml', 'language:\n  output: en\n  modes_dir: modes/de\n');
+    put(user, 'modes/_profile.md', '# Targeting\n');
+    put(user, 'portals.yml', 'tracked_companies: []\n');
+    // Reordered columns require tracker-aliases.json from the code checkout.
+    put(user, 'data/applications.md', '| Company | # | Date | Role | Score | Status | PDF | Report | Notes |\n|---|---|---|---|---|---|---|---|---|\n| Fixture Employer | 7 | 2026-01-02 | Engineer | 4.2/5 | Applied | - | [7](../reports/007-fixture.md) | Synthetic |\n');
+    put(user, 'data/pipeline.md', '- [ ] https://example.test/jobs/8 | Second Employer | Engineer\n');
+    put(user, 'data/scan-history.tsv', 'url\tfirst_seen\nhttps://example.test/jobs/8\t2026-01-03\n');
+    put(user, 'reports/007-fixture.md', '# Fixture report\n');
+    for (const key of envKeys.filter((key) => key !== 'PATH')) delete process.env[key];
+    process.env.CAREER_OPS_DATA_DIR = user;
+    process.chdir(path.join(code, 'web'));
+
+    await t.test('setup, analytics rows, report links and market mode use their intended roots', () => {
+      assert.equal(data.careerOpsRoot(), user);
+      assert.equal(data.careerOpsCodeRoot(), code);
+      assert.deepEqual(data.doctorState(), { phase: 'established', onboardingNeeded: false, missing: [], hasCv: true, hasData: true });
+      const summary = data.pipelineSummary();
+      assert.equal(summary.root, user);
+      assert.equal(summary.applications.length, 1);
+      assert.equal(summary.applications[0].company, 'Fixture Employer');
+      assert.equal(summary.applications[0].n, '7');
+      assert.equal(summary.applications[0].status, 'Applied');
+      assert.equal(summary.inbox[0].postedAt, '2026-01-03');
+      assert.equal(data.findReportFile('7'), path.join(user, 'reports/007-fixture.md'));
+      assert.equal(data.readLanguageConfig().evalModeFile, 'modes/de/angebot.md');
+    });
+
+    await t.test('scripts, canonical states, matching, manifest and real locks remain available', async () => {
+      assert.equal(data.rootScript('doctor'), path.join(code, 'doctor.mjs'));
+      assert.equal(execFileSync(process.execPath, [data.rootScript('doctor')], { encoding: 'utf8' }), 'core-script-ran');
+      assert.ok(readCanonicalStates().some((state) => state.aliases.length > 0));
+      const { normalizeTextKey } = await import(pathToFileURL(path.join(code, 'tracker-parse.mjs')).href);
+      assert.equal(await getNormalizeTextKey(), normalizeTextKey);
+      assert.equal(await resolvePdfIndexPath(), path.join(user, 'data/pdf-index.tsv'));
+      const tracker = path.join(user, 'data/applications.md');
+      await withTrackerLock(tracker, () => assert.ok(fs.existsSync(tracker)));
+      await withFollowupsLock(path.join(user, 'data/follow-ups.md'), () => 'read under lock');
+    });
+
+    await t.test('the real status writer changes the displayed tracker, including its transition ledger', () => {
+      const tracker = path.join(user, 'data/applications.md');
+      const before = fs.readFileSync(tracker, 'utf8');
+      const codeTracker = path.join(code, 'data/applications.md');
+      const codeBefore = before.replace('Fixture Employer', 'Code Decoy');
+      put(code, 'data/applications.md', codeBefore);
+      // The real writer still defaults to its code root on older core versions.
+      // Its explicit tracker override must match the file the web just read.
+      const output = execFileSync(process.execPath, [data.rootScript('set-status'), '7', 'Rejected', '--json'], {
+        cwd: user, env: data.careerOpsEnv(), encoding: 'utf8', timeout: 10_000,
+      });
+      const result = JSON.parse(output);
+      assert.equal(result.company, 'Fixture Employer');
+      assert.equal(result.tracker, tracker);
+      assert.equal(result.newStatus, 'Rejected');
+      assert.equal(data.readApplications()[0].status, 'Rejected');
+      const ledger = fs.readFileSync(path.join(user, 'data/status-log.tsv'), 'utf8');
+      assert.match(ledger, /7\t[^\t]+\tApplied\tRejected\t/);
+      assert.equal(fs.readFileSync(codeTracker, 'utf8'), codeBefore);
+      assert.equal(fs.existsSync(path.join(code, 'data/status-log.tsv')), false);
+      fs.writeFileSync(tracker, before);
+    });
+
+    await t.test('AI runs reject a data-only workspace before starting a CLI', async () => {
+      const bin = path.join(sandbox, 'bin');
+      // A fake executable is first on PATH, so a broken guard cannot start a
+      // developer's installed AI CLI. It is never expected to execute.
+      put(bin, 'claude', '#!/bin/sh\nexit 99\n');
+      fs.chmodSync(path.join(bin, 'claude'), 0o755);
+      process.env.PATH = bin;
+      for (const kind of ['evaluate', 'pdf', 'fix-portal']) {
+        const response = await runAgent(request({ kind, input: '7', cliId: 'claude' }));
+        assert.equal(response.status, 400, kind);
+        assert.match((await response.json()).error, /complete career-ops checkout/, kind);
+      }
+      if (oldEnv.PATH === undefined) delete process.env.PATH;
+      else process.env.PATH = oldEnv.PATH;
+    });
+
+    await t.test('profile and portal creation seed from core and write only to the Data Root', async () => {
+      fs.unlinkSync(path.join(user, 'config/profile.yml'));
+      fs.unlinkSync(path.join(user, 'portals.yml'));
+      const template = fs.readFileSync(path.join(code, 'config/profile.example.yml'), 'utf8');
+      const profile = await saveProfile(request({ name: 'Synthetic Candidate' }));
+      assert.equal(profile.status, 200);
+      assert.deepEqual(await profile.json(), { ok: true, seeded: true });
+      const saved = yaml.load(fs.readFileSync(path.join(user, 'config/profile.yml'), 'utf8'));
+      assert.equal(saved.candidate.full_name, 'Synthetic Candidate');
+      assert.equal(saved.language.output, 'en');
+      const portals = await savePortals(request({ roles: ['Engineer'] }));
+      assert.equal(portals.status, 200);
+      const portalDoc = yaml.load(fs.readFileSync(path.join(user, 'portals.yml'), 'utf8'));
+      assert.equal(portalDoc.tracked_companies[0].name, 'Fixture Employer');
+      assert.deepEqual(portalDoc.title_filter.positive, ['Engineer']);
+      assert.equal(fs.existsSync(path.join(code, 'config/profile.yml')), false);
+      assert.equal(fs.existsSync(path.join(code, 'portals.yml')), false);
+      assert.equal(fs.readFileSync(path.join(code, 'config/profile.example.yml'), 'utf8'), template);
+    });
+
+    await t.test('malformed user configuration is preserved and a code-root CV cannot fill a missing user CV', async () => {
+      const broken = 'candidate: [\n';
+      put(user, 'config/profile.yml', broken);
+      const response = await saveProfile(request({ name: 'Should Not Be Written' }));
+      assert.equal(response.status, 409);
+      assert.equal(fs.readFileSync(path.join(user, 'config/profile.yml'), 'utf8'), broken);
+      fs.unlinkSync(path.join(user, 'cv.md'));
+      assert.equal(data.doctorState().hasCv, false);
+      assert.ok(data.doctorState().missing.includes('cv.md'));
+      assert.equal(fs.readFileSync(path.join(code, 'cv.md'), 'utf8'), '# Wrong workspace\n');
+    });
+
+    await t.test('marker and relative DATA_DIR select the same existing pipeline', () => {
+      process.env.CAREER_OPS_DATA_DIR = '../user data';
+      assert.equal(data.readApplications()[0].n, '7');
+      assert.equal(data.careerOpsEnv().CAREER_OPS_ROOT, user);
+      delete process.env.CAREER_OPS_DATA_DIR;
+      put(code, '.career-ops-data', '../user data\n');
+      assert.equal(data.readApplications()[0].n, '7');
+      assert.equal(data.careerOpsCodeRoot(), code);
+    });
+
+    await t.test('legacy relative ROOT retains its own core and hands children an absolute root', () => {
+      process.env.CAREER_OPS_ROOT = '../user data';
+      process.env.CAREER_OPS_DATA_DIR = code;
+      process.env.CAREER_OPS_TRACKER = 'explicit-tracker.md';
+      assert.equal(data.careerOpsCodeRoot(), user);
+      assert.equal(data.careerOpsRoot(), user);
+      const childEnv = data.careerOpsEnv();
+      assert.equal(childEnv.CAREER_OPS_ROOT, user);
+      assert.equal(childEnv.CAREER_OPS_TRACKER, 'explicit-tracker.md');
+      assert.equal(process.env.CAREER_OPS_ROOT, '../user data');
+    });
+
+    await t.test('an invalid marker reaches readers as an error, without a first-run fallback', () => {
+      delete process.env.CAREER_OPS_ROOT;
+      delete process.env.CAREER_OPS_DATA_DIR;
+      fs.unlinkSync(path.join(code, '.career-ops-data'));
+      fs.mkdirSync(path.join(code, '.career-ops-data'));
+      for (const reader of [data.doctorState, data.readApplications, data.readInbox, data.readMemory]) {
+        assert.throws(reader, { code: 'EISDIR' });
+      }
+    });
+  } finally {
+    process.chdir(oldCwd);
+    for (const [key, value] of Object.entries(oldEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test('both PDF subprocesses receive the normalized workspace environment', async () => {
+  const scratch = fs.realpathSync(fs.mkdtempSync(path.join(tmpdir(), 'co-web-pdf-env-')));
+  try {
+    const script = 'if (process.env.CAREER_OPS_ROOT !== process.cwd()) process.exit(23); process.stdout.write(JSON.stringify({ok: true}));';
+    put(scratch, 'generate-pdf.mjs', script);
+    put(scratch, 'mark-pdf-ready.mjs', script);
+    const { spawn } = await import('node:child_process');
+    const result = await renderAndMarkPdf({
+      spawnFn: spawn, execPath: process.execPath, root: scratch,
+      env: { ...process.env, CAREER_OPS_ROOT: scratch },
+      pdfPaths: { html: path.join(scratch, 'cv-web-007.html'), finalPdf: path.join(scratch, 'out.pdf') },
+      format: 'letter', reportNum: '007',
+    });
+    assert.deepEqual(result, { kind: 'rendered', warnings: [] });
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+});

--- a/web/tests/lib/workspace-data-root.test.mjs
+++ b/web/tests/lib/workspace-data-root.test.mjs
@@ -10,6 +10,8 @@ import * as yaml from 'js-yaml';
 
 const webSrc = fileURLToPath(new URL('../../src/', import.meta.url));
 const coreRoot = fileURLToPath(new URL('../../../', import.meta.url));
+// Core CI installs at the repo root; Web CI installs only under web/.
+const yamlPackageRoot = path.dirname(fileURLToPath(import.meta.resolve('js-yaml/package.json')));
 // The same test-only alias loader used by apply-cv-resolver.test.mjs.
 register('data:text/javascript,' + encodeURIComponent(`
   import fs from 'node:fs';
@@ -67,15 +69,15 @@ test('a separate Data Root retains the pipeline and access to its core', async (
     put(code, 'config/profile.example.yml', 'language:\n  output: en\ncandidate:\n  full_name: Template Person\n');
     put(code, 'templates/portals.example.yml', 'tracked_companies:\n  - name: Fixture Employer\n    ats: greenhouse\n    board: fixture\n');
     put(code, 'doctor.mjs', 'process.stdout.write("core-script-ran");\n');
-    // Exercise the real core in an isolated checkout. Web CI installs only
-    // web/node_modules, so copy the dependency closure and its own YAML package
-    // rather than importing back into a root checkout with missing dependencies.
+    // Exercise the real core in an isolated checkout. Copy its dependency
+    // closure and the resolved YAML package, so either CI install layout works
+    // without importing back into a checkout with missing dependencies.
     for (const relative of ['set-status.mjs', 'tracker-utils.mjs', 'tracker-parse.mjs',
       'path-resolver.mjs', 'pipeline-lock.mjs', 'role-matcher.mjs', 'followup-seed.mjs',
       'followup-cadence.mjs', 'lib/local-today.mjs', 'lib/cli-flags.mjs', 'lib/is-main-module.mjs']) {
       put(code, relative, fs.readFileSync(path.join(coreRoot, relative)));
     }
-    fs.cpSync(new URL('../../node_modules/js-yaml', import.meta.url), path.join(code, 'node_modules/js-yaml'), { recursive: true });
+    fs.cpSync(yamlPackageRoot, path.join(code, 'node_modules/js-yaml'), { recursive: true });
     put(user, 'cv.md', '# Synthetic Candidate\n');
     put(user, 'config/profile.yml', 'language:\n  output: en\n  modes_dir: modes/de\n');
     put(user, 'modes/_profile.md', '# Targeting\n');

--- a/web/tests/lib/workspace-operation.test.mjs
+++ b/web/tests/lib/workspace-operation.test.mjs
@@ -1,0 +1,164 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import { register } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const webSrc = fileURLToPath(new URL('../../src/', import.meta.url));
+const coreRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const spawnKey = Symbol.for('career-ops.test.workspace-spawn');
+// Only the AI CLI is replaced. PDF children and follow-up file locks are real.
+// This exercises delayed HTTP completion without starting an installed agent.
+register('data:text/javascript,' + encodeURIComponent(`
+  import fs from 'node:fs';
+  import path from 'node:path';
+  import { pathToFileURL } from 'node:url';
+  export async function resolve(specifier, context, nextResolve) {
+    if (context.parentURL?.endsWith('/api/run/route.ts')) {
+      if (specifier === '@/lib/clis') return {
+        url: 'data:text/javascript,' + encodeURIComponent('export function resolveCli() { return { spec: { args: () => [] }, binPath: "fixture-cli" }; }'), shortCircuit: true
+      };
+      if (specifier === '@/lib/spawn-cli.mjs') return {
+        url: 'data:text/javascript,' + encodeURIComponent('export function spawnHeadlessCli(...args) { return globalThis[Symbol.for("career-ops.test.workspace-spawn")](...args); }'), shortCircuit: true
+      };
+    }
+    if (specifier.startsWith('@/')) {
+      const base = path.join(${JSON.stringify(webSrc)}, specifier.slice(2));
+      for (const ext of ['.ts', '.tsx', '.mjs', '.js', '.mts', '']) {
+        if (fs.existsSync(base + ext)) return { url: pathToFileURL(base + ext).href, shortCircuit: true };
+      }
+    }
+    return nextResolve(specifier, context);
+  }
+`), pathToFileURL(webSrc));
+
+const { POST: run } = await import('../../src/app/api/run/route.ts');
+const { followupsLogPath, withLogLock, withFollowupsWrite, FollowupsBusyError } = await import('../../src/lib/followups-server.ts');
+
+function put(root, relative, content) {
+  const file = path.join(root, relative);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function withWorkspace(fn) {
+  const sandbox = fs.realpathSync(fs.mkdtempSync(path.join(tmpdir(), 'co-web-operation-')));
+  const code = path.join(sandbox, 'code');
+  const a = path.join(sandbox, 'a');
+  const b = path.join(sandbox, 'b');
+  const oldCwd = process.cwd();
+  const keys = ['CAREER_OPS_ROOT', 'CAREER_OPS_DATA_DIR', 'CAREER_OPS_TRACKER', 'CAREER_OPS_WEB_FOLLOWUPS_LOCK_TIMEOUT_MS'];
+  const env = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  try {
+    fs.mkdirSync(path.join(code, 'web'), { recursive: true });
+    put(code, '.career-ops-data', '../a');
+    put(code, 'tracker-aliases.json', fs.readFileSync(path.join(coreRoot, 'tracker-aliases.json')));
+    for (const root of [a, b]) {
+      put(root, 'cv.md', '# Synthetic candidate\n');
+      put(root, 'config/profile.yml', 'candidate:\n  full_name: Synthetic Candidate\n');
+      put(root, 'reports/007-fixture-2026-01-02.md', '# Fixture\n');
+      put(root, 'data/follow-ups.md', '# Follow-ups\n');
+      put(root, 'generate-pdf.mjs', 'import fs from "node:fs"; fs.writeFileSync("rendered.txt", process.env.CAREER_OPS_ROOT);');
+      put(root, 'mark-pdf-ready.mjs', 'import fs from "node:fs"; fs.writeFileSync("marked.txt", process.env.CAREER_OPS_TRACKER); process.stdout.write(JSON.stringify({ok:true}));');
+    }
+    for (const key of keys) delete process.env[key];
+    process.chdir(path.join(code, 'web'));
+    await fn({ code, a, b });
+  } finally {
+    delete globalThis[spawnKey];
+    process.chdir(oldCwd);
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+test('a PDF run keeps its original workspace when the marker changes before CLI completion', async () => {
+  await withWorkspace(async ({ code, a, b }) => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = () => true;
+    let childClosed = false;
+    child.once('close', () => { childClosed = true; });
+    let initial;
+    globalThis[spawnKey] = (_bin, _args, options) => { initial = options; return child; };
+    let response;
+    try {
+      response = await run(new Request('http://localhost/api/run', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ kind: 'pdf', input: '7', cliId: 'fixture' }),
+      }));
+      assert.equal(response.status, 200);
+      assert.equal(initial.cwd, a);
+      assert.equal(initial.env.CAREER_OPS_TRACKER, path.join(a, 'data/applications.md'));
+      put(code, '.career-ops-data', '../b');
+      child.stdout.write('<<cv-html format="a4">>\n<!DOCTYPE html><html><body>Synthetic CV</body></html>\n<</cv-html>>');
+      child.emit('close', 0);
+      const events = await response.text();
+      assert.match(events, /"type":"done"/);
+      assert.doesNotMatch(events, /"type":"error"/);
+      assert.equal(fs.readFileSync(path.join(a, 'rendered.txt'), 'utf8'), a);
+      assert.equal(fs.readFileSync(path.join(a, 'marked.txt'), 'utf8'), path.join(a, 'data/applications.md'));
+      assert.equal(fs.existsSync(path.join(b, 'rendered.txt')), false);
+      assert.equal(fs.existsSync(path.join(b, 'marked.txt')), false);
+    } finally {
+      if (!childClosed) child.emit('close', 1);
+      if (response?.body && !response.body.locked) await response.body.cancel();
+      child.stdout.destroy();
+      child.stderr.destroy();
+    }
+  });
+});
+
+test('a queued follow-up write still contends on the captured file after the marker changes', async () => {
+  await withWorkspace(async ({ code, a, b }) => {
+    for (const relative of ['followup-seed.mjs', 'followup-cadence.mjs', 'tracker-utils.mjs',
+      'tracker-parse.mjs', 'path-resolver.mjs', 'pipeline-lock.mjs', 'lib/local-today.mjs',
+      'lib/cli-flags.mjs', 'lib/is-main-module.mjs']) {
+      put(code, relative, fs.readFileSync(path.join(coreRoot, relative)));
+    }
+    put(code, 'templates/states.yml', fs.readFileSync(path.join(coreRoot, 'templates/states.yml')));
+    fs.cpSync(new URL('../../node_modules/js-yaml', import.meta.url), path.join(code, 'node_modules/js-yaml'), { recursive: true });
+    const core = await import(pathToFileURL(path.join(code, 'followup-seed.mjs')).href);
+    const file = followupsLogPath();
+    assert.equal(file, path.join(a, 'data/follow-ups.md'));
+    const lockEntered = deferred();
+    const releaseFile = deferred();
+    const releaseQueue = deferred();
+    const queueEntered = deferred();
+    const holder = core.withFollowupsLock(file, async () => { lockEntered.resolve(); await releaseFile.promise; }, { timeoutMs: 1_000 });
+    let queued;
+    let pending;
+    try {
+      await Promise.race([lockEntered.promise, holder.then(() => { throw new Error('lock callback did not run'); })]);
+      queued = withLogLock(async () => { queueEntered.resolve(); await releaseQueue.promise; });
+      await queueEntered.promise;
+      process.env.CAREER_OPS_WEB_FOLLOWUPS_LOCK_TIMEOUT_MS = '100';
+      pending = withFollowupsWrite(file, () => fs.appendFileSync(file, 'must not write under another file lock\n'));
+      const rejected = assert.rejects(pending, FollowupsBusyError);
+      put(code, '.career-ops-data', '../b');
+      assert.equal(followupsLogPath(), path.join(b, 'data/follow-ups.md'));
+      releaseQueue.resolve();
+      await rejected;
+      assert.equal(fs.readFileSync(file, 'utf8'), '# Follow-ups\n');
+      assert.equal(fs.readFileSync(path.join(b, 'data/follow-ups.md'), 'utf8'), '# Follow-ups\n');
+    } finally {
+      releaseQueue.resolve();
+      releaseFile.resolve();
+      await Promise.allSettled([holder, queued, pending]);
+    }
+  });
+});

--- a/web/tests/lib/workspace-operation.test.mjs
+++ b/web/tests/lib/workspace-operation.test.mjs
@@ -10,6 +10,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const webSrc = fileURLToPath(new URL('../../src/', import.meta.url));
 const coreRoot = fileURLToPath(new URL('../../../', import.meta.url));
+// Core CI installs at the repo root; Web CI installs only under web/.
+const yamlPackageRoot = path.dirname(fileURLToPath(import.meta.resolve('js-yaml/package.json')));
 const spawnKey = Symbol.for('career-ops.test.workspace-spawn');
 // Only the AI CLI is replaced. PDF children and follow-up file locks are real.
 // This exercises delayed HTTP completion without starting an installed agent.
@@ -131,7 +133,7 @@ test('a queued follow-up write still contends on the captured file after the mar
       put(code, relative, fs.readFileSync(path.join(coreRoot, relative)));
     }
     put(code, 'templates/states.yml', fs.readFileSync(path.join(coreRoot, 'templates/states.yml')));
-    fs.cpSync(new URL('../../node_modules/js-yaml', import.meta.url), path.join(code, 'node_modules/js-yaml'), { recursive: true });
+    fs.cpSync(yamlPackageRoot, path.join(code, 'node_modules/js-yaml'), { recursive: true });
     const core = await import(pathToFileURL(path.join(code, 'followup-seed.mjs')).href);
     const file = followupsLogPath();
     assert.equal(file, path.join(a, 'data/follow-ups.md'));

--- a/web/tests/lib/workspace-paths.test.mjs
+++ b/web/tests/lib/workspace-paths.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { resolveWorkspacePaths } from '../../src/lib/workspace-paths.mjs';
+
+// Compare the web mirror with the real core resolver in a separate checkout.
+// No process-wide environment/cwd mutation and no access to a user's data.
+for (const name of ['default', 'data-absolute', 'data-relative', 'root-absolute',
+  'root-relative', 'root-wins', 'blank-root', 'marker-absolute', 'marker-relative',
+  'empty-marker', 'env-wins-marker']) {
+  test(`workspace roots agree with core: ${name}`, () => {
+    const sandbox = realpathSync(mkdtempSync(join(tmpdir(), 'co-web-roots-')));
+    try {
+      const codeRoot = join(sandbox, 'checkout');
+      const dataRoot = join(sandbox, 'user data');
+      const alternate = join(sandbox, 'other checkout');
+      mkdirSync(join(codeRoot, 'web'), { recursive: true });
+      mkdirSync(dataRoot);
+      mkdirSync(alternate);
+      copyFileSync(new URL('../../../path-resolver.mjs', import.meta.url), join(codeRoot, 'path-resolver.mjs'));
+      const env = { ...process.env };
+      delete env.CAREER_OPS_ROOT;
+      delete env.CAREER_OPS_DATA_DIR;
+      let expected = codeRoot;
+      let expectedCode = codeRoot;
+      if (['data-absolute', 'root-absolute', 'root-wins', 'blank-root', 'env-wins-marker'].includes(name)) {
+        env.CAREER_OPS_DATA_DIR = dataRoot;
+        expected = dataRoot;
+      }
+      if (name === 'data-relative') {
+        env.CAREER_OPS_DATA_DIR = '../user data';
+        expected = dataRoot;
+      }
+      if (['root-absolute', 'root-wins'].includes(name)) {
+        env.CAREER_OPS_ROOT = alternate;
+        expected = alternate;
+        expectedCode = alternate;
+      }
+      if (name === 'root-relative') {
+        env.CAREER_OPS_ROOT = '../other checkout';
+        expected = alternate;
+        expectedCode = alternate;
+      }
+      if (name === 'blank-root') env.CAREER_OPS_ROOT = '  ';
+      if (['marker-absolute', 'marker-relative', 'empty-marker', 'env-wins-marker'].includes(name)) {
+        const marker = name === 'empty-marker' ? ' \n' : name === 'marker-relative' ? '../user data\n' : alternate + '\n';
+        writeFileSync(join(codeRoot, '.career-ops-data'), marker);
+        if (name === 'marker-relative') expected = dataRoot;
+        if (name === 'marker-absolute') expected = alternate;
+      }
+      const actual = resolveWorkspacePaths({ cwd: join(codeRoot, 'web'), env });
+      assert.deepEqual(actual, { codeRoot: expectedCode, dataRoot: expected });
+      const script = `import { getCareerOpsRoot } from ${JSON.stringify(pathToFileURL(join(codeRoot, 'path-resolver.mjs')).href)}; process.stdout.write(getCareerOpsRoot());`;
+      const core = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+        cwd: sandbox, env, encoding: 'utf8', timeout: 10_000,
+      });
+      assert.equal(actual.dataRoot, core);
+      assert.equal(actual.dataRoot, resolve(actual.dataRoot));
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+}
+
+test('an unreadable marker is an error, not a fresh empty workspace', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'co-web-roots-error-'));
+  try {
+    mkdirSync(join(sandbox, 'web'));
+    mkdirSync(join(sandbox, '.career-ops-data'));
+    assert.throws(() => resolveWorkspacePaths({ cwd: join(sandbox, 'web'), env: {} }), { code: 'EISDIR' });
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test('changing a marker is observed without a server restart', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'co-web-roots-refresh-'));
+  try {
+    mkdirSync(join(sandbox, 'web'));
+    const options = { cwd: join(sandbox, 'web'), env: {} };
+    assert.equal(resolveWorkspacePaths(options).dataRoot, sandbox);
+    writeFileSync(join(sandbox, '.career-ops-data'), 'first');
+    assert.equal(resolveWorkspacePaths(options).dataRoot, join(sandbox, 'first'));
+    writeFileSync(join(sandbox, '.career-ops-data'), 'second');
+    assert.equal(resolveWorkspacePaths(options).dataRoot, join(sandbox, 'second'));
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What does this PR do?

The web now honors `CAREER_OPS_DATA_DIR` and `.career-ops-data`, showing the existing pipeline instead of first-run setup. Core scripts, templates, aliases and locks stay in the checkout; `CAREER_OPS_ROOT` retains its existing checkout override.

Children receive an absolute Data Root and the displayed default tracker. PDF completion and queued follow-up writes keep the workspace selected at the start.

AI evaluation/PDF/portal repair still require user files and core together. Explicit tracker overrides and legacy tracker reading are unchanged.

## Related issue

Fixes #4015.

## Validation

- Core: 8691 passed, 0 failed, 16 existing warnings.
- Web: 523 passed; typecheck and production build passed. Core-only and web-only installs checked.
- Production HTTP smoke, actual status writer/ledger isolation, marker-switch regressions, 9/9 mutation checks.

## Checklist

- [x] Bug fix; CONTRIBUTING and Data Contract reviewed.
- [x] Synthetic fixtures only; no personal data or user-layer changes.
