### PR TITLE
fix(updater): drop SIGNATURES.md from SYSTEM_PATHS so a new signature stops reading as system drift

### DIFF
--- a/tests/updater-signature-ledger-drift.test.mjs
+++ b/tests/updater-signature-ledger-drift.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * updater-signature-ledger-drift.test.mjs — a new manifesto signature must not
+ * read as system drift on every install (#4062).
+ *
+ * SIGNATURES.md is an append-only ledger of who signed MANIFESTO.md. It used
+ * to sit in SYSTEM_PATHS, which put it inside the pathspec check() diffs:
+ *
+ *   systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD')
+ *     → git diff --quiet --ignore-cr-at-eol FETCH_HEAD HEAD -- <SYSTEM_PATHS>
+ *     → any one pathspec differing ⇒ reason: 'system-files-changed'
+ *
+ * The ledger takes dozens of commits a month while the code it ships beside
+ * does not, so the moment anyone signed, every install on the planet started
+ * reporting `update-available / system-files-changed` — the same permanent
+ * false positive as #3149, from a third independent cause (after the SHA-vs-
+ * content bug of #2630 and the ignore-rule route of #2756).
+ *
+ * These tests drive the REAL manifest — read out of update-system.mjs with
+ * extractArrayFromSource, never a hard-coded copy — against throwaway repos
+ * through the same ctx.git seam production uses. Hard-coding the path list
+ * here would pin the fixture instead of the shipped behaviour, and the
+ * regression would come back the first time someone re-added the entry.
+ *
+ *   - upstream appends a signature, nothing else moves → NOT drift
+ *   - upstream edits a genuine system file             → still drift
+ *     (the fix must narrow the pathspec, not blunt the check)
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { pass, fail, rmSync, ROOT } from './helpers.mjs';
+import { gitIn, systemTreeDiffers, extractArrayFromSource } from '../update-system.mjs';
+
+const SIGNATURES = 'SIGNATURES.md';
+// A second real system file, used as the control: whatever the manifest says
+// today, an upstream change to THIS one must still report drift.
+const CONTROL = 'MANIFESTO.md';
+const USER_PATH = 'data/applications.md';
+
+const realSystemPaths = extractArrayFromSource(
+  readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8'),
+  'SYSTEM_PATHS',
+);
+
+function seed(dir, path, body) {
+  mkdirSync(join(dir, dirname(path)), { recursive: true });
+  writeFileSync(join(dir, path), body);
+}
+
+function makeOrigin() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-sig-origin-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  g('config', 'core.autocrlf', 'false');
+  g('config', 'commit.gpgsign', 'false');
+  seed(dir, SIGNATURES, '# Signatures\n\n- @first\n');
+  seed(dir, CONTROL, '# Manifesto\n\nv1\n');
+  seed(dir, USER_PATH, '| base | Acme | Intern |\n');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+  return { dir, g };
+}
+
+function cloneInstall(originDir) {
+  const dir = mkdtempSync(join(tmpdir(), 'co-sig-install-'));
+  gitIn(dir, 'clone', '-q', originDir, '.');
+  const g = (...args) => gitIn(dir, ...args);
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  g('config', 'core.autocrlf', 'false');
+  g('config', 'commit.gpgsign', 'false');
+  return { dir, g };
+}
+
+function cleanup(...dirs) {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+}
+
+console.log('\n🧪 Testing signature-ledger drift (#4062)...');
+
+// ── 0. Fixture preconditions ────────────────────────────────────────────────
+// The two tests below are only meaningful if the real manifest is what it
+// claims to be: non-empty, and still shipping the control file.
+if (realSystemPaths.length > 0 && realSystemPaths.includes(CONTROL)) {
+  pass(`real SYSTEM_PATHS read from update-system.mjs (${realSystemPaths.length} entries, includes ${CONTROL})`);
+} else {
+  fail(`could not read a usable SYSTEM_PATHS from update-system.mjs (${realSystemPaths.length} entries)`);
+}
+
+// ── 1. THE REGRESSION ───────────────────────────────────────────────────────
+// Someone signs the manifesto upstream. Nothing an install runs has changed.
+// check() must not call that system-files-changed.
+{
+  const origin = makeOrigin();
+  const install = cloneInstall(origin.dir);
+  try {
+    appendFileSync(join(origin.dir, SIGNATURES), '- @second\n');
+    origin.g('add', '-A');
+    origin.g('commit', '-qm', 'docs(signatures): add @second');
+
+    install.g('fetch', '-q', origin.dir, 'main');
+
+    // Fixture guard: the ledger really did diverge between the two refs.
+    const changed = install.g('diff', '--name-only', 'FETCH_HEAD', 'HEAD').split('\n').filter(Boolean);
+    if (changed.length === 1 && changed[0] === SIGNATURES) {
+      pass(`fixture: ${SIGNATURES} is the only file differing from upstream`);
+    } else {
+      fail(`fixture: expected only ${SIGNATURES} to differ, got [${changed.join(', ')}]`);
+    }
+
+    const drift = systemTreeDiffers(realSystemPaths, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) });
+    if (drift === false) {
+      pass('a new signature alone is NOT system drift');
+    } else {
+      fail('a new signature alone reported as system drift — #4062 is back');
+    }
+  } finally {
+    cleanup(origin.dir, install.dir);
+  }
+}
+
+// ── 2. The check still works ────────────────────────────────────────────────
+// Narrowing the pathspec must not cost real drift detection: an upstream
+// change to a genuine system file still has to report.
+{
+  const origin = makeOrigin();
+  const install = cloneInstall(origin.dir);
+  try {
+    writeFileSync(join(origin.dir, CONTROL), '# Manifesto\n\nv2\n');
+    origin.g('add', '-A');
+    origin.g('commit', '-qm', 'docs: revise manifesto');
+
+    install.g('fetch', '-q', origin.dir, 'main');
+
+    const drift = systemTreeDiffers(realSystemPaths, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) });
+    if (drift === true) {
+      pass(`an upstream change to ${CONTROL} still reports drift`);
+    } else {
+      fail(`an upstream change to ${CONTROL} read as no-drift — the check was blunted, not narrowed`);
+    }
+  } finally {
+    cleanup(origin.dir, install.dir);
+  }
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -392,7 +392,23 @@ const SYSTEM_PATHS = [
   'DATA_CONTRACT.md',
   'MANIFESTO.md',
   'manifesto.mjs',
-  'SIGNATURES.md',
+  // SIGNATURES.md cannot join SYSTEM_PATHS: unlike every other system file it
+  // is a pure append-only ledger of who signed the manifesto, and it churns
+  // far faster than the code it would ship beside (49 commits in the 30 days
+  // before this was written). Nothing on an install reads it — manifesto.mjs
+  // parses MANIFESTO.md and never opens it — so shipping it buys an install
+  // nothing, while listing it here puts it in the pathspec check() diffs via
+  // systemTreeDiffers, which turns every new signature into a
+  // system-files-changed report on every install in the world that no apply
+  // can clear for long (#4062: the third independent cause of the #3149 class
+  // of permanent update-available, after the SHA-vs-content bug of #2630 and
+  // the ignore-rule route of #2756). Its repo-only coverage is declared in
+  // validate-system-paths-coverage.mjs, and the behaviour is pinned by
+  // tests/updater-signature-ledger-drift.test.mjs.
+  //
+  // Keep this comment free of straight quotes: updater-migration-tests.mjs
+  // parses this array with a comment-blind regex, so an apostrophe here
+  // becomes a phantom manifest entry.
   'CONTRIBUTING.md',
   'MAINTAINERS.md',
   'ARCHITECTURE.md',

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -92,6 +92,17 @@ const EXCLUDES = [
 // this repository only, leaving a candidate's CV stageable in every fork.
 const RECONCILED_NOT_CHECKED_OUT = ['.gitignore'];
 
+// Repo-only files: tracked here, deliberately never shipped to an install.
+//
+// SIGNATURES.md is the append-only ledger of who signed the manifesto. It is
+// read by nobody on an install — manifesto.mjs parses MANIFESTO.md and never
+// touches it — and it changes far more often than the code does, so while it
+// sat in SYSTEM_PATHS every new signature made check()'s content diff report
+// `system-files-changed` on every install in the world, with no `apply` able
+// to clear it for long (#4062). Excluded rather than shipped: the fix is that
+// installs stop tracking a ledger they never use.
+const REPO_ONLY = ['SIGNATURES.md'];
+
 // Trees that live in the repo but deliberately OUTSIDE the updater's world:
 // web/ is the experimental web UI — its own release-please component, never
 // shipped by update-system.mjs, never in the npm package. Excluding it here is
@@ -102,6 +113,7 @@ function covered(file) {
   // If explicitly excluded, it is covered
   if (EXCLUDES.includes(file)) return true;
   if (RECONCILED_NOT_CHECKED_OUT.includes(file)) return true;
+  if (REPO_ONLY.includes(file)) return true;
   if (EXCLUDE_PREFIXES.some((p) => file.startsWith(p))) return true;
 
   return ALL_PATHS.some((path) =>
@@ -149,6 +161,11 @@ if (process.argv.includes('--self-test')) {
   assert(covered('web/package.json') === true, 'web/ tree must be covered (isolation-contract prefix exclude)');
   assert(covered('web-dashboard/index.html') === false, 'web-dashboard/ must NOT ride the web/ prefix exclude');
   assert(covered('.npmignore') === true, '.npmignore must be covered (excluded)');
+  // Asserted through the MECHANISM as well as covered(): if SIGNATURES.md ever
+  // went back into SYSTEM_PATHS, covered() would still answer true while the
+  // #4062 false-positive drift came back on every install.
+  assert(covered('SIGNATURES.md') === true, 'SIGNATURES.md must be covered (repo-only exclude, #4062)');
+  assert(!SYSTEM_PATHS.includes('SIGNATURES.md'), 'SIGNATURES.md must NOT re-enter SYSTEM_PATHS: its churn reads as system-files-changed drift on every install (#4062)');
 
   // Test unrelated file
   assert(covered('untracked-orphan-file-xyz.js') === false, 'untracked-orphan-file-xyz.js must NOT be covered');


### PR DESCRIPTION
Closes #4062

## The bug

`SIGNATURES.md` is an append-only ledger of who signed the manifesto — **49 commits in the last 30 days**, none of which change anything an install runs. While it sat in `SYSTEM_PATHS` it was inside the pathspec `check()` diffs:

```
check(): SHA mismatch
  -> systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD')                          update-system.mjs:1879
  -> git diff --quiet --ignore-cr-at-eol FETCH_HEAD HEAD -- <SYSTEM_PATHS>  :1118-1130
  -> ANY one pathspec differing => reason: 'system-files-changed'           :1894
```

So the moment anyone signs the manifesto, **every install in the world** starts reporting `update-available / system-files-changed` — for a file no install reads. Re-syncing clears it only until the next signature lands, which on current cadence is roughly every other day.

### Reproduction (against `main@da8c6f9`)

Taking `fe06051` as a stale install ref and diffing with the real 315-entry `SYSTEM_PATHS`:

- `git diff --quiet --ignore-cr-at-eol fe06051 HEAD -- <315 paths>` → **exit 1** (drift)
- the same diff with `--name-only` lists **`SIGNATURES.md` and nothing else**
- drop that one entry → **exit 0** (no drift)

## Why this is not "yet another drift fix"

This is **one of several independent causes** of the #3149 class of permanent "update available", and it is orthogonal to the two already fixed below. (A further cause — skill entrypoint symlinks materialised into regular files on `core.symlinks=false` checkouts, confirmed on #3149 — is separate and must **not** be fixed the way this entry is; see the code comment.)

| # | Cause | Fix |
|---|---|---|
| #2630 | `apply()` commits upstream content as a *new* local commit, so HEAD can never equal upstream main — SHA inequality was read as drift | settle same-version mismatches on **content** (`systemTreeDiffers`) |
| #2756 | `.gitignore` cannot be checked out raw (users co-own it), so it stayed permanently out of sync | `reconcileGitignore()` — append-if-missing, excluded from the manifest |
| **#4062 (this PR)** | a **high-churn, install-irrelevant document** sits inside the content diff, so the content check itself fires forever | remove it from the pathspec |

#2630 made the check correct; this PR makes its *input* correct. The check has no way to distinguish "the ledger grew by one name" from "a script changed" — the pathspec is the only place that distinction can live.

It is also orthogonal to #3805 (in review): that one is about a different stage of the same script and the two do not touch the same lines.

## The change

1. **`update-system.mjs`** — remove `'SIGNATURES.md'` from `SYSTEM_PATHS`, replaced by a comment explaining *why it is excluded*, in the same house style as the `.gitignore` rationale at `:1979`.
2. **`validate-system-paths-coverage.mjs`** — removing the entry would make the file an orphan and turn the coverage guard red, so it gets a `REPO_ONLY` group of its own (not folded into `EXCLUDES`, for the same reason `.gitignore` has its own group: these entries differ in *why* they never ship). Two self-test assertions, one of which pins the **mechanism** — `!SYSTEM_PATHS.includes('SIGNATURES.md')` — because `covered()` would keep answering `true` if the entry came back, silently restoring the false positive.
3. **`tests/updater-signature-ledger-drift.test.mjs`** — new, auto-discovered (no `test-all.mjs` edit).

### Why excluded rather than exempted

`manifesto.mjs` only ever parses `MANIFESTO.md`; nothing on an install opens `SIGNATURES.md`. It is a repository-side record of who signed, not a shipped artifact, so it stops shipping instead of shipping-but-ignored. Side effects checked explicitly:

- `staleSystemFiles()` (`:972`) only prunes files the **install has and upstream lacks** — a dropped manifest entry never triggers a delete, so nobody's copy is removed.
- `missingFromTargetManifest()` (`:864`) iterates the **remote** list — no false "missing" warning.
- the only other reference to the filename is `test-all.mjs:1973`, a privacy-scan allowlist, unaffected.

## Test

`tests/updater-signature-ledger-drift.test.mjs` drives the **real** manifest — read out of `update-system.mjs` with `extractArrayFromSource`, never a hard-coded copy, so the test pins shipped behaviour rather than a fixture — against throwaway repos through the same `ctx.git` seam production uses (the approach `tests/updater-drift-detection.test.mjs` established):

- upstream appends one signature, nothing else moves → **not** drift
- upstream edits a genuine system file → **still** drift (the fix must narrow the pathspec, not blunt the check)

**Red-armed both ways.** With `'SIGNATURES.md',` put back:

```
  ✅ real SYSTEM_PATHS read from update-system.mjs (315 entries, includes MANIFESTO.md)
  ✅ fixture: SIGNATURES.md is the only file differing from upstream
  ❌ a new signature alone reported as system drift — #4062 is back
  ✅ an upstream change to MANIFESTO.md still reports drift
📊 Results: 3 passed, 1 failed
FAIL: SIGNATURES.md must NOT re-enter SYSTEM_PATHS (#4062)   [coverage self-test]
```

With it removed:

```
  ✅ real SYSTEM_PATHS read from update-system.mjs (314 entries, includes MANIFESTO.md)
  ✅ fixture: SIGNATURES.md is the only file differing from upstream
  ✅ a new signature alone is NOT system drift
  ✅ an upstream change to MANIFESTO.md still reports drift
📊 Results: 4 passed, 0 failed
ALL SELF-TESTS PASSED
```

Full suite (not `--quick`): **8692 passed, 0 failed, 16 warnings**, exit 0. The 16 warnings are byte-identical to the pre-change baseline apart from one randomized probe filename.

### One note for future editors

`updater-migration-tests.mjs:60` parses `SYSTEM_PATHS` with a **comment-blind** regex, unlike the exported `extractArrayFromSource` which strips comments first. A straight quote or apostrophe anywhere in a comment inside that array becomes a phantom manifest entry and fails the suite with a wall of `SYSTEM_PATHS entry missing from tree`. The new comment is deliberately quote-free and says so in place. Happy to split a parser-convergence hardening into its own PR if you would prefer the two to agree.

## Alternative, if you would rather keep shipping the ledger

Keep the `SYSTEM_PATHS` entry (so installs continue to receive `SIGNATURES.md`) and introduce a separate `DRIFT_EXEMPT_PATHS`, subtracted from the pathspec only at the `systemTreeDiffers` call site in `check()`. That separates "what ships" from "what counts as drift" and generalizes to any future high-churn shipped document.

I went with removal because it is the smaller change and nothing on an install reads the file, so the extra concept buys nothing today — but the exempt-list version is a ~10-line diff and I am glad to switch if you would rather installs keep a current copy of the ledger. Happy to take either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDR1wm73oH8J8cRWnKyv9m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

`SIGNATURES.md` no longer causes false `system-files-changed` notices. Users will not receive repeated update prompts when only the signature ledger changes upstream.

## Changes

- Removed `SIGNATURES.md` from `SYSTEM_PATHS` in `update-system.mjs:395-413`.
- Added repository-only coverage and assertions in `validate-system-paths-coverage.mjs:95-104,164-168`.
- Added regression tests for signature-only changes and real `MANIFESTO.md` drift in `tests/updater-signature-ledger-drift.test.mjs:93-141`.
- Kept symlinked skill entrypoints in `SYSTEM_PATHS`; drift comparison must handle them separately.

## User impact

`check` still detects genuine system-file changes. A signature-only update no longer reports drift or prompts users to apply an update.

The full suite reports 8,692 passed, 0 failed, with 16 warnings.

## System files touched

- `update-system.mjs`
- `validate-system-paths-coverage.mjs`
- `tests/updater-signature-ledger-drift.test.mjs`

`AGENTS.md`, `modes/`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
