### PR TITLE
feat(local-parser): pass an optional postedAt through

### DIFF
--- a/docs/local-parser-cookbook.md
+++ b/docs/local-parser-cookbook.md
@@ -57,7 +57,7 @@ The parser must print one of these JSON shapes to stdout:
 }
 ```
 
-`title` and `url` are required. `company` is optional; when omitted, the scanner uses the `tracked_companies` entry name. Relative URLs are resolved against `careers_url`.
+`title` and `url` are required. `company` is optional; when omitted, the scanner uses the `tracked_companies` entry name. `location` is optional. `postedAt` is optional — an epoch-milliseconds number or a `Date.parse`-able string (`"2026-09-08"`, an ISO timestamp); `posted_at` / `publishedAt` / `published_at` are accepted as aliases. It feeds `--posted-after` / `--since` and the scan output's posting-date column; an unparseable value is dropped and the row is still kept. Relative URLs are resolved against `careers_url`.
 
 ## Artifact Storage
 

--- a/providers/local-parser.mjs
+++ b/providers/local-parser.mjs
@@ -137,6 +137,18 @@ function normalizeLocation(value) {
   return String(value).trim();
 }
 
+// NaN-safe coercion for an optional parser-supplied posting date. Accepts an
+// epoch-milliseconds number or a Date.parse-able string; an unparseable string,
+// a non-finite number, or an absent field yields undefined, so the row is kept
+// without a date rather than carrying a wrong one. `|| undefined` is avoided on
+// purpose — it would also drop a legitimate epoch 0.
+function toEpochMs(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
 function normalizeParserJob(job, entry) {
   if (!job || typeof job !== 'object') return null;
 
@@ -147,12 +159,17 @@ function normalizeParserJob(job, entry) {
   );
   if (!title || !url) return null;
 
-  return {
+  const out = {
     title,
     url,
     company: String(job.company || entry.name || '').trim(),
     location: normalizeLocation(job.location || job.locations),
   };
+
+  const postedAt = toEpochMs(job.postedAt ?? job.posted_at ?? job.publishedAt ?? job.published_at);
+  if (postedAt !== undefined) out.postedAt = postedAt;
+
+  return out;
 }
 
 async function runLocalParser(entry) {

--- a/tests/providers/_fixture-local-parser.mjs
+++ b/tests/providers/_fixture-local-parser.mjs
@@ -20,6 +20,18 @@ if (inputArgs[0] === 'invalid') {
   process.exit(0);
 }
 
+// If the first argument is "posted-at", exercise optional postedAt coercion
+if (inputArgs[0] === 'posted-at') {
+  console.log(JSON.stringify([
+    { title: 'ISO date', url: 'https://example.com/a', postedAt: '2026-09-08' },
+    { title: 'Epoch ms', url: 'https://example.com/b', postedAt: 1757289600000 },
+    { title: 'Snake case', url: 'https://example.com/c', posted_at: '2026-01-15T10:00:00Z' },
+    { title: 'Bad date', url: 'https://example.com/d', postedAt: 'not-a-date' },
+    { title: 'No date', url: 'https://example.com/e' },
+  ]));
+  process.exit(0);
+}
+
 // Default payload
 console.log(JSON.stringify([
   { title: 'Standard Job', url: 'https://example.com/job1', location: ['Remote', 'NY'] },

--- a/tests/providers/_fixture-local-parser.mjs
+++ b/tests/providers/_fixture-local-parser.mjs
@@ -26,6 +26,9 @@ if (inputArgs[0] === 'posted-at') {
     { title: 'ISO date', url: 'https://example.com/a', postedAt: '2026-09-08' },
     { title: 'Epoch ms', url: 'https://example.com/b', postedAt: 1757289600000 },
     { title: 'Snake case', url: 'https://example.com/c', posted_at: '2026-01-15T10:00:00Z' },
+    { title: 'Camel alias', url: 'https://example.com/f', publishedAt: '2026-03-20' },
+    { title: 'Snake alias', url: 'https://example.com/g', published_at: '2026-04-01T00:00:00Z' },
+    { title: 'Epoch zero', url: 'https://example.com/h', postedAt: 0 },
     { title: 'Bad date', url: 'https://example.com/d', postedAt: 'not-a-date' },
     { title: 'No date', url: 'https://example.com/e' },
   ]));

--- a/tests/providers/local-parser.test.mjs
+++ b/tests/providers/local-parser.test.mjs
@@ -141,18 +141,26 @@ try {
   const postedJobs = await localParser.fetch(postedEntry);
   const byTitle = Object.fromEntries(postedJobs.map(j => [j.title, j]));
 
-  if (postedJobs.length === 5) {
+  if (postedJobs.length === 8) {
     pass('localParser.fetch() keeps rows whose postedAt is bad or absent');
   } else {
-    fail(`localParser.fetch() returned ${postedJobs.length} posted-at rows, expected 5`);
+    fail(`localParser.fetch() returned ${postedJobs.length} posted-at rows, expected 8`);
   }
 
   if (byTitle['ISO date']?.postedAt === Date.parse('2026-09-08')
     && byTitle['Epoch ms']?.postedAt === 1757289600000
-    && byTitle['Snake case']?.postedAt === Date.parse('2026-01-15T10:00:00Z')) {
-    pass('localParser.fetch() coerces ISO / epoch-ms / posted_at into postedAt');
+    && byTitle['Snake case']?.postedAt === Date.parse('2026-01-15T10:00:00Z')
+    && byTitle['Camel alias']?.postedAt === Date.parse('2026-03-20')
+    && byTitle['Snake alias']?.postedAt === Date.parse('2026-04-01T00:00:00Z')) {
+    pass('localParser.fetch() coerces ISO / epoch-ms / posted_at / publishedAt / published_at into postedAt');
   } else {
     fail(`postedAt coercion = ${JSON.stringify(postedJobs.map(j => [j.title, j.postedAt]))}`);
+  }
+
+  if (byTitle['Epoch zero']?.postedAt === 0) {
+    pass('localParser.fetch() preserves a legitimate epoch 0 postedAt');
+  } else {
+    fail(`epoch 0 postedAt = ${JSON.stringify(byTitle['Epoch zero'])}`);
   }
 
   if (!('postedAt' in byTitle['Bad date']) && !('postedAt' in byTitle['No date'])) {

--- a/tests/providers/local-parser.test.mjs
+++ b/tests/providers/local-parser.test.mjs
@@ -129,6 +129,38 @@ try {
     fail(`Envelope extraction failed: ${JSON.stringify(envJobs[0])}`);
   }
 
+  // 7b. Fetch - Optional postedAt coercion
+  const postedEntry = {
+    careers_url: 'https://example.com/careers',
+    parser: {
+      command: 'node',
+      script: 'tests/providers/_fixture-local-parser.mjs',
+      args: ['posted-at']
+    }
+  };
+  const postedJobs = await localParser.fetch(postedEntry);
+  const byTitle = Object.fromEntries(postedJobs.map(j => [j.title, j]));
+
+  if (postedJobs.length === 5) {
+    pass('localParser.fetch() keeps rows whose postedAt is bad or absent');
+  } else {
+    fail(`localParser.fetch() returned ${postedJobs.length} posted-at rows, expected 5`);
+  }
+
+  if (byTitle['ISO date']?.postedAt === Date.parse('2026-09-08')
+    && byTitle['Epoch ms']?.postedAt === 1757289600000
+    && byTitle['Snake case']?.postedAt === Date.parse('2026-01-15T10:00:00Z')) {
+    pass('localParser.fetch() coerces ISO / epoch-ms / posted_at into postedAt');
+  } else {
+    fail(`postedAt coercion = ${JSON.stringify(postedJobs.map(j => [j.title, j.postedAt]))}`);
+  }
+
+  if (!('postedAt' in byTitle['Bad date']) && !('postedAt' in byTitle['No date'])) {
+    pass('localParser.fetch() omits postedAt for an unparseable or missing date');
+  } else {
+    fail(`postedAt should be absent: ${JSON.stringify([byTitle['Bad date'], byTitle['No date']])}`);
+  }
+
   // 8. Fetch - Invalid JSON
   try {
     await localParser.fetch({


### PR DESCRIPTION
## What

`normalizeParserJob()` in `providers/local-parser.mjs` returned only `title` / `url` / `company` / `location`, so any posting date a local parser emitted was dropped before `scan.mjs` saw it — even though `scan.mjs` already consumes `job.postedAt` for `--posted-after` / `--posted-before` / `--since` and writes it to the scan output's posting-date column (`postedAt@8`).

This passes `postedAt` through when the parser row carries one: an epoch-milliseconds number, or a `Date.parse`-able string. `posted_at` / `publishedAt` / `published_at` are accepted as aliases, matching the multi-alias handling the function already does for `url` and `title`. Coercion is the NaN-safe `toEpochMs` pattern from `ADDING_A_PROVIDER.md` — an unparseable value is dropped and the row is still kept, never rejected over a bad date. Parsers that emit no date are unaffected.

## Why

Company-specific local parsers frequently sit on a JSON endpoint that already carries a real publication date (e.g. a Personio careers API's `createdAt`, a Workday-proxy's `Job_Posting_Start_Date`). Without passthrough that date is unreachable, so `--since` / `--posted-after` silently treat every local-parser row as undated.

## Changes

- `providers/local-parser.mjs`: `toEpochMs` helper + optional `postedAt` on the normalized row.
- `docs/local-parser-cookbook.md`: the stdout contract documents the new optional field.
- `tests/providers/_fixture-local-parser.mjs`: a `posted-at` case covering ISO, epoch-ms, a snake_case alias, an unparseable value, and an absent field.
- `tests/providers/local-parser.test.mjs`: asserts the three valid forms coerce to a number and the bad / missing ones leave `postedAt` absent while keeping the row.

`node test-all.mjs` passes (0 failed).

Happy to file a tracking issue first if that is preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can include an optional posting date in local-parser output. The parser accepts epoch milliseconds and parseable date strings through `postedAt`, `posted_at`, `publishedAt`, and `published_at` [providers/local-parser.mjs:145-170].

If the date is invalid or absent, the parser keeps the row and omits `postedAt` [providers/local-parser.mjs:162-172].

The cookbook documents the fields and their use with `--posted-after` and `--since` [docs/local-parser-cookbook.md:60].

Fixtures and tests cover aliases, epoch zero, invalid dates, missing dates, and row retention [tests/providers/_fixture-local-parser.mjs:23-35] [tests/providers/local-parser.test.mjs:132-170].

System files touched: `providers/`. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, and `.github/` are not touched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->