### PR TITLE
fix(cover): give {{DATELINE}} the date when an address block renders

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -129,6 +129,36 @@ function buildDateline(letter) {
   return parts.join(" &nbsp;&nbsp; ");
 }
 
+/**
+ * Build the optional recipient address block for a business letter.
+ *
+ * The pack authoring contract places {{RECIPIENT_BLOCK}} bare and expects the
+ * filler to emit its own wrapper, so this returns a complete
+ * `<div class="recipient">` or an empty string, never a bare fragment. Each
+ * line is its own `<div>` rather than a `<br>` join, which is what the packs'
+ * own CSS targets.
+ *
+ * A partial recipient is normal and renders as far as it goes: a company with
+ * no named individual, or a name with no street address, are both ordinary
+ * states for a cover letter. Only a recipient with nothing usable in it, or no
+ * recipient at all, yields the empty string, so a letter without an addressee
+ * still renders instead of failing.
+ *
+ * Accepts `address_lines` (array, the contract's shape) or `address` (string).
+ */
+function buildRecipientBlock(letter) {
+  const r = letter.recipient;
+  if (!r || typeof r !== "object") return "";
+  const addressLines = Array.isArray(r.address_lines)
+    ? r.address_lines
+    : r.address
+      ? [r.address]
+      : [];
+  const lines = [r.name, r.title, r.company, ...addressLines].filter(Boolean).map(escapeHtml);
+  if (!lines.length) return "";
+  return `<div class="recipient">\n${lines.map((l) => `    <div>${l}</div>`).join("\n")}\n  </div>`;
+}
+
 /** Build the optional achievements list for the letter body. */
 function buildAchievementsBlock(achievements) {
   if (!achievements || !achievements.length) return "";
@@ -226,6 +256,7 @@ export function buildHtml(payload, templatePath) {
     "{{CREDENTIALS_BLOCK}}": buildCredentialsBlock(candidate),
     "{{ROLE_TITLE}}": escapeHtml(letter.role_title),
     "{{DATELINE}}": buildDateline(letter),
+    "{{RECIPIENT_BLOCK}}": buildRecipientBlock(letter),
     "{{GREETING_BLOCK}}": greetingBlock,
     "{{OPENING}}": escapeHtml(letter.opening),
     "{{PROFILE_INTRO}}": escapeHtml(letter.profile_intro),

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -140,7 +140,7 @@ function buildDateline(letter) {
  *
  * A partial recipient is normal and renders as far as it goes: a company with
  * no named individual, or a name with no street address, are both ordinary
- * states for a cover letter. Only a recipient with nothing usable in it, or no
+ * states for a cover letter. Only a recipient with nothing usable in it (blank or whitespace-only fields included), or no
  * recipient at all, yields the empty string, so a letter without an addressee
  * still renders instead of failing.
  *
@@ -154,7 +154,12 @@ function buildRecipientBlock(letter) {
     : r.address
       ? [r.address]
       : [];
-  const lines = [r.name, r.title, r.company, ...addressLines].filter(Boolean).map(escapeHtml);
+  // Trim before filtering: `filter(Boolean)` alone keeps "   ", which renders as
+  // a blank line inside the wrapper rather than as the absent field it is.
+  const lines = [r.name, r.title, r.company, ...addressLines]
+    .map((v) => (typeof v === "string" ? v.trim() : v))
+    .filter(Boolean)
+    .map(escapeHtml);
   if (!lines.length) return "";
   return `<div class="recipient">\n${lines.map((l) => `    <div>${l}</div>`).join("\n")}\n  </div>`;
 }

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -124,9 +124,20 @@ function buildCredentialsBlock(candidate) {
 }
 
 /** Build the escaped company, city, and date line for the letter. */
-function buildDateline(letter) {
-  const parts = [letter.company, letter.city, letter.date].filter(Boolean).map(escapeHtml);
-  return parts.join(" &nbsp;&nbsp; ");
+function buildDateline(letter, hasRecipientBlock = false) {
+  // The pack contract gives {{DATELINE}} the date and leaves the company and
+  // city to the address block directly beneath it, so joining all three prints
+  // the company twice, three lines apart.
+  //
+  // Gated on the block actually RENDERING, not on `letter.recipient` merely
+  // being set. An empty or whitespace-only recipient produces no address block,
+  // and dropping company and city for it would lose them with nothing taking
+  // their place. The shipped base template has no address block at all, so it
+  // keeps the full join exactly as before.
+  const parts = hasRecipientBlock
+    ? [letter.date]
+    : [letter.company, letter.city, letter.date];
+  return parts.filter(Boolean).map(escapeHtml).join(" &nbsp;&nbsp; ");
 }
 
 /**
@@ -255,13 +266,14 @@ export function buildHtml(payload, templatePath) {
   // valediction. The <br> is emitted around escaped values, never inside one.
   const signatureBlock = buildSignatureBlock(letter.signature, candidate.name);
 
+  const recipientBlock = buildRecipientBlock(letter);
   const replacements = {
     "{{NAME}}": escapeHtml(candidate.name),
     "{{CONTACT_LINE}}": buildContactLine(candidate),
     "{{CREDENTIALS_BLOCK}}": buildCredentialsBlock(candidate),
     "{{ROLE_TITLE}}": escapeHtml(letter.role_title),
-    "{{DATELINE}}": buildDateline(letter),
-    "{{RECIPIENT_BLOCK}}": buildRecipientBlock(letter),
+    "{{DATELINE}}": buildDateline(letter, Boolean(recipientBlock)),
+    "{{RECIPIENT_BLOCK}}": recipientBlock,
     "{{GREETING_BLOCK}}": greetingBlock,
     "{{OPENING}}": escapeHtml(letter.opening),
     "{{PROFILE_INTRO}}": escapeHtml(letter.profile_intro),

--- a/tests/cover-dateline.test.mjs
+++ b/tests/cover-dateline.test.mjs
@@ -1,0 +1,81 @@
+// tests/cover-dateline.test.mjs — {{DATELINE}} carries the date, not the address.
+//
+// The pack authoring contract fixes both the order and the contents:
+//
+//   {{DATELINE}}                        # the date
+//   {{RECIPIENT_BLOCK}}                 # recipient address block, or empty
+//   Re: Application for {{ROLE_TITLE}}  # reference line
+//   {{GREETING_BLOCK}}                  # salutation
+//
+// buildDateline joined company + city + date, so a letter that renders a
+// recipient printed the company twice, three lines apart. The join is correct
+// for the shipped base template, which has no address block and would otherwise
+// lose that context entirely, so this is a gate rather than a replacement.
+//
+// The absent-recipient case is the one that protects every existing payload:
+// nothing today sets letter.recipient, so nothing today changes.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+function template() {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-dateline-'));
+  const file = join(dir, 'cover-letter-template.html');
+  writeFileSync(file, '{{NAME}}{{ROLE_TITLE}}[D]{{DATELINE}}[/D]{{RECIPIENT_BLOCK}}{{OPENING}}{{PROFILE_INTRO}}');
+  return file;
+}
+
+/** Just the dateline slot's rendered contents. */
+const dateline = (html) => html.slice(html.indexOf('[D]') + 3, html.indexOf('[/D]'));
+
+const payload = (extra) => ({
+  candidate: { name: 'A Candidate' },
+  letter: {
+    role_title: 'Head of Marketing',
+    opening: 'Opening line.',
+    profile_intro: 'Profile intro.',
+    company: 'Example Corp',
+    city: 'Boston, MA',
+    date: 'September 8, 2026',
+    ...extra,
+  },
+});
+
+test('with a recipient, the dateline carries the date alone', () => {
+  // Given the address block below it already names the company and city
+  const html = buildHtml(payload({
+    recipient: { name: 'Jane Reviewer', company: 'Example Corp', address_lines: ['Boston, MA'] },
+  }), template());
+  const d = dateline(html);
+
+  assert.equal(d, 'September 8, 2026');
+  assert.ok(!d.includes('Example Corp'), 'the company belongs to the address block, not the dateline');
+  assert.ok(!d.includes('Boston, MA'), 'the city belongs to the address block, not the dateline');
+  // And it is still present exactly once in the letter as a whole
+  assert.equal((html.match(/Example Corp/g) || []).length, 1, 'the company appears once, not twice');
+});
+
+test('with no recipient, the dateline is unchanged', () => {
+  // This is the compatibility guarantee: no payload today sets a recipient, so
+  // no payload today renders differently.
+  const d = dateline(buildHtml(payload({}), template()));
+
+  assert.equal(d, 'Example Corp &nbsp;&nbsp; Boston, MA &nbsp;&nbsp; September 8, 2026');
+});
+
+test('an empty recipient object does not trigger the gate', () => {
+  // buildRecipientBlock renders nothing for this, so the dateline must keep the
+  // company and city rather than dropping them into a block that never appears.
+  const d = dateline(buildHtml(payload({ recipient: {} }), template()));
+
+  assert.equal(d, 'Example Corp &nbsp;&nbsp; Boston, MA &nbsp;&nbsp; September 8, 2026');
+});
+
+test('a whitespace-only recipient does not trigger the gate either', () => {
+  const d = dateline(buildHtml(payload({ recipient: { name: '   ', company: '\t' } }), template()));
+
+  assert.equal(d, 'Example Corp &nbsp;&nbsp; Boston, MA &nbsp;&nbsp; September 8, 2026');
+});

--- a/tests/cover-recipient-block.test.mjs
+++ b/tests/cover-recipient-block.test.mjs
@@ -1,0 +1,88 @@
+// tests/cover-recipient-block.test.mjs — {{RECIPIENT_BLOCK}} must be fillable.
+//
+// The pack authoring contract lists {{RECIPIENT_BLOCK}} among the required
+// cover-letter slots, but generate-cover-letter.mjs never filled it, so every
+// pack cover template died at substitution with
+// "Unresolved placeholders: {{RECIPIENT_BLOCK}}".
+//
+// The failure is worth a test rather than a one-line map entry because of how it
+// presented: validateTemplate (KINDS.cover) requires only NAME, ROLE_TITLE and
+// OPENING, so a pack template PASSED the validator and then exploded in the
+// substitution pass. A green gate followed by a hard failure is the shape that
+// makes an author distrust the gate, so both halves are pinned here: the slot
+// fills, and an absent recipient is not an error.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+/** A minimal template carrying the pack's recipient slot. */
+function packTemplate() {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-recipient-'));
+  const file = join(dir, 'cover-letter-template.html');
+  writeFileSync(file, '{{NAME}}{{ROLE_TITLE}}{{DATELINE}}{{RECIPIENT_BLOCK}}{{OPENING}}{{PROFILE_INTRO}}');
+  return file;
+}
+
+const base = (recipient) => ({
+  candidate: { name: 'A Candidate' },
+  letter: {
+    role_title: 'Head of Marketing',
+    opening: 'Opening line.',
+    profile_intro: 'Profile intro.',
+    ...(recipient === undefined ? {} : { recipient }),
+  },
+});
+
+test('a template carrying {{RECIPIENT_BLOCK}} renders instead of throwing', () => {
+  // Given the exact shape the pack contract publishes: name, title, company,
+  // then address_lines
+  const html = buildHtml(base({
+    name: 'Jane Reviewer',
+    title: 'Director of Talent',
+    company: 'Example Corp',
+    address_lines: ['100 Example Street', 'Springfield, IL 62704'],
+  }), packTemplate());
+
+  // Then every supplied part reaches the output...
+  for (const part of ['Jane Reviewer', 'Director of Talent', 'Example Corp', '100 Example Street', 'Springfield, IL 62704']) {
+    assert.ok(html.includes(part), `recipient block must carry "${part}"`);
+  }
+  // ...and the token itself is gone
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot must be substituted, not left literal');
+});
+
+test('the recipient block is self-wrapped, one div per line', () => {
+  // The contract is explicit that the filler emits its own wrapper and that the
+  // template places the placeholder bare, so a <br>-joined string would not do.
+  const html = buildHtml(base({ name: 'Jane Reviewer', company: 'Example Corp' }), packTemplate());
+
+  assert.match(html, /<div class="recipient">/, 'the block wraps itself');
+  assert.match(html, /<div>Jane Reviewer<\/div>/);
+  assert.match(html, /<div>Example Corp<\/div>/);
+});
+
+test('an absent recipient renders empty, and is not an error', () => {
+  // Most letters have no addressee. That must stay a rendered letter, not a
+  // failed render, or this fix trades one hard failure for another.
+  const html = buildHtml(base(undefined), packTemplate());
+
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot is still substituted');
+  assert.ok(!html.includes('class="recipient"'), 'no empty wrapper is emitted');
+});
+
+test('a recipient with no usable fields renders empty rather than an empty wrapper', () => {
+  const html = buildHtml(base({ name: '', company: '', address_lines: [] }), packTemplate());
+  assert.ok(!html.includes('class="recipient"'));
+});
+
+test('recipient values are HTML-escaped', () => {
+  // The recipient comes from a payload an agent wrote from a job posting, which
+  // is untrusted content by the project's own rule.
+  const html = buildHtml(base({ name: '<script>alert(1)</script>', company: 'A & B' }), packTemplate());
+
+  assert.ok(!html.includes('<script>'), 'a script tag must not survive into the letter');
+  assert.match(html, /A &amp; B/);
+});

--- a/tests/cover-recipient-block.test.mjs
+++ b/tests/cover-recipient-block.test.mjs
@@ -78,6 +78,28 @@ test('a recipient with no usable fields renders empty rather than an empty wrapp
   assert.ok(!html.includes('class="recipient"'));
 });
 
+test('whitespace-only recipient fields are empty, not content', () => {
+  // filter(Boolean) keeps "   ", so a recipient whose fields are all spaces
+  // produced a wrapper full of blank divs: a visibly indented gap above the Re:
+  // line, on a letter with no addressee. The empty-object case below passes
+  // without this, which is what made it easy to miss.
+  const html = buildHtml(base({ name: '   ', title: '\t', company: '\n', address_lines: ['  ', ''] }), packTemplate());
+
+  assert.ok(!html.includes('class="recipient"'), 'a whitespace-only recipient emits no wrapper');
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot is still substituted');
+});
+
+test('a partially blank recipient keeps only its real lines', () => {
+  // The trim must not become a reason to drop a recipient that has some content.
+  const html = buildHtml(base({ name: '  ', title: 'Director of Talent', company: '   ' }), packTemplate());
+
+  assert.match(html, /<div class="recipient">/);
+  assert.match(html, /<div>Director of Talent<\/div>/);
+  // Bare `<div>` counts content lines only: the wrapper is `<div class="recipient">`
+  // and does not match. Exactly one line survives, so the two blank fields are gone.
+  assert.equal((html.match(/<div>/g) || []).length, 1, 'only the non-blank field renders a line');
+});
+
 test('recipient values are HTML-escaped', () => {
   // The recipient comes from a payload an agent wrote from a job posting, which
   // is untrusted content by the project's own rule.


### PR DESCRIPTION
## What does this PR do?

Gives `{{DATELINE}}` the date alone when an address block renders beneath it, so a pack cover letter stops printing the company twice.

## Related issue

Closes #4068

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## Stacked on #4043, please merge that first

The branch is based on `dev/4042-cover-recipient-block` rather than `main`, and a PR from a fork cannot take a fork branch as its base, so **this diff carries #4043's two commits as well as this one**. Only the last commit belongs to this PR:

| commit | belongs to |
|---|---|
| `8079ed40` fill `{{RECIPIENT_BLOCK}}` | #4043 |
| `9fe49937` whitespace-only recipient fields | #4043 |
| `bccab47c` dateline gate | **this PR** |

`tests/cover-recipient-block.test.mjs` and most of the `generate-cover-letter.mjs` diff are #4043's. Once that merges, this diff reduces to `bccab47c` and `tests/cover-dateline.test.mjs` on its own. Happy to rebase onto `main` at that point if you would rather review it clean.

The follow-up was offered publicly in #4043's body, so it is expected rather than a second bite at the same review.

On stock `main` this change would be strictly worse than today. A payload with a recipient would lose company and city from the dateline and get nothing in their place, because `{{RECIPIENT_BLOCK}}` is still unfilled until #4043 lands. If you would rather I rebase onto `main` after #4043 merges, say the word.

## The gate is on the rendered block, not on the field

Worth flagging because the obvious implementation is wrong. Gating on `letter.recipient` being *set* breaks the case where a recipient exists but is empty or whitespace-only: `buildRecipientBlock` renders nothing for those, so the company and city would vanish from the dateline with no address block to carry them.

Gating on the block actually rendering is what makes every branch safe:

| payload | address block | dateline |
|---|---|---|
| recipient with content | renders | date only |
| recipient `{}` or whitespace-only | renders nothing | company, city, date (unchanged) |
| no recipient | renders nothing | company, city, date (unchanged) |

The shipped `templates/cover-letter-template.html` has no address block, so it keeps the full join in every case.

## Verification

`tests/cover-dateline.test.mjs`, four tests. One is the fix and three are the compatibility guarantees, and those three pass on the unfixed function as well, which is exactly what they are for: nothing today sets `letter.recipient`, so nothing today may render differently.

`node test-all.mjs --quick`: 8690 passed, 0 failed. The five cover suites plus this one: 22 passed, 0 failed, so nothing in #4043 regressed underneath it.

`templates/cover-letter-template.html` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-visible changes

- `generate-cover-letter.mjs`: Adds `{{RECIPIENT_BLOCK}}` rendering for recipient name, title, company, and address lines.
- `generate-cover-letter.mjs`: When the recipient block renders, `{{DATELINE}}` contains only the date. Otherwise, the existing company, city, and date output remains unchanged.
- Empty or whitespace-only recipient data renders no recipient block and preserves the existing dateline.
- Recipient values are HTML-escaped.
- `tests/cover-dateline.test.mjs`: Adds coverage for dateline behavior.
- `tests/cover-recipient-block.test.mjs`: Adds coverage for recipient-block rendering and escaping.
- `templates/cover-letter-template.html`: Unchanged.

## System files

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->