### PR TITLE
fix(invite-match): resolve set-status.mjs from the code root, not the data root

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -43,6 +43,12 @@ import { validateFlags } from './lib/cli-flags.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 const CAREER_OPS = getCareerOpsRoot();
+// Sibling scripts live next to this file in the *code* checkout, which is a
+// different directory from CAREER_OPS whenever the data root is external
+// (CAREER_OPS_ROOT / a .career-ops-data marker). Resolving them off the data
+// root made --apply die with `Cannot find module <data-root>/set-status.mjs`.
+// Same split, and the same constant name, as merge-tracker.mjs (#3761).
+const CAREER_OPS_CODE_ROOT = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = resolveTrackerPath(CAREER_OPS);
 
 // --- CLI args ---
@@ -773,7 +779,7 @@ export function analyzeInvite(text, trackerRows = null) {
  * @returns {object} set-status.mjs's own --json result (or its structured error).
  */
 export function applyRejectionStatus(appNumber, options = {}) {
-  const scriptPath = join(CAREER_OPS, 'set-status.mjs');
+  const scriptPath = join(CAREER_OPS_CODE_ROOT, 'set-status.mjs');
   const env = options.appsFile ? { ...process.env, CAREER_OPS_TRACKER: options.appsFile } : process.env;
   try {
     const out = execFileSync(process.execPath, [scriptPath, String(appNumber), 'Rejected', '--json'], {

--- a/tests/invite-match-data-root.test.mjs
+++ b/tests/invite-match-data-root.test.mjs
@@ -1,0 +1,84 @@
+// invite-match regression coverage for split code/data roots (#3867, finding 4).
+//
+// applyRejectionStatus() spawns set-status.mjs, a sibling in the *code*
+// checkout. It used to resolve that path off CAREER_OPS — the *data* root —
+// so with an external data root the child died with
+// `Cannot find module <data-root>/set-status.mjs`.
+//
+// The CLI is exercised as a child process because importing invite-match.mjs
+// resolves its roots at module load. Every path points at a disposable
+// external data root; no test reads or writes the repository's user-layer
+// fixtures.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const CODE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const TRACKER_HEADER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+].join('\n');
+
+/** Seed a disposable data root outside the code checkout and return its tracker path. */
+function seedDataRoot() {
+  const dataRoot = mkdtempSync(join(tmpdir(), 'career-ops-invite-root-'));
+  const tracker = join(dataRoot, 'data', 'applications.md');
+  mkdirSync(dirname(tracker), { recursive: true });
+  writeFileSync(
+    tracker,
+    `${TRACKER_HEADER}\n| 1 | 2026-01-01 | Fabrikam | Engineer | 4.0/5 | Applied | ❌ | [1](../reports/001-fabrikam.md) | seeded |\n`,
+  );
+  return { dataRoot, tracker };
+}
+
+/** Run invite-match.mjs with the data root detached from the code checkout. */
+function runInviteMatchApply(dataRoot, tracker, stdin) {
+  const env = { ...process.env, CAREER_OPS_ROOT: dataRoot, CAREER_OPS_TRACKER: tracker };
+  delete env.CAREER_OPS_DATA_DIR;
+  const result = spawnSync(process.execPath, [join(CODE_ROOT, 'invite-match.mjs'), '--apply', '--id', '1'], {
+    cwd: CODE_ROOT,
+    env,
+    input: stdin,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  assert.equal(result.error, undefined, `invite-match failed to spawn: ${result.error?.message}`);
+  assert.equal(result.signal, null, `invite-match was killed by ${result.signal}`);
+  return { ...result, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+// `Company: <name>` is the first of invite-match's COMPANY_LINE_PATTERNS, so
+// this pins the tracker row deterministically instead of relying on prose
+// phrasing that the matcher may tighten later.
+const REJECTION = [
+  'Subject: Your application',
+  'Company: Fabrikam',
+  '',
+  'Thank you for your interest in the Engineer role.',
+  'After careful consideration we have decided not to move forward with your application.',
+].join('\n');
+
+test('--apply resolves set-status.mjs from the code root, not the data root', () => {
+  const { dataRoot, tracker } = seedDataRoot();
+  try {
+    const result = runInviteMatchApply(dataRoot, tracker, REJECTION);
+
+    // The specific pre-fix failure: the sibling script was looked up under the
+    // data root. Asserted by name so a future regression is unmistakable.
+    assert.doesNotMatch(
+      result.output,
+      /Cannot find module/,
+      `invite-match resolved a sibling script off the data root:\n${result.output}`,
+    );
+    assert.equal(result.status, 0, result.output);
+    assert.match(readFileSync(tracker, 'utf-8'), /\| Rejected \|/, 'tracker row was not advanced to Rejected');
+  } finally {
+    rmSync(dataRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

`applyRejectionStatus()` in `invite-match.mjs` spawns `set-status.mjs`, a sibling script in the **code** checkout, but resolved its path off `CAREER_OPS` — which is `getCareerOpsRoot()`, the **data** root. When the two are the same directory nothing is wrong; with an external data root (`CAREER_OPS_ROOT`, or a `.career-ops-data` marker) that path does not exist and `--apply` dies with:

```
Cannot find module <data-root>/set-status.mjs
```

This is finding 4 from #3867, reported by @jday013. Verified on `main` (`da8c6f9`), not just on the tag it was filed against.

## Fix

One line, plus the constant it needs:

```js
const CAREER_OPS_CODE_ROOT = dirname(fileURLToPath(import.meta.url));
...
const scriptPath = join(CAREER_OPS_CODE_ROOT, 'set-status.mjs');
```

Same shape and the same constant name `merge-tracker.mjs` already uses for exactly this split (#3761, `merge-tracker.mjs:54`). `dirname` and `fileURLToPath` were already imported here and previously unused, so no import churn.

`CAREER_OPS` keeps resolving the tracker (`APPS_FILE`) — that one genuinely is data, and is left alone.

## Testing

New `tests/invite-match-data-root.test.mjs` — auto-discovered, no registration needed. It spawns the CLI against a disposable external data root seeded in `tmpdir()` and asserts the module-resolution failure **by name**, so a regression is unmistakable rather than showing up as a generic non-zero exit.

**Red-armed.** Reverting the one-line fix turns it red with the reported failure:

```
Error: Cannot find module '/var/folders/.../career-ops-invite-root-scGH6p/set-status.mjs'
  code: 'MODULE_NOT_FOUND'
```

and restoring it returns the suite to green.

Full suite locally: **8689 passed, 0 failed** (16 warnings, all pre-existing and unrelated — none mention `invite`).

## One correction to the report, for the record

#3867 describes this failure as silent (`the catch returns undefined, nothing says so`). That was accurate against `career-ops-v1.32.0`, where `execFileSync` ran without an explicit `stdio` and the child's stderr was inherited. On **current `main`** it is neither silent nor inherited: `applyRejectionStatus`'s catch returns `{ error, code: 'apply-failed' }`, the CLI at `invite-match.mjs:1245-1254` prints `Apply FAILED: ...` and exits 1, and `stdio: ['ignore', 'pipe', 'pipe']` (added deliberately, with a comment explaining why) captures the child's stderr instead.

So the missing piece really was just the second root — no error-reporting work is needed here, and this PR does not add any. The one caller that could still swallow the result is a programmatic one that ignores the return value; today `tests/invite-match.test.mjs` is the only non-CLI caller.

## Scope

Deliberately **not** included, to keep this reviewable and avoid collisions:

- **Finding 6** (`doctor.mjs` dependency check against the data root) is real and reproduces, but `projectRoot` there is also fed to `checkPersonalization`, `checkAutoDir`, `checkPrereq`, `checkPlugins` and `checkPipelineFile`, all of which correctly belong to the data root — it needs a separate `CODE_ROOT` rather than a substitution, and #3982 and #3973 are both already open against that checks array.
- **Finding 5** does not reproduce; `outcome.mjs:43` already uses the code root. Its real split-checkout bug is at `:145` and is covered by #3987 / #3988 / #3990. Details in [my verification comment on #3867](https://github.com/career-ops-hq/career-ops/issues/3867#issuecomment-5627028566).

No user-layer files touched; Data Contract respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDR1wm73oH8J8cRWnKyv9m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can run `invite-match.mjs --apply` with an external data root. The command now resolves `set-status.mjs` from the code checkout through `CAREER_OPS_CODE_ROOT` instead of the data root (`invite-match.mjs:22,184`).

A regression test covers this case and verifies the `Rejected` status update (`tests/invite-match-data-root.test.mjs:1`). The full suite passes: 8,689 tests.

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->