### PR TITLE
feat: UK job boards (HAR-replay pipeline) + NAS-mount suite hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Personal data (user fills these)
 cv.md
+PROFILE.md
 article-digest.md
 local/
 # Everything under data/ is generated or personal at runtime — only .gitkeep

--- a/lib/mjs-files.mjs
+++ b/lib/mjs-files.mjs
@@ -158,6 +158,12 @@ export function collectMjsFiles(root) {
     }
     for (const entry of entries) {
       if (SKIP_DIRS.has(entry.name)) continue;
+      // AppleDouble (`._foo`) files are macOS resource-fork sidecars a
+      // SMB/AFP mount (a NAS, a network share) writes next to every file —
+      // not source, not repo content, and they regenerate on deletion.
+      // `._foo.mjs` ends in `.mjs` and fails the syntax gate with a
+      // SyntaxError nobody can fix without leaving the mount.
+      if (entry.name.startsWith('._')) continue;
       // Symlinked directories can point outside the checkout or back into it;
       // neither should make the walk recurse unpredictably.
       if (entry.isSymbolicLink()) continue;

--- a/providers/adzuna.mjs
+++ b/providers/adzuna.mjs
@@ -1,0 +1,133 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Adzuna provider — UK / EU job aggregator with free API tier
+// https://developer.adzuna.com/overview
+// API key: ADZUNA_APP_ID + ADZUNA_APP_KEY env vars (sign up at adzuna.co.uk)
+// Free tier: 50 requests/day, no auth required but rate-limited.
+//
+// Response shape (from /api/uk/jobs?query=...&results_per_page=N&page=P):
+// {
+//   results: [ { title, description, category, location, salary_min, salary_max,
+//                created: ISO date, company.display_name, redirect_url, ... } ],
+//   count, mean, page, last_page
+// }
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const BASE_URL = 'https://uk.api.adzuna.com/api/jobs/1/search/';
+const DEFAULT_RESULTS_PER_PAGE = 20;
+const MAX_PAGES = 10; // ~200 jobs per search
+
+function getEnvVar(name) {
+  return process.env[name] || '';
+}
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Normalize a single Adzuna job to career-ops Job shape.
+ * @param {any} j
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
+ */
+export function normalizeAdzunaJob(j) {
+  if (!j || typeof j !== 'object') return null;
+
+  const title = clean(j.title || '');
+  if (!title) return null;
+
+  // URL: use redirect_url if available (points to employer ATS), else the Adzuna listing
+  let url = '';
+  if (typeof j.redirect_url === 'string' && j.redirect_url.trim()) {
+    try {
+      const parsed = new URL(j.redirect_url.trim());
+      if (parsed.protocol === 'https:') url = parsed.href;
+    } catch {}
+  }
+  if (!url && typeof j.location === 'object') {
+    url = `https://www.adzuna.co.uk/jobs/details/${j.id}`;
+  }
+  if (!url) return null;
+
+  const company = clean(j.company?.display_name || j.company || 'Adzuna');
+  const location = typeof j.location === 'object'
+    ? clean(j.location.display_name)
+    : clean(j.location);
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
+  const job = { title, url, company, location };
+
+  if (j.created) {
+    const ts = new Date(j.created).getTime();
+    if (Number.isFinite(ts)) job.postedAt = ts;
+  }
+
+  return job;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'adzuna',
+
+  detect(entry) {
+    // Adzuna is a job board, not a company ATS — always requires explicit provider:
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    /** @type {string[]} */
+    const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+    if (keywords.length === 0) {
+      console.warn('adzuna: no keywords provided, skipping');
+      return [];
+    }
+
+    const app_id = getEnvVar('ADZUNA_APP_ID');
+    const app_key = getEnvVar('ADZUNA_APP_KEY');
+    const perPage = Math.min(Number(entry.results_per_page) || DEFAULT_RESULTS_PER_PAGE, 50);
+    const maxPages = Math.min(Number(entry.max_pages) || MAX_PAGES, 20);
+
+    const out = [];
+
+    for (const kw of keywords) {
+      const searchQuery = encodeURIComponent(kw);
+      for (let page = 1; page <= maxPages; page++) {
+        const params = new URLSearchParams({
+          app_id: app_id || 'test',
+          app_key: app_key || 'test',
+          results_per_page: String(perPage),
+          page: String(page),
+          what: searchQuery,
+          where: entry.where || 'london',
+          contract_time: 'full_time',
+          sort_by: 'date',
+        });
+
+        const url = `${BASE_URL}?${params.toString()}`;
+
+        try {
+          const json = await ctx.fetchJson(url, { redirect: 'error' });
+          if (!json || !Array.isArray(json.results)) {
+            console.warn(`adzuna: unexpected response for "${kw}" page ${page}`);
+            break;
+          }
+          for (const job of json.results) {
+            const normalized = normalizeAdzunaJob(job);
+            if (normalized) out.push(normalized);
+          }
+          if (json.results.length < perPage) break; // last page
+        } catch (err) {
+          console.warn(`adzuna: failed for "${kw}" page ${page}: ${err.message}`);
+          break;
+        }
+      }
+    }
+
+    return out;
+  },
+};

--- a/providers/civilservicejobs.mjs
+++ b/providers/civilservicejobs.mjs
@@ -1,0 +1,100 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Civil Service Jobs provider — UK government jobs portal
+// URL: https://www.civilservicejobs.service.gov.uk/csr/index.cgi
+//
+// Uses Playwright one-shot to capture search results as HAR, then replays.
+// The search form is POST-based and requires a session cookie, so direct
+// HTTP fetch will not work without a browser session.
+//
+// Workflow:
+//   1. Capture HAR via scripts/har-capture.mjs (Playwright)
+//   2. Store HAR in data/har/civilservicejobs.har
+//   3. This provider replays it for subsequent scans
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import { getCareerOpsRoot } from '../path-resolver.mjs';
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse Civil Service Jobs listing HTML.
+ * @param {string} html
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseCivilServicePage(html) {
+  const jobs = [];
+  const seen = new Set();
+
+  // Civil Service Jobs uses table rows for listings
+  // Each job has a title link and details in adjacent cells
+  const rowPattern = /<tr[^>]*>(.*?)<\/tr>/gis;
+  let match;
+
+  while ((match = rowPattern.exec(html)) !== null) {
+    const rowHtml = match[1];
+    const titleLinkMatch = rowHtml.match(/<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/i);
+    if (!titleLinkMatch) continue;
+
+    let url = titleLinkMatch[1];
+    const title = clean(titleLinkMatch[2]);
+    if (!title || seen.has(title)) continue;
+
+    // Make URL absolute
+    if (url.startsWith('/')) {
+      url = 'https://www.civilservicejobs.service.gov.uk' + url;
+    }
+
+    // Extract location and other details
+    const locationMatch = rowHtml.match(/<td[^>]*class="[^"]*location[^"]*"[^>]*>([^<]+)<\/td>/i);
+    const location = locationMatch ? clean(locationMatch[1]) : '';
+
+    seen.add(title);
+    jobs.push({
+      title,
+      url,
+      company: 'UK Civil Service',
+      location,
+    });
+  }
+
+  return jobs.slice(0, 30);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'civilservicejobs',
+
+  detect(entry) {
+    return entry.careers_url?.includes('civilservicejobs.service.gov.uk') ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    const harFile = entry.har_file || 'civilservicejobs.har';
+    const harPath = path.join(getCareerOpsRoot(), 'data/har', harFile);
+
+    if (existsSync(harPath)) {
+      const har = JSON.parse(readFileSync(harPath, 'utf8'));
+      const entries = har.log?.entries || [];
+
+      // Find the search results response
+      for (const e of entries) {
+        const url = e.request?.url || '';
+        if (url.includes('civilservicejobs') && e.response?.content?.text) {
+          const html = e.response.content.text;
+          return parseCivilServicePage(html, entry);
+        }
+      }
+    }
+
+    // Fallback: warn that manual capture is needed
+    console.warn('civilservicejobs: no HAR file found. Capture one via scripts/har-capture.mjs');
+    return [];
+  },
+};

--- a/providers/cloudscraper-replay.mjs
+++ b/providers/cloudscraper-replay.mjs
@@ -1,0 +1,153 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Cloudscraper-replay provider — for boards behind Cloudflare/bot-protection
+// that require a real browser session to capture a HAR or cookies.
+//
+// Workflow:
+// 1. User captures a HAR (HTTP Archive) via Playwright once:
+//    - Opens the board search page
+//    - Exports HAR as JSON
+// 2. User stores the HAR in data/har/<board-name>.har
+// 3. This provider replays the HAR using Node's http.request (no browser needed)
+//    for subsequent scans, extracting jobs from the replayed response.
+//
+// To add a new board:
+//   - Create a HAR file in data/har/<board-name>.har
+//   - Add entry in portals.yml with provider: cloudscraper-replay
+//   - Configure har_file and parse_fn (optional, uses default HTML parser)
+//
+// If no HAR exists, falls back to plain HTTP (may be blocked).
+
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { getCareerOpsRoot } from '../path-resolver.mjs';
+import { decodeEntities } from './_html-entities.mjs';
+
+/** @type {string} */
+const DATA_HAR_DIR = 'data/har';
+
+/**
+ * Parse a HAR file and extract the first matching response body.
+ * @param {string} harPath
+ * @param {string} [targetUrl]
+ * @returns {{ headers: object, body: string } | null}
+ */
+function loadHarResponse(harPath, targetUrl) {
+  if (!existsSync(harPath)) return null;
+
+  let har;
+  try {
+    har = JSON.parse(readFileSync(harPath, 'utf8'));
+  } catch {
+    return null;
+  }
+
+  const entries = har.log?.entries || [];
+  for (const entry of entries) {
+    const requestUrl = entry.request?.url || '';
+    const responseUrl = entry.response?.redirectURL || requestUrl;
+
+    // Match if target URL specified and matches, or if this is the search page
+    if (targetUrl && !responseUrl.includes(targetUrl)) continue;
+
+    const response = entry.response;
+    if (!response) continue;
+
+    let body = '';
+    const content = response.content;
+    if (content?.text) {
+      body = content.text;
+    } else if (content?.encoding && content?.data) {
+      // Base64 encoded body
+      body = Buffer.from(content.data, 'base64').toString('utf8');
+    }
+
+    if (body) {
+      return {
+        headers: response.headers?.reduce((acc, h) => {
+          acc[h.name] = h.value;
+          return acc;
+        }, {}) || {},
+        body,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse HTML response for job postings.
+ * Default parser for boards without custom HTML structure.
+ * @param {string} html
+ * @param {object} entry
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseHtmlJobs(html, entry) {
+  const jobs = [];
+  const companyName = entry.name || 'Unknown';
+
+  // Simple regex-based extraction (improve per board)
+  const titlePattern = /<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/gi;
+  let match;
+  const seen = new Set();
+
+  while ((match = titlePattern.exec(html)) !== null) {
+    const url = match[1];
+    const title = decodeEntities(match[2]).trim();
+
+    if (title && !seen.has(title) && url.length > 10) {
+      seen.add(title);
+      jobs.push({ title, url, company: companyName, location: '' });
+    }
+  }
+
+  return jobs.slice(0, 50); // cap to avoid flooding
+}
+
+/** @type {Provider} */
+export default {
+  id: 'cloudscraper-replay',
+
+  detect(entry) {
+    // Always explicit — this is a special-purpose replay provider
+    return entry.provider === 'cloudscraper-replay' ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    const harFile = entry.har_file || entry.name?.toLowerCase().replace(/\s+/g, '-') + '.har';
+    const harPath = path.join(getCareerOpsRoot(), DATA_HAR_DIR, harFile);
+
+    // Load HAR replay
+    const harData = loadHarResponse(harPath, entry.target_url);
+    if (!harData) {
+      // Fallback: try direct HTTP (will likely fail against Cloudflare)
+      console.warn(`cloudscraper-replay: no HAR found for ${harFile}, attempting direct fetch`);
+      try {
+        const html = await ctx.fetchText(entry.careers_url, { redirect: 'error' });
+        return parseHtmlJobs(html, entry);
+      } catch (err) {
+        console.warn(`cloudscraper-replay: direct fetch also failed: ${err.message}`);
+        return [];
+      }
+    }
+
+    // Use HAR response body as if it were a fresh fetch
+    const html = harData.body;
+    if (!html) return [];
+
+    // Custom parser if specified
+    if (entry.parse_fn) {
+      try {
+        // Dynamic require of custom parser function (for board-specific parsing)
+        const parseModule = await import(path.join(getCareerOpsRoot(), entry.parse_fn));
+        if (parseModule.default && typeof parseModule.default === 'function') {
+          return parseModule.default(html, entry);
+        }
+      } catch {}
+    }
+
+    return parseHtmlJobs(html, entry);
+  },
+};

--- a/providers/findajob.mjs
+++ b/providers/findajob.mjs
@@ -1,0 +1,88 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Find a Job UK (DWP) provider — UK government job board
+// URL: https://findajob.dwp.gov.uk/
+//
+// Uses Playwright one-shot to capture search results as HAR, then replays.
+// The search is POST-based with CSRF tokens, requiring a browser session.
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import { getCareerOpsRoot } from '../path-resolver.mjs';
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse Find a Job search results page.
+ * @param {string} html
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseFindAJobPage(html) {
+  const jobs = [];
+  const seen = new Set();
+
+  // Find a Job usesgovuk-style card layouts
+  // Job cards typically have a title link within an h3
+  const cardPattern = /<div[^>]*class="govuk-grid-column[^"]*"[^>]*>([\s\S]*?)<\/div>/gi;
+  let match;
+
+  while ((match = cardPattern.exec(html)) !== null) {
+    const cardHtml = match[1];
+    const titleMatch = cardHtml.match(/<h3[^>]*>.*?<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/i);
+    if (!titleMatch) continue;
+
+    let url = titleMatch[1];
+    const title = clean(titleMatch[2]);
+    if (!title || seen.has(title)) continue;
+    if (url.startsWith('/')) {
+      url = 'https://findajob.dwp.gov.uk' + url;
+    }
+
+    // Extract company and location
+    const companyMatch = cardHtml.match(/company[^<]*<[^>]*>([^<]+)/i);
+    const company = companyMatch ? clean(companyMatch[1]) : 'Unknown Employer';
+
+    const locationMatch = cardHtml.match(/location[^<]*<[^>]*>([^<,]+)/i);
+    const location = locationMatch ? clean(locationMatch[1]) : '';
+
+    seen.add(title);
+    jobs.push({ title, url, company, location });
+  }
+
+  return jobs.slice(0, 30);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'findajob',
+
+  detect(entry) {
+    return entry.careers_url?.includes('findajob.dwp.gov.uk') ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    const harFile = entry.har_file || 'findajob.har';
+    const harPath = path.join(getCareerOpsRoot(), 'data/har', harFile);
+
+    if (existsSync(harPath)) {
+      const har = JSON.parse(readFileSync(harPath, 'utf8'));
+      const entries = har.log?.entries || [];
+
+      for (const e of entries) {
+        const url = e.request?.url || '';
+        if (url.includes('findajob.dwp.gov.uk') && e.response?.content?.text) {
+          const html = e.response.content.text;
+          return parseFindAJobPage(html, entry);
+        }
+      }
+    }
+
+    console.warn('findajob: no HAR file found. Capture one via scripts/har-capture.mjs');
+    return [];
+  },
+};

--- a/providers/indeed.mjs
+++ b/providers/indeed.mjs
@@ -1,0 +1,104 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Indeed UK provider
+// Public API requires authentication; scraping unprotected pages works with care.
+// This provider uses the public Indeed job search page structure.
+//
+// Note: Indeed actively fights scraping. Use cautiously and respect robots.txt.
+// URL: https://uk.indeed.com/jobs?q=<keyword>&l=<location>
+//
+// Alternative: use Indeed's official API (requires account).
+
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
+const INDEED_BASE = 'https://uk.indeed.com';
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse Indeed search results.
+ * @param {string} html
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseIndeedPage(html, companyName) {
+  const jobs = [];
+  // Indeed uses <h2> tags with job titles, <a> with /sv/ redirect links
+  const titlePattern = /<h2[^>]*><a[^>]+href="([^"]+)"/gi;
+  let match;
+  const seen = new Set();
+
+  while ((match = titlePattern.exec(html)) !== null) {
+    const redirectUrl = match[1];
+    const titleMatch = html.substring(match.index, match.index + 500).match(/<a[^>]+href="[^"]+"[^>]*>([^<]+)<\/a>/);
+    const title = titleMatch ? clean(titleMatch[1]) : '';
+
+    if (!title || seen.has(title)) continue;
+
+    // Indeed redirect URLs contain the actual job URL encoded
+    const decodedUrl = redirectUrl.includes('url=') ? decodeURIComponent(redirectUrl.split('url=')[1].split('&')[0]) : redirectUrl;
+
+    // Extract company and location from adjacent markup
+    const context = html.substring(Math.max(0, match.index - 300), match.index + 200);
+    const companyMatch = context.match(/<span[^>]*class="companyName"[^>]*>([^<]+)<\/span>/i);
+    const locationMatch = context.match(/<span[^>]*class="companyLocation"[^>]*>([^<]+)<\/span>/i);
+
+    const company = companyMatch ? clean(companyMatch[1]) : companyName;
+    const location = locationMatch ? clean(locationMatch[1]) : '';
+
+    seen.add(title);
+    jobs.push({ title, url: decodedUrl, company, location });
+  }
+
+  return jobs.slice(0, 30);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'indeed',
+
+  detect(entry) {
+    if (!entry.careers_url) return null;
+    return entry.careers_url.includes('indeed.com') ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    /** @type {string[]} */
+    const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+    if (keywords.length === 0) return [];
+
+    const maxPages = Math.min(Number(entry.max_pages) || 2, 5);
+    const location = entry.location || 'london';
+
+    // One keyword per async lane; pages within a keyword stay sequential so
+    // the short-page early break still saves the requests it always did.
+    const perKeyword = await Promise.all(keywords.map(async (kw) => {
+      const jobs = [];
+      for (let page = 0; page < maxPages; page++) {
+        const url = `${INDEED_BASE}/jobs?q=${encodeURIComponent(kw)}&l=${encodeURIComponent(location)}&start=${page * 15}`;
+
+        try {
+          const html = await ctx.fetchText(url, {
+            headers: { 'user-agent': BROWSER_LIKE_USER_AGENT },
+            redirect: 'error',
+          });
+
+          const pageJobs = parseIndeedPage(html, entry.name || 'Indeed');
+          jobs.push(...pageJobs);
+          if (pageJobs.length < 15) break;
+        } catch (err) {
+          console.warn(`indeed: failed for "${kw}" page ${page}: ${err.message}`);
+          break;
+        }
+      }
+      return jobs;
+    }));
+
+    return perKeyword.flat();
+  },
+};

--- a/providers/jobsite.mjs
+++ b/providers/jobsite.mjs
@@ -1,0 +1,128 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Jobsite provider — UK job board (Centrica/StepTwo group, sister to Totaljobs)
+// URL: https://www.jobsite.co.uk/jobs
+//
+// Uses Playwright one-shot HAR capture, then replays through this provider.
+// The site uses Cloudflare bot protection on search pages.
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import { getCareerOpsRoot } from '../path-resolver.mjs';
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse Jobsite search results page.
+ * @param {string} html
+ * @param {object} [entry]
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseJobsitePage(html, entry) {
+  const jobs = [];
+  const seen = new Set();
+  const companyName = entry?.name || 'Jobsite';
+
+  // Jobsite uses similar structure to Totaljobs
+  const cardPattern = /<article[^>]*class="[^"]*job[^"]*"[^>]*>([\s\S]*?)<\/article>/gi;
+  let match;
+
+  while ((match = cardPattern.exec(html)) !== null) {
+    const cardHtml = match[1];
+    const titleLinkMatch = cardHtml.match(/<a[^>]+href="([^"]+)"[^>]*class="[^"]*job-title[^"]*"[^>]*>([^<]+)<\/a>/i)
+      || cardHtml.match(/<h3[^>]*>.*?<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/i);
+
+    if (!titleLinkMatch) continue;
+
+    let url = titleLinkMatch[1];
+    const title = clean(titleLinkMatch[2]);
+    if (!title || seen.has(title)) continue;
+    if (url.startsWith('/')) {
+      url = 'https://www.jobsite.co.uk' + url;
+    }
+
+    const companyMatch = cardHtml.match(/<span[^>]*class="[^"]*company[^"]*"[^>]*>([^<]+)/i);
+    const company = companyMatch ? clean(companyMatch[1]) : companyName;
+
+    const locationMatch = cardHtml.match(/location[^<]*<[^>]*>([^,]+)/i);
+    const location = locationMatch ? clean(locationMatch[1]) : '';
+
+    seen.add(title);
+    jobs.push({ title, url, company, location });
+  }
+
+  if (jobs.length === 0) {
+    const linkPattern = /<a[^>]+href="(\/jobs\/[^"]+)"[^>]*>([^<]+)<\/a>/gi;
+    while ((match = linkPattern.exec(html)) !== null) {
+      const url = 'https://www.jobsite.co.uk' + match[1];
+      const title = clean(match[2]);
+      if (title && !seen.has(title) && title.length > 10) {
+        seen.add(title);
+        jobs.push({ title, url, company: companyName, location: '' });
+      }
+    }
+  }
+
+  return jobs.slice(0, 30);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'jobsite',
+
+  detect(entry) {
+    return entry.careers_url?.includes('jobsite.co.uk') ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+    if (keywords.length === 0) {
+      console.warn('jobsite: no keywords provided');
+      return [];
+    }
+
+    const harFile = entry.har_file || 'jobsite.har';
+    const harPath = path.join(getCareerOpsRoot(), 'data/har', harFile);
+
+    if (existsSync(harPath)) {
+      const har = JSON.parse(readFileSync(harPath, 'utf8'));
+      const entries = har.log?.entries || [];
+
+      for (const e of entries) {
+        const url = e.request?.url || '';
+        if (url.includes('jobsite.co.uk') && e.response?.content?.text) {
+          const html = e.response.content.text;
+          return parseJobsitePage(html, entry);
+        }
+      }
+    }
+
+    console.warn('jobsite: no HAR file found, attempting direct fetch (may fail)');
+
+    // All keywords fetched in parallel; single-page boards, no pagination.
+    const perKeyword = await Promise.all(keywords.map(async (kw) => {
+      const location = encodeURIComponent(entry.location || 'london');
+      const query = encodeURIComponent(kw);
+      const url = `https://www.jobsite.co.uk/jobs/${query}-jobs-in-${location}`;
+
+      try {
+        const html = await ctx.fetchText(url, {
+          headers: { 'user-agent': BROWSER_LIKE_USER_AGENT },
+          redirect: 'follow',
+        });
+        return parseJobsitePage(html, entry);
+      } catch (err) {
+        console.warn(`jobsite: failed for "${kw}": ${err.message}`);
+        return [];
+      }
+    }));
+
+    return perKeyword.flat();
+  },
+};

--- a/providers/reed.mjs
+++ b/providers/reed.mjs
@@ -1,0 +1,106 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Reed provider — UK's largest job board (AXA group)
+// Public API available: https://www.reed.co.uk/api/ (requires key)
+// Free tier: limited requests/day, no key needed for basic scraping.
+//
+// This provider scrapes the public listing pages directly.
+// URLs: https://www.reed.co.uk/jobs/<keyword>-jobs-in-<location>
+//
+// HTML structure: each job card contains title link, company, location.
+
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
+const REED_BASE = 'https://www.reed.co.uk';
+const PER_PAGE = 50;
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse Reed search results page for job listings.
+ * @param {string} html
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseReedSearchPage(html, companyName) {
+  const jobs = [];
+  // Reed uses job-card elements with href to job details
+  const cardPattern = /<a[^>]+class="job-title"[^>]*href="([^"]+)"[^>]*>([^<]+)<\/a>/gi;
+  let match;
+  const seen = new Set();
+
+  while ((match = cardPattern.exec(html)) !== null) {
+    const rawUrl = match[1];
+    const title = clean(match[2]);
+    if (!title || seen.has(title)) continue;
+
+    let url = rawUrl;
+    if (rawUrl.startsWith('/')) url = REED_BASE + rawUrl;
+
+    // Extract company and location from adjacent elements
+    const cardBlock = html.substring(Math.max(0, match.index - 200), match.index + rawUrl.length + match[2].length + 200);
+    const companyMatch = cardBlock.match(/<span[^>]*class="company-name"[^>]*>([^<]+)<\/span>/i);
+    const locationMatch = cardBlock.match(/<span[^>]*class="job-location"[^>]*>([^<]+)<\/span>/i);
+
+    const company = companyMatch ? clean(companyMatch[1]) : companyName;
+    const location = locationMatch ? clean(locationMatch[1]) : '';
+
+    seen.add(title);
+    jobs.push({ title, url, company, location });
+  }
+
+  return jobs;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'reed',
+
+  detect(entry) {
+    if (!entry.careers_url) return null;
+    return entry.careers_url.includes('reed.co.uk') ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    /** @type {string[]} */
+    const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+    if (keywords.length === 0) {
+      console.warn('reed: no keywords provided');
+      return [];
+    }
+
+    const maxPages = Math.min(Number(entry.max_pages) || 3, 10);
+    const location = entry.location || 'london';
+    const encodedLoc = encodeURIComponent(location);
+
+    // One keyword per async lane; pages within a keyword stay sequential so
+    // the short-page early break still saves the requests it always did.
+    const perKeyword = await Promise.all(keywords.map(async (kw) => {
+      const jobs = [];
+      const encodedKw = encodeURIComponent(kw);
+      for (let page = 1; page <= maxPages; page++) {
+        const url = `${REED_BASE}/jobs/${encodedKw}-jobs-in-${encodedLoc}?page=${page}`;
+        try {
+          const html = await ctx.fetchText(url, {
+            headers: { 'user-agent': BROWSER_LIKE_USER_AGENT },
+            redirect: 'error',
+          });
+          const pageJobs = parseReedSearchPage(html, entry.name || 'Reed');
+          jobs.push(...pageJobs);
+          if (pageJobs.length < PER_PAGE) break; // last page
+        } catch (err) {
+          console.warn(`reed: failed for "${kw}" page ${page}: ${err.message}`);
+          break;
+        }
+      }
+      return jobs;
+    }));
+
+    return out.concat(...perKeyword);
+  },
+};

--- a/providers/totaljobs.mjs
+++ b/providers/totaljobs.mjs
@@ -1,0 +1,133 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Totaljobs provider — UK job board (Centrica/StepTwo group)
+// URL: https://www.totaljobs.com/jobs
+//
+// Uses Playwright one-shot HAR capture, then replays through this provider.
+// The site uses Cloudflare bot protection on search pages.
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import { getCareerOpsRoot } from '../path-resolver.mjs';
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
+/** @param {string} s */
+function clean(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse Totaljobs search results page.
+ * @param {string} html
+ * @param {object} [entry]
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseTotaljobsPage(html, entry) {
+  const jobs = [];
+  const seen = new Set();
+  const companyName = entry?.name || 'Totaljobs';
+
+  // Totaljobs uses article cards with job-title links
+  const cardPattern = /<article[^>]*class="[^"]*job[^"]*"[^>]*>([\s\S]*?)<\/article>/gi;
+  let match;
+
+  while ((match = cardPattern.exec(html)) !== null) {
+    const cardHtml = match[1];
+    const titleLinkMatch = cardHtml.match(/<a[^>]+href="([^"]+)"[^>]*class="[^"]*job-title[^"]*"[^>]*>([^<]+)<\/a>/i)
+      || cardHtml.match(/<h3[^>]*>.*?<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/i);
+
+    if (!titleLinkMatch) continue;
+
+    let url = titleLinkMatch[1];
+    const title = clean(titleLinkMatch[2]);
+    if (!title || seen.has(title)) continue;
+    if (url.startsWith('/')) {
+      url = 'https://www.totaljobs.com' + url;
+    }
+
+    const companyMatch = cardHtml.match(/<span[^>]*class="[^"]*company[^"]*"[^>]*>([^<]+)/i)
+      || cardHtml.match(/<[^>]*>([^<,]+),\s*(.+?)\s*<\/[^>]*>/i);
+    const company = companyMatch ? clean(companyMatch[1]) : companyName;
+
+    const locationMatch = cardHtml.match(/location[^<]*<[^>]*>([^,]+)/i);
+    const location = locationMatch ? clean(locationMatch[1]) : '';
+
+    seen.add(title);
+    jobs.push({ title, url, company, location });
+  }
+
+  // Fallback: simple anchor pattern
+  if (jobs.length === 0) {
+    const linkPattern = /<a[^>]+href="(\/jobs\/[^"]+)"[^>]*>([^<]+)<\/a>/gi;
+    while ((match = linkPattern.exec(html)) !== null) {
+      const url = 'https://www.totaljobs.com' + match[1];
+      const title = clean(match[2]);
+      if (title && !seen.has(title) && title.length > 10) {
+        seen.add(title);
+        jobs.push({ title, url, company: companyName, location: '' });
+      }
+    }
+  }
+
+  return jobs.slice(0, 30);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'totaljobs',
+
+  detect(entry) {
+    return entry.careers_url?.includes('totaljobs.com') ? entry : null;
+  },
+
+  async fetch(entry, ctx) {
+    const keywords = Array.isArray(entry.keywords) ? entry.keywords : [];
+    if (keywords.length === 0) {
+      console.warn('totaljobs: no keywords provided');
+      return [];
+    }
+
+    const harFile = entry.har_file || 'totaljobs.har';
+    const harPath = path.join(getCareerOpsRoot(), 'data/har', harFile);
+
+    // Check for HAR replay first
+    if (existsSync(harPath)) {
+      const har = JSON.parse(readFileSync(harPath, 'utf8'));
+      const entries = har.log?.entries || [];
+
+      for (const e of entries) {
+        const url = e.request?.url || '';
+        if (url.includes('totaljobs.com') && e.response?.content?.text) {
+          // Use HAR response as the source
+          const html = e.response.content.text;
+          return parseTotaljobsPage(html, entry);
+        }
+      }
+    }
+
+    // Fallback: try direct HTTP (may be blocked by Cloudflare)
+    console.warn('totaljobs: no HAR file found, attempting direct fetch (may fail)');
+
+    // All keywords fetched in parallel; single-page boards, no pagination.
+    const perKeyword = await Promise.all(keywords.map(async (kw) => {
+      const location = encodeURIComponent(entry.location || 'london');
+      const query = encodeURIComponent(kw);
+      const url = `https://www.totaljobs.com/jobs/${query}-jobs-in-${location}`;
+
+      try {
+        const html = await ctx.fetchText(url, {
+          headers: { 'user-agent': BROWSER_LIKE_USER_AGENT },
+          redirect: 'follow',
+        });
+        return parseTotaljobsPage(html, entry);
+      } catch (err) {
+        console.warn(`totaljobs: failed for "${kw}": ${err.message}`);
+        return [];
+      }
+    }));
+
+    return perKeyword.flat();
+  },
+};

--- a/scripts/har-capture.mjs
+++ b/scripts/har-capture.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// har-capture.mjs — one-shot Playwright HAR recorder for browser-gated job boards.
+//
+// Usage:
+//   node scripts/har-capture.mjs <board> [url]
+//
+// Boards with a baked-in search URL (keywords/location come from portals.yml
+// values, hard-coded here to keep this a single dependency-free script):
+//   civilservicejobs, findajob, totaljobs, jobsite, indeed, reed
+// Or pass any URL explicitly:
+//   node scripts/har-capture.mjs custom "https://example.com/jobs?q=python"
+//
+// Output: data/har/<board>.har — replayed offline by the matching provider.
+// Re-run when a board's listing goes stale (they hold a snapshot, not a feed).
+
+import { mkdirSync } from 'fs';
+import path from 'path';
+import { chromium } from 'playwright';
+import { getCareerOpsRoot } from '../path-resolver.mjs';
+
+const KEYWORDS = ['python software engineer', 'machine learning engineer', 'data engineer'];
+const LOCATION = 'london';
+
+const BOARDS = {
+  civilservicejobs: 'https://www.civilservicejobs.service.gov.uk/csr/index.cgi',
+  findajob: 'https://findajob.dwp.gov.uk/search?q=python&location=London',
+  totaljobs: `https://www.totaljobs.com/jobs/${encodeURIComponent(KEYWORDS[0])}-jobs-in-${LOCATION}`,
+  jobsite: `https://www.jobsite.co.uk/jobs/${encodeURIComponent(KEYWORDS[0])}-jobs-in-${LOCATION}`,
+  indeed: `https://uk.indeed.com/jobs?q=${encodeURIComponent(KEYWORDS[0])}&l=${LOCATION}`,
+  reed: `https://www.reed.co.uk/jobs/${encodeURIComponent(KEYWORDS[0])}-jobs-in-${LOCATION}`,
+};
+
+const board = process.argv[2];
+if (!board) {
+  console.error('Usage: node scripts/har-capture.mjs <board|custom> [url]\nKnown boards: ' + Object.keys(BOARDS).join(', '));
+  process.exit(1);
+}
+
+const url = process.argv[3] || BOARDS[board];
+if (!url) {
+  console.error(`Unknown board "${board}". Pass a URL: node scripts/har-capture.mjs ${board} "https://..."`);
+  process.exit(1);
+}
+
+const outDir = path.join(getCareerOpsRoot(), 'data', 'har');
+mkdirSync(outDir, { recursive: true });
+const outFile = path.join(outDir, `${board}.har`);
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ recordHar: { path: outFile } });
+const page = await context.newPage();
+
+console.log(`Capturing ${url} ...`);
+await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+// Cloudflare interstitials and result hydration need a beat; job rows
+// rendering is the real signal we waited for.
+await page.waitForTimeout(8000);
+
+const title = await page.title();
+console.log(`Page: ${title}`);
+console.log(`HAR written: ${outFile}`);
+
+await context.close();   // closing the context flushes the HAR
+await browser.close();

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -422,7 +422,15 @@ try {
     // matched by basename ONLY at the repo root, so nested fixture subdirs such
     // as test-fixtures/upgrade/state-*/data and .../reports still get copied.
     if (dirname(src) === ROOT && exclude.includes(name)) return;
-    const stat = statSync(src);
+    // readdir→stat race: the harness (or a test) deleted the entry between
+    // listing it and reaching it. Same tolerance the walker below applies.
+    let stat;
+    try {
+      stat = statSync(src);
+    } catch (err) {
+      if (err?.code === 'ENOENT') return;
+      throw err;
+    }
     if (stat.isDirectory()) {
       // A linked worktree is a whole second checkout of this repo and carries a
       // `.git` FILE, not a directory, so the name-based exclusion above never
@@ -434,10 +442,24 @@ try {
       if (src !== ROOT && isNestedCheckout(src)) return;
       mkdirSync(dest, { recursive: true });
       for (const entry of readdirSync(src)) {
+        // AppleDouble (`._foo`) sidecars: macOS resource-fork metadata written
+        // by SMB/AFP mounts (a NAS). Not repo content, unreadable to copyfile
+        // (EACCES) on this mount, and regenerated the moment they are deleted.
+        if (entry.startsWith('._')) continue;
         copyDirSync(join(src, entry), join(dest, entry), exclude);
       }
     } else {
-      copyFileSync(src, dest);
+      try {
+        copyFileSync(src, dest);
+      } catch (err) {
+        // Runtime-state files (agent harness logs, session records) can be
+        // unreadable to copyfile while the suite runs — especially on a NAS
+        // mount where another process holds them open. They are not repo
+        // source; nothing in the throwaway tree reads them. Skip and go on
+        // rather than abort the whole section on one log file.
+        if (err?.code === 'EACCES' || err?.code === 'EPERM') return;
+        throw err;
+      }
     }
   };
 
@@ -450,6 +472,11 @@ try {
     '.career-ops-web',
     '.playwright-mcp',
     '.agents',
+    // OMC runtime state: session transcripts, hook checkpoints, cron job
+    // records — written and re-written by the agent harness WHILE the suite
+    // runs. Nothing in the throwaway copy reads them, and a NAS-mounted
+    // checkout can deny copyfile on files another process holds (EACCES).
+    '.omc',
     'cdp-diff.patch',
     'cdp-diff-focused.patch',
     'test_diff.patch',
@@ -17387,7 +17414,16 @@ try {
     for (const name of readdirSync(dir)) {
       if (name === 'node_modules' || name.startsWith('.')) continue;
       const p = join(dir, name);
-      const statResult = statSync(p);
+      // statSync follows symlinks, so a DANGLING one (e.g. chloe-home ->
+      // a path that only exists on its author's Mac) throws ENOENT and
+      // crashed the whole drift-guard into one meaningless failure. A
+      // symlink is never a repo script; skip it either way.
+      let statResult;
+      try {
+        statResult = statSync(p);
+      } catch {
+        continue;
+      }
       if (statResult.isDirectory()) continue;
       if (!name.endsWith('.mjs')) continue;
       if (/-tests?\.mjs$/.test(name) || /\.test\.mjs$/.test(name)) continue;


### PR DESCRIPTION
## Summary

Adds 8 UK job-board providers and a Playwright-HAR capture/replay pipeline, plus three classes of suite hardening for NAS-mounted checkouts.

### Providers (8 new)
- **Direct fetch** (keywords parallelised via `Promise.all`): `adzuna`, `reed`, `indeed`, `totaljobs`, `jobsite`
- **HAR-replay-only**: `civilservicejobs`, `findajob` (boards too hostile for plain fetch; provider reads `data/har/<board>.har`)
- **Shared HAR player**: `cloudscraper-replay`
- `scripts/har-capture.mjs` — Playwright captures each board once into `data/har/<board>.har`; afterwards no browser needed

### Suite hardening (all hit in one run on a NAS SMB mount)
1. `lib/mjs-files.mjs`: skip AppleDouble `._foo` sidecars — the mount regenerates them after deletion, so exclusion (not deletion) is the durable fix
2. `test-all.mjs` `copyDirSync`: skip `._*`, exclude `.omc/`, tolerate `EACCES` on copyfile and `ENOENT` on the readdir→stat race
3. `test-all.mjs` drift-guard §62: `statSync` follows symlinks, so a dangling root symlink (`chloe-home -> /Users/...` macOS-only path) crashed the entire check into one meaningless failure — skip unstatable entries

### Privacy
`PROFILE.md` (user dossier, contains PII) added to `.gitignore` user layer alongside `cv.md`.

## Known limits
- `civilservicejobs`/`findajob` HARs currently hold bot-check/error pages — need a recapture (possibly headed mode) before they yield results
- Adzuna requires `ADZUNA_APP_ID`/`ADZUNA_APP_KEY` env vars

## Test plan
- [x] `node scripts/check-syntax.mjs` — 706 files pass
- [x] `node test-all.mjs` — 8856 passed, 0 failed (15 pre-existing warnings, all template-author fixture noise)
- [x] All 95 providers load through the real registry path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add UK providers for Adzuna, Reed, Indeed, Totaljobs, Jobsite, Civil Service Jobs, and Find a Job: `providers/*.mjs`.
- Add parallel keyword searches for Indeed: `providers/indeed.mjs:80`.
- Add HAR capture and replay for browser-gated boards: `scripts/har-capture.mjs:35`, `providers/cloudscraper-replay.mjs:118`.
- Add `PROFILE.md` to the personal-data ignore rules: `.gitignore:3`.
- Harden NAS checkout handling by skipping AppleDouble files, `.omc/`, transient entries, and unstatable paths: `lib/mjs-files.mjs:161`, `test-all.mjs:418`.

## User impact

Users can search more UK job boards and replay browser-captured results without a live browser. Adzuna searches require credentials. Missing or blocked HAR captures return no results or may fall back to direct fetch.

Validation passed: 706 files, 8,856 tests, and 95 providers.

## System files

Changed: `.gitignore`, `providers/`, `lib/mjs-files.mjs`, `test-all.mjs`, and `scripts/har-capture.mjs`.

Present but not changed: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->