### PR TITLE
docs(openai-eval): document Requesty as an OpenAI-compatible endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,11 +26,11 @@ OPENROUTER_API_KEY=sk-or-v1-paste-your-key-here
 # CAREER_OPS_MODEL=google/gemini-2.5-pro:free
 
 # ── OpenAI-compatible eval (openai-eval.mjs) ─────────────────────────────────
-# Evaluate offers with ANY OpenAI-compatible endpoint (OpenAI, OpenRouter,
+# Evaluate offers with ANY OpenAI-compatible endpoint (OpenAI, OpenRouter, Requesty,
 # Together, Groq, DeepSeek, Zhipu GLM, LM Studio, llama.cpp, vLLM, Ollama /v1).
 # Required for: node openai-eval.mjs "JD text here"
 # OPENAI_API_KEY=your_provider_key_here
-# OPENAI_BASE_URL=https://api.openai.com/v1   # e.g. https://openrouter.ai/api/v1
+# OPENAI_BASE_URL=https://api.openai.com/v1   # e.g. https://openrouter.ai/api/v1 or https://router.requesty.ai/v1
 # OPENAI_MODEL=gpt-4o-mini                     # e.g. deepseek/deepseek-chat
 
 # ── Other integrations (add your own below) ──────────────────────────────────

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -238,7 +238,7 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 > OPENAI_API_KEY=your_key \
 > node openai-eval.mjs --file ./jds/job.txt
 > ```
-> Requesty (`https://router.requesty.ai/v1`) is another OpenAI-compatible router that works the same way — one key across OpenAI, Anthropic, Google, DeepSeek and others, with the same `cache_control` prompt caching the OpenRouter path uses:
+> Requesty (`https://router.requesty.ai/v1`) is another OpenAI-compatible router that works the same way — one key across OpenAI, Anthropic, Google, DeepSeek and others. Prompt caching depends on the model: Anthropic models honor the `cache_control` breakpoints the script already sends, while OpenAI models such as `gpt-4o-mini` cache automatically on the provider side without any request changes:
 > ```bash
 > OPENAI_BASE_URL=https://router.requesty.ai/v1 \
 > OPENAI_MODEL=openai/gpt-4o-mini \

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -231,13 +231,21 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 | **Kimi K2.5** | Moonshot AI | API pricing applies | Verified with OpenCode using the Moonshot OpenAI-compatible endpoint. Produces structured Markdown suitable for Career-Ops evaluations. See the verified OpenCode recipe below. |
 
 
-> **Standalone evaluator (no CLI config needed):** every OpenAI-compatible provider above (DeepSeek, Qwen, GLM, Together, Groq, OpenRouter, …) works directly through `node openai-eval.mjs` — just set a base URL, model, and key:
+> **Standalone evaluator (no CLI config needed):** every OpenAI-compatible provider above (DeepSeek, Qwen, GLM, Together, Groq, OpenRouter, Requesty, …) works directly through `node openai-eval.mjs` — just set a base URL, model, and key:
 > ```bash
 > OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
 > OPENAI_MODEL=deepseek/deepseek-chat \
 > OPENAI_API_KEY=your_key \
 > node openai-eval.mjs --file ./jds/job.txt
 > ```
+> Requesty (`https://router.requesty.ai/v1`) is another OpenAI-compatible router that works the same way — one key across OpenAI, Anthropic, Google, DeepSeek and others, with the same `cache_control` prompt caching the OpenRouter path uses:
+> ```bash
+> OPENAI_BASE_URL=https://router.requesty.ai/v1 \
+> OPENAI_MODEL=openai/gpt-4o-mini \
+> OPENAI_API_KEY=your_requesty_key \
+> node openai-eval.mjs --file ./jds/job.txt
+> ```
+>
 > Run `node openai-eval.mjs --help` for per-provider examples. For 100% local/private use, point `--url` at a local server (LM Studio / llama.cpp / vLLM) or use `node ollama-eval.mjs`.
 
 > NVIDIA NIM also works (hosted `https://integrate.api.nvidia.com/v1` or a self-hosted container's `/v1`), e.g. `--model meta/llama-3.3-70b-instruct`. The hosted free tier can queue for minutes, so raise `OPENAI_TIMEOUT_MS` above the 300s default.

--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -3,7 +3,7 @@
  * openai-eval.mjs — OpenAI-compatible Job Offer Evaluator for career-ops
  *
  * Evaluate job offers with ANY OpenAI-compatible chat endpoint instead of Claude.
- * Works with OpenAI, OpenRouter, Together, Groq, DeepSeek, Zhipu GLM, MiniMax,
+ * Works with OpenAI, OpenRouter, Requesty, Together, Groq, DeepSeek, Zhipu GLM, MiniMax,
  * Fireworks, and local servers that speak the OpenAI API (LM Studio, llama.cpp,
  * vLLM, Ollama's /v1). Point it at a base URL + model + key and go.
  *
@@ -103,6 +103,7 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
 
   PROVIDER EXAMPLES (cheap / free-tier friendly — addresses token cost)
     OpenRouter:  --url https://openrouter.ai/api/v1   --model deepseek/deepseek-chat
+    Requesty:    --url https://router.requesty.ai/v1  --model deepseek/deepseek-chat
     Together:    --url https://api.together.xyz/v1     --model meta-llama/Llama-3.3-70B-Instruct-Turbo
     Groq:        --url https://api.groq.com/openai/v1  --model llama-3.3-70b-versatile
     DeepSeek:    --url https://api.deepseek.com/v1     --model deepseek-chat
@@ -377,7 +378,7 @@ LEGITIMACY: <High Confidence | Proceed with Caution | Suspicious>
 // OpenRouter runner. The static prefix (shared + oferta + cv, ~12K tokens) is
 // byte-identical across every offer, yet was re-sent and re-billed each call.
 //
-// Host-gated on purpose: OpenAI-compatible gateways (OpenRouter, DeepSeek, …)
+// Host-gated on purpose: OpenAI-compatible gateways (OpenRouter, Requesty, DeepSeek, …)
 // honor an ephemeral `cache_control` breakpoint on the prefix and reuse it
 // across back-to-back calls within the cache TTL. api.openai.com instead caches
 // long prefixes automatically and may reject the non-standard field, so it gets


### PR DESCRIPTION
## What

Documents **Requesty** (https://requesty.ai) as a supported endpoint for the standalone OpenAI-compatible evaluator, alongside OpenRouter. Requesty is an OpenAI-compatible LLM router (one key across OpenAI, Anthropic, Google, DeepSeek, …), so `openai-eval.mjs` already works with it unchanged, this PR just makes that discoverable:

- `openai-eval.mjs`: header provider list, a `Requesty: --url https://router.requesty.ai/v1 --model deepseek/deepseek-chat` line in `--help` PROVIDER EXAMPLES, and the `cache_control` host-gate comment now names Requesty among the gateways that honor the ephemeral prompt-cache breakpoint (it does, same behaviour as the OpenRouter runner).
- `.env.example`: `OPENAI_BASE_URL` example now shows both routers.
- `docs/RUNNING_ON_A_BUDGET.md`: one short recipe block for Requesty under the standalone-evaluator note.

No code paths change; no personal data, scan results or pipeline data included. Scope kept to docs/examples on purpose, a separate `requesty-runner.mjs` would duplicate `openrouter-runner.mjs`, whose free-tier model rotation and `:free` filtering are OpenRouter-specific.

## Testing

- `node test-all.mjs` → 8687 passed, 0 failed (16 warnings, identical on a clean `main`).
- Live: `node openai-eval.mjs --url https://router.requesty.ai/v1 --model openai/gpt-4o-mini --file jd.txt --no-save` with an isolated `CAREER_OPS_ROOT` and a throwaway cv.md produced a full evaluation report (`SCORE: 4.2`, archetype + legitimacy sections, requirement table), exit 0.

- [x] I have read CONTRIBUTING.md
- [x] Docs/provider change, no issue needed per CONTRIBUTING
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can run `openai-eval.mjs` with Requesty by setting `OPENAI_BASE_URL`, `OPENAI_MODEL`, and `OPENAI_API_KEY`.

- `.env.example:29-34`: Adds Requesty to the provider list and shows its base URL.
- `openai-eval.mjs:6,105-106`: Adds Requesty to the documentation and provider examples.
- `openai-eval.mjs:381-384`: Documents `cache_control` handling for OpenAI-compatible gateways.
- `docs/RUNNING_ON_A_BUDGET.md:285-296`: Adds Requesty setup and caching guidance.
- No evaluator code paths or separate Requesty runner changed. Existing OpenRouter-specific rotation and `:free` filtering remain unchanged.
- No breaking changes are documented.

Validation: 8,687 tests passed, and a live Requesty evaluation succeeded. A later quick-suite run reported 8,943 passing tests with 0 failures.

System files touched: None of `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
