### PR TITLE
fix(analyze-patterns): validate threshold and vendor flags

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -1678,6 +1678,37 @@ if (isMainModule(import.meta.url)) {
     requireOperand: true,
   });
 
+  // Strict validation for numeric value flags. Errors exit with code 2 to
+  // match recent conventions. Presence is detected via flagValue so both
+  // `--flag value` and `--flag=value` are accepted.
+  const rawMinThreshold = flagValue(args, '--min-threshold');
+  if (rawMinThreshold !== undefined) {
+    const text = String(rawMinThreshold).trim();
+    if (!/^\d+$/.test(text)) {
+      console.error(`Error: --min-threshold requires a non-negative integer, got "${rawMinThreshold}"`);
+      process.exit(2);
+    }
+    const parsed = Number(text);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) {
+      console.error(`Error: --min-threshold requires a non-negative integer, got "${rawMinThreshold}"`);
+      process.exit(2);
+    }
+  }
+
+  const rawMinVendor = flagValue(args, '--min-vendor-n');
+  if (rawMinVendor !== undefined) {
+    const text = String(rawMinVendor).trim();
+    if (!/^\d+$/.test(text)) {
+      console.error(`Error: --min-vendor-n requires a positive integer, got "${rawMinVendor}"`);
+      process.exit(2);
+    }
+    const parsed = Number(text);
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+      console.error(`Error: --min-vendor-n requires a positive integer, got "${rawMinVendor}"`);
+      process.exit(2);
+    }
+  }
+
   if (args.includes('--self-test')) {
     runSelfTest();
   }

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -1673,6 +1673,15 @@ function printSummary(result) {
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (isMainModule(import.meta.url)) {
+  for (const flag of VALUE_FLAGS) {
+    const index = args.indexOf(flag);
+    const next = index === -1 ? undefined : args[index + 1];
+    if (index !== -1 && (next === undefined || next.startsWith('--'))) {
+      console.error(`Error: ${flag} requires a value`);
+      process.exit(2);
+    }
+  }
+
   validateFlags(args, KNOWN_FLAGS, USAGE, {
     valueFlags: VALUE_FLAGS,
     requireOperand: true,
@@ -1685,12 +1694,12 @@ if (isMainModule(import.meta.url)) {
   if (rawMinThreshold !== undefined) {
     const text = String(rawMinThreshold).trim();
     if (!/^\d+$/.test(text)) {
-      console.error(`Error: --min-threshold requires a non-negative integer, got "${rawMinThreshold}"`);
+      console.error(`Error: --min-threshold requires a positive integer, got "${rawMinThreshold}"`);
       process.exit(2);
     }
     const parsed = Number(text);
-    if (!Number.isSafeInteger(parsed) || parsed < 0) {
-      console.error(`Error: --min-threshold requires a non-negative integer, got "${rawMinThreshold}"`);
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+      console.error(`Error: --min-threshold requires a positive integer, got "${rawMinThreshold}"`);
       process.exit(2);
     }
   }

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -1673,12 +1673,45 @@ function printSummary(result) {
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (isMainModule(import.meta.url)) {
+  // Validate every occurrence rather than only the first value returned by
+  // flagValue(). Duplicate flags are ambiguous and must not hide a bad later
+  // value.
   for (const flag of VALUE_FLAGS) {
-    const index = args.indexOf(flag);
-    const next = index === -1 ? undefined : args[index + 1];
-    if (index !== -1 && (next === undefined || next.startsWith('--'))) {
-      console.error(`Error: ${flag} requires a value`);
+    const occurrences = [];
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg === flag) {
+        const next = args[i + 1];
+        if (next === undefined || next.startsWith('--')) {
+          console.error(`Error: ${flag} requires a value`);
+          process.exit(2);
+        }
+        occurrences.push(next);
+      } else if (arg.startsWith(`${flag}=`)) {
+        const value = arg.slice(flag.length + 1);
+        if (value === '') {
+          console.error(`Error: ${flag} requires a value`);
+          process.exit(2);
+        }
+        occurrences.push(value);
+      }
+    }
+    if (occurrences.length > 1) {
+      console.error(`Error: ${flag} must not be repeated`);
       process.exit(2);
+    }
+    if (occurrences.length === 1) {
+      const raw = occurrences[0];
+      const text = String(raw).trim();
+      if (!/^\d+$/.test(text)) {
+        console.error(`Error: ${flag} requires a positive integer, got "${raw}"`);
+        process.exit(2);
+      }
+      const parsed = Number(text);
+      if (!Number.isSafeInteger(parsed) || parsed < 1) {
+        console.error(`Error: ${flag} requires a positive integer, got "${raw}"`);
+        process.exit(2);
+      }
     }
   }
 
@@ -1686,37 +1719,6 @@ if (isMainModule(import.meta.url)) {
     valueFlags: VALUE_FLAGS,
     requireOperand: true,
   });
-
-  // Strict validation for numeric value flags. Errors exit with code 2 to
-  // match recent conventions. Presence is detected via flagValue so both
-  // `--flag value` and `--flag=value` are accepted.
-  const rawMinThreshold = flagValue(args, '--min-threshold');
-  if (rawMinThreshold !== undefined) {
-    const text = String(rawMinThreshold).trim();
-    if (!/^\d+$/.test(text)) {
-      console.error(`Error: --min-threshold requires a positive integer, got "${rawMinThreshold}"`);
-      process.exit(2);
-    }
-    const parsed = Number(text);
-    if (!Number.isSafeInteger(parsed) || parsed < 1) {
-      console.error(`Error: --min-threshold requires a positive integer, got "${rawMinThreshold}"`);
-      process.exit(2);
-    }
-  }
-
-  const rawMinVendor = flagValue(args, '--min-vendor-n');
-  if (rawMinVendor !== undefined) {
-    const text = String(rawMinVendor).trim();
-    if (!/^\d+$/.test(text)) {
-      console.error(`Error: --min-vendor-n requires a positive integer, got "${rawMinVendor}"`);
-      process.exit(2);
-    }
-    const parsed = Number(text);
-    if (!Number.isSafeInteger(parsed) || parsed < 1) {
-      console.error(`Error: --min-vendor-n requires a positive integer, got "${rawMinVendor}"`);
-      process.exit(2);
-    }
-  }
 
   if (args.includes('--self-test')) {
     runSelfTest();

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -151,11 +151,11 @@ test('fix-slugs rejects missing --file values (bare, empty, or next-is-flag)', (
 // The CLI should reject unusable or unsafe integers (including 9007199254740992)
 // with an exit code of 2 so callers can distinguish usage errors from runtime
 // failures.
-for (const bad of ['abc', '-5', '1.5', '9007199254740992']) {
+for (const bad of ['abc', '0', '-5', '1.5', '9007199254740992']) {
   test(`analyze-patterns: --min-threshold ${bad} exits 2`, () => {
     const r = runScript('analyze-patterns.mjs', '--min-threshold', bad);
     assert.equal(r.status, 2, `exited ${r.status}, want 2 for bad value ${bad}`);
-    assert.match(r.all, /--min-threshold requires a non-negative integer, got/);
+    assert.match(r.all, /--min-threshold requires a positive integer, got/);
   });
 }
 
@@ -166,6 +166,18 @@ for (const bad of ['abc', '0', '-1', '1.5', '9007199254740992']) {
     assert.match(r.all, /--min-vendor-n requires a positive integer, got/);
   });
 }
+
+test('analyze-patterns: bare --min-threshold exits 2', () => {
+  const r = runScript('analyze-patterns.mjs', '--min-threshold');
+  assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+  assert.match(r.all, /--min-threshold requires a value/);
+});
+
+test('analyze-patterns: bare --min-vendor-n exits 2', () => {
+  const r = runScript('analyze-patterns.mjs', '--min-vendor-n');
+  assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+  assert.match(r.all, /--min-vendor-n requires a value/);
+});
 
 
 // --- missing operand for a RECOGNIZED value-taking flag (#3087) ------------

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -147,6 +147,27 @@ test('fix-slugs rejects missing --file values (bare, empty, or next-is-flag)', (
   assert.doesNotMatch(rShortFlagEq.all, /no portals file at/i);
 });
 
+// --- analyze-patterns specific: invalid numeric flag values must exit 2 -----
+// The CLI should reject unusable or unsafe integers (including 9007199254740992)
+// with an exit code of 2 so callers can distinguish usage errors from runtime
+// failures.
+for (const bad of ['abc', '-5', '1.5', '9007199254740992']) {
+  test(`analyze-patterns: --min-threshold ${bad} exits 2`, () => {
+    const r = runScript('analyze-patterns.mjs', '--min-threshold', bad);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2 for bad value ${bad}`);
+    assert.match(r.all, /--min-threshold requires a non-negative integer, got/);
+  });
+}
+
+for (const bad of ['abc', '0', '-1', '1.5', '9007199254740992']) {
+  test(`analyze-patterns: --min-vendor-n ${bad} exits 2`, () => {
+    const r = runScript('analyze-patterns.mjs', '--min-vendor-n', bad);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2 for bad value ${bad}`);
+    assert.match(r.all, /--min-vendor-n requires a positive integer, got/);
+  });
+}
+
+
 // --- missing operand for a RECOGNIZED value-taking flag (#3087) ------------
 //
 // A different defect than an unrecognized flag: the flag is spelled right,

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -167,15 +167,45 @@ for (const bad of ['abc', '0', '-1', '1.5', '9007199254740992']) {
   });
 }
 
-test('analyze-patterns: bare --min-threshold exits 2', () => {
-  const r = runScript('analyze-patterns.mjs', '--min-threshold');
-  assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+for (const [flag, value] of [
+  ['--min-threshold', '5'],
+  ['--min-vendor-n', '5'],
+]) {
+  test(`analyze-patterns: bare ${flag} exits 2`, () => {
+    const r = runScript('analyze-patterns.mjs', flag);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+    assert.match(r.all, new RegExp(`${flag} requires a value`));
+  });
+
+  test(`analyze-patterns: empty ${flag}= exits 2`, () => {
+    const r = runScript('analyze-patterns.mjs', `${flag}=`);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+    assert.match(r.all, new RegExp(`${flag} requires a value`));
+  });
+
+  test(`analyze-patterns: ${flag} followed by another flag exits 2`, () => {
+    const other = flag === '--min-threshold' ? '--summary' : '--self-test';
+    const r = runScript('analyze-patterns.mjs', flag, other);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+    assert.match(r.all, new RegExp(`${flag} requires a value`));
+  });
+
+  test(`analyze-patterns: duplicate ${flag} occurrences exit 2`, () => {
+    const r = runScript('analyze-patterns.mjs', flag, value, `${flag}=abc`);
+    assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+    assert.match(r.all, new RegExp(`${flag} must not be repeated`));
+  });
+}
+
+test('analyze-patterns: duplicate --min-threshold with bare later occurrence exits 2', () => {
+  const r = runScript('analyze-patterns.mjs', '--min-threshold', '5', '--min-threshold');
+  assert.equal(r.status, 2, 'duplicate bare --min-threshold must exit 2');
   assert.match(r.all, /--min-threshold requires a value/);
 });
 
-test('analyze-patterns: bare --min-vendor-n exits 2', () => {
-  const r = runScript('analyze-patterns.mjs', '--min-vendor-n');
-  assert.equal(r.status, 2, `exited ${r.status}, want 2`);
+test('analyze-patterns: duplicate --min-vendor-n with bare later occurrence exits 2', () => {
+  const r = runScript('analyze-patterns.mjs', '--min-vendor-n', '5', '--min-vendor-n');
+  assert.equal(r.status, 2, 'duplicate bare --min-vendor-n must exit 2');
   assert.match(r.all, /--min-vendor-n requires a value/);
 });
 


### PR DESCRIPTION
Closes #3113

## Summary

* validate --min-threshold and --min-vendor-n as strict positive integers
* reject invalid and unsafe integer values with exit status 2
* preserve the existing analyze-patterns execution and self-test behavior

## Validation

* node analyze-patterns.mjs --self-test
* node test-all.mjs --only cli-flag-validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`analyze-patterns.mjs:83-91` now validates `--min-threshold` and `--min-vendor-n` before execution.

Users can provide positive integers in separated or equals-sign forms. Missing, duplicate, zero, negative, fractional, non-numeric, or unsafe values identify the flag and exit with status `2`.

Valid invocations and self-tests keep their existing behavior. Invalid flags now fail instead of being ignored or replaced with defaults.

## Files changed

: `analyze-patterns.mjs:70-91,1718`
: `tests/cli-flag-validation.test.mjs:155-209`

Tests cover invalid values, missing operands, duplicate flags, and unsafe integers.

`AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are present but unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->