### PR TITLE
fix(tests): skip web-argv static half when web/ is not installed

### DIFF
--- a/tests/web-core-argv-contract.test.mjs
+++ b/tests/web-core-argv-contract.test.mjs
@@ -14,7 +14,7 @@
 // real script.
 import { pass, fail, ROOT, NODE, rmSync, walkFiles } from './helpers.mjs';
 import { spawnSync } from 'child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, relative, sep } from 'path';
 
@@ -153,6 +153,16 @@ try {
   // web route — or a whole new route that spawns a script — cannot land
   // without going through a probe.
 
+  // web/ ships as its own release-please component and is excluded from
+  // SYSTEM_PATHS wholesale (validate-system-paths-coverage.mjs,
+  // EXCLUDE_PREFIXES = ['web/']), so `update-system.mjs apply` never installs
+  // it. An install created that way has no web/ at all, and the two checks
+  // below read the web sources unconditionally: readFileSync threw ENOENT and
+  // took the whole suite with it, so the argv probes above — which need only
+  // the core scripts and are the point of this file — reported nothing either.
+  if (!existsSync(join(ROOT, 'web', 'src'))) {
+    pass('web/src absent — static half skipped (web/ is a separate component)');
+  } else {
   // Every `"--flag"` literal in a listed source must appear in its argv here.
   // This covers the argv literals the routes write inline; it does NOT cover a
   // flag assembled at runtime from a variable or a template string.
@@ -183,6 +193,7 @@ try {
   const stale = [...listed].filter((f) => !spawners.includes(f));
   if (stale.length === 0) pass('no stale entries — every listed source still spawns a core script');
   else fail(`listed sources that no longer spawn a core script: ${stale.join(', ')}`);
+  }
 } finally {
   rmSync(sandbox, { recursive: true, force: true });
 }


### PR DESCRIPTION
## What does this PR do?

`tests/web-core-argv-contract.test.mjs` reads the listed web sources unconditionally, so on an installation without `web/` it throws `ENOENT` and the whole suite is contained — including the argv probes above it, which need nothing but the core scripts. This guards the static half on `existsSync(web/src)`.

## Related issue

None — bug fix, sent straight in per the template.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Why an install can have no `web/`

`web/` ships as its own release-please component and is excluded from the coverage check wholesale:

```js
// validate-system-paths-coverage.mjs
// web/ is the experimental web UI — its own release-please component, never …
const EXCLUDE_PREFIXES = ['web/'];
```

None of the 315 `SYSTEM_PATHS` entries covers the prefix either, so `update-system.mjs apply` never installs it. That is by design — but line 161 then reads `web/src/app/api/followups/route.ts` regardless:

```js
const src = readFileSync(join(ROOT, site.source), 'utf-8');
```

The throw is not contained inside the static half. It takes the argv probes with it — the one place tying a web route's transcribed argv to the script it actually spawns, which is the stated purpose of the file.

## Evidence

Clean checkout of `main`, `npm install --ignore-scripts`, running the single suite. "web/ absent" simulates an `update-system.mjs apply` install by moving `web/` aside:

|          | `web/` present      | `web/` absent              |
|----------|---------------------|----------------------------|
| before   | exit 0, 10 passes   | **exit 1, ENOENT, 7 passes** |
| after    | exit 0, 10 passes   | exit 0, 8 passes           |

The "web/ present" output is **byte-identical** before and after (`diff` over the ✅/❌ lines) — a full checkout sees no change at all. Without `web/`, the probes now run and the static half reports as skipped.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — 8684 passed, 0 failed; `npm run lint` clean (693 files)
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

Roadmap box deliberately left unchecked: this is a defect fix restoring documented behaviour, not a direction change, so I did not weigh it against discussion #156.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

When `web/src` is absent, `tests/web-core-argv-contract.test.mjs` skips static web-source checks instead of failing with `ENOENT`. Core argv probes still run: `tests/web-core-argv-contract.test.mjs:5-6,88-99`.

Full checkouts keep the existing behavior. The change affects no public entities.

Files touched: `tests/web-core-argv-contract.test.mjs` only. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` were not changed.

Validation passed: full suite with 8,684 tests and lint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->