### PR TITLE
fix: run the web test suite on the minimum supported Node

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -16169,13 +16169,13 @@ try {
         if (existsSync(join(ROOT, 'web', 'tests', 'lib'))) {
           fail('web/tests/lib contains no *.test.mjs — the #2185 unit suites are not being gated');
         }
-      } else if (run(NODE, ['--test', ...webUnits], { timeout: 180000 }) !== null) {
+      } else if (run(NODE, ['--experimental-strip-types', '--test', ...webUnits], { timeout: 180000 }) !== null) {
         pass('web pdf write-scope unit suites pass (#2185)');
       } else {
         // The signal distinguishes a timeout/kill from an assertion failure —
         // run()'s default 30s is short for six suites in one child process.
         const killed = lastRunFailure()?.signal;
-        fail(`web pdf write-scope unit suites failed${killed ? ` (killed: ${killed})` : ''} (run: node --test ${webUnits.join(' ')})`);
+        fail(`web pdf write-scope unit suites failed${killed ? ` (killed: ${killed})` : ''} (run: node --experimental-strip-types --test ${webUnits.join(' ')})`);
       }
 
       // Parity: everything web/package.json would run must be something we DO run.

--- a/web/README.md
+++ b/web/README.md
@@ -11,7 +11,7 @@ database, no server. If you never run it, nothing about your CLI workflow change
 
 ## Quick start
 
-Requires Node 22+ (see [Tests](#tests) — `npm test`'s glob discovery needs it).
+Requires Node 22.6+ (see [Tests](#tests) — `npm test` needs glob discovery, and `--experimental-strip-types` for the suites that import `.ts` modules directly; the flag landed in 22.6.0).
 
 ```bash
 cd web

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@career-ops/web",
   "version": "0.10.0",
   "private": true,
-  "description": "Official web experience for career-ops \u2014 local-first.",
+  "description": "Official web experience for career-ops — local-first.",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/web/package.json
+++ b/web/package.json
@@ -2,13 +2,13 @@
   "name": "@career-ops/web",
   "version": "0.10.0",
   "private": true,
-  "description": "Official web experience for career-ops — local-first.",
+  "description": "Official web experience for career-ops \u2014 local-first.",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test \"tests/**/*.test.mjs\""
+    "test": "node --experimental-strip-types --test \"tests/**/*.test.mjs\""
   },
   "engines": {
     "node": ">=22.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "test": "node --experimental-strip-types --test \"tests/**/*.test.mjs\""
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.6.0"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.80",


### PR DESCRIPTION
## Problem

`web/package.json` declares `"engines": { "node": ">=22.0.0" }`, but two suites cannot run there at all:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
  for web/src/lib/apply/cv.ts
  for web/src/lib/explore-ai.ts
```

`apply-cv-resolver.test.mjs` and `explore-ai-dedup.test.mjs` import `.ts` modules directly. Node strips types automatically only from **23.6**; on 22.x it needs `--experimental-strip-types`, which neither call site passed.

## Why this reads as two known-failing suites

The failure is a **loader error, not an assertion**, so both suites abort before executing a single test. They surface as two red lines rather than as eleven tests that never ran — so it looks like two flaky suites instead of missing coverage.

## Two call sites

| | |
|---|---|
| `web/package.json` | the `npm test` script |
| `test-all.mjs` | the #2185 write-scope gate, which invokes the web suites directly and so was unaffected by the `package.json` script |

Fixing only the first leaves the core suite still failing, which is how the second site was found.

The flag remains valid on 23.6+ and 24, where type stripping is already the default. The failure message's reproduce hint is updated to match the invocation it now describes.

## Verification

On Node v22.14.0:

| | before | after |
|---|---|---|
| `npm test` in `web/` | 499 tests, 2 failing suites | **508 tests, 0 failures** |
| `test-all.mjs` web gate | fail | pass |

Eleven tests that were never executing now execute, and all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Web tests now support direct TypeScript module imports with Node.js 22.6.0 or later:

- `web/package.json:10`: Adds `--experimental-strip-types` to `npm test`.
- `test-all.mjs:76`: Adds the flag to the web test gate.
- `test-all.mjs:80`: Updates the reported command.
- `web/package.json`: Raises the minimum Node.js version to `>=22.6.0`.
- `web/README.md`: Documents the new Node.js requirement and corrected reproduction hint.

On older Node.js 22.x versions, web tests do not support this flag and may fail. On Node.js v22.14.0, the suite passes all 508 tests.

`AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->