### PR TITLE
fix(verifiers): resolve provider plugins like the scanner (#4026)

### DIFF
--- a/tests/verifiers-plugin-providers.test.mjs
+++ b/tests/verifiers-plugin-providers.test.mjs
@@ -1,0 +1,74 @@
+// tests/verifiers-plugin-providers.test.mjs — the scanner and both health
+// checkers must resolve providers through the SAME path (#4026).
+//
+// scan.mjs folds enabled provider plugins into its map with
+// mergeProviderPlugins(). verify-pipeline.mjs and verify-portals.mjs did not,
+// so a supported `provider: <plugin-id>` portals entry was reported as an
+// "unknown provider" that "never scans" — while the scanner scanned it. The
+// divergence is the bug and it can reappear the moment a caller drifts, so it
+// is pinned structurally (three callers must agree) AND behaviorally (an
+// enabled stub plugin resolves in verify-pipeline's own load path).
+import { readFileSync, existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { pass, fail, warn, NODE } from './helpers.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+console.log('\nverifiers resolve provider plugins like the scanner (#4026)');
+
+// ── 1. Structural: all three provider-map builders call mergeProviderPlugins ──
+{
+  const callers = ['scan.mjs', 'verify-pipeline.mjs', 'verify-portals.mjs'];
+  const missing = callers.filter((f) => !/mergeProviderPlugins\s*\(/.test(readFileSync(join(ROOT, f), 'utf8')));
+  if (missing.length === 0) {
+    pass('scan.mjs, verify-pipeline.mjs and verify-portals.mjs all call mergeProviderPlugins()');
+  } else {
+    fail(`these provider-map builders skip mergeProviderPlugins() and will disagree with the scanner: ${missing.join(', ')}`);
+  }
+}
+
+// ── 2. Behavioral: run the real verify-pipeline.mjs against a portals entry
+//    using the bundled `apify` plugin, enabled. Before the fix it printed
+//    "unknown provider: apify" and exited 1; after, apify resolves (to an
+//    actionable "missing env APIFY_TOKEN" stub here) and the false error is
+//    gone. verify-pipeline resolves plugins from its own CODE_ROOT, so
+//    config/plugins.yml has to live in the real checkout — skip rather than
+//    clobber a real user's config. ──
+{
+  const pluginsConfig = join(ROOT, 'config', 'plugins.yml');
+  if (existsSync(pluginsConfig)) {
+    warn('config/plugins.yml already exists — skipping the spawn test rather than overwriting it');
+  } else {
+    const tmp = mkdtempSync(join(tmpdir(), 'co-4026-'));
+    try {
+      writeFileSync(pluginsConfig, 'plugins:\n  apify: { enabled: true }\n');
+      const portals = join(tmp, 'portals.yml');
+      writeFileSync(portals,
+        'tracked_companies:\n  - name: "apify 4026"\n    provider: apify\n    actor: x/y\n    enabled: true\n');
+
+      let out = '';
+      let exitCode = 0;
+      try {
+        out = execFileSync(NODE, [join(ROOT, 'verify-pipeline.mjs')], {
+          cwd: ROOT, encoding: 'utf8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env, CAREER_OPS_PORTALS: portals, APIFY_TOKEN: '' },
+        });
+      } catch (e) {
+        out = `${e.stdout || ''}${e.stderr || ''}`;
+        exitCode = e.status ?? 1;
+      }
+
+      if (!/unknown provider:\s*apify/i.test(out)) {
+        pass('verify-pipeline.mjs resolves an enabled `apify` plugin provider instead of "unknown provider"');
+      } else {
+        fail(`verify-pipeline.mjs still reports the enabled apify plugin as an unknown provider (exit ${exitCode})`);
+      }
+    } finally {
+      if (existsSync(pluginsConfig)) unlinkSync(pluginsConfig);
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+}

--- a/tests/verifiers-plugin-providers.test.mjs
+++ b/tests/verifiers-plugin-providers.test.mjs
@@ -6,69 +6,130 @@
 // so a supported `provider: <plugin-id>` portals entry was reported as an
 // "unknown provider" that "never scans" — while the scanner scanned it. The
 // divergence is the bug and it can reappear the moment a caller drifts, so it
-// is pinned structurally (three callers must agree) AND behaviorally (an
-// enabled stub plugin resolves in verify-pipeline's own load path).
-import { readFileSync, existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from 'fs';
+// is pinned structurally (three callers must run the call) AND behaviorally
+// (the real verifiers resolve an enabled plugin instead of flagging it).
+import {
+  readFileSync, existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, cpSync,
+  symlinkSync, readdirSync,
+} from 'fs';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { pass, fail, warn, NODE } from './helpers.mjs';
+import { pass, fail, NODE } from './helpers.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 console.log('\nverifiers resolve provider plugins like the scanner (#4026)');
 
-// ── 1. Structural: all three provider-map builders call mergeProviderPlugins ──
+// Strip block and line comments so a commented-out mention of the call does
+// not satisfy the structural check (a call-only revert must redden it).
+function stripJsComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+// A throwaway checkout that verify-pipeline/verify-portals run FROM, so the
+// test never reads, writes, or deletes the developer's real config/plugins.yml
+// (mergeProviderPlugins resolves plugins/ and config/plugins.yml from the
+// script's own CODE_ROOT). Copies the flat scripts plus the four dirs the
+// verifiers reach into; node_modules is symlinked.
+function prepareFixtureCodeRoot(tmp) {
+  const codeRoot = join(tmp, 'code-root');
+  mkdirSync(codeRoot, { recursive: true });
+  for (const entry of readdirSync(ROOT, { withFileTypes: true })) {
+    if (entry.isFile() && /\.(mjs|cjs|json)$/.test(entry.name)) {
+      cpSync(join(ROOT, entry.name), join(codeRoot, entry.name));
+    }
+  }
+  for (const dir of ['providers', 'plugins', 'templates', 'lib', 'batch']) {
+    if (existsSync(join(ROOT, dir))) cpSync(join(ROOT, dir), join(codeRoot, dir), { recursive: true });
+  }
+  if (existsSync(join(ROOT, 'node_modules'))) {
+    symlinkSync(join(ROOT, 'node_modules'), join(codeRoot, 'node_modules'), 'dir');
+  }
+  return codeRoot;
+}
+
+const MINIMAL_TRACKER =
+  '# Applications Tracker\n\n' +
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+  '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+  '| 1 | 2026-01-05 | Northwind | Backend Engineer | 4.2/5 | Applied | ❌ | - | fixture |\n';
+
+// ── 1. Structural: all three provider-map builders run mergeProviderPlugins ──
 {
   const callers = ['scan.mjs', 'verify-pipeline.mjs', 'verify-portals.mjs'];
-  const missing = callers.filter((f) => !/mergeProviderPlugins\s*\(/.test(readFileSync(join(ROOT, f), 'utf8')));
+  const missing = callers.filter(
+    (f) => !/\bmergeProviderPlugins\s*\(/.test(stripJsComments(readFileSync(join(ROOT, f), 'utf8'))),
+  );
   if (missing.length === 0) {
-    pass('scan.mjs, verify-pipeline.mjs and verify-portals.mjs all call mergeProviderPlugins()');
+    pass('scan.mjs, verify-pipeline.mjs and verify-portals.mjs all run mergeProviderPlugins()');
   } else {
     fail(`these provider-map builders skip mergeProviderPlugins() and will disagree with the scanner: ${missing.join(', ')}`);
   }
 }
 
-// ── 2. Behavioral: run the real verify-pipeline.mjs against a portals entry
-//    using the bundled `apify` plugin, enabled. Before the fix it printed
-//    "unknown provider: apify" and exited 1; after, apify resolves (to an
-//    actionable "missing env APIFY_TOKEN" stub here) and the false error is
-//    gone. verify-pipeline resolves plugins from its own CODE_ROOT, so
-//    config/plugins.yml has to live in the real checkout — skip rather than
-//    clobber a real user's config. ──
+// ── 2. Behavioral: run the real verifiers against a portals entry using the
+//    bundled `apify` plugin, enabled. Before the fix both printed
+//    "unknown provider: apify"; after, apify resolves to an actionable
+//    "missing env APIFY_TOKEN" stub. A minimal tracker is seeded so
+//    verify-pipeline gets past its "no applications.md" early exit and actually
+//    reaches the provider-resolution check. ──
 {
-  const pluginsConfig = join(ROOT, 'config', 'plugins.yml');
-  if (existsSync(pluginsConfig)) {
-    warn('config/plugins.yml already exists — skipping the spawn test rather than overwriting it');
-  } else {
-    const tmp = mkdtempSync(join(tmpdir(), 'co-4026-'));
-    try {
-      writeFileSync(pluginsConfig, 'plugins:\n  apify: { enabled: true }\n');
-      const portals = join(tmp, 'portals.yml');
-      writeFileSync(portals,
-        'tracked_companies:\n  - name: "apify 4026"\n    provider: apify\n    actor: x/y\n    enabled: true\n');
+  const tmp = mkdtempSync(join(tmpdir(), 'co-4026-'));
+  try {
+    const codeRoot = prepareFixtureCodeRoot(tmp);
+    mkdirSync(join(codeRoot, 'config'), { recursive: true });
+    writeFileSync(join(codeRoot, 'config', 'plugins.yml'), 'plugins:\n  apify: { enabled: true }\n');
 
-      let out = '';
-      let exitCode = 0;
+    const tracker = join(tmp, 'applications.md');
+    writeFileSync(tracker, MINIMAL_TRACKER);
+
+    const portals = join(tmp, 'portals.yml');
+    writeFileSync(portals,
+      'tracked_companies:\n' +
+      '  - name: "apify entry"\n    provider: apify\n    actor: x/y\n    enabled: true\n' +
+      '  - name: "bogus entry"\n    provider: definitely-not-a-provider\n    enabled: true\n');
+
+    const runVerifier = (script, extraArgs = []) => {
       try {
-        out = execFileSync(NODE, [join(ROOT, 'verify-pipeline.mjs')], {
-          cwd: ROOT, encoding: 'utf8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'],
-          env: { ...process.env, CAREER_OPS_PORTALS: portals, APIFY_TOKEN: '' },
-        });
+        return {
+          out: execFileSync(NODE, [join(codeRoot, script), ...extraArgs], {
+            cwd: codeRoot, encoding: 'utf8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'],
+            env: { ...process.env, CAREER_OPS_PORTALS: portals, CAREER_OPS_TRACKER: tracker, APIFY_TOKEN: '' },
+          }),
+          code: 0,
+        };
       } catch (e) {
-        out = `${e.stdout || ''}${e.stderr || ''}`;
-        exitCode = e.status ?? 1;
+        return { out: `${e.stdout || ''}${e.stderr || ''}`, code: e.status ?? 1 };
       }
+    };
 
-      if (!/unknown provider:\s*apify/i.test(out)) {
-        pass('verify-pipeline.mjs resolves an enabled `apify` plugin provider instead of "unknown provider"');
-      } else {
-        fail(`verify-pipeline.mjs still reports the enabled apify plugin as an unknown provider (exit ${exitCode})`);
-      }
-    } finally {
-      if (existsSync(pluginsConfig)) unlinkSync(pluginsConfig);
-      rmSync(tmp, { recursive: true, force: true });
+    const pipeline = runVerifier('verify-pipeline.mjs');
+    if (/unknown provider:\s*apify/i.test(pipeline.out)) {
+      fail(`verify-pipeline.mjs still reports the enabled apify plugin as an unknown provider (exit ${pipeline.code})`);
+    } else {
+      pass('verify-pipeline.mjs resolves an enabled `apify` plugin provider instead of "unknown provider"');
     }
+    // Negative direction: a genuinely unknown id must STILL be flagged — the
+    // fix must not turn the check into accept-everything.
+    if (/unknown provider:\s*definitely-not-a-provider/i.test(pipeline.out)) {
+      pass('verify-pipeline.mjs still flags a genuinely unknown provider id');
+    } else {
+      fail('verify-pipeline.mjs stopped flagging an unknown provider id — the resolution check is now too permissive');
+    }
+
+    const portalsRun = runVerifier('verify-portals.mjs', ['--file', portals]);
+    if (/unknown provider:\s*apify/i.test(portalsRun.out)) {
+      fail(`verify-portals.mjs still reports the enabled apify plugin as an unknown provider (exit ${portalsRun.code})`);
+    } else if (/missing env APIFY_TOKEN/i.test(portalsRun.out)) {
+      pass('verify-portals.mjs resolves `apify` to the actionable missing-env plugin stub');
+    } else {
+      fail(`verify-portals.mjs did not prove apify reached the missing-env plugin path (exit ${portalsRun.code})`);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
   }
 }

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -531,6 +531,7 @@ if (!existsSync(PORTALS_FILE)) {
   try {
     const { findUnclaimedEntries } = await import('./audit-portals.mjs');
     const { loadProviders } = await import('./providers/_registry.mjs');
+    const { mergeProviderPlugins } = await import('./plugins/_engine.mjs');
     const yaml = await import('js-yaml');
 
     const cfg = yaml.load(readFileSync(PORTALS_FILE, 'utf-8')) || {};
@@ -540,7 +541,15 @@ if (!existsSync(PORTALS_FILE)) {
       ...(Array.isArray(cfg.tracked_companies) ? cfg.tracked_companies : []),
       ...(Array.isArray(cfg.job_boards) ? cfg.job_boards : []),
     ];
-    const providers = await loadProviders(join(CAREER_OPS, 'providers'));
+    // providers/ and plugins/ both ship in the code layer — resolve them from
+    // CODE_ROOT (scan.mjs does the same). Without mergeProviderPlugins() the
+    // health check sees only providers/*.mjs and reports every enabled
+    // plugin-provider entry as an unknown provider that "never scans", while
+    // the scanner resolves and scans it (#4026). No-op for a plugin-free
+    // install: mergeProviderPlugins returns before any work when
+    // config/plugins.yml is absent.
+    const providers = await loadProviders(join(CODE_ROOT, 'providers'));
+    await mergeProviderPlugins(providers, { root: CODE_ROOT });
     const { silent, handoff, unknownProvider } = findUnclaimedEntries(entries, providers);
 
     // findUnclaimedEntries silently skips an entry with no (or blank) `name` —

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -724,6 +724,13 @@ async function main() {
   // SuccessFactors, SmartRecruiters, …) get a real reachability probe instead
   // of an un-actionable "skipped".
   const providers = await loadProviders(PROVIDERS_DIR);
+  // Fold in enabled keyed/auth-gated provider plugins, exactly as scan.mjs does
+  // — without this the verifier resolves only providers/*.mjs and disagrees
+  // with the scanner on every plugin-provider entry (#4026). No-op for a
+  // plugin-free install (mergeProviderPlugins returns before config/plugins.yml
+  // is read when it is absent).
+  const { mergeProviderPlugins } = await import('./plugins/_engine.mjs');
+  await mergeProviderPlugins(providers, { root: dirname(PROVIDERS_DIR) });
   const httpCtx = makeHttpCtx();
   const { found, results } = await verifyPortalsFile(filePath, { fetchJson, providers, httpCtx });
   if (!found) {


### PR DESCRIPTION
Fixes #4026.

## The bug

`verify-pipeline.mjs` and `verify-portals.mjs` build their provider map with `loadProviders()` alone. `scan.mjs` also calls `mergeProviderPlugins()` (`scan.mjs:2869`). So the health checkers can't see plugin providers, and report every `provider: <plugin-id>` portals entry as an **unknown provider** that *"never scans"* — while the scanner resolves and scans it.

This hits the **bundled `apify` plugin**, so it needs no third-party code. And `verify-pipeline.mjs` exits non-zero on the false error, which cascades into `test-all.mjs`: the reporter measured 8 extra failures, all from this one defect, making real failures indistinguishable from the artefact.

## Verified before/after

`config/plugins.yml` enabling `apify`, `portals.yml` with `provider: apify`, `APIFY_TOKEN` unset:

| | before | after |
|---|---|---|
| `verify-pipeline.mjs` | `❌ ... unknown provider: apify. The entry never scans` → `1 errors` → exit 1 | `0 errors` → exit 0 |
| `verify-portals.mjs` | `unknown provider` | `❌ apify — plugin "apify" inactive: missing env APIFY_TOKEN — add to .env` (actionable) |

## The fix

Both verifiers now mirror `scan.mjs`: `loadProviders()` from `CODE_ROOT`, then `await mergeProviderPlugins(providers, { root: CODE_ROOT })`.

- `mergeProviderPlugins()` returns before any work (no discovery, no dotenv, no `process.env` read) when `config/plugins.yml` is absent, so a **plugin-free install is byte-identical**.
- An enabled-but-unconfigured plugin resolves to `inactiveProviderStub()` — an actionable *"missing env APIFY_TOKEN"* message rather than *"unknown provider"*.
- `verify-pipeline.mjs` also had `loadProviders(join(CAREER_OPS, 'providers'))` — the **data** root; `providers/` ships in the code layer, so it now uses `CODE_ROOT` to match `scan.mjs` (identical on a non-split install, correct on a split one).

## Tests — `tests/verifiers-plugin-providers.test.mjs`

1. **Structural:** `scan.mjs`, `verify-pipeline.mjs` and `verify-portals.mjs` all call `mergeProviderPlugins()` — the reporter's point that "the divergence is the bug, and it can reappear anywhere a third caller loads providers".
2. **Behavioral:** spawns the real `verify-pipeline.mjs` against an enabled `apify` portals entry and asserts stdout carries no `unknown provider: apify`. Writes `config/plugins.yml` into the checkout (gitignored, removed in `finally`) and **skips** if one already exists rather than clobbering a real user's config.

Both assertions redden on a straight revert of the fix.

## Test plan

- [x] `node tests/verifiers-plugin-providers.test.mjs` — 2/2
- [x] `node verify-pipeline.mjs` / `node verify-portals.mjs` on a plugin-free checkout — unchanged (0 errors)
- [x] `node test-all.mjs` — 8689 passed, 0 failed (1 pre-existing local flake: `update-system.mjs check` SIGTERM'd on this machine's slow link to GitHub — untouched by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can configure bundled plugin providers, such as `apify`, without false `unknown provider` or `never scans` errors.

Changes:

- `verify-pipeline.mjs:551-552`: Loads providers from `CODE_ROOT/providers` and merges enabled plugins.
- `verify-portals.mjs:764-767`: Merges plugins before provider validation.
- `tests/verifiers-plugin-providers.test.mjs:61-141`: Adds structural and behavioral regression coverage.
- Tests isolate `CAREER_OPS_ROOT` and remove inherited `CAREER_OPS_REPORTS`.
- Inactive plugins report actionable errors, such as `missing env APIFY_TOKEN`.
- Plugin-free installations preserve existing behavior because plugin merging returns early without `config/plugins.yml`.

Validation: `test-all.mjs` reported 8692 passed and 0 failed.

System files not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->