### PR TITLE
fix(cover): fill {{RECIPIENT_BLOCK}} so pack cover templates render

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -129,6 +129,36 @@ function buildDateline(letter) {
   return parts.join(" &nbsp;&nbsp; ");
 }
 
+/**
+ * Build the optional recipient address block for a business letter.
+ *
+ * The pack authoring contract places {{RECIPIENT_BLOCK}} bare and expects the
+ * filler to emit its own wrapper, so this returns a complete
+ * `<div class="recipient">` or an empty string, never a bare fragment. Each
+ * line is its own `<div>` rather than a `<br>` join, which is what the packs'
+ * own CSS targets.
+ *
+ * A partial recipient is normal and renders as far as it goes: a company with
+ * no named individual, or a name with no street address, are both ordinary
+ * states for a cover letter. Only a recipient with nothing usable in it, or no
+ * recipient at all, yields the empty string, so a letter without an addressee
+ * still renders instead of failing.
+ *
+ * Accepts `address_lines` (array, the contract's shape) or `address` (string).
+ */
+function buildRecipientBlock(letter) {
+  const r = letter.recipient;
+  if (!r || typeof r !== "object") return "";
+  const addressLines = Array.isArray(r.address_lines)
+    ? r.address_lines
+    : r.address
+      ? [r.address]
+      : [];
+  const lines = [r.name, r.title, r.company, ...addressLines].filter(Boolean).map(escapeHtml);
+  if (!lines.length) return "";
+  return `<div class="recipient">\n${lines.map((l) => `    <div>${l}</div>`).join("\n")}\n  </div>`;
+}
+
 /** Build the optional achievements list for the letter body. */
 function buildAchievementsBlock(achievements) {
   if (!achievements || !achievements.length) return "";
@@ -226,6 +256,7 @@ export function buildHtml(payload, templatePath) {
     "{{CREDENTIALS_BLOCK}}": buildCredentialsBlock(candidate),
     "{{ROLE_TITLE}}": escapeHtml(letter.role_title),
     "{{DATELINE}}": buildDateline(letter),
+    "{{RECIPIENT_BLOCK}}": buildRecipientBlock(letter),
     "{{GREETING_BLOCK}}": greetingBlock,
     "{{OPENING}}": escapeHtml(letter.opening),
     "{{PROFILE_INTRO}}": escapeHtml(letter.profile_intro),

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -140,7 +140,7 @@ function buildDateline(letter) {
  *
  * A partial recipient is normal and renders as far as it goes: a company with
  * no named individual, or a name with no street address, are both ordinary
- * states for a cover letter. Only a recipient with nothing usable in it, or no
+ * states for a cover letter. Only a recipient with nothing usable in it (blank or whitespace-only fields included), or no
  * recipient at all, yields the empty string, so a letter without an addressee
  * still renders instead of failing.
  *
@@ -154,7 +154,12 @@ function buildRecipientBlock(letter) {
     : r.address
       ? [r.address]
       : [];
-  const lines = [r.name, r.title, r.company, ...addressLines].filter(Boolean).map(escapeHtml);
+  // Trim before filtering: `filter(Boolean)` alone keeps "   ", which renders as
+  // a blank line inside the wrapper rather than as the absent field it is.
+  const lines = [r.name, r.title, r.company, ...addressLines]
+    .map((v) => (typeof v === "string" ? v.trim() : v))
+    .filter(Boolean)
+    .map(escapeHtml);
   if (!lines.length) return "";
   return `<div class="recipient">\n${lines.map((l) => `    <div>${l}</div>`).join("\n")}\n  </div>`;
 }

--- a/tests/cover-recipient-block.test.mjs
+++ b/tests/cover-recipient-block.test.mjs
@@ -1,0 +1,88 @@
+// tests/cover-recipient-block.test.mjs — {{RECIPIENT_BLOCK}} must be fillable.
+//
+// The pack authoring contract lists {{RECIPIENT_BLOCK}} among the required
+// cover-letter slots, but generate-cover-letter.mjs never filled it, so every
+// pack cover template died at substitution with
+// "Unresolved placeholders: {{RECIPIENT_BLOCK}}".
+//
+// The failure is worth a test rather than a one-line map entry because of how it
+// presented: validateTemplate (KINDS.cover) requires only NAME, ROLE_TITLE and
+// OPENING, so a pack template PASSED the validator and then exploded in the
+// substitution pass. A green gate followed by a hard failure is the shape that
+// makes an author distrust the gate, so both halves are pinned here: the slot
+// fills, and an absent recipient is not an error.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+/** A minimal template carrying the pack's recipient slot. */
+function packTemplate() {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-recipient-'));
+  const file = join(dir, 'cover-letter-template.html');
+  writeFileSync(file, '{{NAME}}{{ROLE_TITLE}}{{DATELINE}}{{RECIPIENT_BLOCK}}{{OPENING}}{{PROFILE_INTRO}}');
+  return file;
+}
+
+const base = (recipient) => ({
+  candidate: { name: 'A Candidate' },
+  letter: {
+    role_title: 'Head of Marketing',
+    opening: 'Opening line.',
+    profile_intro: 'Profile intro.',
+    ...(recipient === undefined ? {} : { recipient }),
+  },
+});
+
+test('a template carrying {{RECIPIENT_BLOCK}} renders instead of throwing', () => {
+  // Given the exact shape the pack contract publishes: name, title, company,
+  // then address_lines
+  const html = buildHtml(base({
+    name: 'Jane Reviewer',
+    title: 'Director of Talent',
+    company: 'Example Corp',
+    address_lines: ['100 Example Street', 'Springfield, IL 62704'],
+  }), packTemplate());
+
+  // Then every supplied part reaches the output...
+  for (const part of ['Jane Reviewer', 'Director of Talent', 'Example Corp', '100 Example Street', 'Springfield, IL 62704']) {
+    assert.ok(html.includes(part), `recipient block must carry "${part}"`);
+  }
+  // ...and the token itself is gone
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot must be substituted, not left literal');
+});
+
+test('the recipient block is self-wrapped, one div per line', () => {
+  // The contract is explicit that the filler emits its own wrapper and that the
+  // template places the placeholder bare, so a <br>-joined string would not do.
+  const html = buildHtml(base({ name: 'Jane Reviewer', company: 'Example Corp' }), packTemplate());
+
+  assert.match(html, /<div class="recipient">/, 'the block wraps itself');
+  assert.match(html, /<div>Jane Reviewer<\/div>/);
+  assert.match(html, /<div>Example Corp<\/div>/);
+});
+
+test('an absent recipient renders empty, and is not an error', () => {
+  // Most letters have no addressee. That must stay a rendered letter, not a
+  // failed render, or this fix trades one hard failure for another.
+  const html = buildHtml(base(undefined), packTemplate());
+
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot is still substituted');
+  assert.ok(!html.includes('class="recipient"'), 'no empty wrapper is emitted');
+});
+
+test('a recipient with no usable fields renders empty rather than an empty wrapper', () => {
+  const html = buildHtml(base({ name: '', company: '', address_lines: [] }), packTemplate());
+  assert.ok(!html.includes('class="recipient"'));
+});
+
+test('recipient values are HTML-escaped', () => {
+  // The recipient comes from a payload an agent wrote from a job posting, which
+  // is untrusted content by the project's own rule.
+  const html = buildHtml(base({ name: '<script>alert(1)</script>', company: 'A & B' }), packTemplate());
+
+  assert.ok(!html.includes('<script>'), 'a script tag must not survive into the letter');
+  assert.match(html, /A &amp; B/);
+});

--- a/tests/cover-recipient-block.test.mjs
+++ b/tests/cover-recipient-block.test.mjs
@@ -78,6 +78,28 @@ test('a recipient with no usable fields renders empty rather than an empty wrapp
   assert.ok(!html.includes('class="recipient"'));
 });
 
+test('whitespace-only recipient fields are empty, not content', () => {
+  // filter(Boolean) keeps "   ", so a recipient whose fields are all spaces
+  // produced a wrapper full of blank divs: a visibly indented gap above the Re:
+  // line, on a letter with no addressee. The empty-object case below passes
+  // without this, which is what made it easy to miss.
+  const html = buildHtml(base({ name: '   ', title: '\t', company: '\n', address_lines: ['  ', ''] }), packTemplate());
+
+  assert.ok(!html.includes('class="recipient"'), 'a whitespace-only recipient emits no wrapper');
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot is still substituted');
+});
+
+test('a partially blank recipient keeps only its real lines', () => {
+  // The trim must not become a reason to drop a recipient that has some content.
+  const html = buildHtml(base({ name: '  ', title: 'Director of Talent', company: '   ' }), packTemplate());
+
+  assert.match(html, /<div class="recipient">/);
+  assert.match(html, /<div>Director of Talent<\/div>/);
+  // Bare `<div>` counts content lines only: the wrapper is `<div class="recipient">`
+  // and does not match. Exactly one line survives, so the two blank fields are gone.
+  assert.equal((html.match(/<div>/g) || []).length, 1, 'only the non-blank field renders a line');
+});
+
 test('recipient values are HTML-escaped', () => {
   // The recipient comes from a payload an agent wrote from a job posting, which
   // is untrusted content by the project's own rule.


### PR DESCRIPTION
## What does this PR do?

Fills `{{RECIPIENT_BLOCK}}` in `generate-cover-letter.mjs`, so a cover template that uses the pack authoring contract's recipient slot renders instead of dying with `Unresolved placeholders: {{RECIPIENT_BLOCK}}`.

## Related issue

Closes #4042

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## Why it was invisible

Core is entirely self-consistent here, which is what kept this hidden. The `replacements` map holds 14 entries, the shipped `templates/cover-letter-template.html` uses 14 slots, and the two sets match exactly in both directions. Nothing in core had a reason to fill a 15th slot. The gap only appears for a template built to the published pack contract, and packs ship their own filler for preview generation, so pack previews rendered correctly the whole time.

The sharper half is the gate. `validateTemplate` requires only `NAME`, `ROLE_TITLE` and `OPENING` for `kind=cover`, so a pack cover template passes validation and then fails in the substitution pass. That is the same shape as #3775 on the CV side: a template satisfying the published contract, waved through by the validator, dying because core fills fewer slots than the contract promises.

## The change

One function and one map entry.

`buildRecipientBlock` returns a complete `<div class="recipient">` or an empty string, because the contract places the placeholder bare and expects the filler to wrap itself. Each line is its own `<div>` rather than a `<br>` join, which is what the packs' CSS targets. It accepts `address_lines` (the contract's shape) and also a plain `address` string.

A partial recipient renders as far as it goes. A company with no named individual, or a name with no street address, are both ordinary states for a cover letter. Only a recipient with nothing usable in it, or no recipient at all, gives the empty string, so a letter with no addressee still renders rather than trading one hard failure for another.

## Deliberately not in this change

`templates/cover-letter-template.html` is untouched. Adding the slot to core's own shipped letter would change core's output, which is a design decision rather than part of this bug.

`buildDateline` is also untouched. It joins company, city and date, and under the pack contract the company lives in the address block, so a pack letter prints the company twice. Gating that join on `letter.recipient` would fix it and keep every existing payload byte-identical, but it is a separate behavioural question and I did not want to argue two things in one PR. Happy to follow up if you want it.

## Verification

`tests/cover-recipient-block.test.mjs`, five tests, confirmed red on the unfixed tree first (5 failed, 0 passed) and green after. They pin both halves: the slot fills with the contract's shape and escaping holds, and an absent or empty recipient renders nothing without erroring.

`node test-all.mjs --quick`: 8688 passed, 0 failed. The five cover suites together: 16 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can render pack cover-letter templates with `{{RECIPIENT_BLOCK}}` without unresolved-placeholder errors.

`generate-cover-letter.mjs:149` renders `letter.recipient` from `address_lines` or `address`. It trims and HTML-escapes usable lines, then emits a self-wrapped `<div class="recipient">`. It returns an empty string when no usable recipient exists. `buildHtml` substitutes the block at `generate-cover-letter.mjs:264`.

Tests cover substitution, partial data, whitespace-only fields, missing data, self-wrapping, and HTML escaping in `tests/cover-recipient-block.test.mjs:39`.

The default cover-letter template and `buildDateline` behavior remain unchanged.

System files touched: none. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->