### PR TITLE
test(url-key): give url-key.mjs its own suite

### DIFF
--- a/tests/merge-tracker-url-dedup.test.mjs
+++ b/tests/merge-tracker-url-dedup.test.mjs
@@ -1,9 +1,10 @@
 // tests/merge-tracker-url-dedup.test.mjs — URL-keyed deterministic dedup.
 //
-// Unit-tests normalizeUrl (pure), then drives the REAL merge-tracker.mjs CLI
-// end-to-end against a temp tracker via the CAREER_OPS_TRACKER /
-// CAREER_OPS_ADDITIONS env hooks — the merge path is where the bug lived, so
-// asserting on the resulting tracker rows is what actually proves the fix.
+// Drives the REAL merge-tracker.mjs CLI end-to-end against a temp tracker via
+// the CAREER_OPS_TRACKER / CAREER_OPS_ADDITIONS env hooks — the merge path is
+// where the bug lived, so asserting on the resulting tracker rows is what
+// actually proves the fix. normalizeUrl's own unit cases live in
+// tests/url-key.test.mjs.
 import { pass, fail } from './helpers.mjs';
 import assert from 'node:assert';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
@@ -11,43 +12,10 @@ import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { normalizeUrl } from '../url-key.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MERGE = join(HERE, '..', 'merge-tracker.mjs');
 const ok = (name, fn) => { try { fn(); pass(name); } catch (e) { fail(`${name} — ${e.message}`); } };
-
-// ───────────────────────── normalizeUrl (unit) ─────────────────────────
-console.log('normalizeUrl()');
-ok('strips utm_* and gh_src, keeps gh_jid', () => {
-  const a = normalizeUrl('https://careers.airbnb.com/positions/8028783?gh_jid=8028783&utm_source=x&gh_src=abc');
-  assert.equal(a, 'https://careers.airbnb.com/positions/8028783?gh_jid=8028783');
-});
-ok('lowercases host, forces https, drops trailing slash + fragment', () => {
-  assert.equal(normalizeUrl('HTTP://Jobs.Lever.co/Stripe/123/#apply'), 'https://jobs.lever.co/Stripe/123');
-});
-ok('query order does not matter (sorted)', () => {
-  assert.equal(normalizeUrl('https://x.com/j?b=2&a=1'), normalizeUrl('https://x.com/j?a=1&b=2'));
-});
-ok('two genuinely different postings stay different', () => {
-  assert.notEqual(
-    normalizeUrl('https://job-boards.greenhouse.io/doordashusa/jobs/8027044'),
-    normalizeUrl('https://job-boards.greenhouse.io/doordashusa/jobs/8026972'));
-});
-ok('idempotent', () => {
-  const once = normalizeUrl('https://X.com/a/?utm_source=y');
-  assert.equal(once, normalizeUrl(once));
-});
-ok('anything that is not an http(s) posting yields NO key', () => {
-  assert.equal(normalizeUrl(''), '');
-  assert.equal(normalizeUrl(null), '');
-  // Non-http references and placeholders must not become comparable values.
-  // The earlier lowercased-string fallback gave every one of these a key, so
-  // two unrelated employers whose report said "N/A" matched each other.
-  for (const v of ['local:jds/foo.md', 'N/A', 'n/a', 'TBD', '—', '-', 'none', 'see email']) {
-    assert.equal(normalizeUrl(v), '', `${JSON.stringify(v)} must yield no key`);
-  }
-});
 
 // ───────────────────────── merge-tracker (integration) ─────────────────────────
 const HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes | URL |';

--- a/tests/url-key.test.mjs
+++ b/tests/url-key.test.mjs
@@ -1,0 +1,46 @@
+// tests/url-key.test.mjs — normalizeUrl, the deterministic posting-URL key.
+//
+// url-key.mjs is a root script and gets its own suite, per ARCHITECTURE.md's
+// `{module}.test.mjs` rule. These cases previously lived inside
+// merge-tracker-url-dedup.test.mjs, which meant the only way to run url-key's
+// unit tests was to run a suite named for a different script.
+//
+// The merge-tracker integration cases stay where they are: they drive the real
+// CLI end-to-end, and the merge path is a different thing to prove.
+import { pass, fail } from './helpers.mjs';
+import assert from 'node:assert';
+import { normalizeUrl } from '../url-key.mjs';
+
+const ok = (name, fn) => { try { fn(); pass(name); } catch (e) { fail(`${name} — ${e.message}`); } };
+
+console.log('normalizeUrl()');
+ok('strips utm_* and gh_src, keeps gh_jid', () => {
+  const a = normalizeUrl('https://careers.airbnb.com/positions/8028783?gh_jid=8028783&utm_source=x&gh_src=abc');
+  assert.equal(a, 'https://careers.airbnb.com/positions/8028783?gh_jid=8028783');
+});
+ok('lowercases host, forces https, drops trailing slash + fragment', () => {
+  assert.equal(normalizeUrl('HTTP://Jobs.Lever.co/Stripe/123/#apply'), 'https://jobs.lever.co/Stripe/123');
+});
+ok('query order does not matter (sorted)', () => {
+  assert.equal(normalizeUrl('https://x.com/j?b=2&a=1'), normalizeUrl('https://x.com/j?a=1&b=2'));
+});
+ok('two genuinely different postings stay different', () => {
+  assert.notEqual(
+    normalizeUrl('https://job-boards.greenhouse.io/doordashusa/jobs/8027044'),
+    normalizeUrl('https://job-boards.greenhouse.io/doordashusa/jobs/8026972'));
+});
+ok('idempotent', () => {
+  const once = normalizeUrl('https://X.com/a/?utm_source=y');
+  assert.equal(once, normalizeUrl(once));
+});
+ok('anything that is not an http(s) posting yields NO key', () => {
+  assert.equal(normalizeUrl(''), '');
+  assert.equal(normalizeUrl(null), '');
+  // Non-http references and placeholders must not become comparable values.
+  // The earlier lowercased-string fallback gave every one of these a key, so
+  // two unrelated employers whose report said "N/A" matched each other.
+  for (const v of ['local:jds/foo.md', 'N/A', 'n/a', 'TBD', '—', '-', 'none', 'see email']) {
+    assert.equal(normalizeUrl(v), '', `${JSON.stringify(v)} must yield no key`);
+  }
+});
+


### PR DESCRIPTION
## What does this PR do?

Moves `normalizeUrl`'s unit tests out of `tests/merge-tracker-url-dedup.test.mjs` into a new `tests/url-key.test.mjs`, so `url-key.mjs` has a suite named for itself.

## Related issue

Closes #4070

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt, send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## Why

`ARCHITECTURE.md:30` and `CONTRIBUTING.md:189` both specify `tests/{module}.test.mjs` for the root script a suite covers. `url-key.mjs` had no suite at all. Its unit cases sat inside a file named for `merge-tracker.mjs`, which means someone changing `normalizeUrl` had no obvious file to run, and `test-all.mjs --only url-key` matched nothing.

## It is a move, not a rewrite

The file was already sectioned by a divider comment at line 52, and the split follows that seam exactly:

| exercises | blocks | goes to |
|---|---|---|
| `normalizeUrl` | 6 | `tests/url-key.test.mjs` |
| drives the `merge-tracker.mjs` CLI | 16 | stays |
| both | 0 | n/a |

Nothing exercised both, so no case had to be duplicated or rewritten. The assertions are byte-identical to what they were; only their file changed. Both headers now point at each other, and the `normalizeUrl` import is dropped from the file that no longer uses it.

## Verification

`node tests/url-key.test.mjs`: 6 passed. `node tests/merge-tracker-url-dedup.test.mjs`: unchanged, all green. `node test-all.mjs --quick`: 8687 passed, 0 failed.

Checked for orphaned imports in the file the cases left, since that is the obvious way to break a move like this: every remaining import is still referenced.

## Origin

The review bot raised this on #3653. I declined it there on a cost I had not measured, and the size I quoted was wrong, so this is the corrected answer. It is a separate PR because #3653 is carrying two confirmed bug findings and a test reorganization would compete with them for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `tests/url-key.test.mjs:1` as the dedicated `normalizeUrl` test suite.
- Moved URL-key unit tests out of `tests/merge-tracker-url-dedup.test.mjs:14`.
- Kept merge-tracker integration tests in their existing suite.
- Preserved behavior and assertions.
- No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

## Verification

- URL-key tests passed: 6 tests.
- Merge-tracker tests remained green.
- `test-all.mjs --quick` passed: 8,687 tests, 0 failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->