### PR TITLE
fix(web): resolve the data root exactly as the core does

### DIFF
--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
 import { atomicWrite } from "@/lib/core/safe-write";
+import { resolveDataRoot } from "@/lib/core/data-root.mjs";
 import { parseApplications } from "@/lib/tracker-table.mjs";
 // One definition of the `{n}-RESERVED.md` convention, shared with
 // run-cli-support.mjs — see report-files.mjs for why it lives there.
@@ -20,9 +21,24 @@ import { pdfIndexEntryForReport } from "@/lib/apply/cv-selection.mjs";
  * checkout — see web/.env.local.
  */
 export function careerOpsRoot(): string {
-  const env = process.env.CAREER_OPS_ROOT?.trim();
-  if (env) return env;
-  return path.resolve(process.cwd(), "..");
+  // `process.cwd()` is `<core>/web` for `next dev`/`next start`, so its parent is
+  // the core checkout — the same directory `path-resolver.mjs` calls `__dirname`.
+  // resolveDataRoot() needs it explicitly because relative env values and marker
+  // contents resolve against it; see data-root.mjs for why that base matters.
+  const coreRoot = path.resolve(process.cwd(), "..");
+  return resolveDataRoot(
+    coreRoot,
+    (p) => {
+      try {
+        return fs.readFileSync(p, "utf8");
+      } catch {
+        return null; // absent, unreadable, or a directory — all mean "no marker"
+      }
+    },
+    process.env,
+    path.resolve,
+    path.join,
+  );
 }
 
 /**

--- a/web/src/lib/core/data-root.mjs
+++ b/web/src/lib/core/data-root.mjs
@@ -1,0 +1,62 @@
+// Plain .mjs (same pattern as run-cli-support.mjs / tracker-table.mjs) so
+// tests/lib/data-root.test.mjs can import it directly under Node. Import it with
+// the .mjs extension included.
+
+/**
+ * Resolve the career-ops data root, matching the core's `path-resolver.mjs`
+ * EXACTLY.
+ *
+ * WHY THIS EXISTS — the divergence it closes:
+ *
+ * `web/`'s resolver honored only `CAREER_OPS_ROOT`, then fell back to the
+ * parent directory. The core honors `CAREER_OPS_ROOT` → `CAREER_OPS_DATA_DIR`
+ * → a `.career-ops-data` marker file → its own directory (AGENTS.md, "Path
+ * Resolution Override & Precedence"). A user with a marker file therefore had
+ * the CLI and the web app reading two different data roots, with nothing
+ * reporting the disagreement.
+ *
+ * THE SUBTLE HALF — the resolution BASE, not just the order:
+ *
+ * `path-resolver.mjs` resolves relative values against `__dirname`, i.e. the
+ * CORE CHECKOUT. `web/` runs with `process.cwd() === <core>/web`, so resolving
+ * a relative value against the cwd points one directory too deep. A marker
+ * containing `../shared-data` would mean `<core>/../shared-data` to the CLI and
+ * `<core>/web/../shared-data` — i.e. `<core>/shared-data` — to the web app.
+ * Same string, two directories, no error. `coreRoot` is therefore a required
+ * argument here: it is the one value that must agree with the core's
+ * `__dirname`, and making it explicit keeps it from being silently re-derived.
+ *
+ * NOT IMPLEMENTED BY IMPORTING THE CORE, deliberately: `path-resolver.mjs`
+ * derives `__dirname` from `import.meta.url`. Bundled into the Next server
+ * output, that URL becomes the bundle's location rather than the checkout's, so
+ * importing it would resolve relative values against `.next/server/...`. The
+ * import would look more DRY and be silently wrong. `tests/lib/data-root.test.mjs`
+ * pins the two implementations together instead.
+ *
+ * Absolute env values and marker contents are unaffected — `path.resolve` returns
+ * an absolute input unchanged — so every existing install keeps its current root.
+ *
+ * @param {string} coreRoot Absolute path to the career-ops checkout (path-resolver's `__dirname`).
+ * @param {(p: string) => string | null} readMarker Reads a file, or null when absent/unreadable.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {(...parts: string[]) => string} resolve `path.resolve`
+ * @param {(...parts: string[]) => string} join `path.join`
+ * @returns {string} Absolute data root.
+ */
+export function resolveDataRoot(coreRoot, readMarker, env, resolve, join) {
+  // Precedence order is the core's, including CAREER_OPS_ROOT winning over
+  // CAREER_OPS_DATA_DIR when both are set.
+  const fromEnv = env.CAREER_OPS_ROOT?.trim() || env.CAREER_OPS_DATA_DIR?.trim();
+  if (fromEnv) return resolve(coreRoot, fromEnv);
+
+  const marker = readMarker(join(coreRoot, ".career-ops-data"));
+  if (marker) {
+    const content = marker.trim();
+    // An empty or whitespace-only marker is not a root — the core falls through
+    // to its default rather than resolving to `coreRoot` by accident, and a
+    // disagreement here would be invisible.
+    if (content) return resolve(coreRoot, content);
+  }
+
+  return coreRoot;
+}

--- a/web/tests/lib/data-root.test.mjs
+++ b/web/tests/lib/data-root.test.mjs
@@ -1,0 +1,150 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { resolveDataRoot } from "../../src/lib/core/data-root.mjs";
+
+const CORE = path.resolve(import.meta.dirname, "../../..");
+
+/** resolveDataRoot wired to a real directory, like careerOpsRoot() wires it. */
+function resolve(coreRoot, env = {}) {
+  const readMarker = (p) => {
+    try {
+      return fs.readFileSync(p, "utf8");
+    } catch {
+      return null;
+    }
+  };
+  return resolveDataRoot(coreRoot, readMarker, env, path.resolve, path.join);
+}
+
+function tmpdir() {
+  // realpath: macOS symlinks /var → /private/var, and an unresolved base makes
+  // every assertion below compare two spellings of the same directory.
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "data-root-")));
+}
+
+test("no env, no marker → the core root itself", () => {
+  const core = tmpdir();
+  assert.equal(resolve(core), core);
+});
+
+test("CAREER_OPS_ROOT (absolute) wins and is returned unchanged", () => {
+  const core = tmpdir();
+  const other = tmpdir();
+  assert.equal(resolve(core, { CAREER_OPS_ROOT: other }), other);
+});
+
+test("CAREER_OPS_DATA_DIR is honored — the variable web/ previously ignored", () => {
+  const core = tmpdir();
+  const other = tmpdir();
+  assert.equal(resolve(core, { CAREER_OPS_DATA_DIR: other }), other);
+});
+
+test("CAREER_OPS_ROOT beats CAREER_OPS_DATA_DIR when both are set", () => {
+  const core = tmpdir();
+  const win = tmpdir();
+  const lose = tmpdir();
+  assert.equal(resolve(core, { CAREER_OPS_ROOT: win, CAREER_OPS_DATA_DIR: lose }), win);
+});
+
+test(".career-ops-data marker is honored — the file web/ previously ignored", () => {
+  const core = tmpdir();
+  const data = tmpdir();
+  fs.writeFileSync(path.join(core, ".career-ops-data"), data);
+  assert.equal(resolve(core), data);
+});
+
+test("env beats the marker", () => {
+  const core = tmpdir();
+  const viaMarker = tmpdir();
+  const viaEnv = tmpdir();
+  fs.writeFileSync(path.join(core, ".career-ops-data"), viaMarker);
+  assert.equal(resolve(core, { CAREER_OPS_ROOT: viaEnv }), viaEnv);
+});
+
+test("an empty marker falls through to the core root, never resolving to it by accident", () => {
+  const core = tmpdir();
+  fs.writeFileSync(path.join(core, ".career-ops-data"), "   \n");
+  assert.equal(resolve(core), core);
+});
+
+test("a trailing newline in the marker is trimmed (editors add one)", () => {
+  const core = tmpdir();
+  const data = tmpdir();
+  fs.writeFileSync(path.join(core, ".career-ops-data"), `${data}\n`);
+  assert.equal(resolve(core), data);
+});
+
+// ── the regression this module exists for ────────────────────────────────────
+
+test("RELATIVE values resolve against the CORE root, not web/", () => {
+  const core = tmpdir();
+  fs.mkdirSync(path.join(core, "web"), { recursive: true });
+  fs.writeFileSync(path.join(core, ".career-ops-data"), "./shared-data");
+
+  // The bug: resolving against process.cwd() (= <core>/web) yields
+  // <core>/web/shared-data. The core yields <core>/shared-data.
+  assert.equal(resolve(core), path.join(core, "shared-data"));
+  assert.notEqual(resolve(core), path.join(core, "web", "shared-data"));
+});
+
+test("a dot-dot relative marker escapes the checkout, as the core intends", () => {
+  const core = tmpdir();
+  fs.writeFileSync(path.join(core, ".career-ops-data"), "../sibling-data");
+  assert.equal(resolve(core), path.resolve(core, "../sibling-data"));
+});
+
+// ── agreement with the core (the point of the whole module) ──────────────────
+
+test("AGREES with the core's path-resolver.mjs on every branch", async (t) => {
+  const src = path.join(CORE, "path-resolver.mjs");
+  if (!fs.existsSync(src)) return t.skip("core path-resolver.mjs not present");
+
+  // The core resolver derives __dirname from import.meta.url, so it reads the
+  // directory it is LOADED FROM. Copying it into a fixture is the pattern its
+  // own header prescribes ("test fixtures copy this file standalone").
+  const cases = [
+    { name: "no env, no marker", marker: null, env: {} },
+    { name: "absolute marker", marker: "ABS", env: {} },
+    { name: "relative marker", marker: "./shared-data", env: {} },
+    { name: "dot-dot marker", marker: "../sibling-data", env: {} },
+    { name: "empty marker", marker: "  \n", env: {} },
+    { name: "CAREER_OPS_ROOT absolute", marker: null, env: { CAREER_OPS_ROOT: "ABS" } },
+    { name: "CAREER_OPS_ROOT relative", marker: null, env: { CAREER_OPS_ROOT: "./from-env" } },
+    { name: "CAREER_OPS_DATA_DIR relative", marker: null, env: { CAREER_OPS_DATA_DIR: "./from-data-dir" } },
+    { name: "both env vars set", marker: null, env: { CAREER_OPS_ROOT: "./win", CAREER_OPS_DATA_DIR: "./lose" } },
+    { name: "env overrides marker", marker: "./from-marker", env: { CAREER_OPS_ROOT: "./from-env" } },
+  ];
+
+  for (const c of cases) {
+    const core = tmpdir();
+    const abs = tmpdir();
+    const subst = (v) => (v === "ABS" ? abs : v);
+
+    fs.copyFileSync(src, path.join(core, "path-resolver.mjs"));
+    if (c.marker !== null) fs.writeFileSync(path.join(core, ".career-ops-data"), subst(c.marker));
+
+    const env = Object.fromEntries(Object.entries(c.env).map(([k, v]) => [k, subst(v)]));
+
+    const saved = { ...process.env };
+    delete process.env.CAREER_OPS_ROOT;
+    delete process.env.CAREER_OPS_DATA_DIR;
+    Object.assign(process.env, env);
+
+    let core_answer;
+    try {
+      // cache-bust: each fixture is a distinct module instance
+      const mod = await import(`${pathToFileURL(path.join(core, "path-resolver.mjs")).href}?c=${encodeURIComponent(c.name)}`);
+      core_answer = mod.getCareerOpsRoot();
+    } finally {
+      for (const k of Object.keys(process.env)) delete process.env[k];
+      Object.assign(process.env, saved);
+    }
+
+    const web_answer = resolve(core, env);
+    assert.equal(web_answer, core_answer, `disagreement on: ${c.name}`);
+  }
+});


### PR DESCRIPTION
## Problem

`web/`'s `careerOpsRoot()` honors only `CAREER_OPS_ROOT`, then falls back to the parent directory:

```ts
const env = process.env.CAREER_OPS_ROOT?.trim();
if (env) return env;
return path.resolve(process.cwd(), "..");
```

The core's `path-resolver.mjs` honors `CAREER_OPS_ROOT` -> `CAREER_OPS_DATA_DIR` -> a `.career-ops-data` marker -> its own directory, which `AGENTS.md` documents under **Path Resolution Override & Precedence**.

A user with a marker file has the CLI and the web app reading **two different data roots**, and nothing reports the disagreement.

## The subtler half: the resolution base

`path-resolver.mjs` resolves relative values against `__dirname` — the checkout. `web/` runs with `cwd = <root>/web`.

A marker containing `../shared-data` therefore means:

| | resolves to |
|---|---|
| CLI | `<root>/../shared-data` |
| web | `<root>/shared-data` |

Same string, two directories, no error. `resolveDataRoot()` takes `coreRoot` as an explicit argument rather than re-deriving it.

## Why not just import the core resolver

It would be DRYer, and it would be silently wrong. `path-resolver.mjs` derives `__dirname` from `import.meta.url`; bundled into the Next server output, that resolves relative values against `.next/server/...`.

Instead, `tests/lib/data-root.test.mjs` includes an **agreement test** that loads the core's real `path-resolver.mjs` from a fixture and compares both implementations across ten branches — the pattern that file's own header prescribes ("test fixtures copy this file standalone").

## Compatibility

Absolute env values and marker contents are returned unchanged by `path.resolve`, so **every existing install keeps its current root**. The behavior change is limited to relative values and to `CAREER_OPS_DATA_DIR` / marker files, which previously did nothing in `web/`.

## Verification

11 new tests. Negative control — reintroducing either bug fails the suite:

| injected bug | result |
|---|---|
| ignore `CAREER_OPS_DATA_DIR` | 2 failures, agreement test catches it |
| web-relative resolution base | 3 failures, agreement test catches it |
| (fixed) | 11 pass |

Note for reviewers: this suite imports only `.mjs`, so it runs on Node 22 without extra flags. Two neighbouring suites do not — that is a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Web data-root resolution now matches the core resolver.

From the user’s point of view:

: `CAREER_OPS_ROOT` takes priority.
: `CAREER_OPS_DATA_DIR` is used when `CAREER_OPS_ROOT` is not set.
: `.career-ops-data` is used when neither variable is set.
: The checkout directory is the final fallback.
: Relative paths resolve from the checkout directory.
: Absolute paths keep their existing roots.

The web app uses a local resolver because bundling the core resolver would change its `__dirname` base: `web/src/lib/career-ops.ts:12`.

The resolver is defined in `web/src/lib/core/data-root.mjs:1`. Tests cover precedence, marker files, relative paths, and agreement with the core resolver: `web/tests/lib/data-root.test.mjs:1`.

## Touched system files

`update-system.mjs` is included in the changed-file list.

No changes are reported for `AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->