### PR TITLE
fix(providers): refuse redirects by default in _http.mjs

### DIFF
--- a/providers/ADDING_A_PROVIDER.md
+++ b/providers/ADDING_A_PROVIDER.md
@@ -114,10 +114,11 @@ file's header comment must name the target list (reference:
 
 ### SSRF hardening
 
-- Always pass `redirect: 'error'` to `fetchJson` / `fetchText`. `_http.mjs`
-  defaults to `redirect: 'follow'` by design — that is not a safe default
-  for a provider, since a server-side redirect could point the request at an
-  internal address.
+- `fetchJson` / `fetchText` / `fetchResponse` refuse redirects by default
+  (`redirect: 'error'`): a server-side redirect could point the request at an
+  internal address after the IP guard already passed the original host. Never
+  pass `redirect: 'follow'` in a provider; if a portal genuinely moved, fix
+  the URL instead.
 - If the final URL is built from `portals.yml` data (`entry.api`,
   `entry.careers_url`), check the hostname against an allowlist **before**
   any network call. Reference: `assertGreenhouseUrl` in

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -27,7 +27,11 @@ async function fetchWithTimeout(url, opts = {}, consume) {
   return providerFetchContext.run({ url: String(url) }, () => fetchInContext(url, opts, consume));
 }
 
-async function fetchInContext(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'follow' } = {}, consume) {
+// redirect defaults to 'error': a provider fetch must never follow a 3xx, or a
+// server-side redirect could point the request at a private address after the
+// ip guard already passed the original host (#4079). Callers that really need
+// to follow redirects opt in explicitly.
+async function fetchInContext(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'error' } = {}, consume) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -118,8 +122,8 @@ export async function fetchText(url, opts = {}) {
 // Returns a Response (after the timeout + non-2xx guard) so providers that need
 // response headers — csod.mjs reads Set-Cookie to prime the session its search
 // API requires — can route through ctx instead of re-implementing fetch. Pass
-// redirect:'error' like every other provider call so a 3xx can't be followed to
-// a private IP.
+// redirect:'error' is the default here like everywhere else, so a 3xx can't be
+// followed to a private IP.
 //
 // The body is read here, inside the timer window, and handed back as an
 // equivalent Response. Two reasons: returning the live Response would let a

--- a/providers/hecklerkoch.mjs
+++ b/providers/hecklerkoch.mjs
@@ -40,9 +40,10 @@ export function resolveListUrl(entry) {
   if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
   const host = u.host.toLowerCase();
   if (host !== 'heckler-koch.com' && !host.endsWith('.heckler-koch.com')) return null;
-  // The apex 301s to www (same registrable domain, https both ends). Pin it
-  // here so the transport's redirect:'error' never refuses a host detect() accepts.
+  // The apex 301s to www and http 301s to https (same registrable domain). Pin
+  // both here so the transport's redirect:'error' never refuses a URL detect() accepts.
   if (host === 'heckler-koch.com') u.host = 'www.heckler-koch.com';
+  u.protocol = 'https:';
   // A Stellenangebote path passes through; anything else on the host defaults.
   if (/Stellenangebote/i.test(u.pathname)) return `${u.origin}${u.pathname}`;
   return `${u.origin}/de/Karriere/Stellenangebote`;

--- a/providers/hecklerkoch.mjs
+++ b/providers/hecklerkoch.mjs
@@ -40,6 +40,9 @@ export function resolveListUrl(entry) {
   if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
   const host = u.host.toLowerCase();
   if (host !== 'heckler-koch.com' && !host.endsWith('.heckler-koch.com')) return null;
+  // The apex 301s to www (same registrable domain, https both ends). Pin it
+  // here so the transport's redirect:'error' never refuses a host detect() accepts.
+  if (host === 'heckler-koch.com') u.host = 'www.heckler-koch.com';
   // A Stellenangebote path passes through; anything else on the host defaults.
   if (/Stellenangebote/i.test(u.pathname)) return `${u.origin}${u.pathname}`;
   return `${u.origin}/de/Karriere/Stellenangebote`;

--- a/providers/rheinmetall.mjs
+++ b/providers/rheinmetall.mjs
@@ -39,11 +39,13 @@ export function resolveListUrl(entry) {
   const raw = entry.api || entry.careers_url || '';
   try {
     const u = new URL(raw);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
     const host = u.host.toLowerCase();
     if (host !== 'rheinmetall.com' && !host.endsWith('.rheinmetall.com')) return null;
-    // The apex 301s to www (same registrable domain, https both ends). Pin it
-    // here so the transport's redirect:'error' never refuses a host detect() accepts.
+    // The apex 301s to www and http 301s to https (same registrable domain). Pin
+    // both here so the transport's redirect:'error' never refuses a URL detect() accepts.
     if (host === 'rheinmetall.com') u.host = 'www.rheinmetall.com';
+    u.protocol = 'https:';
     if (/\/career\/vacancies\/?$/.test(u.pathname)) return `${u.origin}${u.pathname.replace(/\/$/, '')}`;
     // Any other rheinmetall.com URL (e.g. the branded career hub) → EN default.
     return `${u.origin}/en/career/vacancies`;

--- a/providers/rheinmetall.mjs
+++ b/providers/rheinmetall.mjs
@@ -41,6 +41,9 @@ export function resolveListUrl(entry) {
     const u = new URL(raw);
     const host = u.host.toLowerCase();
     if (host !== 'rheinmetall.com' && !host.endsWith('.rheinmetall.com')) return null;
+    // The apex 301s to www (same registrable domain, https both ends). Pin it
+    // here so the transport's redirect:'error' never refuses a host detect() accepts.
+    if (host === 'rheinmetall.com') u.host = 'www.rheinmetall.com';
     if (/\/career\/vacancies\/?$/.test(u.pathname)) return `${u.origin}${u.pathname.replace(/\/$/, '')}`;
     // Any other rheinmetall.com URL (e.g. the branded career hub) → EN default.
     return `${u.origin}/en/career/vacancies`;

--- a/tests/providers/_http.test.mjs
+++ b/tests/providers/_http.test.mjs
@@ -207,3 +207,32 @@ if (isRefusedRedirectError(transportFailure) === false) {
     globalThis.fetch = realFetch;
   }
 }
+
+// The default redirect policy is the SSRF guard's second half (#4079): the
+// ip guard checks the host that was asked for, and only redirect:'error'
+// stops a 3xx from pointing the follow-up request somewhere else. It has to
+// be the default, not something every provider remembers to pass.
+{
+  const { fetchText, fetchJson } = await import(pathToFileURL(join(ROOT, 'providers/_http.mjs')).href);
+  const realFetch = globalThis.fetch;
+  const seen = [];
+  globalThis.fetch = async (url, init) => {
+    seen.push({ url: String(url), redirect: init?.redirect });
+    return new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  try {
+    await fetchText('https://example.test/list');
+    await fetchJson('https://example.test/api');
+    await fetchText('https://example.test/legacy', { redirect: 'follow' });
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  if (seen.length === 3 && seen[0].redirect === 'error' && seen[1].redirect === 'error') {
+    pass("fetchText/fetchJson default to redirect:'error'");
+  } else {
+    fail(`fetchText/fetchJson should default to redirect:'error' — got ${JSON.stringify(seen)}`);
+  }
+  if (seen[2]?.redirect === 'follow') pass("an explicit redirect option still passes through");
+  else fail(`explicit redirect:'follow' should pass through — got ${JSON.stringify(seen[2])}`);
+}
+

--- a/tests/providers/ats-ssrf-hardening.test.mjs
+++ b/tests/providers/ats-ssrf-hardening.test.mjs
@@ -1,7 +1,8 @@
 // tests/providers/ats-ssrf-hardening.test.mjs — moved verbatim from test-all.mjs (#1440).
-// _http.mjs defaults to redirect:'follow', so a server-side redirect from any
-// of these ATS APIs to an internal address is an SSRF vector. Every other GET
-// provider passes redirect:'error'; these two were missing it.
+// _http.mjs used to default to redirect:'follow' (it now defaults to
+// redirect:'error', see providers/_http.mjs), so a server-side redirect from
+// any of these ATS APIs to an internal address was an SSRF vector. Every other
+// GET provider passes redirect:'error' explicitly; these two were missing it.
 // (workday's redirect:'error' coverage lives in its own "Provider — workday"
 // section, checked across every paginated request, not just the first.)
 import { pass, fail, ROOT } from '../helpers.mjs';

--- a/tests/providers/hecklerkoch.test.mjs
+++ b/tests/providers/hecklerkoch.test.mjs
@@ -15,6 +15,8 @@ try {
   // The apex 301s to www; with redirect:'error' as the transport default it has to be pinned, not followed.
   if (hkListUrl({ api: 'https://heckler-koch.com/de/Karriere/Stellenangebote' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() pins the apex host to www');
   else fail(`hecklerkoch.resolveListUrl() should pin the apex to www: ${hkListUrl({ api: 'https://heckler-koch.com/de/Karriere/Stellenangebote' })}`);
+  if (hkListUrl({ api: 'http://heckler-koch.com/de/Karriere/Stellenangebote' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() upgrades http to https');
+  else fail(`hecklerkoch.resolveListUrl() should upgrade http to https: ${hkListUrl({ api: 'http://heckler-koch.com/de/Karriere/Stellenangebote' })}`);
   if (hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() defaults to the Stellenangebote list');
   else fail(`hecklerkoch.resolveListUrl() default wrong: ${hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' })}`);
   if (hk.detect({ careers_url: 'https://evil.com/x.heckler-koch.com' }) === null && hk.detect({ careers_url: 'https://heckler-koch.com.evil.com/x' }) === null) {

--- a/tests/providers/hecklerkoch.test.mjs
+++ b/tests/providers/hecklerkoch.test.mjs
@@ -17,6 +17,8 @@ try {
   else fail(`hecklerkoch.resolveListUrl() should pin the apex to www: ${hkListUrl({ api: 'https://heckler-koch.com/de/Karriere/Stellenangebote' })}`);
   if (hkListUrl({ api: 'http://heckler-koch.com/de/Karriere/Stellenangebote' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() upgrades http to https');
   else fail(`hecklerkoch.resolveListUrl() should upgrade http to https: ${hkListUrl({ api: 'http://heckler-koch.com/de/Karriere/Stellenangebote' })}`);
+  if (hkListUrl({ api: 'ftp://www.heckler-koch.com/de/Karriere/Stellenangebote' }) === null) pass('hecklerkoch.resolveListUrl() rejects non-http schemes');
+  else fail('hecklerkoch.resolveListUrl() should reject non-http schemes');
   if (hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() defaults to the Stellenangebote list');
   else fail(`hecklerkoch.resolveListUrl() default wrong: ${hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' })}`);
   if (hk.detect({ careers_url: 'https://evil.com/x.heckler-koch.com' }) === null && hk.detect({ careers_url: 'https://heckler-koch.com.evil.com/x' }) === null) {

--- a/tests/providers/hecklerkoch.test.mjs
+++ b/tests/providers/hecklerkoch.test.mjs
@@ -12,6 +12,9 @@ try {
   if (hk.id === 'hecklerkoch') pass('hecklerkoch.id is "hecklerkoch"');
   else fail(`hecklerkoch.id is ${JSON.stringify(hk.id)}`);
 
+  // The apex 301s to www; with redirect:'error' as the transport default it has to be pinned, not followed.
+  if (hkListUrl({ api: 'https://heckler-koch.com/de/Karriere/Stellenangebote' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() pins the apex host to www');
+  else fail(`hecklerkoch.resolveListUrl() should pin the apex to www: ${hkListUrl({ api: 'https://heckler-koch.com/de/Karriere/Stellenangebote' })}`);
   if (hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() defaults to the Stellenangebote list');
   else fail(`hecklerkoch.resolveListUrl() default wrong: ${hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' })}`);
   if (hk.detect({ careers_url: 'https://evil.com/x.heckler-koch.com' }) === null && hk.detect({ careers_url: 'https://heckler-koch.com.evil.com/x' }) === null) {

--- a/tests/providers/rheinmetall.test.mjs
+++ b/tests/providers/rheinmetall.test.mjs
@@ -18,6 +18,9 @@ try {
   else fail('rheinmetall.resolveListUrl() should keep /de/career/vacancies');
   if (resolveListUrl({ careers_url: 'https://www.rheinmetall.com/en/career' }) === 'https://www.rheinmetall.com/en/career/vacancies') pass('rheinmetall.resolveListUrl() defaults non-list URLs to /en/career/vacancies');
   else fail('rheinmetall.resolveListUrl() should default to the EN list');
+  // The apex 301s to www; with redirect:'error' as the transport default it has to be pinned, not followed.
+  if (resolveListUrl({ api: 'https://rheinmetall.com/en/career/vacancies' }) === 'https://www.rheinmetall.com/en/career/vacancies') pass('rheinmetall.resolveListUrl() pins the apex host to www');
+  else fail(`rheinmetall.resolveListUrl() should pin the apex to www: ${resolveListUrl({ api: 'https://rheinmetall.com/en/career/vacancies' })}`);
   if (resolveListUrl({ careers_url: 'https://evil.com/x.rheinmetall.com' }) === null) pass('rheinmetall.resolveListUrl() rejects path-spoofed host');
   else fail('rheinmetall.resolveListUrl() should reject path-spoofed host');
   if (rheinmetall.detect({ careers_url: 'https://rheinmetall.com.evil.com/en/career/vacancies' }) === null) pass('rheinmetall.detect() rejects suffix-spoofed host');

--- a/tests/providers/rheinmetall.test.mjs
+++ b/tests/providers/rheinmetall.test.mjs
@@ -21,6 +21,10 @@ try {
   // The apex 301s to www; with redirect:'error' as the transport default it has to be pinned, not followed.
   if (resolveListUrl({ api: 'https://rheinmetall.com/en/career/vacancies' }) === 'https://www.rheinmetall.com/en/career/vacancies') pass('rheinmetall.resolveListUrl() pins the apex host to www');
   else fail(`rheinmetall.resolveListUrl() should pin the apex to www: ${resolveListUrl({ api: 'https://rheinmetall.com/en/career/vacancies' })}`);
+  if (resolveListUrl({ api: 'http://rheinmetall.com/en/career/vacancies' }) === 'https://www.rheinmetall.com/en/career/vacancies') pass('rheinmetall.resolveListUrl() upgrades http to https');
+  else fail(`rheinmetall.resolveListUrl() should upgrade http to https: ${resolveListUrl({ api: 'http://rheinmetall.com/en/career/vacancies' })}`);
+  if (resolveListUrl({ api: 'ftp://www.rheinmetall.com/en/career/vacancies' }) === null) pass('rheinmetall.resolveListUrl() rejects non-http schemes');
+  else fail('rheinmetall.resolveListUrl() should reject non-http schemes');
   if (resolveListUrl({ careers_url: 'https://evil.com/x.rheinmetall.com' }) === null) pass('rheinmetall.resolveListUrl() rejects path-spoofed host');
   else fail('rheinmetall.resolveListUrl() should reject path-spoofed host');
   if (rheinmetall.detect({ careers_url: 'https://rheinmetall.com.evil.com/en/career/vacancies' }) === null) pass('rheinmetall.detect() rejects suffix-spoofed host');

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -34,6 +34,14 @@ import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 
 import { fetchJson as defaultFetchJson, fetchTextHead as defaultFetchText, makeHttpCtx } from './providers/_http.mjs';
+
+// The portal probes are the one place that keeps following redirects: they hit
+// the ATS vendors' own hosts (a moved board answers with a 3xx that is the
+// signal), and `_http.mjs` now refuses redirects by default for provider
+// fetches (#4079). Opting in here keeps the probe results as they were.
+const followRedirects = (fetchFn) => (url, opts = {}) => fetchFn(url, { redirect: 'follow', ...opts });
+const probeFetchJson = followRedirects(defaultFetchJson);
+const probeFetchText = followRedirects(defaultFetchText);
 import { decodeEntities } from './providers/_html-entities.mjs';
 import { asciiFold } from './lib/ascii-fold.mjs';
 import { loadProviders, resolveProvider } from './providers/_registry.mjs';
@@ -232,7 +240,7 @@ export function classifyFetchError(err) {
 export async function probeSlug(
   ats,
   slug,
-  { fetchJson = defaultFetchJson, eu = false } = {},
+  { fetchJson = probeFetchJson, eu = false } = {},
 ) {
   const spec = ATS[ats];
   if (!spec)
@@ -550,7 +558,7 @@ export async function probeProvider(entry, provider, baseCtx) {
  */
 export async function verifyCompanies(
   companies,
-  { fetchJson = defaultFetchJson, fetchText = defaultFetchText, providers = null, httpCtx = null } = {},
+  { fetchJson = probeFetchJson, fetchText = probeFetchText, providers = null, httpCtx = null } = {},
 ) {
   const list = Array.isArray(companies) ? companies : [];
   const results = [];
@@ -609,7 +617,7 @@ export async function verifyCompanies(
  */
 export async function verifyPortalsFile(
   filePath,
-  { fetchJson = defaultFetchJson, providers = null, httpCtx = null } = {},
+  { fetchJson = probeFetchJson, providers = null, httpCtx = null } = {},
 ) {
   if (!existsSync(filePath)) return { found: false, results: [] };
   const config = yaml.load(readFileSync(filePath, 'utf-8'));
@@ -707,7 +715,7 @@ async function runAdd(name, { fetchJson }) {
 async function main() {
   const args = process.argv.slice(2);
   const strict = args.includes('--strict');
-  const fetchJson = defaultFetchJson;
+  const fetchJson = probeFetchJson;
 
   const addFlag = args.indexOf('--add');
   if (addFlag !== -1) {


### PR DESCRIPTION
Fixes #4079.

`fetchInContext` defaulted `redirect` to `'follow'`, so the SSRF guard's second half was opt-in: `_ip-guard.mjs` checks the host that was asked for, and only `redirect: 'error'` stops a 3xx from pointing the follow-up request somewhere else. As the issue lists, `deutschebahn`, `hecklerkoch`, `rheinmetall` and `softgarden` never passed it.

**Change**

- `providers/_http.mjs`: the default is `redirect: 'error'` for `fetchJson` / `fetchText` / `fetchResponse`. An explicit `redirect` option (`'manual'` for jobvite, or `'follow'`) still passes through unchanged, so the 74 providers that already pass it are unaffected and the four that did not are covered by the default.
- `verify-portals.mjs`: the portal probes keep following redirects by opting in at their two injectable fetch defaults (`probeFetchJson` / `probeFetchText`), so probe results do not change. That is the only caller outside `providers/` that imported the helpers directly.
- `providers/ADDING_A_PROVIDER.md`: the SSRF section now describes the default instead of asking authors to remember the option.
- `tests/providers/_http.test.mjs`: with `globalThis.fetch` stubbed, `fetchText`/`fetchJson` send `redirect: 'error'` by default and an explicit option passes through.

`node tests/providers/_http.test.mjs` passes; `node scripts/check-syntax.mjs` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `providers/_http.mjs:34`: Provider HTTP calls now use `redirect: 'error'` by default. A 3xx response fails instead of following a redirect.
- `providers/ADDING_A_PROVIDER.md:117`: Provider guidance documents the new default and recommends fixing moved URLs.
- `verify-portals.mjs:38-44`: Portal probes explicitly follow redirects, so portal verification behavior remains unchanged.
- `tests/providers/_http.test.mjs:211-235`: Tests verify the safe default and explicit redirect handling.
- `tests/providers/ats-ssrf-hardening.test.mjs`: The header comment now matches the new default.
- `providers/hecklerkoch.mjs` and `providers/rheinmetall.mjs`: Apex hosts are rewritten to their `www` hosts.
- `tests/providers/hecklerkoch.test.mjs` and `tests/providers/rheinmetall.test.mjs`: Tests verify the host rewrites and reject unsupported URL schemes.

From the user's point of view: Provider requests no longer follow redirects by default. If a provider requires a redirect, it must use the final URL or explicitly set `redirect: 'follow'`. Portal verification continues to follow redirects. The `hecklerkoch` and `rheinmetall` providers now use their `www` hosts.

Touched system files: `providers/`, `verify-portals.mjs`, and `tests/providers/`. No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->