### PR TITLE
fix(web): stop /api/apply/drive closing its stream twice on success

### DIFF
--- a/web/src/app/api/apply/drive/route.ts
+++ b/web/src/app/api/apply/drive/route.ts
@@ -47,7 +47,6 @@ export async function POST(req: Request) {
           // to review + submit themselves. We never submit.
           if (result.reached) await handoffSession(s.id).catch(() => {});
           emit({ t: "done", filled: result.reached, turns: result.turns, reason: result.reason });
-          controller.close();
           return;
         }
 
@@ -55,7 +54,6 @@ export async function POST(req: Request) {
           const fin = await finalizeDrivenSession(s.id, cliId);
           if (fin) {
             emit({ t: "done", reached: true, turns: result.turns, title: fin.title, fields: fin.fields, issues: fin.issues });
-            controller.close();
             return;
           }
         }

--- a/web/tests/lib/drive-stream-close.test.mjs
+++ b/web/tests/lib/drive-stream-close.test.mjs
@@ -1,0 +1,98 @@
+// Guards the ReadableStream in src/app/api/apply/drive/route.ts (issue #3966).
+//
+// The stream's `start(controller)` wraps the whole drive in try/catch/finally
+// and closes the controller in the `finally`. Two success paths inside the
+// `try` also closed it and then returned -- and a `return` runs the `finally`,
+// so those paths closed twice. The second close throws
+// `TypeError: Invalid state: Controller is already closed` (ERR_INVALID_STATE)
+// out of an async `start`, which Next.js surfaces as `failed to pipe response`
+// and a 500 after the body has already been streamed.
+//
+// It was the two SUCCESS paths that were wrong -- the error path returned
+// through the `finally` alone and was fine -- which is why it only showed up
+// once the agent actually reached and filled a form.
+//
+// route.ts is TypeScript inside a Next.js route and its `start` closure cannot
+// be imported and exercised here, so this reads the source and asserts the
+// shape instead. Same approach, and the same self-checking discipline, as
+// tests/lib/core-writer-await.test.mjs: every anchor this test relies on is
+// asserted to exist first, so a rename or a refactor fails loudly instead of
+// matching nothing and passing.
+//
+// Run (from web/, as `npm test` does):  node --test tests/lib/drive-stream-close.test.mjs
+// From the repo root:                   node --test web/tests/lib/drive-stream-close.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const SRC = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "app",
+  "api",
+  "apply",
+  "drive",
+  "route.ts",
+);
+const src = readFileSync(SRC, "utf8");
+
+/**
+ * The `try { ... } finally { ... }` inside `start`, split into its two halves.
+ *
+ * Located by the `finally` that closes the controller rather than by brace
+ * counting: the body is full of nested braces and object literals, and a
+ * counter that drifts would silently redefine what "inside the try" means.
+ */
+function tryAndFinally() {
+  const finallyRe = /\n(\s*)\} finally \{\n([\s\S]*?)\n\1\}\n/;
+  const m = src.match(finallyRe);
+  assert.ok(m, "could not find the `} finally {` block in route.ts — did the stream stop using try/finally?");
+  return { beforeFinally: src.slice(0, m.index), finallyBody: m[2] };
+}
+
+const closeRe = /\bcontroller\s*\.\s*close\s*\(/g;
+const count = (s) => (s.match(closeRe) ?? []).length;
+
+test("self-check: the anchors this test reads still exist", () => {
+  assert.match(src, /new ReadableStream/, "route.ts no longer builds a ReadableStream");
+  assert.match(src, /async start\(controller\)/, "route.ts no longer has an `async start(controller)`");
+  assert.ok(count(src) > 0, "route.ts never closes the controller — the test would pass vacuously");
+});
+
+test("the controller is closed only in the finally, never on a path that returns through it", () => {
+  const { beforeFinally, finallyBody } = tryAndFinally();
+
+  assert.equal(
+    count(finallyBody),
+    1,
+    "the finally must close the controller exactly once — it is the single exit for every path",
+  );
+
+  // Every `return` in the try runs the finally on its way out, so any close
+  // before it is the first of two. This is the assertion that actually fails
+  // on the #3966 bug.
+  assert.equal(
+    count(beforeFinally),
+    0,
+    `controller.close() is called ${count(beforeFinally)} time(s) before the finally; ` +
+      "each one double-closes, because the `return` that follows runs the finally too. " +
+      "Let the finally do it.",
+  );
+});
+
+test("the success paths still return, so the finally is what closes them", () => {
+  const { beforeFinally } = tryAndFinally();
+  // Guards the other way a fix could go wrong: dropping the `return`s along
+  // with the closes would fall through into the "didn't reach a form" branch
+  // and emit an error after a `done`.
+  const returns = (beforeFinally.match(/\n\s+return;\n/g) ?? []).length;
+  assert.ok(
+    returns >= 2,
+    `expected the two success paths to still return early, found ${returns} bare \`return;\` in the try`,
+  );
+});


### PR DESCRIPTION
## What does this PR do?

Removes two `controller.close()` calls from the success paths inside `start(controller)`'s `try` block in `/api/apply/drive`, so the `finally` is the only place the stream is closed.

## Related issue

Closes #3966

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The mechanism

`start(controller)` wraps the whole drive in `try` / `catch` / `finally` and closes the controller in the `finally`. Two paths inside the `try` closed it and then returned:

```ts
if (goal === "full") {
  …
  emit({ t: "done", filled: result.reached, … });
  controller.close();   // ← first close
  return;               // ← runs the finally, which closes again
}
```

A `return` runs the `finally` on its way out, so both of those paths closed twice. The second close throws `TypeError: Invalid state: Controller is already closed` (`ERR_INVALID_STATE`) out of an async `start`, which Next.js reports as `failed to pipe response` and a 500 — after the body has already been streamed, which is why the browser sees `Failed to fetch` rather than an error the UI can render.

**It is the two success paths that were wrong.** The error path at the bottom of the `try` returns through the `finally` alone and was always correct. That asymmetry is what makes @dbaikov's report specific: it only appears once the agent actually reaches and fills a form (`goal === "full"`, and the `reached` + `finalizeDrivenSession` path), not when the drive fails.

I checked whether this is a pattern worth changing more broadly: the sibling route `apply/prefill/route.ts` has no `finally` and returns on every path, so it is not affected and nothing else needs touching. The fix stays at two deleted lines.

Nothing is lost by deferring to the `finally` — `emit()` has already written the `done` frame before the close in both paths.

## Tests

`web/tests/lib/drive-stream-close.test.mjs` (new).

`route.ts` is TypeScript inside a Next.js route and the `start` closure cannot be imported and exercised, so this reads the source and asserts the shape — the same approach as the existing `tests/lib/core-writer-await.test.mjs`, and with the same self-checking discipline: a `self-check` test asserts every anchor it relies on (`new ReadableStream`, `async start(controller)`, at least one `controller.close(`) still exists, so a rename fails loudly instead of matching nothing and passing.

Three tests:

1. **self-check** — the anchors exist.
2. **the real assertion** — `controller.close()` appears exactly once in the `finally`, and **zero** times before it. This is the one that catches #3966.
3. **the other way a fix could go wrong** — the two success paths still `return` early. Dropping the `return`s along with the closes would fall through into the "didn't reach a form" branch and emit an `error` frame after a `done`.

The `finally` block is located by matching `} finally {` rather than by counting braces: the body is full of nested braces and object literals, and a counter that drifted would silently redefine what "inside the try" means.

**Verification:**

- New test on the fix: **3 passed**.
- Red control — reverting only `route.ts` to `main` and re-running: **fails** with
  `controller.close() is called 2 time(s) before the finally; each one double-closes, because the return that follows runs the finally too.`
- All of `web/tests/lib/*.test.mjs`: **500 passed, 0 failed**.
- `node test-all.mjs --quick`: **8687 passed, 0 failed** (16 warnings, all pre-existing — the personal-data heuristic firing on the owner's own name and `cv-sync-check.mjs` needing user data).

**What I did not do:** I have not run the Next.js UI through a real apply flow against a live posting — that needs a browser session and a real job form. The 500 is reproduced and fixed at the stream level, and the UI recovery follows from it, but I am stating that as inference rather than something I watched happen.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgtWMywGTyu6twnk1Bu9nP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`/api/apply/drive` no longer closes its `ReadableStream` controller twice. The route now closes the controller only in `finally` at `web/src/app/api/apply/drive/route.ts`. This prevents `ERR_INVALID_STATE` and related 500 responses during the application flow.

A source-shape test verifies the single close and preserves both early-return paths in `web/tests/lib/drive-stream-close.test.mjs`.

User-visible result: AI form filling can complete or report its underlying failure without an additional `Controller is already closed` error.

## Files changed

- `web/src/app/api/apply/drive/route.ts`
- `web/tests/lib/drive-stream-close.test.mjs`

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->