### PR TITLE
feat(pdf): add optional `context` line to CV experience entries

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -356,12 +356,15 @@ function buildExperience(entries, partial) {
       const location = e.location
         ? `\n    <div class="job-location">${escapeHtml(e.location)}</div>`
         : '';
+      const context = e.context
+        ? `\n    <div class="job-context">${escapeHtml(e.context)}</div>`
+        : '';
       return `<div class="job">
     <div class="job-header">
       <span class="job-company">${escapeHtml(e.company)}</span>
       <span class="job-period">${escapeHtml(e.dates || e.period || '')}</span>
     </div>
-    <div class="job-role">${escapeHtml(e.role)}</div>${location}
+    <div class="job-role">${escapeHtml(e.role)}</div>${location}${context}
     <ul>
 ${bullets}
     </ul>
@@ -376,12 +379,14 @@ ${bullets}
       : '';
     const blockValues = new Map([
       ['LOCATION_BLOCK', { value: escapeHtml(e.location || ''), present: Boolean(e.location) }],
+      ['CONTEXT_BLOCK', { value: escapeHtml(e.context || ''), present: Boolean(e.context) }],
     ]);
     return fillEntry(entryTemplate, blocks, {
       COMPANY: escapeHtml(e.company || ''),
       PERIOD: escapeHtml(e.dates || e.period || ''),
       ROLE: escapeHtml(e.role || ''),
       LOCATION: escapeHtml(e.location || ''),
+      CONTEXT: escapeHtml(e.context || ''),
       BULLETS: bullets,
     }, blockValues);
   }).join('\n  ');
@@ -826,6 +831,7 @@ async function runSelfTest() {
       company: 'Test Corp',
       role: 'Test Engineer',
       location: 'Remote',
+      context: 'Seed-stage startup; joined as employee #7.',
       dates: 'June 2024 - Present',
       bullets: [
         'Built automated testing pipelines with CI/CD integration',
@@ -966,6 +972,10 @@ async function runSelfTest() {
     console.error('Self-test failed: job-location block not rendered when location is present');
     process.exit(1);
   }
+  if (!html.includes('class="job-context"') || !html.includes('Seed-stage startup; joined as employee #7.')) {
+    console.error('Self-test failed: job-context block not rendered when context is present');
+    process.exit(1);
+  }
   if (!html.includes('class="edu-location"')) {
     console.error('Self-test failed: edu-location block not rendered when education location is present');
     process.exit(1);
@@ -988,6 +998,10 @@ async function runSelfTest() {
   }
   if (noLocHtml.includes('class="job-location"')) {
     console.error('Self-test failed: job-location block rendered when location is absent');
+    process.exit(1);
+  }
+  if (noLocHtml.includes('class="job-context"')) {
+    console.error('Self-test failed: job-context block rendered when context is absent');
     process.exit(1);
   }
   if (noLocHtml.includes('class="edu-location"')) {

--- a/lib/cv-payload-schema.mjs
+++ b/lib/cv-payload-schema.mjs
@@ -21,7 +21,7 @@ export const ENTRY_FIELD_SPECS = {
   html: {
     experience: {
       required: ['company', 'role'],
-      known: ['company', 'role', 'location', 'dates', 'period', 'bullets'],
+      known: ['company', 'role', 'location', 'context', 'dates', 'period', 'bullets'],
     },
     projects: {
       required: ['name'],

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -164,6 +164,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
       "company": "Company Name",
       "role": "Job Title",
       "location": "Remote",
+      "context": "Early-stage startup; joined at growth stage. Product reached 500k MAU and was acquired by BigCo.",
       "dates": "June 2022 - Present",
       "bullets": ["Achievement bullet with JD keywords injected", "Another quantified-impact bullet"]
     }
@@ -205,7 +206,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. |
 | `summary` | string | Personalized summary with keywords. Supports `**…**` emphasis (see **Markdown bold** below). |
 | `competencies` | string[] | 6-8 keyword phrases → competency tags. |
-| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected; `**…**` emphasis supported). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
+| `experience[]` | object | `company`, `role`, `location` (optional), `context` (optional), `dates`, `bullets` (reordered, keyword-injected; `**…**` emphasis supported). `context` is an un-bulleted italic line rendered directly under the role — for a one-line company/scope note (company size/stage, an acquisition, headcount owned, team the role sat in) that is background, not an achievement. Keep it short; keep achievements in `bullets`. Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
 | `projects[]` | object | `name`, `url` (optional project/repo link), `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `location` (optional, city/state), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |

--- a/templates/cv-template.compact.html
+++ b/templates/cv-template.compact.html
@@ -193,6 +193,14 @@ version: 1.0.0
     font-size: 8.5px;
     color: #6b7480;
   }
+
+  .job-context {
+    font-style: italic;
+    font-size: 9px;
+    line-height: 1.45;
+    color: #55606d;
+    margin-top: 2px;
+  }
   .job-location::before {
     content: "  \00B7  ";
     color: #b0b7c2;
@@ -284,6 +292,7 @@ version: 1.0.0
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/cv-template.executive.html
+++ b/templates/cv-template.executive.html
@@ -171,6 +171,14 @@ version: 1.0.0
     margin-top: 1px;
   }
 
+  .job-context {
+    font-style: italic;
+    font-size: 10px;
+    line-height: 1.5;
+    color: #55606d;
+    margin-top: 3px;
+  }
+
   .job ul {
     margin-top: 4px;
     padding-left: 17px;
@@ -275,6 +283,7 @@ version: 1.0.0
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -221,6 +221,14 @@
     color: #888;
   }
 
+  .job-context {
+    font-style: italic;
+    font-size: 10.5px;
+    line-height: 1.55;
+    color: #555;
+    margin-top: 3px;
+  }
+
   .job ul {
     padding-left: 18px;
     margin-top: 6px;
@@ -458,6 +466,7 @@
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/cv-template.jake.html
+++ b/templates/cv-template.jake.html
@@ -177,6 +177,14 @@ version: 1.0.0
     text-align: right;
   }
 
+  .job-context {
+    font-style: italic;
+    font-size: 10px;
+    line-height: 1.5;
+    color: #444;
+    margin-top: 3px;
+  }
+
   .job ul {
     clear: both;   /* required: ends the .job-role float before the bullets */
     margin-top: 2px;
@@ -268,6 +276,7 @@ version: 1.0.0
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/cv-template.leadership.html
+++ b/templates/cv-template.leadership.html
@@ -189,6 +189,14 @@ version: 1.0.0
     text-align: right;
   }
 
+  .job-context {
+    font-style: italic;
+    font-size: 10px;
+    line-height: 1.5;
+    color: #55606d;
+    margin-top: 3px;
+  }
+
   .job ul {
     clear: both;   /* required: ends the .job-role float before the bullets */
     margin-top: 4px;
@@ -285,6 +293,7 @@ version: 1.0.0
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/cv-template.modern.html
+++ b/templates/cv-template.modern.html
@@ -205,6 +205,14 @@ version: 1.0.0
     margin-top: 0.5px;
   }
 
+  .job-context {
+    font-style: italic;
+    font-size: 9.5px;
+    line-height: 1.5;
+    color: #55606d;
+    margin-top: 3px;
+  }
+
   .job ul {
     margin-top: 5px;
     padding-left: 14px;
@@ -318,6 +326,7 @@ version: 1.0.0
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -215,6 +215,14 @@ version: 1.0.0
     color: #888;
   }
 
+  .job-context {
+    font-style: italic;
+    font-size: 10.5px;
+    line-height: 1.55;
+    color: #555;
+    margin-top: 3px;
+  }
+
   .job ul {
     padding-left: 18px;
     margin-top: 6px;
@@ -434,6 +442,7 @@ version: 1.0.0
   .job-company,
   .job-role,
   .job-location,
+  .job-context,
   .edu-location,
   .project-title {
     break-after: avoid;

--- a/templates/sections/experience.html
+++ b/templates/sections/experience.html
@@ -7,6 +7,7 @@
     ROLE             — job title
     BULLETS          — rendered <li> tags
     LOCATION_BLOCK   — conditional: .job-location div when location present; omitted when absent
+    CONTEXT_BLOCK    — conditional: .job-context div (un-bulleted company/scope note) when context present; omitted when absent
 
   Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
@@ -18,9 +19,11 @@
   </div>
   <div class="job-role">{{ROLE}}</div>
   {{LOCATION_BLOCK}}
+  {{CONTEXT_BLOCK}}
   <ul>
     {{BULLETS}}
   </ul>
 </div>
 <!--LOCATION_BLOCK--><div class="job-location">{{LOCATION}}</div><!--/LOCATION_BLOCK-->
+<!--CONTEXT_BLOCK--><div class="job-context">{{CONTEXT}}</div><!--/CONTEXT_BLOCK-->
 <!--/ENTRY-->


### PR DESCRIPTION
## What

Adds an optional `context` field to CV experience entries. It renders as a short, **un-bulleted italic line directly under the role** — for background that isn't an achievement:

- company size / stage ("Early-stage startup; joined at growth stage.")
- an acquisition ("Product reached 500k MAU and was acquired by BigCo.")
- headcount owned, or the team the role sat in

## Why

Today that information has two bad homes: a **bullet** (where it competes with real achievements and dilutes the six-second scan), or **nowhere** (dropped in tailoring). Many source CVs already write a one-line company blurb under the title; the generated CV had no way to keep that shape.

## Changes

| File | Change |
|---|---|
| `lib/cv-payload-schema.mjs` | `context` added to the `html` experience `known` keys (optional). Unknown-key warning no longer fires for it. |
| `build-cv-html.mjs` | Rendered in **both** the partial and the fallback builder as `<div class="job-context">`; conditional — emitted only when present. Self-test extended (present → rendered, absent → not). |
| `templates/sections/experience.html` | `{{CONTEXT_BLOCK}}` conditional, mirroring the existing `{{LOCATION_BLOCK}}`. |
| `templates/cv-template*.html` (all 7 variants) | `.job-context` style — italic, muted, sits under the role — and added to the page-break-avoid selector list so it stays attached to its bullets. |
| `modes/pdf.md` | JSON schema example + field-reference table row. |

## Compatibility

Fully backward compatible. A payload with no `context` renders byte-identical to before — the `CONTEXT_BLOCK` conditional and the fallback `e.context ? … : ''` both collapse to nothing.

## Testing

- `node build-cv-html.mjs --test` passes (extended with present/absent assertions for the new block).
- Rendered against all 7 templates; `verify-cv-facts.mjs` unaffected.

Happy to open a tracking issue first if that's preferred per CONTRIBUTING — the change is small and additive so I went straight to a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can add an optional `context` field to experience entries. The field renders as a short, italic, muted, unbulleted line below the role.

Use `context` for company stage, acquisitions, headcount, or team context. Keep achievements in `bullets`: `modes/pdf.md:167,209`.

Entries without `context` render unchanged. Both HTML paths support the field: `build-cv-html.mjs:359-389` and `templates/sections/experience.html:22,28`.

## User impact

- The HTML schema accepts `context`: `lib/cv-payload-schema.mjs:24`.
- All seven CV templates style `.job-context` and apply page-break handling: `templates/cv-template*.html`.
- Self-tests cover present and absent values: `build-cv-html.mjs:975-1004`.

## System files

`AGENTS.md`, `DATA_CONTRACT.md`, `update-system.mjs`, `providers/`, and `.github/` are not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->