### PR TITLE
test: pin JSON-last-on-stdout contract for set-status.mjs (#3855)

### DIFF
--- a/set-status.mjs
+++ b/set-status.mjs
@@ -235,6 +235,9 @@ const failWith = makeCliFailWith(flags.json);
 function failUsage(message) {
   const msg = message ?? 'Expected 2 arguments: <report#|company> <state>';
   if (rawArgs.includes('--json')) {
+    // CONTRACT: The JSON document must be the last thing printed on stdout.
+    // web/src/lib/parseCliJson reads it back and expects nothing after the closing brace.
+    // See tests/set-status-json-last-stdout.test.mjs (#3855).
     console.log(JSON.stringify({ error: msg, code: 'usage' }));
     console.error(`❌ ${msg}`);
   } else {
@@ -649,6 +652,9 @@ const result = {
 };
 
 if (flags.json) {
+  // CONTRACT: The JSON document must be the last thing printed on stdout.
+  // web/src/lib/parseCliJson reads it back and expects nothing after the closing brace.
+  // See tests/set-status-json-last-stdout.test.mjs (#3855).
   console.log(JSON.stringify(result, null, 2));
 } else {
   const verb = flags.dryRun ? 'would set' : changed ? 'set' : 'already';

--- a/tests/set-status-json-last-stdout.test.mjs
+++ b/tests/set-status-json-last-stdout.test.mjs
@@ -1,0 +1,100 @@
+// tests/set-status-json-last-stdout.test.mjs — set-status.mjs must keep stdout
+// clean so that --json output stays machine-parseable (issue #3855).
+//
+// The contract with web/src/lib/parseCliJson is that the JSON document is the
+// last thing printed on stdout. A single console.log added after the result
+// (a farewell line, a hint, a debug print) makes every successful status
+// write come back to the web as a 500, while the write itself lands in
+// applications.md and status-log.tsv.
+//
+// Run:  node --test tests/set-status-json-last-stdout.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function sandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-json-stdout-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  writeFileSync(join(dir, 'data', 'applications.md'), [
+    '# Applications Tracker',
+    '',
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 7 | 2026-02-01 | Acme | Backend Engineer | 4.4/5 | Evaluated | ✅ | [7](../reports/007-acme-2026-02-01.md) | notes |',
+    '',
+  ].join('\n'));
+  return dir;
+}
+
+function setStatus(dir, args) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'set-status.mjs'), ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CAREER_OPS_TRACKER: join(dir, 'data', 'applications.md') },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  return r;
+}
+
+test('success: JSON result is the last thing on stdout', () => {
+  const dir = sandbox();
+  try {
+    const r = setStatus(dir, ['--row', '7', 'Applied', '--json']);
+    assert.equal(r.status, 0, `set-status failed: ${r.stderr}`);
+
+    // Find the JSON object in stdout
+    const jsonStart = r.stdout.indexOf('{');
+    assert.notEqual(jsonStart, -1, 'no JSON object found in stdout');
+
+    // Extract everything after the closing brace
+    const jsonEnd = r.stdout.lastIndexOf('}');
+    assert.notEqual(jsonEnd, -1, 'no closing brace found in stdout');
+
+    const afterJson = r.stdout.slice(jsonEnd + 1);
+
+    // Assert that nothing follows the JSON but whitespace
+    assert.equal(
+      afterJson.trim(),
+      '',
+      `stdout has content after the JSON closing brace: ${JSON.stringify(afterJson)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});
+
+test('failure: JSON error is the last thing on stdout', () => {
+  const dir = sandbox();
+  try {
+    // Trigger a usage error (missing arguments) with --json
+    const r = setStatus(dir, ['--json']);
+    assert.notEqual(r.status, 0, 'expected non-zero exit for usage error');
+
+    // Find the JSON object in stdout
+    const jsonStart = r.stdout.indexOf('{');
+    assert.notEqual(jsonStart, -1, 'no JSON object found in stdout');
+
+    // Extract everything after the closing brace
+    const jsonEnd = r.stdout.lastIndexOf('}');
+    assert.notEqual(jsonEnd, -1, 'no closing brace found in stdout');
+
+    const afterJson = r.stdout.slice(jsonEnd + 1);
+
+    // Assert that nothing follows the JSON but whitespace
+    assert.equal(
+      afterJson.trim(),
+      '',
+      `stdout has content after the JSON closing brace: ${JSON.stringify(afterJson)}`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Adds a test that pins the contract that set-status.mjs's JSON result must be the last thing printed on stdout, for both the success and failure paths. Also adds inline comments at the two JSON output sites naming this contract for future contributors.

## Related issue

Fixes #3855

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added tests in `tests/set-status-json-last-stdout.test.mjs`: `set-status.mjs --json` now has coverage for one success and one failure.
- The tests use a temporary `CAREER_OPS_ROOT` and verify that only whitespace follows the final JSON object.
- Added comments in `set-status.mjs` near the JSON output sites: the JSON result must be the last stdout content for `web/src/lib/parseCliJson`.
- No runtime behavior changed.
- Touched system files: `set-status.mjs` and `tests/set-status-json-last-stdout.test.mjs`. No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->