### PR TITLE
fix(set-status): add --help/-h and list the canonical states in usage

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1077,7 +1077,15 @@ node set-status.mjs --report N <state> [--note "..."]       # row whose Report c
 node set-status.mjs "Company Name" Applied --role "Role"    # narrow match by role fragment
 node set-status.mjs --row 12 Applied
 node set-status.mjs --report 345 Applied --on 2026-08-01
+node set-status.mjs --help                                  # usage + the canonical states, exits 0
 ```
+
+`--help`/`-h` prints the usage block followed by every canonical state with its
+one-line description, read from `templates/states.yml` rather than duplicated —
+so the states are answerable at the prompt instead of requiring another file.
+It short-circuits before any tracker access and exits 0. A bare invocation with
+no operands still prints usage and exits 1, because missing operands are a usage
+error rather than a request for help.
 
 A bare number or company name is convenient, but becomes ambiguous when multiple tracker rows exist for a company or when tracker row IDs and report IDs diverge. That divergence is permanent once it starts: `reserve-report-num.mjs` treats tracker row IDs as occupied when it allocates a report number, so a row that never got a report still consumes a number the report sequence then skips — the two counters leapfrog each other and never realign. On a diverged tracker "5" may mean tracker row #5 or report #5, which are different applications. Base selectors resolve the main target, while explicit selectors and filters disambiguate the target row:
 

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -138,18 +138,10 @@ Examples:
   node set-status.mjs --row 7 Discarded --dry-run`;
 
 /**
- * Render the canonical states for `--help`.
+ * Render the canonical states from states.yml for `--help`.
  *
- * The states live in templates/states.yml, and before this the usage block only
- * NAMED that file — so the one question a caller actually has at the prompt
- * ("which states may I pass?") was answerable only by opening another file, or
- * by guessing wrong and reading the rejection. The list is already loaded at
- * runtime for that rejection message; printing it up front costs nothing.
- *
- * Help must never be the thing that fails, so an unreadable or malformed
- * states.yml degrades to the static pointer instead of throwing: a broken
- * states file is a real error, but it belongs to the run that tries to WRITE a
- * state, not to `--help`.
+ * A broken states.yml degrades to a pointer rather than throwing: that failure
+ * belongs to the run that tries to WRITE a state, not to `--help`.
  *
  * @returns {string} The states section, or a pointer line when unreadable.
  */
@@ -187,15 +179,9 @@ const VALUE_FLAGS = { '--note': 'note', '--role': 'role', '--on': 'on', '--row':
 /**
  * Is the caller asking for help, rather than passing "--help" as a VALUE?
  *
- * Scanned before the main loop so help wins over a "missing operand" error and
- * over an invalid flag value — a caller reaching for --help after a failed run
- * usually still has the bad arguments on the line, and re-rejecting them
- * instead of answering is the behavior this exists to remove.
- *
- * Value positions are skipped, so `--note "--help"` records a note and does not
- * silently turn a write into a help screen that exits 0. Values are only
- * skipped here, never validated: validation stays in the main loop so its
- * error messages and exit codes remain the single source of truth.
+ * Runs before the main loop so help answers a line that still carries the bad
+ * arguments from a failed run. Value positions are skipped but never validated
+ * — validation stays in the loop, which owns the error messages and exit codes.
  *
  * @param {string[]} args - argv slice.
  * @returns {boolean}
@@ -203,17 +189,13 @@ const VALUE_FLAGS = { '--note': 'note', '--role': 'role', '--on': 'on', '--row':
 function wantsHelp(args) {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a in VALUE_FLAGS) { i++; continue; } // skip this flag's value
+    if (Object.hasOwn(VALUE_FLAGS, a)) { i++; continue; } // skip this flag's value
     if (a === '--help' || a === '-h') return true;
   }
   return false;
 }
 
-// Exits 0: asking for help is a successful outcome, and a non-zero exit breaks
-// `cmd --help || true` idioms and CI smoke checks. Previously --help fell
-// through to the unknown-flag branch and exited 1, and a bare invocation exited
-// 1 as a missing-operand error, so there was no exit-0 path to the help text at
-// all (#3857 fixed the same class in plugin-install.mjs).
+// Exits 0 so `cmd --help` works in CI smoke checks and `|| true` idioms.
 if (wantsHelp(rawArgs)) {
   console.log(`${USAGE}\n${renderStatesSection()}`);
   process.exit(EXIT_OK);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -128,7 +128,54 @@ const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "...
 
   Tracker row IDs and report IDs are separate counters that diverge permanently
   once any row exists without a report. Prefer --row/--report (or the company
-  name) over a bare number, and prefer any of them over --force.`;
+  name) over a bare number, and prefer any of them over --force.
+
+Examples:
+  node set-status.mjs --report 12 Applied
+  node set-status.mjs --report 12 Interview --note "recruiter screen booked"
+  node set-status.mjs "Acme Corp" Rejected --on 2026-08-01
+  node set-status.mjs "Acme Corp" Applied --role "Platform Engineer"
+  node set-status.mjs --row 7 Discarded --dry-run`;
+
+/**
+ * Render the canonical states for `--help`.
+ *
+ * The states live in templates/states.yml, and before this the usage block only
+ * NAMED that file — so the one question a caller actually has at the prompt
+ * ("which states may I pass?") was answerable only by opening another file, or
+ * by guessing wrong and reading the rejection. The list is already loaded at
+ * runtime for that rejection message; printing it up front costs nothing.
+ *
+ * Help must never be the thing that fails, so an unreadable or malformed
+ * states.yml degrades to the static pointer instead of throwing: a broken
+ * states file is a real error, but it belongs to the run that tries to WRITE a
+ * state, not to `--help`.
+ *
+ * @returns {string} The states section, or a pointer line when unreadable.
+ */
+function renderStatesSection() {
+  let states;
+  try {
+    states = loadCanonicalStates(STATES_FILE);
+  } catch {
+    return `\nCanonical states: see ${STATES_FILE}`;
+  }
+  if (!states.length) return `\nCanonical states: see ${STATES_FILE}`;
+  const width = Math.max(...states.map(st => st.label.length));
+  const lines = states.map((st) => {
+    const terminal = st.terminal ? '  (terminal)' : '';
+    const desc = st.description ? `  ${st.description}` : '';
+    return `  ${st.label.padEnd(width)}${desc}${terminal}`;
+  });
+  return [
+    '',
+    'Canonical states (aliases also accepted — see templates/states.yml):',
+    ...lines,
+    '',
+    '  A terminal state ends the application. Discarded is YOUR decision or a',
+    '  closed req; Rejected is theirs; SKIP means never applied for.',
+  ].join('\n');
+}
 
 // ── argument parsing ─────────────────────────────────────────────
 
@@ -136,6 +183,41 @@ const rawArgs = process.argv.slice(2);
 const positional = [];
 const flags = { note: null, role: null, on: null, row: null, report: null, source: null, force: false, dryRun: false, json: false };
 const VALUE_FLAGS = { '--note': 'note', '--role': 'role', '--on': 'on', '--row': 'row', '--report': 'report', '--source': 'source' };
+
+/**
+ * Is the caller asking for help, rather than passing "--help" as a VALUE?
+ *
+ * Scanned before the main loop so help wins over a "missing operand" error and
+ * over an invalid flag value — a caller reaching for --help after a failed run
+ * usually still has the bad arguments on the line, and re-rejecting them
+ * instead of answering is the behavior this exists to remove.
+ *
+ * Value positions are skipped, so `--note "--help"` records a note and does not
+ * silently turn a write into a help screen that exits 0. Values are only
+ * skipped here, never validated: validation stays in the main loop so its
+ * error messages and exit codes remain the single source of truth.
+ *
+ * @param {string[]} args - argv slice.
+ * @returns {boolean}
+ */
+function wantsHelp(args) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a in VALUE_FLAGS) { i++; continue; } // skip this flag's value
+    if (a === '--help' || a === '-h') return true;
+  }
+  return false;
+}
+
+// Exits 0: asking for help is a successful outcome, and a non-zero exit breaks
+// `cmd --help || true` idioms and CI smoke checks. Previously --help fell
+// through to the unknown-flag branch and exited 1, and a bare invocation exited
+// 1 as a missing-operand error, so there was no exit-0 path to the help text at
+// all (#3857 fixed the same class in plugin-install.mjs).
+if (wantsHelp(rawArgs)) {
+  console.log(`${USAGE}\n${renderStatesSection()}`);
+  process.exit(EXIT_OK);
+}
 
 // Who is driving this write. A caller that delegates here instead of touching
 // the tracker itself — the web status route — needs its ledger rows to stay
@@ -171,7 +253,7 @@ for (let i = 0; i < rawArgs.length; i++) {
   else if (a === '--force') { flags.force = true; }
   else if (a === '--dry-run') { flags.dryRun = true; }
   else if (a === '--json') { flags.json = true; }
-  else if (a.startsWith('--')) { failUsage(`Unknown flag: ${a}`); }
+  else if (a === '-h' || a.startsWith('--')) { failUsage(`Unknown flag: ${a}`); }
   else { positional.push(a); }
 }
 

--- a/tests/set-status-help-flag.test.mjs
+++ b/tests/set-status-help-flag.test.mjs
@@ -1,0 +1,130 @@
+// tests/set-status-help-flag.test.mjs — set-status.mjs must answer --help/-h
+// with the canonical states, exit 0, and never touch the tracker.
+//
+// Before this fix, `node set-status.mjs --help` fell through to the unknown
+// flag branch and exited 1 — the same "a flag the caller obviously meant is
+// rejected instead of answered" class already fixed in plugin-install.mjs
+// (#3857), scan.mjs (#2270) and scan-ats-full.mjs (#1633/#1635). Bare
+// invocation printed usage but exited 1 as a missing-operand error, so there
+// was no exit-0 path to the help text at all, which breaks `cmd --help` in CI
+// smoke checks and `|| true` idioms.
+//
+// The usage block also only NAMED templates/states.yml rather than listing it,
+// so the one question a caller has at the prompt ("which states may I pass?")
+// required opening another file. The list is already loaded to build the
+// invalid-state rejection; these tests pin that it is printed up front too.
+//
+// HERMETIC: every run pins CAREER_OPS_TRACKER at a path that does not exist.
+// If --help were NOT handled before the tracker check, the run would reach
+// "No tracker found" instead of exiting on the flag itself — so that message
+// doubles as proof the tracker was consulted. Each assertion also checks the
+// subprocess actually ran (no spawn error, no signal), so a timeout cannot
+// pass silently.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { loadCanonicalStates } from '../tracker-utils.mjs';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const NO_TRACKER = join(tmpdir(), 'career-ops-no-such-tracker.md');
+const NO_TRACKER_FOUND = /No tracker found/i;
+
+function runSetStatus(...args) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'set-status.mjs'), ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CAREER_OPS_TRACKER: NO_TRACKER },
+  });
+  assert.equal(r.error, undefined, `set-status.mjs failed to spawn: ${r.error?.message}`);
+  assert.equal(r.signal, null, `set-status.mjs was killed by ${r.signal} (timeout?)`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+const STATES = loadCanonicalStates(join(ROOT, 'templates', 'states.yml'));
+
+test('--help exits 0 and prints the usage block', () => {
+  const r = runSetStatus('--help');
+  assert.equal(r.status, 0, `--help should exit 0, got ${r.status}: ${r.all}`);
+  assert.match(r.all, /Usage: node set-status\.mjs/);
+});
+
+test('-h behaves identically to --help', () => {
+  const long = runSetStatus('--help');
+  const short = runSetStatus('-h');
+  assert.equal(short.status, 0, `-h should exit 0, got ${short.status}`);
+  assert.equal(short.stdout, long.stdout, '-h and --help should print the same text');
+});
+
+test('--help lists every canonical state from states.yml', () => {
+  const r = runSetStatus('--help');
+  assert.ok(STATES.length > 0, 'states.yml yielded no states');
+  for (const st of STATES) {
+    assert.ok(
+      r.all.includes(st.label),
+      `--help omitted canonical state "${st.label}" — the list must come from states.yml, not a hardcoded copy`,
+    );
+  }
+});
+
+test('--help explains each state rather than only naming it', () => {
+  const r = runSetStatus('--help');
+  const described = STATES.filter(st => st.description);
+  assert.ok(described.length > 0, 'no states.yml entry carries a description');
+  for (const st of described) {
+    assert.ok(
+      r.all.includes(st.description),
+      `--help omitted the description for "${st.label}"`,
+    );
+  }
+});
+
+test('--help marks terminal states', () => {
+  const r = runSetStatus('--help');
+  assert.ok(STATES.some(st => st.terminal), 'no states.yml entry is marked terminal');
+  assert.match(r.all, /\(terminal\)/, '--help should mark terminal states');
+});
+
+test('--help never consults the tracker', () => {
+  const r = runSetStatus('--help');
+  assert.doesNotMatch(
+    r.all,
+    NO_TRACKER_FOUND,
+    '--help reached the tracker check; it must short-circuit before any tracker access',
+  );
+});
+
+test('--help wins over otherwise-invalid arguments', () => {
+  // A caller reaching for help after a failed run often still has the bad
+  // arguments on the line. Help must answer, not re-reject them.
+  const r = runSetStatus('--report', 'not-a-number', 'Bogus', '--help');
+  assert.equal(r.status, 0, `--help should win over invalid args, got ${r.status}: ${r.all}`);
+  assert.match(r.all, /Usage: node set-status\.mjs/);
+});
+
+test('"--help" in a VALUE position is not a help request', () => {
+  // `--note --help` must stay the pre-existing "never consume a flag as a
+  // value" error. Printing help and exiting 0 here would turn a refused write
+  // into a silent success for any script that checks only the exit code.
+  const r = runSetStatus('--report', '1', 'Applied', '--note', '--help');
+  assert.equal(r.status, 1, `--note --help should exit 1, got ${r.status}: ${r.all}`);
+  assert.match(r.all, /Missing value for --note/);
+  assert.doesNotMatch(r.all, /Canonical states \(aliases/, 'a value position triggered the help screen');
+});
+
+test('an unrecognized flag still exits 1 and does not print help', () => {
+  const r = runSetStatus('--bogus');
+  assert.equal(r.status, 1, `unknown flag should exit 1, got ${r.status}`);
+  assert.match(r.all, /Unknown flag: --bogus/);
+  assert.doesNotMatch(r.all, NO_TRACKER_FOUND, 'unknown flag reached the tracker check');
+});
+
+test('bare invocation still reports a usage error rather than succeeding', () => {
+  // Missing operands are a real error; only --help/-h is a successful exit.
+  const r = runSetStatus();
+  assert.equal(r.status, 1, `bare invocation should exit 1, got ${r.status}`);
+  assert.match(r.all, /Usage: node set-status\.mjs/);
+});

--- a/tests/set-status-help-flag.test.mjs
+++ b/tests/set-status-help-flag.test.mjs
@@ -1,25 +1,10 @@
 // tests/set-status-help-flag.test.mjs — set-status.mjs must answer --help/-h
 // with the canonical states, exit 0, and never touch the tracker.
 //
-// Before this fix, `node set-status.mjs --help` fell through to the unknown
-// flag branch and exited 1 — the same "a flag the caller obviously meant is
-// rejected instead of answered" class already fixed in plugin-install.mjs
-// (#3857), scan.mjs (#2270) and scan-ats-full.mjs (#1633/#1635). Bare
-// invocation printed usage but exited 1 as a missing-operand error, so there
-// was no exit-0 path to the help text at all, which breaks `cmd --help` in CI
-// smoke checks and `|| true` idioms.
-//
-// The usage block also only NAMED templates/states.yml rather than listing it,
-// so the one question a caller has at the prompt ("which states may I pass?")
-// required opening another file. The list is already loaded to build the
-// invalid-state rejection; these tests pin that it is printed up front too.
-//
 // HERMETIC: every run pins CAREER_OPS_TRACKER at a path that does not exist.
 // If --help were NOT handled before the tracker check, the run would reach
 // "No tracker found" instead of exiting on the flag itself — so that message
-// doubles as proof the tracker was consulted. Each assertion also checks the
-// subprocess actually ran (no spawn error, no signal), so a timeout cannot
-// pass silently.
+// doubles as proof the tracker was consulted.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
@@ -98,17 +83,14 @@ test('--help never consults the tracker', () => {
 });
 
 test('--help wins over otherwise-invalid arguments', () => {
-  // A caller reaching for help after a failed run often still has the bad
-  // arguments on the line. Help must answer, not re-reject them.
   const r = runSetStatus('--report', 'not-a-number', 'Bogus', '--help');
   assert.equal(r.status, 0, `--help should win over invalid args, got ${r.status}: ${r.all}`);
   assert.match(r.all, /Usage: node set-status\.mjs/);
 });
 
 test('"--help" in a VALUE position is not a help request', () => {
-  // `--note --help` must stay the pre-existing "never consume a flag as a
-  // value" error. Printing help and exiting 0 here would turn a refused write
-  // into a silent success for any script that checks only the exit code.
+  // Must stay the pre-existing "never consume a flag as a value" error: a help
+  // screen exiting 0 would read as success to a script checking only the code.
   const r = runSetStatus('--report', '1', 'Applied', '--note', '--help');
   assert.equal(r.status, 1, `--note --help should exit 1, got ${r.status}: ${r.all}`);
   assert.match(r.all, /Missing value for --note/);
@@ -123,7 +105,6 @@ test('an unrecognized flag still exits 1 and does not print help', () => {
 });
 
 test('bare invocation still reports a usage error rather than succeeding', () => {
-  // Missing operands are a real error; only --help/-h is a successful exit.
   const r = runSetStatus();
   assert.equal(r.status, 1, `bare invocation should exit 1, got ${r.status}`);
   assert.match(r.all, /Usage: node set-status\.mjs/);

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -700,12 +700,9 @@ export function writeFileAtomic(path, content) {
  * their aliases. Parsing it here (instead of hardcoding the list) means a new
  * state or alias lands in one file and every consumer follows.
  *
- * `description` and `terminal` are passed through so a caller can EXPLAIN the
- * states rather than just list them — `set-status.mjs --help` prints the
- * one-line description beside each label, which is what distinguishes the two
- * states a user is most likely to confuse (`Discarded`, chosen by the
- * candidate, from `SKIP`, never applied for). Both default rather than throw:
- * a states.yml entry that omits them is still a usable state.
+ * `description` and `terminal` are passed through for callers that EXPLAIN the
+ * states rather than list them (set-status.mjs --help). Both default rather
+ * than throw: an entry omitting them is still a usable state.
  *
  * @param {string} statesPath - Path to templates/states.yml.
  * @returns {{id:string,label:string,aliases:string[],description:string,terminal:boolean}[]} Parsed state entries.

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -700,8 +700,15 @@ export function writeFileAtomic(path, content) {
  * their aliases. Parsing it here (instead of hardcoding the list) means a new
  * state or alias lands in one file and every consumer follows.
  *
+ * `description` and `terminal` are passed through so a caller can EXPLAIN the
+ * states rather than just list them — `set-status.mjs --help` prints the
+ * one-line description beside each label, which is what distinguishes the two
+ * states a user is most likely to confuse (`Discarded`, chosen by the
+ * candidate, from `SKIP`, never applied for). Both default rather than throw:
+ * a states.yml entry that omits them is still a usable state.
+ *
  * @param {string} statesPath - Path to templates/states.yml.
- * @returns {{id:string,label:string,aliases:string[]}[]} Parsed state entries.
+ * @returns {{id:string,label:string,aliases:string[],description:string,terminal:boolean}[]} Parsed state entries.
  */
 export function loadCanonicalStates(statesPath) {
   const doc = yaml.load(readFileSync(statesPath, 'utf-8'));
@@ -712,6 +719,8 @@ export function loadCanonicalStates(statesPath) {
     id: String(s.id ?? ''),
     label: String(s.label ?? ''),
     aliases: Array.isArray(s.aliases) ? s.aliases.map(String) : [],
+    description: String(s.description ?? ''),
+    terminal: s.terminal === true,
   }));
 }
 


### PR DESCRIPTION
## Problem

`node set-status.mjs --help` fell through to the unknown-flag branch and exited 1:

```
❌ Unknown flag: --help
```

A bare invocation printed usage but exited 1 as a missing-operand error, so there was **no exit-0 path to the help text at all**. That breaks `cmd --help` in CI smoke checks and `|| true` idioms. This is the same class already fixed in `plugin-install.mjs` (#3857), `scan.mjs` (#2270) and `scan-ats-full.mjs` (#1633/#1635).

Separately, the usage block only *named* `templates/states.yml`:

```
<state>            Canonical state from templates/states.yml (aliases accepted)
```

So the one question a caller has at the prompt — *which states may I pass?* — was answerable only by opening another file, or by guessing wrong and reading the rejection. The list is already loaded at runtime to build that rejection message, so printing it up front costs nothing.

## What changed

`--help`/`-h` now prints usage plus the canonical states and exits 0:

```
Canonical states (aliases also accepted — see templates/states.yml):
  Evaluated  Offer evaluated with report, pending decision
  Applied    Application submitted
  Responded  Company has responded (not yet interview)
  Interview  Active interview process
  Offer      Offer received  (terminal)
  Rejected   Rejected by company  (terminal)
  Discarded  Discarded by candidate or offer closed  (terminal)
  SKIP       Doesn't fit, don't apply  (terminal)
  Hired      Offer accepted, job landed!  (terminal)

  A terminal state ends the application. Discarded is YOUR decision or a
  closed req; Rejected is theirs; SKIP means never applied for.
```

Design decisions worth reviewing:

- **Handled before any other parsing**, so help wins over a missing-operand error *and* over an invalid flag value. A caller reaching for `--help` after a failed run usually still has the bad arguments on the line; re-rejecting them instead of answering is the behavior this removes.
- **Detection skips value positions.** `--note "--help"` stays the existing "never consume a flag as a value" error rather than becoming a help screen that exits 0 — which would turn a refused write into a silent success for any script checking only the exit code.
- **The states section is generated from `states.yml`**, with each description and a terminal marker — not a hardcoded copy. A test asserts every state in that file appears, so a new state cannot silently go undocumented.
- **An unreadable or malformed `states.yml` degrades to the static pointer** instead of throwing. A broken states file is a real error, but it belongs to the run that tries to *write* a state, not to `--help`.
- **Bare invocation still exits 1.** Missing operands are a usage error, not a request for help.
- Adds a worked examples block.

`loadCanonicalStates()` now passes `description` and `terminal` through from `states.yml`. Additive — the other callers (`normalize-statuses`, `funnel-velocity`, `followup-cadence`, `check-jd-archive`, `test-all`) read only `id`/`label`/`aliases`.

## Testing

New `tests/set-status-help-flag.test.mjs` — 10 tests, all passing. Hermetic: every run pins `CAREER_OPS_TRACKER` at a nonexistent path, so `No tracker found` doubles as proof that help short-circuits before any tracker access. Each assertion also checks the subprocess actually ran (no spawn error, no signal), so a timeout cannot pass silently. Mirrors the structure of `tests/scan-help-flag.test.mjs`.

Coverage: exit 0 and usage printed; `-h` byte-identical to `--help`; every canonical state present; every description present; terminal states marked; tracker never consulted; help wins over invalid args; `--help` in a value position is *not* a help request; unknown flag still exits 1; bare invocation still exits 1.

Also verified clean: `tests/tracker-utils.test.mjs`, `tests/states-alias-coverage.test.mjs`, `tests/set-status-seeds-followup.test.mjs`, and direct runs of all four `loadCanonicalStates` consumers.

`node test-all.mjs --quick` on my machine reports 8666 passed / 10 failed. **The 10 failures are pre-existing and environmental, not from this change** — I confirmed by stashing the diff and re-running the failing suites, which fail identically on a clean baseline. They are `node:sqlite is not available. tracker.mjs needs Node >= 22.5 (you are on v20.19.6)` and the `web/` unit suites, whose dependencies I had not installed. I expect CI on Node >= 22.5 to be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can run `node set-status.mjs --help` or `node set-status.mjs -h` to view usage, canonical states, descriptions, terminal markers, and examples. Help exits with code 0 and runs before tracker access: `set-status.mjs:141-151`.

Help detection skips option values. Therefore, `--note --help` keeps its existing missing-value error. Bare invocation remains a usage error with exit code 1: `set-status.mjs:180-198`.

If `states.yml` cannot be read or parsed, help prints a static pointer instead of failing: `set-status.mjs:141-151`. `loadCanonicalStates()` now returns `description` and `terminal` fields: `tracker-utils.mjs:710-734`.

The change adds tests for help output, state documentation, argument handling, tracker isolation, malformed state data, and exit codes: `tests/set-status-help-flag.test.mjs:34-110`.

The documentation adds the new help invocation and behavior: `docs/SCRIPTS.md:1069-1088`.

## System files

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->