### PR TITLE
fix(web): add vertical padding to pipeline facet chips (#4038)

### DIFF
--- a/web/src/components/inbox/facet-chips.tsx
+++ b/web/src/components/inbox/facet-chips.tsx
@@ -74,7 +74,7 @@ export function FacetChips({
               type="button"
               onClick={() => setWithin(within === w.days ? null : w.days)}
               className={cn(
-                "rounded-md px-2.5 text-xs font-medium transition-colors max-sm:min-h-[44px]",
+                "rounded-md px-2.5 py-1 text-xs font-medium transition-colors max-sm:min-h-[44px]",
                 within === w.days ? "bg-brand-soft text-brand" : "text-muted hover:text-foreground",
               )}
             >
@@ -130,7 +130,7 @@ function Pill({ on, onClick, children }: { on: boolean; onClick: () => void; chi
       type="button"
       onClick={onClick}
       className={cn(
-        "shrink-0 rounded-full border px-2.5 text-xs font-medium transition-colors max-sm:min-h-[44px]",
+        "shrink-0 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors max-sm:min-h-[44px]",
         on ? "border-brand/40 bg-brand-soft text-brand" : "border-border text-muted hover:text-foreground",
       )}
     >


### PR DESCRIPTION
## What does this PR do?

Adds the missing `py-1` to the two pipeline-inbox facet-chip class strings, so the freshness segmented control and the source/seniority pills keep a real hit area on desktop.

`web/src/components/inbox/facet-chips.tsx` built both controls with `px-2.5` and no `py-*`. `max-sm:min-h-[44px]` only applies below the `sm` breakpoint, so at desktop widths the buttons collapse to the 16px line box inside a `p-0.5` container — a click that lands a couple of pixels off does nothing, which reads as "the filter is broken". The equivalent control on Explore has always carried the vertical padding (`web/src/components/explore/filter-builder.tsx:149`: `"rounded-md px-2.5 py-1 text-xs font-medium transition-colors max-sm:min-h-[44px]"`), so this brings the two surfaces back in line. The location input in the same row already has `py-1` (`facet-chips.tsx:104`).

## Related issue

Fixes the first of the two defects in #4038.

The second defect (an un-scored `triage-row` has no link to the posting) is deliberately **not** touched here: the issue leaves the destination open (`/jobs/{id}` vs. `InboxJob.url`), and a two-line CSS fix should not wait on that call. Happy to follow up separately if you want it in this shape.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Testing

- `cd web && npm run typecheck` → clean, exit 0.
- `cd web && npm test` → `# tests 497 / # pass 491 / # fail 0 / # skipped 6`.
- `npm run lint` (root, `scripts/check-syntax.mjs`) → passes; it only runs `node --check` over repository `.mjs` files, which this change does not touch.
- Nothing in-tree pins these class strings: `web/tests/` covers `lib/` only (`node --test "tests/**/*.test.mjs"`), and `grep -rn "facet-chips"` matches only `src/components/inbox/facet-chips.tsx` and its single consumer `src/components/inbox/inbox-triage.tsx` — no component test, snapshot, or assertion to update. The diff is two Tailwind utility strings and cannot alter types or data flow.
- The shared prefix now matches `web/src/components/explore/filter-builder.tsx:149` verbatim, which is how the two controls drifted apart in the first place.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] Not a new feature or architecture change — bug fix, sent straight in per CONTRIBUTING
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] `web` typecheck + `web` tests pass (see Testing). `node test-all.mjs` covers the core `.mjs` scripts, which this web-only change does not touch; I started it and it could not complete in my sandbox (the harness's temp-dir cleanup is blocked there, not a test failure), while the root `npm run lint` syntax gate over 693 `.mjs` files passes.
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no user-layer files modified)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## Notes for reviewer

Scope is 1 file, +2/-2 lines: no new dependencies, no refactor, no behaviour change beyond the two chips' vertical padding. Mobile is unaffected — `max-sm:min-h-[44px]` still governs below `sm`, and `py-1` (4px top/bottom) is far below the 44px floor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `py-1` to the freshness control and source/seniority pills in `web/src/components/inbox/facet-chips.tsx`. Users now get the intended desktop vertical hit area. Mobile controls keep `max-sm:min-h-[44px]`.

Only `web/src/components/inbox/facet-chips.tsx` changes. No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->