### PR TITLE
fix(dashboard): stats panels overflow their column, and "evaluated" labels three different numbers

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -992,8 +992,11 @@ func ComputeProgressMetrics(apps []model.CareerApplication) model.ProgressMetric
 	interview := statusCounts["interview"] + statusCounts["offer"] + statusCounts["hired"]
 	offer := statusCounts["offer"] + statusCounts["hired"]
 
+	// Top stage counts every tracked row, including rows backfilled without a
+	// score (#1799) — hence "Tracked", not "Evaluated", which already means both
+	// a status value and the Stats screen's scored count.
 	pm.FunnelStages = []model.FunnelStage{
-		{Label: "Evaluated", Count: total, Pct: 100.0},
+		{Label: "Tracked", Count: total, Pct: 100.0},
 		{Label: "Applied", Count: applied, Pct: safePct(applied, total)},
 		{Label: "Responded", Count: responded, Pct: safePct(responded, applied)},
 		{Label: "Interview", Count: interview, Pct: safePct(interview, applied)},

--- a/dashboard/internal/data/progress_metrics_test.go
+++ b/dashboard/internal/data/progress_metrics_test.go
@@ -35,7 +35,7 @@ func TestComputeProgressMetricsCountsHiredInEveryStage(t *testing.T) {
 		label string
 		want  int
 	}{
-		{"Evaluated", 1},
+		{"Tracked", 1},
 		{"Applied", 1},
 		{"Responded", 1},
 		{"Interview", 1},
@@ -98,5 +98,30 @@ func TestComputeProgressMetricsFunnelIsMonotonic(t *testing.T) {
 	// offer = offer+hired = 2
 	if offer != 2 {
 		t.Errorf("Offer = %d, want 2", offer)
+	}
+}
+
+// The top funnel stage counts every tracked row, scored or not — a row
+// backfilled without an evaluation (#1799) sits there with no score. So it must
+// not borrow the word the Stats header uses for the scored count, nor the
+// canonical "Evaluated" status: computeFunnel() in stats.mjs already warns that
+// the same word standing for two different numbers reads as a bug, and this
+// label made it three.
+//
+// The AvgScore assertion is the other half of the same defect: the Progress
+// header renders this stage's count and AvgScore side by side, but AvgScore
+// divides by the scored rows only. Naming the count honestly is what stops the
+// two halves of that line from contradicting each other.
+func TestFunnelTopStageCountsUnscoredRowsAndIsNotNamedEvaluated(t *testing.T) {
+	apps := appsWithStatuses("Applied", "Applied")
+	apps[0].Score = 4.2 // one evaluated, one backfilled with no evaluation
+
+	pm := ComputeProgressMetrics(apps)
+
+	if got := stageCount(pm, "Tracked"); got != 2 {
+		t.Errorf("Tracked stage = %d, want 2 — both rows are tracked even though only one carries a score", got)
+	}
+	if pm.AvgScore != 4.2 {
+		t.Errorf("AvgScore = %v, want 4.2 — the average covers scored rows only, which is why the count beside it cannot be called 'evaluated'", pm.AvgScore)
 	}
 }

--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -328,7 +328,7 @@ var En = Catalog{
 
 	// Progress screen
 	ProgressTitle:   "SEARCH PROGRESS",
-	ProgressSummary: "%d evaluated | %.1f avg score",
+	ProgressSummary: "%d tracked | %.1f avg score",
 	FunnelTitle:     "Pipeline Funnel",
 	ScoresTitle:     "Score Distribution",
 	RatesTitle:      "Conversion Rates",
@@ -492,7 +492,7 @@ var Tr = Catalog{
 
 	// Progress screen
 	ProgressTitle:   "TAKİP İLERLEMESİ",
-	ProgressSummary: "%d değerlendirildi | %.1f ort. puan",
+	ProgressSummary: "%d takipte | %.1f ort. puan",
 	FunnelTitle:     "Pipeline Hunisi",
 	ScoresTitle:     "Puan Dağılımı",
 	RatesTitle:      "Dönüşüm Oranları",
@@ -656,7 +656,7 @@ var Es = Catalog{
 
 	// Progress screen
 	ProgressTitle:   "PROGRESO DE BÚSQUEDA",
-	ProgressSummary: "%d evaluadas | %.1f puntuación media",
+	ProgressSummary: "%d en seguimiento | %.1f puntuación media",
 	FunnelTitle:     "Embudo del proceso",
 	ScoresTitle:     "Distribución de puntuaciones",
 	RatesTitle:      "Tasas de conversión",

--- a/dashboard/internal/ui/screens/stats.go
+++ b/dashboard/internal/ui/screens/stats.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/santifer/career-ops/dashboard/internal/data"
 	"github.com/santifer/career-ops/dashboard/internal/i18n"
@@ -45,10 +46,82 @@ func (m StatsModel) Init() tea.Cmd {
 	return nil
 }
 
+const (
+	// twoColumnMinWidth is the terminal width at which renderBody switches from a
+	// single stacked column to two side-by-side columns. It has to clear the
+	// widest fixed-content panel: the pie chart's 17-column disc, its 4-column
+	// gap and its legend come to 55 columns that nothing can shrink, and the
+	// right column is only m.width/2-2 wide. At 110 the layout engaged four
+	// columns before that fit, and the pie wrapped into the panel below it.
+	twoColumnMinWidth = 114
+
+	// panelPadW is the horizontal padding every stats panel adds around its rows
+	// (Padding(0, 2), so two columns on each side).
+	panelPadW = 4
+
+	// Fixed cell widths, named so the bar budget and the lipgloss.Width call that
+	// renders the cell cannot drift apart — that drift is what let the rows
+	// overflow in the first place.
+	archetypeCountW = 10 // "%4d (%.0f%%)"
+	archetypeScoreW = 10 // "★ %.1f/5"
+	labelCountW     = 18 // work-mode and location label cell
+	payLabelW       = 16 // salary band label cell
+	barGapW         = 1  // single space either side of an archetype bar
+
+	// minReadableBarW is the point below which an archetype bar stops conveying
+	// proportion, so the label cell gives up its width instead.
+	minReadableBarW = 8
+)
+
 // Resize updates dimensions.
 func (m *StatsModel) Resize(width, height int) {
 	m.width = width
 	m.height = height
+}
+
+// contentWidth returns the number of columns a single panel may occupy. Above
+// twoColumnMinWidth renderBody places each panel inside a box roughly half the
+// terminal wide, so a panel that sizes itself off m.width overflows that box
+// and is wrapped by lipgloss — losing its indent in the process.
+func (m StatsModel) contentWidth() int {
+	if m.width >= twoColumnMinWidth {
+		return m.width/2 - 2
+	}
+	return m.width
+}
+
+// rightColumnWidth returns the width of the second column of the two-column
+// layout, which renderBody gives whatever contentWidth leaves over.
+func (m StatsModel) rightColumnWidth() int {
+	if m.width >= twoColumnMinWidth {
+		return m.width - m.contentWidth() - 4
+	}
+	return m.width
+}
+
+// barWidth returns the bar column for a panel row whose other cells occupy
+// fixedCells columns: the preferred width, clamped to what the panel column
+// has left, and floored at one glyph so a tight column yields a short chart
+// rather than no chart. Without the clamp a row came out wider than the box
+// holding it and lipgloss wrapped it, dropping the panel's indent.
+func (m StatsModel) barWidth(avail, fixedCells int) int {
+	preferred := 25
+	if avail < 90 {
+		preferred = 15
+	}
+	return max(1, min(preferred, avail-panelPadW-fixedCells))
+}
+
+// countCells renders each row's trailing count cell and returns them with the
+// widest, so the variable-width count column can be budgeted before the bar.
+func countCells(stats []model.LabelCountStat, format string) ([]string, int) {
+	cells := make([]string, len(stats))
+	widest := 0
+	for i, s := range stats {
+		cells[i] = fmt.Sprintf(format, s.Count, s.Pct)
+		widest = max(widest, lipgloss.Width(cells[i]))
+	}
+	return cells, widest
 }
 
 // Update processes navigation and input events for the stats analytics dashboard.
@@ -116,9 +189,9 @@ func (m StatsModel) renderBody() string {
 	locations := m.renderLabelCountTable(i18n.Current.LocationTitle, m.metrics.Locations)
 	pay := m.renderPay()
 
-	if m.width >= 110 {
-		leftColWidth := m.width/2 - 2
-		rightColWidth := m.width - leftColWidth - 4
+	if m.width >= twoColumnMinWidth {
+		leftColWidth := m.contentWidth()
+		rightColWidth := m.rightColumnWidth()
 
 		leftCol := lipgloss.NewStyle().Width(leftColWidth).Render(
 			lipgloss.JoinVertical(lipgloss.Left,
@@ -229,8 +302,8 @@ func (m StatsModel) renderInsights() string {
 	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Yellow).Render("💡 " + i18n.Current.StatsStrategicInsights)
 
 	boxW := m.width - 6
-	if m.width >= 110 {
-		boxW = m.width/2 - 6
+	if m.width >= twoColumnMinWidth {
+		boxW = m.contentWidth() - 4
 	}
 
 	boxStyle := lipgloss.NewStyle().
@@ -365,35 +438,36 @@ func (m StatsModel) renderArchetypeChart() string {
 		return strings.Join(lines, "\n")
 	}
 
+	// Size against the panel column, not the terminal: in the two-column
+	// layout this panel is rendered into a box half the terminal wide.
+	avail := m.contentWidth()
+
+	// The count cell overflows its nominal width once a share rounds to 100%
+	// (a single archetype, or one that dominates), so measure it rather than
+	// assuming — an over-full cell wraps and takes the row with it.
+	maxCount := 0
+	counts := make([]string, len(m.metrics.Archetypes))
+	countW := archetypeCountW
+	for i, a := range m.metrics.Archetypes {
+		maxCount = max(maxCount, a.Count)
+		counts[i] = fmt.Sprintf("%4d (%.0f%%)", a.Count, a.Pct)
+		countW = max(countW, lipgloss.Width(counts[i]))
+	}
+
+	fixedCells := func(labelW int) int {
+		return labelW + countW + 2*barGapW + archetypeScoreW
+	}
+
+	// Prefer the wide label cell, but fall back to the narrow one when the panel
+	// is too tight to leave a readable bar beside it.
 	labelW := 26
-	if m.width < 90 {
+	if m.width < 90 || m.barWidth(avail, fixedCells(26)) < minReadableBarW {
 		labelW = 20
 	}
+	barMaxW := m.barWidth(avail, fixedCells(labelW))
 
-	maxCount := 0
-	for _, a := range m.metrics.Archetypes {
-		if a.Count > maxCount {
-			maxCount = a.Count
-		}
-	}
-
-	barMaxW := 25
-	if m.width < 90 {
-		barMaxW = 15
-	}
-
-	for _, a := range m.metrics.Archetypes {
-		label := a.Label
-		if lipgloss.Width(label) > labelW-1 {
-			runes := []rune(label)
-			cut := labelW - 2
-			if cut < 0 {
-				cut = 0
-			}
-			if cut < len(runes) {
-				label = string(runes[:cut]) + "…"
-			}
-		}
+	for i, a := range m.metrics.Archetypes {
+		label := ansi.Truncate(a.Label, labelW-1, "…")
 
 		barW := 0
 		if maxCount > 0 {
@@ -406,12 +480,12 @@ func (m StatsModel) renderArchetypeChart() string {
 		color := m.scoreColor(a.AvgScore)
 		barStyle := lipgloss.NewStyle().Foreground(color)
 		labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(labelW)
-		countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(10)
-		scoreStyle := lipgloss.NewStyle().Bold(true).Foreground(color).Width(10).Align(lipgloss.Right)
+		countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(countW)
+		scoreStyle := lipgloss.NewStyle().Bold(true).Foreground(color).Width(archetypeScoreW).Align(lipgloss.Right)
 
 		bar := barStyle.Render(strings.Repeat("█", barW))
 		lbl := labelStyle.Render(label)
-		countStr := countStyle.Render(fmt.Sprintf("%4d (%.0f%%)", a.Count, a.Pct))
+		countStr := countStyle.Render(counts[i])
 
 		scoreStr := "-"
 		if a.AvgScore > 0 {
@@ -438,18 +512,16 @@ func (m StatsModel) renderLabelCountTable(title string, stats []model.LabelCount
 		return strings.Join(lines, "\n")
 	}
 
-	labelW := 18
-	barMaxW := 25
-	if m.width < 90 {
-		barMaxW = 15
-	}
-
 	maxCount := 0
 	for _, s := range stats {
 		if s.Count > maxCount {
 			maxCount = s.Count
 		}
 	}
+
+	// The count cell is variable-width, so measure it before budgeting the bar.
+	counts, countW := countCells(stats, "  %d (%.0f%%)")
+	barMaxW := m.barWidth(m.contentWidth(), labelCountW+countW)
 
 	barColors := []lipgloss.Color{
 		m.theme.Green,
@@ -476,25 +548,15 @@ func (m StatsModel) renderLabelCountTable(title string, stats []model.LabelCount
 			color = barColors[i]
 		}
 
-		label := s.Label
-		if lipgloss.Width(label) > labelW-1 {
-			runes := []rune(label)
-			cut := labelW - 2
-			if cut < 0 {
-				cut = 0
-			}
-			if cut < len(runes) {
-				label = string(runes[:cut]) + "…"
-			}
-		}
+		label := ansi.Truncate(s.Label, labelCountW-1, "…")
 
 		barStyle := lipgloss.NewStyle().Foreground(color)
-		labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(labelW)
+		labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(labelCountW)
 		countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
 
 		bar := barStyle.Render(strings.Repeat("█", barW))
 		lbl := labelStyle.Render(label)
-		count := countStyle.Render(fmt.Sprintf("  %d (%.0f%%)", s.Count, s.Pct))
+		count := countStyle.Render(counts[i])
 
 		lines = append(lines, padStyle.Render(lbl+bar+count))
 	}
@@ -550,12 +612,13 @@ func (m StatsModel) renderPay() string {
 			}
 		}
 
-		barMaxW := 25
-		if m.width < 90 {
-			barMaxW = 15
-		}
+		// The count cell is variable-width, so measure it before budgeting the bar.
+		counts, countW := countCells(m.metrics.PayHistogram, "  %2d (%.0f%%)")
+		// This panel sits in the right-hand column, which gets whatever the left
+		// one leaves over rather than the same width.
+		barMaxW := m.barWidth(m.rightColumnWidth(), payLabelW+countW)
 
-		for _, b := range m.metrics.PayHistogram {
+		for i, b := range m.metrics.PayHistogram {
 			barW := 0
 			if maxHist > 0 {
 				barW = b.Count * barMaxW / maxHist
@@ -565,12 +628,12 @@ func (m StatsModel) renderPay() string {
 			}
 
 			barStyle := lipgloss.NewStyle().Foreground(m.theme.Green)
-			labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(16)
+			labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(payLabelW)
 			countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
 
 			bar := barStyle.Render(strings.Repeat("█", barW))
 			lbl := labelStyle.Render(b.Label)
-			cnt := countStyle.Render(fmt.Sprintf("  %2d (%.0f%%)", b.Count, b.Pct))
+			cnt := countStyle.Render(counts[i])
 
 			lines = append(lines, padStyle.Render(lbl+bar+cnt))
 		}

--- a/dashboard/internal/ui/screens/stats_width_test.go
+++ b/dashboard/internal/ui/screens/stats_width_test.go
@@ -1,0 +1,205 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+)
+
+// statsMetricsWideShape returns metrics whose bars run the full width: the
+// 44-count leader is what produces a maximum-width bar, since every other bar
+// is scaled to count/maxCount. A fixture where all counts are small yields
+// short bars that fit whatever space is left, and hides this bug entirely.
+//
+// The locations table carries a CJK label longer than the cell so the
+// truncation path is exercised in a width the label's rune count alone would
+// not catch.
+func statsMetricsWideShape() model.StatsMetrics {
+	return model.StatsMetrics{
+		Archetypes: []model.ArchetypeStat{
+			{Label: "AI Solutions & FDE", Count: 44, Pct: 24.6, AvgScore: 3.3},
+			{Label: "Applied AI Engineering", Count: 31, Pct: 17.3, AvgScore: 3.6},
+			{Label: "ML Platform / Infrastructure", Count: 28, Pct: 15.6, AvgScore: 3.4},
+			{Label: "Research Engineering", Count: 12, Pct: 6.7, AvgScore: 3.8},
+			{Label: "Other", Count: 2, Pct: 1.1, AvgScore: 0},
+		},
+		WorkModes: []model.LabelCountStat{
+			{Label: "On-site", Count: 162, Pct: 90.5},
+			{Label: "Hybrid", Count: 12, Pct: 6.7},
+			{Label: "Remote", Count: 5, Pct: 2.8},
+		},
+		Locations: []model.LabelCountStat{
+			{Label: "新竹科學園區 竹科三期", Count: 118, Pct: 65.9},
+			{Label: "Taipei, Taiwan", Count: 44, Pct: 24.6},
+			{Label: "Tainan, Taiwan", Count: 17, Pct: 9.5},
+		},
+		Pay: model.PayStats{
+			Count: 31, PostedCount: 24, EstCount: 7,
+			AvgPayMax: 185000, MedianPayMax: 170000, MaxPayMax: 320000,
+		},
+		PayHistogram: []model.LabelCountStat{
+			{Label: "$100K - $140K", Count: 11, Pct: 35.5},
+			{Label: "$140K - $180K", Count: 14, Pct: 45.2},
+			{Label: "$220K+", Count: 6, Pct: 19.4},
+		},
+		ScoreTiers: []model.LabelCountStat{
+			{Label: "Strong (4.0-4.4)", Count: 21, Pct: 12.3},
+			{Label: "Viable (3.5-3.9)", Count: 58, Pct: 33.9},
+			{Label: "Below Bar (<3.0)", Count: 92, Pct: 53.8},
+		},
+		SeniorityMix: []model.LabelCountStat{
+			{Label: "Mid-Level", Count: 151, Pct: 84.4},
+			{Label: "Senior", Count: 28, Pct: 15.6},
+		},
+		QualityBarPct: 12.3,
+	}
+}
+
+// pieChartW is what a pie panel occupies no matter the terminal: a 17-column
+// disc, a 4-column gap, a legend built from a fixed-width label and count cell,
+// and the panel's own padding. Nothing in it scales down, which is why
+// twoColumnMinWidth has to clear it — and why the sweep cannot assert it at
+// widths narrower than this.
+const pieChartW = 55
+
+type widthTestPanel struct {
+	name  string
+	body  string
+	avail int
+	rows  int // expected line count; 0 when the panel's height is not fixed
+	floor int // narrowest column this panel's fixed content can occupy
+}
+
+// panelsForWidthTest returns every panel renderBody assembles, paired with the
+// column it is placed into: four in the left column, two in the right once the
+// terminal reaches twoColumnMinWidth.
+func (m StatsModel) panelsForWidthTest() []widthTestPanel {
+	left, right := m.contentWidth(), m.rightColumnWidth()
+	return []widthTestPanel{
+		{"archetypes", m.renderArchetypeChart(), left, 1 + len(m.metrics.Archetypes), archetypeRowFloor},
+		{"work modes", m.renderLabelCountTable("Work Mode", m.metrics.WorkModes), left, 1 + len(m.metrics.WorkModes), 0},
+		{"locations", m.renderLabelCountTable("Location", m.metrics.Locations), left, 1 + len(m.metrics.Locations), 0},
+		{"pay", m.renderPay(), right, 0, 0},
+		{"fit quality pie", m.renderPieChart("Fit Quality Distribution", "Quality Breakdown",
+			m.metrics.ScoreTiers, []lipgloss.Color{m.theme.Green, m.theme.Sky, m.theme.Red}, true), right, 0, pieChartW},
+		{"seniority pie", m.renderPieChart("Seniority Mix", "Seniority Mix",
+			m.metrics.SeniorityMix, []lipgloss.Color{m.theme.Mauve, m.theme.Peach}, false), right, 0, pieChartW},
+	}
+}
+
+// Every line a stats panel renders must fit the column it is placed into.
+//
+// renderBody puts its panels inside lipgloss boxes roughly half the terminal
+// wide, but the panels used to size their label and bar columns off the
+// *terminal* width. The row then came out wider than the box holding it, so
+// lipgloss wrapped it — and the wrapped remainder starts at column 0, losing
+// the panel's indent and colliding with the neighbouring column.
+//
+// The row-count assertion is the load-bearing half. Wrapping makes lines
+// *narrower*, not wider, so a width-only check passes straight through the
+// defect it is meant to catch; only counting the rows proves nothing wrapped.
+//
+// The sweep covers both sides of the two-column threshold and both sides of
+// 158, where the old fixed budget starts fitting on its own. The single-column
+// layout is not exempt: at 60 columns the archetype row came to 61, so the whole
+// screen rendered one column wider than the terminal. It stops at 50 because
+// below that each panel hits a floor no bar budget can move — see
+// TestStatsArchetypeRowFloor.
+func TestStatsPanelsFitTheirColumn(t *testing.T) {
+	metrics := statsMetricsWideShape()
+
+	for _, width := range []int{50, 60, 70, 80, 100, 113, 114, 120, 140, 157, 158, 200} {
+		m := makeStatsModel(t, width, 40, metrics)
+
+		for _, panel := range m.panelsForWidthTest() {
+			if panel.avail < panel.floor {
+				continue // fixed content that no budget can shrink; see the floor tests
+			}
+			lines := strings.Split(panel.body, "\n")
+
+			for i, line := range lines {
+				if got := lipgloss.Width(line); got > panel.avail {
+					t.Errorf("terminal %d: %s line %d measured %d columns, but its column is only %d wide",
+						width, panel.name, i, got, panel.avail)
+				}
+			}
+
+			if panel.rows > 0 && len(lines) != panel.rows {
+				t.Errorf("terminal %d: %s rendered %d lines, want %d — a row wrapped and lost its indent",
+					width, panel.name, len(lines), panel.rows)
+			}
+
+			if panel.name == "archetypes" && !strings.Contains(panel.body, "█") {
+				t.Errorf("terminal %d: the bar column was squeezed to nothing", width)
+			}
+		}
+	}
+}
+
+// archetypeRowFloor is the narrowest terminal an archetype row can still fit:
+// the padding, label, count, score and the two gaps around the bar leave
+// exactly one column for a one-glyph bar. Below it the row is knowingly allowed
+// to overflow — the alternative is a chart with no bar at all, the same trade
+// pipeline.go's role floor makes.
+const archetypeRowFloor = panelPadW + 20 + archetypeCountW + 2*barGapW + archetypeScoreW + 1
+
+// Pin the floor so a change to any fixed cell cannot move it unnoticed: one
+// column narrower must overflow, and the floor itself must not.
+func TestStatsArchetypeRowFloor(t *testing.T) {
+	metrics := statsMetricsWideShape()
+
+	widest := func(width int) int {
+		m := makeStatsModel(t, width, 40, metrics)
+		w := 0
+		for _, line := range strings.Split(m.renderArchetypeChart(), "\n") {
+			w = max(w, lipgloss.Width(line))
+		}
+		return w
+	}
+
+	if got := widest(archetypeRowFloor); got != archetypeRowFloor {
+		t.Errorf("at the floor (%d) the widest row measured %d, want exactly %d",
+			archetypeRowFloor, got, archetypeRowFloor)
+	}
+	if got := widest(archetypeRowFloor - 1); got <= archetypeRowFloor-1 {
+		t.Errorf("one column below the floor the row measured %d, so the floor is not where the constants say it is",
+			got)
+	}
+}
+
+// A label wider than its cell must be cut to the cell's *display* width. Cutting
+// by rune count instead lets a CJK label — two columns per rune — pass the guard
+// untouched and overflow, which is the same wrap this file exists to prevent.
+func TestStatsLabelsTruncateByDisplayWidth(t *testing.T) {
+	const cjk = "新竹科學園區 竹科三期" // 11 runes, 21 columns
+
+	m := makeStatsModel(t, 200, 40, model.StatsMetrics{
+		WorkModes: []model.LabelCountStat{{Label: cjk, Count: 10, Pct: 100}},
+	})
+
+	if lipgloss.Width(cjk) <= labelCountW {
+		t.Fatalf("fixture no longer exceeds the %d-column cell; pick a wider label", labelCountW)
+	}
+
+	lines := strings.Split(m.renderLabelCountTable("Work Mode", m.metrics.WorkModes), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("rendered %d lines, want 2 (title + one row) — the label wrapped", len(lines))
+	}
+}
+
+// A single archetype takes 100% of the pipeline, and "100" is one column wider
+// than the count cell's nominal width. The cell has to grow to match, or it
+// wraps and splits the row.
+func TestStatsArchetypeCountCellFitsAFullShare(t *testing.T) {
+	m := makeStatsModel(t, 200, 40, model.StatsMetrics{
+		Archetypes: []model.ArchetypeStat{{Label: "AI Solutions & FDE", Count: 44, Pct: 100, AvgScore: 3.3}},
+	})
+
+	lines := strings.Split(m.renderArchetypeChart(), "\n")
+	if len(lines) != 2 {
+		t.Errorf("rendered %d lines, want 2 (title + one row) — the 100%% count cell wrapped", len(lines))
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes two rendering bugs on the dashboard's Stats and Progress screens. The stats
panels sized their columns off the terminal width while being rendered into a box
half that wide, so rows wrapped and lost their indent; and the word "evaluated"
labelled three different numbers, two of which appear on adjacent screens.

## Related issue

None — these are bug fixes, which CONTRIBUTING explicitly exempts from
issue-first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

> On `test-all.mjs`: 8673 passed, 1 failed — `update-system.mjs check crashed
> (exit null, signal SIGTERM)`. That check makes a network call to GitHub and was
> killed by the harness timeout; running `node update-system.mjs check` on its own
> exits 0. This PR touches only `dashboard/internal/**` (five Go files, no Node),
> so it cannot be the cause. Flagging it rather than quietly ticking the box.
>
> `go test ./...` in `dashboard/` is green: 220 passed across 6 packages.

---

## What I hit

I run career-ops on a job search in Taiwan — 179 rows in the tracker, mostly
Chinese-language postings — and I use the Go dashboard to look at it. Two things
were wrong every time I opened it.

**The archetype chart falls apart in a normal terminal.** At 120 columns the top
three bars wrap, the wrapped half starts at column 0 with the panel indent gone,
and it collides with the pie charts in the right-hand column:

```
  By Archetype
  AI & ML Engineering         44 (26%)
█████████████████████████    ★ 3.6/5          <- indent gone, under the panel
  Agentic & Automation        38 (22%)
█████████████████████    ★ 3.2/5
  AI Solutions & FDE          16 (9%)  █████████    ★
3.3/5                                                 <- score split in half
```

**Two screens one keypress apart disagree.** Progress says `179 evaluated`, Stats
says `171 evaluated`. Same tracker.

## Why

**The layout bug.** `renderBody` places the panels inside lipgloss boxes roughly
half the terminal wide, but `renderArchetypeChart`, `renderLabelCountTable` and
`renderPay` sized their label and bar cells off `m.width` — the terminal, not the
box. An archetype row comes to a fixed 77 columns; the box is 53–76. Every
terminal from 110 to 157 columns is affected, and 120 is the common case.
`renderInsights` already computed `m.width/2 - 6` for exactly this reason, so the
mechanism was known — it just never reached the bar charts.

At 60 columns the same arithmetic makes the row 61 wide, so the *whole screen*
renders one column wider than the terminal and every line wraps.

**Why it survived this long.** It cannot be seen by measuring `View()`. lipgloss
pads each line back out to the terminal width, so the assembled screen always
measures exactly right. The only way to catch it is to measure a panel *before*
it goes into its box — which is what the new test does.

**The number bug.** Progress renders `FunnelStages[0].Count`, which is
`len(apps)`; Stats counts rows carrying a score. Mine differ because 8 rows were
backfilled without an evaluation (#1799). `Evaluated` is a canonical status value
as well, so the word stood for three different things. The Progress header also
contradicted itself — it pairs that count with `AvgScore`, which divides by the
scored rows only.

`computeFunnel()` in `stats.mjs`, described in its own docstring as the canonical
funnel definition, has no evaluated stage at all, and warns:

> Keys are deliberately NOT bare status names ... the same word for two different
> numbers would read as a bug.

## What I changed

**Renamed, did not renumber.** The top funnel stage becomes `Tracked` and
`ProgressSummary` reads `%d tracked`. **No counting logic changes**, so the Go
funnel stays in step with `stats.mjs`. Stats keeps `evaluated` for the number
that really is the evaluated count.

**Budget the cells against the panel column.** `contentWidth()` /
`rightColumnWidth()` give a panel its real width, and `barWidth()` clamps the bar
to what is left after the fixed cells, floored at one glyph.

Three related fixes fell out of writing the test:

- The pie chart's 17-column disc, gap and legend come to **55 columns that
  nothing can shrink**, so the two-column layout never fit at its old 110
  threshold — the pie wrapped into the panel below. Raised to 114.
- Label truncation guarded on **display width** but cut by **rune count**, so a
  CJK label at two columns per rune passed the guard untouched and overflowed.
  Replaced both hand-rolled copies with `ansi.Truncate` from the `x/ansi` package
  this package already imports in `viewer.go` — that removes ~20 lines.
- The archetype count cell is one column wider than its reserved width once a
  share rounds to 100% (a single archetype, or a first-run tracker). Cells are
  measured now, and the fixed widths are named so the bar budget and the
  `lipgloss.Width` call that renders the cell cannot drift apart.

## Tests

`stats_width_test.go` follows the invariant `pipeline_width_test.go` already
establishes for the pipeline screen — a rendered row must fit the width it was
given — and extends it to all six stats panels across 12 terminal widths.

It asserts **row counts as well as widths**. That is the load-bearing half:
wrapping makes lines *narrower*, so a width-only check passes straight through
the defect. Panels whose fixed content has a hard floor (the pie at 55 columns,
the archetype row at 47) are skipped below it rather than silently excluded.

Both tests fail against `main` and pass here.

## Compatibility

Checked by rendering both revisions against the same 179-row tracker and diffing
the output:

| terminal | vs `main` |
|---|---|
| 70–109 | **byte-identical** |
| 200 | **byte-identical** (the old arithmetic already fit) |
| 60 | fixed — the screen was 1 column wider than the terminal |
| 110 | now single-column; the two-column layout could not fit the pie here |
| 120–158 | fixed |

## One thing to check

The Turkish and Spanish `ProgressSummary` strings are mine and I am not a native
speaker of either. Turkish reuses `takip`, the root already in that screen's own
title (`TAKİP İLERLEMESİ`); Spanish uses `en seguimiento`. Happy to take any
correction.

## Not in this PR

- The funnel stage labels in `data/career.go` are hardcoded English and never go
  through `i18n`, so the Progress funnel stays English under `--lang tr`. Separate
  issue; I did not want to mix it in here.
- `renderInsights` reserves 6 columns in the single-column branch and 4 in the
  two-column one. One of them is wrong by 2, but fixing it changes rendering
  beyond this bug.
- `screens/stats.go:316` and `internal/data/stats.go` are not `gofmt`-clean on
  `main`. I left them alone to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-visible changes

- Stats panels now size labels, counts, and bars to their assigned panel columns. Narrow terminals no longer wrap rows or lose indentation.
- Pie-chart thresholds, CJK label truncation, and archetype count-cell sizing now use the available display width.
- The Progress funnel now labels its top stage `Tracked`. Its summary separates tracked applications from the scored applications counted in Stats.
- Added width and row-count coverage for six stats panels across 12 terminal widths.

## Files changed

- `dashboard/internal/data/career.go: ComputeProgressMetrics`: Renames the top funnel stage to `Tracked`.
- `dashboard/internal/data/progress_metrics_test.go`: Verifies tracked-row counting and scored-row averages.
- `dashboard/internal/i18n/catalog.go`: Updates English, Turkish, and Spanish progress summaries.
- `dashboard/internal/ui/screens/stats.go`: Adds panel-width helpers and display-width-safe row sizing.
- `dashboard/internal/ui/screens/stats_width_test.go`: Adds terminal-width and row-layout tests.

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->