### PR TITLE
fix(dashboard): neutralize control characters in the help-bar flash

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -1966,6 +1966,13 @@ func previewOutcome(app model.CareerApplication) string {
 // Stripping at the write path stops new bytes entering the tracker. It cannot
 // speak for a report header, a scan TSV, or a child process's stderr, none of
 // which pass through cell() -- and the flash renders all three.
+//
+// Text from those sources need not be valid UTF-8. strings.Map hands the
+// mapping function utf8.RuneError for a byte it cannot decode and writes
+// U+FFFD, so a raw 0x9b -- the byte an 8-bit terminal reads as CSI -- is
+// replaced rather than passed through. That is the property the guard needs;
+// it shows as a replacement character rather than disappearing, which is the
+// honest rendering of a byte nothing can decode.
 func sanitizeFlash(s string) string {
 	return strings.Map(func(r rune) rune {
 		switch {

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -1947,6 +1947,37 @@ func previewOutcome(app model.CareerApplication) string {
 	return outcome
 }
 
+// sanitizeFlash neutralizes control characters in the flash line.
+//
+// Every flash reaches the terminal through the single lipgloss.Render below,
+// and lipgloss wraps the string it is given without escaping it. Most of what
+// the flash line carries is not the program's own words: a tracker URL or a
+// manifest path read out of a file, or the last line a failed child process
+// printed. A control byte in any of those reaches the terminal as an
+// instruction rather than as text, which is how a cell that renders correctly
+// everywhere else can still move the cursor or repaint the help bar.
+//
+// The range is the one tracker-utils.mjs strips at the tracker write path
+// (CONTROL_CHARS, #3892): C0, DEL and C1. It differs deliberately in one
+// respect. cell() keeps \t, \r and \n because it has already folded them to a
+// space and dropping them there would glue words together; the help bar is a
+// single line, so they are folded to a space here instead of being kept.
+//
+// Stripping at the write path stops new bytes entering the tracker. It cannot
+// speak for a report header, a scan TSV, or a child process's stderr, none of
+// which pass through cell() -- and the flash renders all three.
+func sanitizeFlash(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			return ' '
+		case r < 0x20, r == 0x7f, r >= 0x80 && r <= 0x9f:
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func (m PipelineModel) renderHelp() string {
 	style := lipgloss.NewStyle().
 		Foreground(m.theme.Subtext).
@@ -1963,7 +1994,7 @@ func (m PipelineModel) renderHelp() string {
 			Background(m.theme.Surface).
 			Width(m.width).
 			Padding(0, 1)
-		return flashStyle.Render(m.flash)
+		return flashStyle.Render(sanitizeFlash(m.flash))
 	}
 
 	if m.colPicker {

--- a/dashboard/internal/ui/screens/pipeline_flash_test.go
+++ b/dashboard/internal/ui/screens/pipeline_flash_test.go
@@ -1,0 +1,86 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+	"github.com/santifer/career-ops/dashboard/internal/theme"
+)
+
+// newFlashTestModel builds the smallest pipeline model that renders a help bar.
+func newFlashTestModel(t *testing.T) PipelineModel {
+	t.Helper()
+	return NewPipelineModel(
+		theme.NewTheme("catppuccin-mocha"),
+		[]model.CareerApplication{{Company: "Globex", Role: "Engineer", Status: "Evaluated", Score: 4.0}},
+		model.PipelineMetrics{Total: 1},
+		t.TempDir(),
+		120,
+		40,
+	)
+}
+
+func TestSanitizeFlashDropsControlCharacters(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// The realistic shape: an escape sequence pasted into a tracker cell
+			// travels into the flash as part of the URL it could not open.
+			name: "escape sequence in a target",
+			in:   "Could not open https://example.com/\x1b[2J\x1b[1;31mFAKE: exit status 1",
+			want: "Could not open https://example.com/[2J[1;31mFAKE: exit status 1",
+		},
+		{
+			name: "bare escape and DEL",
+			in:   "a\x1bb\x7fc",
+			want: "abc",
+		},
+		{
+			name: "C1 control",
+			in:   "a\u0085c",
+			want: "ac",
+		},
+		{
+			// The help bar is one line, so the three whitespace controls are
+			// folded rather than dropped: dropping them would glue words.
+			name: "whitespace controls become spaces",
+			in:   "one\ttwo\rthree\nfour",
+			want: "one two three four",
+		},
+		{
+			name: "ordinary text is untouched",
+			in:   "Could not open /tmp/cv.pdf: exit status 1 — café ✅",
+			want: "Could not open /tmp/cv.pdf: exit status 1 — café ✅",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeFlash(tc.in); got != tc.want {
+				t.Fatalf("sanitizeFlash(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The guard has to sit at the render, not at one producer: renderHelp is the
+// single place every flash reaches the terminal.
+func TestRenderHelpStripsControlCharactersFromFlash(t *testing.T) {
+	pm := newFlashTestModel(t)
+	pm.flash = "Could not open https://example.com/\x1b[2Jwiped: exit status 1"
+
+	out := pm.renderHelp()
+
+	// lipgloss emits its own escape sequences for colour, so assert on the
+	// injected one specifically rather than on escapes in general.
+	if strings.Contains(out, "\x1b[2J") {
+		t.Fatalf("renderHelp passed an injected escape sequence through: %q", out)
+	}
+	if !strings.Contains(out, "wiped") {
+		t.Fatalf("renderHelp dropped the surrounding text: %q", out)
+	}
+}

--- a/dashboard/internal/ui/screens/pipeline_flash_test.go
+++ b/dashboard/internal/ui/screens/pipeline_flash_test.go
@@ -52,6 +52,16 @@ func TestSanitizeFlashDropsControlCharacters(t *testing.T) {
 			want: "one two three four",
 		},
 		{
+			// A byte that is not valid UTF-8 never reaches the terminal as
+			// itself: strings.Map hands the mapping function utf8.RuneError
+			// and writes U+FFFD, so a raw 0x9b — the byte an 8-bit terminal
+			// would read as CSI — is already destroyed. It is replaced rather
+			// than dropped, which is why the want here is not "ac".
+			name: "raw 0x9b is not valid UTF-8 and becomes the replacement rune",
+			in:   "a\x9bc",
+			want: "a\uFFFDc",
+		},
+		{
 			name: "ordinary text is untouched",
 			in:   "Could not open /tmp/cv.pdf: exit status 1 — café ✅",
 			want: "Could not open /tmp/cv.pdf: exit status 1 — café ✅",
@@ -64,6 +74,29 @@ func TestSanitizeFlashDropsControlCharacters(t *testing.T) {
 				t.Fatalf("sanitizeFlash(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// The property that matters is narrower than any single expected string: no
+// byte that a terminal could read as the start of an escape sequence survives,
+// whether it arrived as a well-formed rune or as a raw byte in text that was
+// never valid UTF-8 (a path or a child process's stderr need not be).
+func TestSanitizeFlashLeavesNoEscapeIntroducerByte(t *testing.T) {
+	inputs := []string{
+		"a\x1bc",   // ESC
+		"a\x9bc",   // raw CSI byte, invalid UTF-8 on its own
+		"a\u009bc", // the same C1 control, correctly encoded
+		"a\x80c",   // a stray continuation byte
+		"one\ttwo",
+		"café ✅",
+	}
+	for _, in := range inputs {
+		out := sanitizeFlash(in)
+		for i := 0; i < len(out); i++ {
+			if out[i] == 0x1b || out[i] == 0x9b {
+				t.Fatalf("sanitizeFlash(%q) = %q left byte %#x at %d", in, out, out[i], i)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Neutralizes control characters in the dashboard's help-bar flash, at the single place every flash reaches the terminal (`renderHelp`), rather than at each of the six producers that compose `m.flash`.

## Related issue

Closes #4027

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Why the render and not the producers

`flashStyle.Render(m.flash)` (`pipeline.go:1966`) is the only line that puts a flash on screen, and lipgloss wraps the string it is given verbatim. Six places compose `m.flash`; three splice in text the program did not write:

| site | what it splices in |
|---|---|
| `pipeline.go:477` | `summarizeCmdError(err, out)` — **the last non-empty line of `node generate-pdf.mjs`'s `CombinedOutput()`** (`main.go:278,293-300`) |
| `pipeline.go:654` | a report manifest path (`entry.HTMLPath`) |
| `pipeline.go:1025` | a Go error string |

Guarding the producers would mean six guards that must all be remembered again for the seventh, and a reader of `m.flash = …` could not tell which ones were. One `strings.Map` at the render covers all of them.

## Relationship to #3892 / #3902

`cell()` now strips `CONTROL_CHARS` at the tracker write path and `verify-pipeline.mjs` Check 16 catches one already written (`dadc8f6`). **That closes the tracker as a source, and this PR does not duplicate it.** What it cannot speak for is the three rows above — a child process's stderr, a manifest path, and a Go error string never pass through `cell()`.

The range here is the one `tracker-utils.mjs:100` exports, so the two halves of the codebase agree on what a control character is. One deliberate difference: `cell()` keeps `\t`, `\r` and `\n` because it has already folded them to a space; the help bar is a single line, so it folds them itself.

The dashboard's own OSC-8 hyperlinks (`pipeline.go:1995`, `viewer.go:608`) are untouched — the flash branch returns at `pipeline.go:1967`, before the manifesto link is composed.

## Tests

`dashboard/internal/ui/screens/pipeline_flash_test.go`:

- `TestSanitizeFlashDropsControlCharacters` — escape sequence inside a target, bare `ESC`/`DEL`, a C1 byte, the three whitespace controls folding to a space, and ordinary text (including accents and an emoji) passing through unchanged.
- `TestRenderHelpStripsControlCharactersFromFlash` — drives the real `renderHelp()`, asserting on the injected `\x1b[2J` specifically rather than on escapes in general, since lipgloss emits its own for colour.

Both fail without the change. Reverting only the `sanitizeFlash(...)` call at the render site:

```
--- FAIL: TestRenderHelpStripsControlCharactersFromFlash (0.00s)
    pipeline_flash_test.go:81: renderHelp passed an injected escape sequence through:
    " Could not open https://example.com/\x1b[2Jwiped: exit status 1 ..."
```

Green with it: `go build ./...`, `go vet ./...` and `go test ./...` under `dashboard/` all pass, and `node test-all.mjs --quick` exits 0 ("passed with warnings" — the warnings are the pre-existing personal-data heuristic firing on the owner's own name in `funding.json` / `HIRED.md` / `stats.go`, and `cv-sync-check.mjs` needing user data; none are from this change).

`gofmt -l` reports `internal/data/stats.go`, `internal/ui/screens/stats.go` and `main.go` — all three are that way on `main` and are untouched here.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

Context: this came out of a CodeRabbit finding on #3925. That PR adds a sixth flash producer, and the finding asked for sanitizing there. The exposure is real but it is not that PR's — it belongs to the shared render site and predates it, so #3925 stays as reviewed and the guard lands here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgtWMywGTyu6twnk1Bu9nP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Dashboard help-bar flashes now sanitize terminal control characters at `renderHelp` in `dashboard/internal/ui/screens/pipeline.go`.

Users see safe, single-line flash messages. Tabs, newlines, and carriage returns become spaces. Other C0, DEL, and C1 controls are removed. Ordinary text and dashboard-generated hyperlinks remain unchanged.

Tests cover sanitization, invalid UTF-8 bytes, and render-time protection in `dashboard/internal/ui/screens/pipeline_flash_test.go`.

Files touched: `dashboard/internal/ui/screens/pipeline.go`, `dashboard/internal/ui/screens/pipeline_flash_test.go`. No system files were touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->