### PR TITLE
feat(scan): opt-in location_filter.strict fails closed on empty locations (#3276)

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -286,8 +286,13 @@ export function matchedTitleKeywords(title, titleFilter) {
 // ── Location filter ─────────────────────────────────────────────────
 // Optional. If `location_filter` is absent from portals.yml, all locations pass.
 // Semantics (case-insensitive substring, in this order):
-//   - Empty / whitespace-only / non-string location → pass (don't penalize
-//     missing or malformed provider data)
+//   - Empty / whitespace-only / non-string location AND no URL hint → pass
+//     (don't penalize missing or malformed provider data), UNLESS
+//     `location_filter.strict: true` and a restricting tier (`allow`, `block`,
+//     or `block_hard`) is configured — then reject, because a location-
+//     restricted sweep against a provider that does not return locations
+//     (iCIMS) otherwise silently inverts into "everything, plus matches from
+//     everywhere else" (#3276). Opt-in and default-unchanged.
 //   - `block_hard` matches → reject (the only tier `always_allow` cannot
 //     override; for country-level terms that are never a false rejection)
 //   - `always_allow` matches → pass (takes precedence over `block` — lets a
@@ -512,12 +517,20 @@ export function buildLocationFilter(locationFilter) {
   const allow = compileLocationKeywordList(locationFilter.allow);
   const block = compileLocationKeywordList(locationFilter.block);
   const blockHard = compileLocationKeywordList(locationFilter.block_hard);
+  // Opt-in: fail closed when there is nothing to judge on. Only meaningful when
+  // a restricting tier is configured — `{ strict: true }` alone restricts
+  // nothing and must not reject every location-less posting (#3276).
+  const strict = locationFilter.strict === true
+    && (allow.length > 0 || block.length > 0 || blockHard.length > 0);
 
   return (location, url, title) => {
     const lower = typeof location === 'string' ? location.trim().toLowerCase() : '';
     const hint = locationHintFromUrl(url);
-    // Nothing to judge on either field → pass (don't penalize missing data).
-    if (lower === '' && hint === '') return true;
+    // Nothing to judge on either field → pass (don't penalize missing data),
+    // unless the config opted into strict mode: a location-restricted sweep
+    // against a provider that never returns a location would otherwise let
+    // every out-of-region posting through (#3276).
+    if (lower === '' && hint === '') return !strict;
     const matches = (m) => (lower !== '' && m(lower)) || (hint !== '' && m(hint));
     // `block_hard` is the ONE tier always_allow cannot override. It exists because
     // a European city name can be a whole word inside a non-European location, so

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -100,6 +100,15 @@
 # Do NOT copy your whole `block` list here: a city in block_hard would kill
 # "Stockholm or London" postings, which is exactly what always_allow prevents.
 #
+# `strict: true` (optional) fails CLOSED when a posting has no location at all
+# (empty structured field AND no city in the URL). The default passes such a
+# posting — "don't penalize missing provider data" — which is right for a
+# broad sweep. But a location-*restricted* sweep over a provider that never
+# returns a location (iCIMS is the common case) then lets every out-of-region
+# posting through: the "only these places" allow list is never consulted.
+# Turn strict on for those sweeps. It only bites when a restricting tier
+# (allow / block / block_hard) is set; `strict: true` alone restricts nothing.
+#
 # Example below targets US-based remote + a couple of US metros, blocking
 # common foreign hubs. Customize to your geography.
 
@@ -108,6 +117,7 @@
 #   always_allow:
 #     - "United States"   # also admits City, ST homonyms (Dublin, OH) via USPS states
 #     - "New York"
+#   # strict: true       # reject postings with no location — see note above
 #   allow:
 #     - "Remote"
 #     - "United States"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7772,6 +7772,50 @@ try {
     fail('remote-title rescue changed behavior for non-remote or malformed titles');
   }
 
+  // Case 28: `location_filter.strict` (#3276). A location-restricted sweep over
+  // a provider that never returns a location (iCIMS) otherwise lets every
+  // out-of-region posting through, because the empty-location short-circuit
+  // passes before `allow` is consulted.
+  {
+    const lenient = buildLocationFilter({ allow: ['puerto rico', 'san juan'] });
+    const strict = buildLocationFilter({ allow: ['puerto rico', 'san juan'], strict: true });
+    const icimsUrl = 'https://careers-peraton.icims.com/jobs/168257/data-architect/job';
+    if (
+      // default: an empty-location iCIMS posting still passes (unchanged)
+      lenient('', icimsUrl) === true &&
+      // strict: the same posting is now rejected — no location, no confirmation
+      strict('', icimsUrl) === false &&
+      strict('', undefined) === false &&
+      strict(null, null) === false &&
+      // strict never touches a posting that DOES carry a matching location
+      strict('San Juan, PR', undefined) === true &&
+      // strict still rejects a real out-of-region location (allow unchanged)
+      strict('Boston, MA', undefined) === false
+    ) {
+      pass('location_filter.strict fails closed on empty locations without changing the default');
+    } else {
+      fail('location_filter.strict did not gate empty-location postings correctly');
+    }
+  }
+
+  // Case 29: `strict: true` alone — with no allow/block/block_hard — restricts
+  // nothing and must not reject every location-less posting.
+  {
+    const strictNoTiers = buildLocationFilter({ strict: true });
+    const strictBlockOnly = buildLocationFilter({ block: ['india'], strict: true });
+    if (
+      strictNoTiers('', undefined) === true &&
+      strictNoTiers('Anywhere', undefined) === true &&
+      // a block-only strict config DOES fail closed (can't confirm it's not blocked)
+      strictBlockOnly('', undefined) === false &&
+      strictBlockOnly('Berlin, Germany', undefined) === true
+    ) {
+      pass('strict:true with no restricting tier is inert; block-only strict fails closed');
+    } else {
+      fail('strict:true handling of the no-tier / block-only cases is wrong');
+    }
+  }
+
   if (
     shouldDedupScanHistoryRow({ firstSeen: '2026-06-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&
     shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === false &&

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7772,49 +7772,8 @@ try {
     fail('remote-title rescue changed behavior for non-remote or malformed titles');
   }
 
-  // Case 28: `location_filter.strict` (#3276). A location-restricted sweep over
-  // a provider that never returns a location (iCIMS) otherwise lets every
-  // out-of-region posting through, because the empty-location short-circuit
-  // passes before `allow` is consulted.
-  {
-    const lenient = buildLocationFilter({ allow: ['puerto rico', 'san juan'] });
-    const strict = buildLocationFilter({ allow: ['puerto rico', 'san juan'], strict: true });
-    const icimsUrl = 'https://careers-peraton.icims.com/jobs/168257/data-architect/job';
-    if (
-      // default: an empty-location iCIMS posting still passes (unchanged)
-      lenient('', icimsUrl) === true &&
-      // strict: the same posting is now rejected — no location, no confirmation
-      strict('', icimsUrl) === false &&
-      strict('', undefined) === false &&
-      strict(null, null) === false &&
-      // strict never touches a posting that DOES carry a matching location
-      strict('San Juan, PR', undefined) === true &&
-      // strict still rejects a real out-of-region location (allow unchanged)
-      strict('Boston, MA', undefined) === false
-    ) {
-      pass('location_filter.strict fails closed on empty locations without changing the default');
-    } else {
-      fail('location_filter.strict did not gate empty-location postings correctly');
-    }
-  }
-
-  // Case 29: `strict: true` alone — with no allow/block/block_hard — restricts
-  // nothing and must not reject every location-less posting.
-  {
-    const strictNoTiers = buildLocationFilter({ strict: true });
-    const strictBlockOnly = buildLocationFilter({ block: ['india'], strict: true });
-    if (
-      strictNoTiers('', undefined) === true &&
-      strictNoTiers('Anywhere', undefined) === true &&
-      // a block-only strict config DOES fail closed (can't confirm it's not blocked)
-      strictBlockOnly('', undefined) === false &&
-      strictBlockOnly('Berlin, Germany', undefined) === true
-    ) {
-      pass('strict:true with no restricting tier is inert; block-only strict fails closed');
-    } else {
-      fail('strict:true handling of the no-tier / block-only cases is wrong');
-    }
-  }
+  // location_filter.strict coverage lives in tests/location-filter-strict.test.mjs.
+  // Keep this central harness focused on broad scan integration behavior.
 
   if (
     shouldDedupScanHistoryRow({ firstSeen: '2026-06-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&

--- a/tests/location-filter-strict.test.mjs
+++ b/tests/location-filter-strict.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildLocationFilter } from '../scan.mjs';
+
+test('location_filter.strict fails closed on empty locations without changing the default', () => {
+  const lenient = buildLocationFilter({ allow: ['puerto rico', 'san juan'] });
+  const strict = buildLocationFilter({ allow: ['puerto rico', 'san juan'], strict: true });
+  const icimsUrl = 'https://careers-peraton.icims.com/jobs/168257/data-architect/job';
+
+  assert.equal(lenient('', icimsUrl), true, 'default: empty-location iCIMS posting still passes');
+  assert.equal(strict('', icimsUrl), false, 'strict: empty-location iCIMS posting is rejected');
+  assert.equal(strict('', undefined), false);
+  assert.equal(strict(null, null), false);
+  assert.equal(strict('San Juan, PR', undefined), true, 'strict preserves matching locations');
+  assert.equal(strict('Boston, MA', undefined), false, 'strict still rejects real out-of-region locations');
+});
+
+test('strict:true with no restricting tier is inert; block-only strict fails closed', () => {
+  const strictNoTiers = buildLocationFilter({ strict: true });
+  const strictBlockOnly = buildLocationFilter({ block: ['india'], strict: true });
+
+  assert.equal(strictNoTiers('', undefined), true);
+  assert.equal(strictNoTiers('Anywhere', undefined), true);
+  assert.equal(strictBlockOnly('', undefined), false, 'block-only strict cannot confirm an empty location is safe');
+  assert.equal(strictBlockOnly('Berlin, Germany', undefined), true);
+});

--- a/tests/validate-portals-location-filter-strict.test.mjs
+++ b/tests/validate-portals-location-filter-strict.test.mjs
@@ -1,0 +1,56 @@
+// tests/validate-portals-location-filter-strict.test.mjs — validate-portals
+// type-checks the opt-in `location_filter.strict` flag (#3276): a boolean is
+// accepted, a non-boolean is rejected by name, and omitting it stays valid.
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, run, NODE } from './helpers.mjs';
+
+console.log('\nvalidate-portals — location_filter.strict');
+
+const tmp = mkdtempSync(join(tmpdir(), 'co-lfs-'));
+
+const CONFIG = (strictLine) => `
+title_filter:
+  positive: ["AI Engineer"]
+location_filter:
+  allow: ["Puerto Rico"]
+${strictLine}
+tracked_companies:
+  - name: "Acme"
+    careers_url: "https://jobs.lever.co/acme"
+`;
+
+try {
+  const boolPath = join(tmp, 'strict-bool.yml');
+  writeFileSync(boolPath, CONFIG('  strict: true'), 'utf-8');
+
+  const stringPath = join(tmp, 'strict-string.yml');
+  writeFileSync(stringPath, CONFIG('  strict: "yes"'), 'utf-8');
+
+  const absentPath = join(tmp, 'strict-absent.yml');
+  writeFileSync(absentPath, CONFIG(''), 'utf-8');
+
+  const boolResult = run(NODE, ['validate-portals.mjs', '--file', boolPath]);
+  if (boolResult !== null && boolResult.includes('0 errors')) {
+    pass('validate-portals accepts location_filter.strict: true');
+  } else {
+    fail('validate-portals should accept a boolean location_filter.strict');
+  }
+
+  const stringResult = run(NODE, ['validate-portals.mjs', '--file', stringPath]);
+  if (stringResult === null) {
+    pass('validate-portals rejects a non-boolean location_filter.strict');
+  } else {
+    fail('validate-portals should reject location_filter.strict: "yes"');
+  }
+
+  const absentResult = run(NODE, ['validate-portals.mjs', '--file', absentPath]);
+  if (absentResult !== null && absentResult.includes('0 errors')) {
+    pass('validate-portals accepts a location_filter with no strict key');
+  } else {
+    fail('validate-portals should accept a location_filter that omits strict');
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -170,6 +170,9 @@ export async function validatePortalsConfig(config, { providerIds = new Set() } 
       validateKeywordList(config.location_filter.allow, 'location_filter.allow', errors);
       validateKeywordList(config.location_filter.block, 'location_filter.block', errors);
       validateKeywordList(config.location_filter.block_hard, 'location_filter.block_hard', errors);
+      if (config.location_filter.strict !== undefined && typeof config.location_filter.strict !== 'boolean') {
+        add(errors, 'location_filter.strict', 'must be a boolean when set');
+      }
     }
   }
 


### PR DESCRIPTION
Closes #3276 (`confirmed`, design specified by @santifer).

## The bug

`buildLocationFilter()` short-circuits to **pass** when a posting has no location at all — empty structured field **and** no city in the URL — before the `allow` list is ever consulted:

```js
if (lower === '' && hint === '') return true;   // "don't penalize missing data"
```

For a broad sweep that default is right. For a **location-restricted** sweep over a provider that never returns a structured location — **iCIMS** is the common case, its URLs (`careers-{tenant}.icims.com/jobs/{id}/{slug}/job`) carry no geography either — it silently inverts the filter: the "only these places" `allow` list is never applied, and every out-of-region posting passes.

From the issue, one `scan-ats-full.mjs --since 45 --dry-run` run restricted to one region: **59 matches, 0 in the requested region**, 51 of them empty-location iCIMS rows.

@santifer:
> The fix that respects both users: an opt-in `location_filter.strict: true` that fails closed on empty fields, default unchanged.

## The fix

`location_filter.strict: true` (opt-in). When set **and** a restricting tier (`allow` / `block` / `block_hard`) is configured, a location-less posting is **rejected** instead of passed. `strict: true` alone restricts nothing and stays inert — the flag only bites when there is a restriction to enforce.

- **`scan.mjs`** — the `strict` flag plus the single gated `return`:
  ```js
  if (lower === '' && hint === '') return !strict;
  ```
- **`validate-portals.mjs`** — type-checks `strict` (`must be a boolean when set`), same shape as `visa_filter.enabled`.
- **`templates/portals.example.yml`** — documents when to turn it on (iCIMS-class providers, restricted sweeps).

## Tests — `test-all.mjs` cases 28–29

- **28:** the iCIMS repro from the issue — empty location + non-empty `allow` passes by default, is rejected under `strict`; a posting that *does* carry a matching location still passes; a real out-of-region location still rejects.
- **29:** `strict: true` with no `allow`/`block`/`block_hard` is inert (passes everything); a block-only `strict` config fails closed on empty locations but passes a real non-blocked one.

## Test plan

- [x] `node validate-portals.mjs --self-test`
- [x] `node validate-portals.mjs --file templates/portals.example.yml` — 0 errors
- [x] `node --test tests/providers/icims.test.mjs tests/scan-dedup-location-aware.test.mjs`
- [x] `node test-all.mjs` — 8689 passed, 0 failed (16 pre-existing warnings: external board 503s, Workday truncation notes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can set `location_filter.strict: true` to reject postings with no location data when `allow`, `block`, or `block_hard` is configured. Matching locations still pass, and out-of-region locations remain rejected. Default behavior remains unchanged. Strict mode alone has no effect. Non-boolean values fail validation.

## Changes

- `scan.mjs:287-296, 519-549`: Adds strict handling for empty locations.
- `validate-portals.mjs:165-174`: Requires `strict` to be boolean.
- `templates/portals.example.yml:103-120`: Documents strict mode and `block_hard`.
- `modes/scan.md:218-221`: Documents filtering behavior.
- `tests/location-filter-strict.test.mjs:5-36`: Covers empty locations and strict edge cases.
- `tests/validate-portals-location-filter-strict.test.mjs:24-53`: Covers valid, invalid, and omitted values.
- `test-all.mjs:7775`: Points to the dedicated strict-filter tests.

System files touched: `modes/` is touched through `modes/scan.md`. `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->