### PR TITLE
docs(local-parser): keep a private parser script out of Git

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -622,11 +622,13 @@ For custom SSR pages, configure a tracked company with `scan_method: local_parse
 ```yaml
 parser:
   command: node
-  script: scripts/parsers/example-company-jobs.js
+  script: local/example-company-jobs.js
   format: jobs-json-v1
 ```
 
 Use `args` only for reusable parsers that intentionally accept runtime parameters such as `{careers_url}` or `{company}`.
+
+The script must resolve inside the repo root (security boundary in `providers/local-parser.mjs`). Keep a private, non-contributed parser under a gitignored path — `local/` is ignored by default — so it is never staged; `portals.yml` itself is already gitignored. Use `scripts/parsers/` only for a parser you intend to upstream. See [local-parser-cookbook.md](local-parser-cookbook.md).
 
 If a parser writes full extraction artifacts for debugging or audit, store them under `data/parser-output/{company}/`. `scan.mjs` reads stdout and does not require those JSON files after parsing. Keep generated JSON artifacts out of git; `.gitkeep` placeholders are the only exception for preserving directory structure.
 

--- a/docs/local-parser-cookbook.md
+++ b/docs/local-parser-cookbook.md
@@ -16,12 +16,23 @@ Most local parsers are company-specific: the script already knows the source URL
   scan_method: local_parser
   parser:
     command: node
-    script: scripts/parsers/example-company-jobs.js
+    script: local/example-company-jobs.js
     format: jobs-json-v1
   enabled: true
 ```
 
 `args` are optional. Use them in whatever way helps the parser author: to make one script reusable across multiple companies, pass `{careers_url}` or `{company}`, enable a debug flag, store a JSON snapshot, or control any other script-specific behavior. `scan.mjs` executes the parser without shell interpolation and expands `{careers_url}` and `{company}` in parser arguments before execution.
+
+## Where the script lives
+
+`providers/local-parser.mjs` only runs a script that resolves **inside the repository root** — a whitelisted interpreter (`node`, `python3`, …) must take an in-repo script as its first argument, and a path that escapes the root is rejected. This is a deliberate boundary: `portals.yml` is not fully trusted on a shared or template config, so the parser command cannot point at an arbitrary binary or a file outside the checkout.
+
+Because the script has to sit in the tree, put a parser you do not intend to contribute under a path that Git ignores, so it is never staged:
+
+- `local/` is gitignored by default. `local/acme-jobs.mjs` is the simplest home for a one-off, company-specific parser.
+- `portals.yml` is already a user-layer file (gitignored), so the `parser:` block that points at the script stays private too.
+
+Use `scripts/parsers/` only for a parser you plan to open a PR for. `career-ops` does not bundle company-specific parser scripts, so in practice that is rare.
 
 ## Token savings
 

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -44,10 +44,12 @@ Recommended Contract:
   scan_method: local_parser
   parser:
     command: node
-    script: scripts/parsers/example-company-jobs.js
+    script: local/example-company-jobs.js
     format: jobs-json-v1
   enabled: true
 ```
+
+The script must resolve inside the repo root (security boundary in `providers/local-parser.mjs`). Keep a private, non-contributed parser under a gitignored path — `local/` is ignored by default — so it is never staged; `scripts/parsers/` is for a parser you intend to upstream. See `docs/local-parser-cookbook.md`.
 
 Typically, the parser is company-specific and already knows the URL, selectors, and pagination. `args` is optional: use it however it helps the script author, for example, to reuse it across companies, pass `{careers_url}` or `{company}`, activate a debug flag, save a JSON snapshot, or control any parser-specific behavior.
 

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -906,13 +906,19 @@ search_queries:
 # already know their target careers URL. `args` are optional and can help the
 # parser author (reuse across companies, debug flags, JSON snapshots, etc.).
 #
+# The script must resolve inside the repo root (security boundary in
+# providers/local-parser.mjs). Keep a private, non-contributed parser under a
+# gitignored path — `local/` is ignored by default — so it is never staged;
+# `portals.yml` itself is already gitignored. Use `scripts/parsers/` only for a
+# parser you intend to upstream. See docs/local-parser-cookbook.md.
+#
 # JavaScript parser:
 # - name: Example JS Company
 #   careers_url: https://example.com/careers
 #   scan_method: local_parser
 #   parser:
 #     command: node
-#     script: scripts/parsers/example-js-company-jobs.js
+#     script: local/example-js-company-jobs.js
 #     format: jobs-json-v1
 #   enabled: true
 #
@@ -922,7 +928,7 @@ search_queries:
 #   scan_method: local_parser
 #   parser:
 #     command: python3
-#     script: scripts/parsers/example_python_company_jobs.py
+#     script: local/example_python_company_jobs.py
 #     format: jobs-json-v1
 #   enabled: true
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4870,7 +4870,7 @@ const portalExample = readFile('templates/portals.example.yml');
 if (
   portalExample.includes('script: local/example-js-company-jobs.js') &&
   portalExample.includes('script: local/example_python_company_jobs.py') &&
-  !/^\s*#?\s*script:\s*scripts\/parsers\//m.test(portalExample)
+  !/^\s*#?\s*script:\s*['"]?scripts\/parsers\//m.test(portalExample)
 ) {
   pass('portals example points the local-parser script at a gitignored path');
 } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4866,19 +4866,20 @@ if (!fileExists('scripts/parsers/cohere_jobs.py')) {
 const portalExample = readFile('templates/portals.example.yml');
 if (
   !portalExample.includes('cohere_jobs.py') &&
-  portalExample.includes('scan_method: local_parser') &&
+  portalExample.includes('script: local/example-js-company-jobs.js') &&
+  portalExample.includes('script: local/example_python_company_jobs.py') &&
   portalExample.includes('already know their target careers URL')
 ) {
-  pass('portals example documents a generic local parser contract');
+  pass('portals example documents a generic local parser contract with gitignored script paths');
 } else {
-  fail('portals example still points at a bundled Cohere parser');
+  fail('portals example lost the generic local-parser contract or its gitignored script paths');
 }
-// The example parser script must not sit under a Git-tracked path — following
-// it verbatim would stage a user's private parser (see local-parser-cookbook.md).
+// Belt and braces: no commented example may reintroduce the Git-tracked path —
+// following one verbatim would stage a user's private parser (see docs/local-parser-cookbook.md).
 if (!/^\s*#?\s*script:\s*scripts\/parsers\//m.test(portalExample)) {
-  pass('portals example points the parser script at a gitignored path, not scripts/parsers/');
+  pass('portals example keeps the parser script out of the Git-tracked scripts/parsers/');
 } else {
-  fail('portals example still shows the parser script under the Git-tracked scripts/parsers/');
+  fail('portals example shows the parser script under the Git-tracked scripts/parsers/');
 }
 
 // Security hardening: command allowlist, in-repo script containment, careers_url/company validation.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4866,13 +4866,19 @@ if (!fileExists('scripts/parsers/cohere_jobs.py')) {
 const portalExample = readFile('templates/portals.example.yml');
 if (
   !portalExample.includes('cohere_jobs.py') &&
-  portalExample.includes('scripts/parsers/example-js-company-jobs.js') &&
-  portalExample.includes('scripts/parsers/example_python_company_jobs.py') &&
+  portalExample.includes('scan_method: local_parser') &&
   portalExample.includes('already know their target careers URL')
 ) {
   pass('portals example documents a generic local parser contract');
 } else {
   fail('portals example still points at a bundled Cohere parser');
+}
+// The example parser script must not sit under a Git-tracked path — following
+// it verbatim would stage a user's private parser (see local-parser-cookbook.md).
+if (!/^\s*#?\s*script:\s*scripts\/parsers\//m.test(portalExample)) {
+  pass('portals example points the parser script at a gitignored path, not scripts/parsers/');
+} else {
+  fail('portals example still shows the parser script under the Git-tracked scripts/parsers/');
 }
 
 // Security hardening: command allowlist, in-repo script containment, careers_url/company validation.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4863,23 +4863,18 @@ if (!fileExists('scripts/parsers/cohere_jobs.py')) {
   fail('Cohere parser example is still bundled as a runtime script');
 }
 
+// templates/portals.example.yml is copied verbatim by new users — its local-parser
+// example must point the script at a gitignored path, not the Git-tracked
+// scripts/parsers/ (see docs/local-parser-cookbook.md).
 const portalExample = readFile('templates/portals.example.yml');
 if (
-  !portalExample.includes('cohere_jobs.py') &&
   portalExample.includes('script: local/example-js-company-jobs.js') &&
   portalExample.includes('script: local/example_python_company_jobs.py') &&
-  portalExample.includes('already know their target careers URL')
+  !/^\s*#?\s*script:\s*scripts\/parsers\//m.test(portalExample)
 ) {
-  pass('portals example documents a generic local parser contract with gitignored script paths');
+  pass('portals example points the local-parser script at a gitignored path');
 } else {
-  fail('portals example lost the generic local-parser contract or its gitignored script paths');
-}
-// Belt and braces: no commented example may reintroduce the Git-tracked path —
-// following one verbatim would stage a user's private parser (see docs/local-parser-cookbook.md).
-if (!/^\s*#?\s*script:\s*scripts\/parsers\//m.test(portalExample)) {
-  pass('portals example keeps the parser script out of the Git-tracked scripts/parsers/');
-} else {
-  fail('portals example shows the parser script under the Git-tracked scripts/parsers/');
+  fail('portals example local-parser script is under the Git-tracked scripts/parsers/');
 }
 
 // Security hardening: command allowlist, in-repo script containment, careers_url/company validation.


### PR DESCRIPTION
## What does this PR do?

`docs/local-parser-cookbook.md`, `docs/SCRIPTS.md`, `modes/scan.md` and `templates/portals.example.yml` all show the local-parser `script:` under `scripts/parsers/`, a Git-tracked path. The feature exists for a user's own parser — #594 and #595 established that the project does not bundle company-specific ones — and #1092's hardening requires the script to resolve inside the repository root. Following the example verbatim therefore leaves a user's private parser staged for commit, and nothing in the docs points at a location Git ignores.

This adds that guidance. No provider or scanner behaviour changes.

- `docs/local-parser-cookbook.md`: new "Where the script lives" section. The script has to sit in the tree (the security boundary in `providers/local-parser.mjs`), so a parser you do not intend to contribute goes under a gitignored path — `local/` is ignored by default, and `portals.yml` is already a user-layer file. `scripts/parsers/` is for a parser you plan to open a PR for.
- `docs/SCRIPTS.md`, `modes/scan.md`: the same note in short form, next to their existing parser-config snippet.
- `templates/portals.example.yml`: the two commented examples now point at `local/…`, with a comment explaining why.
- `test-all.mjs`: the "portals example documents a generic local parser contract" check no longer keys on the exact example filenames (which this PR changes); it asserts the stable tokens instead, plus a new check that the example `script:` is not under `scripts/parsers/`.

## Related issue

None — documentation.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can keep private local-parser scripts in the gitignored `local/` directory: `docs/SCRIPTS.md:625`, `docs/local-parser-cookbook.md:19`, `modes/scan.md:47`, and `templates/portals.example.yml:921`.

`scripts/parsers/` is reserved for parsers intended for upstream submission: `docs/SCRIPTS.md:631`. Scripts must resolve inside the repository root: `modes/scan.md:52`.

`test-all.mjs:4866` validates that portal examples use gitignored parser paths.

No provider or scanner behavior changes.

## Files touched

Changed files: `docs/SCRIPTS.md`, `docs/local-parser-cookbook.md`, `modes/scan.md`, `templates/portals.example.yml`, and `test-all.mjs`.

Unchanged system files: `AGENTS.md`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->