### PR TITLE
fix(web): resolve the CV template from cv.template on dashboard runs

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -14,6 +14,7 @@ import { renderAndMarkPdf, writeCvHtml, pdfRunOutcome } from "@/lib/pdf-render.m
 import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
 import { buildPrompt, isShellSafeCompanyName } from "@/lib/run-prompts.mjs";
 import { claudeCliArgs } from "@/lib/claude-invocation.mjs";
+import { resolveCvTemplate } from "@/lib/core/cv-template";
 import { acquireTrackerWrite, releaseTrackerWrite } from "@/lib/core/run-registry";
 
 export const runtime = "nodejs";
@@ -111,7 +112,12 @@ export async function POST(req: Request) {
     kind === "evaluate"
       ? readInbox().find((j) => j.url === input)?.postedAt ?? readScanDates().get(input)
       : undefined;
-  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang });
+  // Which CV template the worker fills. Resolved HERE, for the same reason `lang`
+  // is: the worker has no Bash (#2172), so it cannot run cv-templates.mjs and the
+  // prompt used to name the base template outright, silently ignoring cv.template
+  // (#4034). Only pdf fills a template, so nothing else pays for the lookup.
+  const cvTemplate = kind === "pdf" ? await resolveCvTemplate() : undefined;
+  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang, cvTemplate });
 
   const isClaude = cliId === "claude";
   // Which tools each kind gets, and the whole claude argv, live in

--- a/web/src/lib/core/cv-template.ts
+++ b/web/src/lib/core/cv-template.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { careerOpsRoot } from "@/lib/career-ops";
+import { BASE_CV_TEMPLATE } from "@/lib/run-prompts.mjs";
+
+/**
+ * ACL for the core's CV-template resolver (cv-templates.mjs), so a dashboard pdf
+ * run fills the same template the CLI fills (#4034).
+ *
+ * The worker cannot resolve this itself. pdf lost Bash in #2172 and must never
+ * regain it, so it can neither run cv-templates.mjs nor list templates/, and the
+ * prompt named the base template outright as a result. That silently overrode
+ * cv.template for anyone who had set one: same report, two different CVs,
+ * depending only on where the run was started.
+ *
+ * Resolution stays the core's. We call resolveTemplate with no dir or profile
+ * override, so it uses cv-templates.mjs's own defaults relative to the user's
+ * checkout — the same paths, the same CAREER_OPS_PROFILE handling, and template
+ * packs (#3202) resolve here exactly as they do on the CLI. Reimplementing the
+ * lookup in the web app would be a second source of truth that drifts.
+ *
+ * Never throws: a template that cannot be resolved yields the base template, and
+ * the run still produces a CV. `fallback: true` already covers a name that does
+ * not exist; the catch is for a checkout too old to export resolveTemplate, and
+ * for a template whose placeholders fail validation.
+ */
+export async function resolveCvTemplate(): Promise<string> {
+  const root = careerOpsRoot();
+  const file = path.join(root, "cv-templates.mjs");
+  try {
+    const mod = await import(/* webpackIgnore: true */ pathToFileURL(file).href);
+    if (typeof mod?.resolveTemplate !== "function") return BASE_CV_TEMPLATE;
+    const abs = mod.resolveTemplate("cv", null, { fallback: true });
+    if (typeof abs !== "string" || !abs) return BASE_CV_TEMPLATE;
+    // The prompt names a repo-relative path, and always with forward slashes:
+    // path.relative gives backslashes on Windows, which is not how any of the
+    // agent-facing paths in this prompt are written.
+    const rel = path.relative(root, abs).split(path.sep).join("/");
+    return rel || BASE_CV_TEMPLATE;
+  } catch {
+    return BASE_CV_TEMPLATE;
+  }
+}

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -51,7 +51,30 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
 /** ISO calendar date, the only form the dashboard's POSTED column parses. */
 const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
 
-export function buildPrompt({ kind, input, memory, today, postedAt, lang }) {
+/** The CV template every run falls back to, relative to the career-ops root. */
+export const BASE_CV_TEMPLATE = "templates/cv-template.html";
+
+/**
+ * Shapes cv-templates.mjs can produce: a flat `templates/cv-template.<name>.html`
+ * or a file inside a template pack (#3202). Anything else is not a template this
+ * prompt should name.
+ */
+const CV_TEMPLATE_RE = /^templates\/[A-Za-z0-9][A-Za-z0-9._/-]*\.html$/;
+
+/**
+ * The template path is interpolated into an agent's instructions, so it is a
+ * trust boundary even though config/profile.yml is the user's own file: a path
+ * that never went through the resolver has no business reaching a worker. An
+ * unrecognized value falls back to the base template rather than throwing,
+ * because a CV the user can still send beats a run that dies on their config.
+ */
+function safeCvTemplate(value) {
+  return typeof value === "string" && !value.includes("..") && CV_TEMPLATE_RE.test(value)
+    ? value
+    : BASE_CV_TEMPLATE;
+}
+
+export function buildPrompt({ kind, input, memory, today, postedAt, lang, cvTemplate }) {
   // AGENTS.md's "Output Language vs Market Modes" composition rule. The CLI
   // picks this up by reading AGENTS.md interactively; a one-shot headless
   // prompt has no such chance, so the rule has to be stated in the prompt or a
@@ -85,10 +108,10 @@ Target: ${input}`;
     // cv.md or data/applications.md. The agent now emits the CV inline and the
     // backend (a plain Node process, no CLI sandbox) writes and renders it, so
     // pdf mode runs with no write tool at all.
-    return `You are tailoring the user's ATS-optimized CV for application #${input}, headless, on their machine. Run the REAL career-ops "pdf" mode's CONTENT step: follow modes/pdf.md's TAILORING rules exactly (do not improvise your own scoring or format). Apply its CONTENT rules — keyword injection, ordering, the competency grid, project selection, and its never-invent-a-skill rule. Its steps that shell out (the jd-skill-gap.mjs check, template resolution) and its build/save/render steps are NOT performed on web runs; the platform handles output itself.
+    return `You are tailoring the user's ATS-optimized CV for application #${input}, headless, on their machine. Run the REAL career-ops "pdf" mode's CONTENT step: follow modes/pdf.md's TAILORING rules exactly (do not improvise your own scoring or format). Apply its CONTENT rules — keyword injection, ordering, the competency grid, project selection, and its never-invent-a-skill rule. Its steps that shell out (the jd-skill-gap.mjs check) and its build/save/render steps are NOT performed on web runs; the platform handles output itself.
 1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md (for the JD keywords + analysis).
 2. Tailor the CV per modes/pdf.md: inject the JD's keywords into the summary + first bullets, reorder experience by relevance, build the competency grid, pick the top 3–4 projects. NEVER invent skills — only reword REAL experience using the JD's vocabulary.
-3. Fill templates/cv-template.html's {{...}} placeholders with the tailored content. Use that template even though modes/pdf.md resolves one via cv-templates.mjs: web runs always use the base template. ${CV_ENVELOPE_INSTRUCTION}
+3. Fill ${safeCvTemplate(cvTemplate)}'s {{...}} placeholders with the tailored content. Use that exact file: the platform already resolved it from cv.template through cv-templates.mjs, so do NOT run modes/pdf.md's own template-resolution step. ${CV_ENVELOPE_INSTRUCTION}
 4. Emit the envelope EXACTLY ONCE. The platform writes the HTML, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
 
 After the envelope, end with EXACTLY one final line: VERDICT: {5 if the complete HTML envelope was emitted, else 1}/5 — {a one-line summary, ≤12 words}`;

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -357,3 +357,53 @@ test("buildPrompt: evaluate does not enumerate the report's sections", () => {
   assert.ok(!/blocks?\s+A[–-]F/i.test(prompt), "the prompt must not name a subset of the mode file's sections");
   assert.ok(/EVERY section its report template specifies/i.test(prompt), "it must defer to the mode file for the section set");
 });
+
+test("buildPrompt: the pdf prompt fills the template the caller resolved", () => {
+  // Given a user whose config/profile.yml selects a non-base CV template. The
+  // route resolves it through cv-templates.mjs and hands the path in; the worker
+  // cannot resolve it itself, because pdf has no Bash (#2172) and must not regain it.
+  const prompt = buildPrompt({ kind: "pdf", ...ARGS, cvTemplate: "templates/cv-template.mine.html" });
+
+  // Then that file is what gets filled, and the old pin is gone
+  assert.match(prompt, /templates\/cv-template\.mine\.html/);
+  assert.ok(
+    !/web runs always use the base template/i.test(prompt),
+    "the prompt must not pin the base template over the user's own choice",
+  );
+});
+
+test("buildPrompt: the pdf prompt falls back to the base template", () => {
+  // Given no resolved template: cv.template unset, or a resolution that failed
+  const prompt = buildPrompt({ kind: "pdf", ...ARGS });
+
+  // Then the base template is still what gets filled, which is today's behaviour
+  assert.match(prompt, /templates\/cv-template\.html/);
+});
+
+test("buildPrompt: a path cv-templates.mjs could not have produced is refused", () => {
+  // Given a value that did not come from the resolver. The path is interpolated
+  // into an agent's instructions, so this is a trust boundary even though
+  // config/profile.yml is the user's own file.
+  // Each fixture is a string the prompt cannot contain for any OTHER reason:
+  // "cv.md" would pass this assertion trivially, because step 1 already names it.
+  for (const bad of [
+    "../../etc/passwd",
+    "templates/../secrets.html",
+    "secrets/cv-template.html",
+    "templates/x.html; cat ~/.ssh/id_rsa",
+    "/etc/passwd",
+  ]) {
+    const prompt = buildPrompt({ kind: "pdf", ...ARGS, cvTemplate: bad });
+    assert.ok(!prompt.includes(bad), `must not interpolate ${bad}`);
+    assert.match(prompt, /templates\/cv-template\.html/, "must fall back to the base template");
+  }
+});
+
+test("buildPrompt: the pdf prompt still forbids resolving a template in-agent", () => {
+  // Given the guard the pinned sentence was carrying: pdf has no Bash, so an
+  // agent that follows modes/pdf.md's resolution step stalls on a tool it lacks.
+  const prompt = buildPrompt({ kind: "pdf", ...ARGS, cvTemplate: "templates/cv-template.mine.html" });
+
+  assert.match(prompt, /cv-templates\.mjs/);
+  assert.match(prompt, /already resolved/i);
+});


### PR DESCRIPTION
## What does this PR do?

The dashboard's pdf prompt named `templates/cv-template.html` outright, so a user who had set `cv.template` got their own template from the CLI and the base template from the web run. The route now resolves the template through `cv-templates.mjs` and passes the path into `buildPrompt`, the same way it already resolves `language`.

## Related issue

Closes #4034

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## How it works

The worker cannot do this resolution itself. pdf has no Bash (#2172) and must never regain it, so it can neither run `cv-templates.mjs` nor list `templates/`. That is why the prompt named the base template in the first place, in 1301ed4c, whose actual purpose was taking Write and Edit away from that worker. That part stands untouched here.

Three changes:

`web/src/lib/core/cv-template.ts` is a new ACL over `cv-templates.mjs`, following the pattern the other modules in that directory already use for repo-root modules (`text-key.ts`, `tracker-lock.ts`, `pdf-index.ts`, `followups-lock.ts`): a runtime `import()` of the user's own checkout. `resolveTemplate` is called with no `dir` or `profilePath` override, so it uses its own defaults relative to that checkout and template packs (#3202) resolve here exactly as they do on the CLI. It never throws; anything unexpected yields the base template.

`web/src/app/api/run/route.ts` resolves the path for `kind === "pdf"` only and passes it to `buildPrompt` as `cvTemplate`, next to `lang`.

`web/src/lib/run-prompts.mjs` takes `cvTemplate` and names it in step 3. The old sentence carried a real guard, which is preserved in the new one: the agent is still told not to run the mode's own template-resolution step, because it has no tool to run it with. The preamble no longer lists template resolution among the steps that are simply skipped, since the platform now performs it.

A path that did not come from the resolver falls back to the base template rather than throwing. `config/profile.yml` is the user's own file, but the value is interpolated into an agent's instructions, so the prompt is a trust boundary regardless of where the string came from. Falling back keeps a bad config from turning into a failed run.

## Verification

- `web/tests/lib/run-prompts.test.mjs` gains four tests: the resolved template is what the prompt names, an absent one still yields the base template, a path the resolver could not have produced is refused, and the do-not-resolve-it-yourself guard survives. Confirmed red before the change (three of the four failed).
- One of those fixtures caught a mistake in its own first draft: asserting the prompt does not contain `cv.md` passes trivially, because step 1 already names `cv.md`. The fixtures are now strings the prompt cannot contain for any other reason.
- `node test-all.mjs --quick`: 8686 passed, 0 failed.
- `web`: `npm run typecheck` clean, `npm run build` clean, `npm test` 501 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Dashboard PDF runs now honor `cv.template` from `config/profile.yml`, matching CLI behavior.

## User impact

- Selected flat templates and template packs now apply to dashboard PDF runs.
- Unset, invalid, or unresolved templates use `templates/cv-template.html`.
- The PDF worker still cannot resolve templates or use Bash.

## Changes

- `web/src/app/api/run/route.ts:...`: Resolves the template for PDF runs and passes it to `buildPrompt`.
- `web/src/lib/core/cv-template.ts:...`: Adds runtime loading of `cv-templates.mjs` with safe fallback handling.
- `web/src/lib/run-prompts.mjs:...`: Uses the resolved template path and validates unsafe paths.
- `web/tests/lib/run-prompts.test.mjs:...`: Adds coverage for resolution, fallback, invalid paths, and the worker guard.

System files touched: none of `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->