### PR TITLE
fix(set-status): resolve the tracker from the data root, not the code dir (#3867 finding 1)

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -21,7 +21,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, chmodSync, utimesSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, chmodSync, utimesSync, realpathSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -1419,6 +1419,48 @@ for (const bad of ['correction', 'backfill', 'cell-edit', 'nonsense']) {
       if (r.code !== 0) pass('#3075: Notes is a fallback only — a populated Report cell wins');
       else fail('#3075: a Notes link overrode a populated Report cell');
     } finally { rmSync(sb.dir, { recursive: true, force: true }); }
+  }
+}
+
+// ── #3867: the tracker resolves from the configured data root, not the code dir ──
+//    A split checkout points CAREER_OPS_DATA_DIR at a data-only directory and
+//    leaves no tracker beside the code. set-status.mjs used to resolve its
+//    tracker from `dirname(import.meta.url)` (the code dir), so every command
+//    failed with "No tracker found". It must honour the data root for user data
+//    while still reading templates/states.yml from the codebase.
+{
+  const dataDir = mkdtempSync(join(tmpdir(), 'co-setstatus-dataroot-'));
+  mkdirSync(join(dataDir, 'data'), { recursive: true });
+  const tracker = join(dataDir, 'data', 'applications.md');
+  writeFileSync(tracker, TRACKER_9);
+  const lock = join(dataDir, 'career-ops-merge-tracker-test.lock');
+  const env = {
+    ...process.env,
+    CAREER_OPS_DATA_DIR: dataDir,
+    // getCareerOpsRoot() reads CAREER_OPS_ROOT before CAREER_OPS_DATA_DIR, so a
+    // value inherited from the dev/CI environment would win and point the probe
+    // at the wrong tree. Clear it, mirroring web-core-argv-contract's clearing
+    // of CAREER_OPS_DATA_DIR when it drives the root the other way.
+    CAREER_OPS_ROOT: '',
+    CAREER_OPS_TRACKER: '',       // no explicit override — force root resolution
+    CAREER_OPS_TRACKER_LOCK: lock,
+  };
+  try {
+    const r = execFileSync(NODE, [join(ROOT, 'set-status.mjs'), '2', 'Interview', '--dry-run', '--json'], {
+      cwd: ROOT, env, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const out = JSON.parse(r);
+    // set-status canonicalizes the tracker path (realpath); do the same on the
+    // expected side so a /var → /private/var symlink on macOS is not a failure.
+    if (out.tracker === realpathSync(tracker)) {
+      pass('#3867: set-status resolves the tracker from CAREER_OPS_DATA_DIR/data/applications.md');
+    } else {
+      fail(`#3867: expected tracker ${realpathSync(tracker)}, got ${out.tracker}`);
+    }
+  } catch (e) {
+    fail(`#3867: set-status failed under a split checkout: ${(e.stderr || e.message || '').split('\n')[0]}`);
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
   }
 }
 

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -95,13 +95,21 @@ import { fileURLToPath } from 'url';
 import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, loadCanonicalStates, resolveCanonicalState,
   normalizeCompany, cell, CLI_EXIT, makeCliFailWith, acquireTrackerLockForCli,
 } from './tracker-utils.mjs';
 
-const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
+// The tracker (and its status-log.tsv / follow-ups.md siblings) is USER data —
+// resolve it from the configured data root (CAREER_OPS_ROOT / CAREER_OPS_DATA_DIR
+// / .career-ops-data), so a split checkout finds the tracker instead of looking
+// for it beside the code (#3867). templates/states.yml is a SYSTEM file and
+// stays bound to the codebase directory — same split as merge-tracker.mjs and
+// normalize-statuses.mjs (#3500).
+const CODE_ROOT = dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
+const STATES_FILE = join(CODE_ROOT, 'templates/states.yml');
 
 // LOCK_TIMEOUT is not destructured here — that exit path is raised inside
 // acquireTrackerLockForCli() itself (tracker-utils.mjs), via CLI_EXIT.LOCK_TIMEOUT.
@@ -260,7 +268,7 @@ if (!newStatus) {
 
 // ── tracker access ───────────────────────────────────────────────
 
-const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
 if (!existsSync(APPS_FILE)) {
   failWith(EXIT_NOT_FOUND, 'no-tracker', `No tracker found at ${APPS_FILE}`);
 }

--- a/tests/web-core-argv-contract.test.mjs
+++ b/tests/web-core-argv-contract.test.mjs
@@ -105,9 +105,9 @@ try {
     ...process.env,
     CAREER_OPS_ROOT: sandbox,
     CAREER_OPS_DATA_DIR: '',
-    // set-status.mjs resolves its root from the codebase, not from
-    // CAREER_OPS_ROOT, so without this the probe would read and write the
-    // developer's own tracker.
+    // set-status.mjs resolves the tracker from CAREER_OPS_ROOT since #3867; the
+    // explicit CAREER_OPS_TRACKER is kept as a belt-and-braces so the probe can
+    // never touch the developer's own tracker even if that resolution regresses.
     CAREER_OPS_TRACKER: tracker,
     // verify-portals.mjs reads portals.yml relative to the codebase root, and
     // a real one would put this probe on the network. Point it at a path that


### PR DESCRIPTION
Finding 1 of #3867 (`confirmed` + `help wanted`; finding 2 was #3761, finding 3 is separate).

## The bug

`set-status.mjs` bound its root to `dirname(fileURLToPath(import.meta.url))` and handed that to `resolveTrackerPath()`. On a split checkout — code at `~/career-ops`, data-only root at `~/career-ops-data` via `CAREER_OPS_DATA_DIR`, which `path-resolver.mjs`'s documented precedence honours — it looked for `applications.md` (and `status-log.tsv` / `follow-ups.md`, resolved as its siblings) **beside the code**, not in the data root.

@santifer confirmed by reading:
> Finding 1 holds by reading: `set-status.mjs:103` sets its root from `import.meta.url` and never calls `getCareerOpsRoot()`.

Worse than a clean "not found": if any `applications.md` happened to sit in the code checkout (a developer's own, say), set-status would silently read and write *that* one.

## The fix

Split the single root into two, exactly as `merge-tracker.mjs` and `normalize-statuses.mjs` already do (#3500):

- `CODE_ROOT` → `templates/states.yml` (a **system** file — unchanged)
- `DATA_ROOT = getCareerOpsRoot()` → the tracker (**user** data)

`status-log.tsv` and `follow-ups.md` are derived from `dirname(APPS_FILE)`, so they follow for free. `CAREER_OPS_TRACKER` still overrides everything.

## Tests

- **`set-status-tests.mjs` new case (#3867):** a `CAREER_OPS_DATA_DIR` split checkout with no tracker beside the code; asserts `set-status --json` resolves `tracker` to `<data-dir>/data/applications.md`. Verified it **fails on `main`** (resolves to the repo's own tracker) and passes with the fix. 97/97.
- **`tests/web-core-argv-contract.test.mjs`:** the comment that documented the old behaviour as intended is updated; its explicit `CAREER_OPS_TRACKER` is kept as belt-and-braces. Still green.

## Test plan

- [x] `node set-status-tests.mjs` — 97 passed, 0 failed
- [x] `node --test tests/web-core-argv-contract.test.mjs tests/set-status-seeds-followup.test.mjs`
- [x] `node test-all.mjs` — 8686 passed, 0 failed (1 pre-existing local flake: `update-system.mjs check` SIGTERM'd on this machine's slow link to GitHub — untouched by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`set-status.mjs` now resolves the tracker from `CAREER_OPS_DATA_DIR` and loads `templates/states.yml` from the code directory. `CAREER_OPS_TRACKER` keeps precedence. `status-log.tsv` and `follow-ups.md` continue to use the tracker directory.

Users can run `set-status.mjs` with separate code and data roots.

## Tests

Added split-checkout regression coverage in `set-status-tests.mjs`. Updated the web-core argument contract comment in `tests/web-core-argv-contract.test.mjs`.

Validation passed: 97 dedicated tests and 8,686 full-suite tests. One pre-existing local GitHub-link flake remains.

## Files touched

- `set-status.mjs`
- `set-status-tests.mjs`
- `tests/web-core-argv-contract.test.mjs`

The change does not touch these system files: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->