### PR TITLE
fix(tracker): resolve tracker paths via resolveTrackerPath(DATA_ROOT) across CLI tools (#4087)

### DIFF
--- a/linkedin-join.mjs
+++ b/linkedin-join.mjs
@@ -83,7 +83,7 @@ import { getCareerOpsRoot, resolveTrackerPath } from './path-resolver.mjs';
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
 const DEFAULT_CSV = join(DATA_ROOT, 'data/Connections.csv');
-const TRACKER_PATH = resolveTrackerPath(DATA_ROOT);
+export const TRACKER_PATH = resolveTrackerPath(DATA_ROOT);
 const PORTALS_PATH = join(DATA_ROOT, 'portals.yml');
 const CONTACTS_PATH = join(DATA_ROOT, 'data/contacts.tsv');
 

--- a/linkedin-join.mjs
+++ b/linkedin-join.mjs
@@ -78,12 +78,12 @@ import { resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-par
 import { asciiFold } from './lib/ascii-fold.mjs';
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
-import { getCareerOpsRoot } from './path-resolver.mjs';
+import { getCareerOpsRoot, resolveTrackerPath } from './path-resolver.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
 const DEFAULT_CSV = join(DATA_ROOT, 'data/Connections.csv');
-const TRACKER_PATH = join(DATA_ROOT, 'data/applications.md');
+const TRACKER_PATH = resolveTrackerPath(DATA_ROOT);
 const PORTALS_PATH = join(DATA_ROOT, 'portals.yml');
 const CONTACTS_PATH = join(DATA_ROOT, 'data/contacts.tsv');
 

--- a/paste-reply.mjs
+++ b/paste-reply.mjs
@@ -46,12 +46,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { renameSyncWithRetry } from './tracker-utils.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_ROOT = getCareerOpsRoot();
 const CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
-  || path.join(__dirname, 'data', 'reply-candidates.json');
+  || path.join(DATA_ROOT, 'data', 'reply-candidates.json');
 
 
 /**

--- a/paste-reply.mjs
+++ b/paste-reply.mjs
@@ -51,7 +51,7 @@ import { renameSyncWithRetry } from './tracker-utils.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
 
 const DATA_ROOT = getCareerOpsRoot();
-const CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
+export const CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
   || path.join(DATA_ROOT, 'data', 'reply-candidates.json');
 
 

--- a/rejection-latency.mjs
+++ b/rejection-latency.mjs
@@ -64,7 +64,7 @@ const DATA_ROOT = getCareerOpsRoot();
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(DATA_ROOT, 'data/active-interviews.md'))
   ? join(DATA_ROOT, 'data/active-interviews.md')
   : join(DATA_ROOT, 'active-interviews.md');
-const DEFAULT_TRACKER_PATH = resolveTrackerPath(DATA_ROOT);
+export const DEFAULT_TRACKER_PATH = resolveTrackerPath(DATA_ROOT);
 const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(DATA_ROOT, 'config/profile.yml');
 
 export const DEFAULT_COURTESY_DAYS = 30;

--- a/rejection-latency.mjs
+++ b/rejection-latency.mjs
@@ -57,16 +57,14 @@ import { roleFuzzyMatch } from './role-matcher.mjs';
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { localToday } from './lib/local-today.mjs';
 import { isMainModule } from './lib/is-main-module.mjs';
-import { getCareerOpsRoot } from './path-resolver.mjs';
+import { getCareerOpsRoot, resolveTrackerPath } from './path-resolver.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(DATA_ROOT, 'data/active-interviews.md'))
   ? join(DATA_ROOT, 'data/active-interviews.md')
   : join(DATA_ROOT, 'active-interviews.md');
-const DEFAULT_TRACKER_PATH = existsSync(join(DATA_ROOT, 'data/applications.md'))
-  ? join(DATA_ROOT, 'data/applications.md')
-  : join(DATA_ROOT, 'applications.md');
+const DEFAULT_TRACKER_PATH = resolveTrackerPath(DATA_ROOT);
 const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(DATA_ROOT, 'config/profile.yml');
 
 export const DEFAULT_COURTESY_DAYS = 30;

--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -20,13 +20,15 @@ import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
 } from './tracker-utils.mjs';
+import { getCareerOpsRoot } from './path-resolver.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
 import { localToday } from './lib/local-today.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DEFAULT_CANDIDATES_PATH = path.join(__dirname, 'data', 'reply-candidates.json');
-const APPS_FILE = resolveTrackerPath(__dirname);
-const FOLLOWUPS_FILE = path.join(__dirname, 'data', 'follow-ups.md');
+const DATA_ROOT = getCareerOpsRoot();
+const DEFAULT_CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
+  || path.join(DATA_ROOT, 'data', 'reply-candidates.json');
+const APPS_FILE = resolveTrackerPath(DATA_ROOT);
+const FOLLOWUPS_FILE = path.join(DATA_ROOT, 'data', 'follow-ups.md');
 
 // Helper to ask a question in the CLI
 function askQuestion(query) {

--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -23,12 +23,13 @@ import {
 import { getCareerOpsRoot } from './path-resolver.mjs';
 import { validateFlags } from './lib/cli-flags.mjs';
 import { localToday } from './lib/local-today.mjs';
+import { isMainModule } from './lib/is-main-module.mjs';
 
 const DATA_ROOT = getCareerOpsRoot();
-const DEFAULT_CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
+export const DEFAULT_CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
   || path.join(DATA_ROOT, 'data', 'reply-candidates.json');
-const APPS_FILE = resolveTrackerPath(DATA_ROOT);
-const FOLLOWUPS_FILE = path.join(DATA_ROOT, 'data', 'follow-ups.md');
+export const APPS_FILE = resolveTrackerPath(DATA_ROOT);
+export const FOLLOWUPS_FILE = path.join(DATA_ROOT, 'data', 'follow-ups.md');
 
 // Helper to ask a question in the CLI
 function askQuestion(query) {
@@ -358,7 +359,9 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('Fatal:', err);
-  process.exit(1);
-});
+if (isMainModule(import.meta.url)) {
+  main().catch(err => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}

--- a/scan.mjs
+++ b/scan.mjs
@@ -88,7 +88,7 @@ try {
 const parseYaml = yaml.load;
 
 // ── Config ──────────────────────────────────────────────────────────
-import { getCareerOpsRoot } from './path-resolver.mjs';
+import { getCareerOpsRoot, resolveTrackerPath } from './path-resolver.mjs';
 const CODE_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const DATA_ROOT = getCareerOpsRoot();
 
@@ -107,7 +107,7 @@ const PROFILE_PATH = process.env.CAREER_OPS_PROFILE || path.join(DATA_ROOT, 'con
 // anchored one (#3510). One resolution, imported, cannot drift.
 export const SCAN_HISTORY_PATH = process.env.CAREER_OPS_SCAN_HISTORY || path.join(DATA_ROOT, 'data/scan-history.tsv');
 export const PIPELINE_PATH = process.env.CAREER_OPS_PIPELINE || path.join(DATA_ROOT, 'data/pipeline.md');
-const APPLICATIONS_PATH = path.join(DATA_ROOT, 'data/applications.md');
+export const APPLICATIONS_PATH = resolveTrackerPath(DATA_ROOT);
 const PROVIDERS_DIR = path.resolve(CODE_ROOT, 'providers');
 
 // Ensure required directories exist (fresh setup). Stays rooted in the user-data

--- a/tests/cli-tracker-path-resolution.test.mjs
+++ b/tests/cli-tracker-path-resolution.test.mjs
@@ -2,13 +2,13 @@
  * tests/cli-tracker-path-resolution.test.mjs
  *
  * Asserts that CLI tools (scan.mjs, reply-watch.mjs, linkedin-join.mjs,
- * rejection-latency.mjs) resolve their tracker and data paths via
- * resolveTrackerPath(DATA_ROOT) rather than hardcoding 'data/applications.md'
+ * paste-reply.mjs, rejection-latency.mjs) resolve their tracker and data paths
+ * via resolveTrackerPath(DATA_ROOT) rather than hardcoding 'data/applications.md'
  * or anchoring to the code repository (__dirname).
  */
 
-import { pass, fail, ROOT, NODE } from './helpers.mjs';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { pass, fail, ROOT, NODE, rmSync } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
@@ -16,128 +16,242 @@ import { canonicalizeTrackerPath } from '../path-resolver.mjs';
 
 console.log('\nCLI tracker path resolution — CAREER_OPS_TRACKER & CAREER_OPS_DATA_DIR support');
 
+const TRACKER_HEADER = '# Applications Tracker\n\n| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n|---|------|---------|------|-------|--------|-----|--------|-------|\n| 1 | 2026-06-01 | Acme Corp | Staff Engineer | 4.5/5 | Interview | ❌ | - | |\n';
+
+function evalModule(script, envOverrides = {}) {
+  const cleanEnv = { ...process.env };
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === null || v === undefined) {
+      delete cleanEnv[k];
+    } else {
+      cleanEnv[k] = v;
+    }
+  }
+  const out = execFileSync(NODE, ['--input-type=module', '-e', script], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    env: cleanEnv,
+  });
+  return JSON.parse(out.trim());
+}
+
 const tmp = mkdtempSync(join(tmpdir(), 'co-tracker-res-'));
+const flatTrackerDir = mkdtempSync(join(tmpdir(), 'co-flat-'));
 
 try {
-  const dataDir = join(tmp, 'data');
-  mkdirSync(dataDir, { recursive: true });
-
   const customTracker = join(tmp, 'custom-tracker.md');
-  const trackerHeader = '# Applications Tracker\n\n| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n|---|------|---------|------|-------|--------|-----|--------|-------|\n| 1 | 2026-06-01 | Acme | Dev | 4.0/5 | Applied | ❌ | - | |\n';
-  writeFileSync(customTracker, trackerHeader);
+  writeFileSync(customTracker, TRACKER_HEADER);
 
-  // 1. scan.mjs honors CAREER_OPS_TRACKER for APPLICATIONS_PATH
-  const scanCheck = execFileSync(NODE, [
-    '-e',
-    `
-    process.env.CAREER_OPS_TRACKER = ${JSON.stringify(customTracker)};
-    import('./scan.mjs').then(m => {
-      if (m.APPLICATIONS_PATH === ${JSON.stringify(canonicalizeTrackerPath(customTracker))}) {
-        console.log('OK');
-      } else {
-        console.error('MISMATCH:', m.APPLICATIONS_PATH);
-        process.exit(1);
-      }
-    });
-    `,
-  ], { cwd: ROOT, encoding: 'utf-8' });
-
-  if (scanCheck.trim() === 'OK') {
-    pass('scan.mjs: APPLICATIONS_PATH respects CAREER_OPS_TRACKER');
-  } else {
-    fail('scan.mjs: APPLICATIONS_PATH did not match CAREER_OPS_TRACKER');
-  }
-
-  // 2. scan.mjs honors flat root layout when data/applications.md is absent
-  const flatTrackerDir = mkdtempSync(join(tmpdir(), 'co-flat-'));
   const flatTrackerFile = join(flatTrackerDir, 'applications.md');
-  writeFileSync(flatTrackerFile, trackerHeader);
+  writeFileSync(flatTrackerFile, TRACKER_HEADER);
 
-  const flatCheck = execFileSync(NODE, [
-    '-e',
-    `
-    delete process.env.CAREER_OPS_TRACKER;
-    process.env.CAREER_OPS_DATA_DIR = ${JSON.stringify(flatTrackerDir)};
-    import('./scan.mjs').then(m => {
-      if (m.APPLICATIONS_PATH === ${JSON.stringify(canonicalizeTrackerPath(flatTrackerFile))}) {
-        console.log('OK');
-      } else {
-        console.error('MISMATCH:', m.APPLICATIONS_PATH);
-        process.exit(1);
-      }
+  // 1. scan.mjs respects CAREER_OPS_TRACKER
+  try {
+    const res = evalModule(
+      "import { APPLICATIONS_PATH } from './scan.mjs'; console.log(JSON.stringify({ path: APPLICATIONS_PATH }));",
+      { CAREER_OPS_TRACKER: customTracker }
+    );
+    if (res.path === canonicalizeTrackerPath(customTracker)) {
+      pass('scan.mjs: APPLICATIONS_PATH respects CAREER_OPS_TRACKER');
+    } else {
+      fail(`scan.mjs: expected ${customTracker}, got ${res.path}`);
+    }
+  } catch (err) {
+    fail(`scan.mjs CAREER_OPS_TRACKER test failed: ${err.message}`);
+  }
+
+  // 2. scan.mjs honors flat root layout under CAREER_OPS_DATA_DIR
+  try {
+    const res = evalModule(
+      "import { APPLICATIONS_PATH } from './scan.mjs'; console.log(JSON.stringify({ path: APPLICATIONS_PATH }));",
+      { CAREER_OPS_TRACKER: null, CAREER_OPS_DATA_DIR: flatTrackerDir }
+    );
+    if (res.path === canonicalizeTrackerPath(flatTrackerFile)) {
+      pass('scan.mjs: APPLICATIONS_PATH resolves flat applications.md under CAREER_OPS_DATA_DIR');
+    } else {
+      fail(`scan.mjs: expected flat tracker ${flatTrackerFile}, got ${res.path}`);
+    }
+  } catch (err) {
+    fail(`scan.mjs flat layout test failed: ${err.message}`);
+  }
+
+  // 3. reply-watch.mjs respects CAREER_OPS_TRACKER
+  try {
+    const res = evalModule(
+      "import { APPS_FILE } from './reply-watch.mjs'; console.log(JSON.stringify({ path: APPS_FILE }));",
+      { CAREER_OPS_TRACKER: customTracker }
+    );
+    if (res.path === canonicalizeTrackerPath(customTracker)) {
+      pass('reply-watch.mjs: APPS_FILE respects CAREER_OPS_TRACKER');
+    } else {
+      fail(`reply-watch.mjs: expected ${customTracker}, got ${res.path}`);
+    }
+  } catch (err) {
+    fail(`reply-watch.mjs CAREER_OPS_TRACKER test failed: ${err.message}`);
+  }
+
+  // 4. reply-watch.mjs resolves flat applications.md under CAREER_OPS_DATA_DIR and anchors candidates/followups to DATA_ROOT
+  try {
+    const res = evalModule(
+      "import { APPS_FILE, DEFAULT_CANDIDATES_PATH, FOLLOWUPS_FILE } from './reply-watch.mjs'; console.log(JSON.stringify({ apps: APPS_FILE, candidates: DEFAULT_CANDIDATES_PATH, followups: FOLLOWUPS_FILE }));",
+      { CAREER_OPS_TRACKER: null, CAREER_OPS_DATA_DIR: flatTrackerDir }
+    );
+    const expectedApps = canonicalizeTrackerPath(flatTrackerFile);
+    const expectedCandidates = join(flatTrackerDir, 'data', 'reply-candidates.json');
+    const expectedFollowups = join(flatTrackerDir, 'data', 'follow-ups.md');
+    if (res.apps === expectedApps && res.candidates === expectedCandidates && res.followups === expectedFollowups) {
+      pass('reply-watch.mjs: resolves flat tracker and anchors candidates/followups to CAREER_OPS_DATA_DIR');
+    } else {
+      fail(`reply-watch.mjs: mismatch under CAREER_OPS_DATA_DIR: ${JSON.stringify(res)}`);
+    }
+  } catch (err) {
+    fail(`reply-watch.mjs flat layout test failed: ${err.message}`);
+  }
+
+  // 5. linkedin-join.mjs respects CAREER_OPS_TRACKER and flat layout
+  try {
+    const resTracker = evalModule(
+      "import { TRACKER_PATH } from './linkedin-join.mjs'; console.log(JSON.stringify({ path: TRACKER_PATH }));",
+      { CAREER_OPS_TRACKER: customTracker }
+    );
+    const resFlat = evalModule(
+      "import { TRACKER_PATH } from './linkedin-join.mjs'; console.log(JSON.stringify({ path: TRACKER_PATH }));",
+      { CAREER_OPS_TRACKER: null, CAREER_OPS_DATA_DIR: flatTrackerDir }
+    );
+    if (
+      resTracker.path === canonicalizeTrackerPath(customTracker) &&
+      resFlat.path === canonicalizeTrackerPath(flatTrackerFile)
+    ) {
+      pass('linkedin-join.mjs: TRACKER_PATH respects CAREER_OPS_TRACKER and flat CAREER_OPS_DATA_DIR');
+    } else {
+      fail(`linkedin-join.mjs: TRACKER_PATH mismatch (tracker: ${resTracker.path}, flat: ${resFlat.path})`);
+    }
+  } catch (err) {
+    fail(`linkedin-join.mjs TRACKER_PATH test failed: ${err.message}`);
+  }
+
+  // 6. linkedin-join.mjs drives execution down the path that reads the tracker
+  try {
+    const connectionsCsv = join(tmp, 'Connections.csv');
+    writeFileSync(
+      connectionsCsv,
+      'First Name,Last Name,URL,Email Address,Company,Position,Connected On\nAlice,Smith,https://linkedin.com/in/alicesmith,,Acme Corp,Staff Engineer,01 Jan 2024\n'
+    );
+
+    const cliOut = execFileSync(NODE, [
+      'linkedin-join.mjs',
+      '--tracker-only',
+      '--csv', connectionsCsv,
+    ], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, CAREER_OPS_TRACKER: customTracker },
     });
-    `,
-  ], { cwd: ROOT, encoding: 'utf-8' });
 
-  if (flatCheck.trim() === 'OK') {
-    pass('scan.mjs: APPLICATIONS_PATH resolves flat applications.md layout under CAREER_OPS_DATA_DIR');
-  } else {
-    fail('scan.mjs: APPLICATIONS_PATH did not resolve flat layout');
-  }
-  rmSync(flatTrackerDir, { recursive: true, force: true });
-
-  // 3. reply-watch.mjs resolves tracker against CAREER_OPS_DATA_DIR
-  const extDataDir = mkdtempSync(join(tmpdir(), 'co-ext-data-'));
-  const extDataSubdir = join(extDataDir, 'data');
-  mkdirSync(extDataSubdir, { recursive: true });
-  const extTracker = join(extDataSubdir, 'applications.md');
-  writeFileSync(extTracker, trackerHeader);
-
-  const replyWatchCheck = execFileSync(NODE, [
-    '-e',
-    `
-    delete process.env.CAREER_OPS_TRACKER;
-    process.env.CAREER_OPS_DATA_DIR = ${JSON.stringify(extDataDir)};
-    // Run reply-watch with empty stdin to observe tracker discovery
-    const cp = await import('child_process');
-    try {
-      const out = cp.execFileSync(${JSON.stringify(NODE)}, ['reply-watch.mjs'], {
-        cwd: ${JSON.stringify(ROOT)},
-        input: '',
-        encoding: 'utf-8',
-        env: { ...process.env, CAREER_OPS_DATA_DIR: ${JSON.stringify(extDataDir)} }
-      });
-      console.log('OK');
-    } catch (e) {
-      console.error(e.stderr || e.stdout);
-      process.exit(1);
+    const data = JSON.parse(cliOut);
+    const matchedTarget = Array.isArray(data.targets) && data.targets.some(t => t.company && /acme/i.test(t.company));
+    if (matchedTarget) {
+      pass('linkedin-join.mjs: CLI reads targets from custom tracker and finds connection match');
+    } else {
+      fail(`linkedin-join.mjs: expected target Acme Corp in CLI output: ${cliOut}`);
     }
-    `,
-  ], { cwd: ROOT, encoding: 'utf-8' });
-
-  if (replyWatchCheck.trim() === 'OK') {
-    pass('reply-watch.mjs: discovers tracker under CAREER_OPS_DATA_DIR without CAREER_OPS_TRACKER');
-  } else {
-    fail('reply-watch.mjs: failed to discover tracker under CAREER_OPS_DATA_DIR');
+  } catch (err) {
+    fail(`linkedin-join.mjs CLI execution test failed: ${err.message}`);
   }
-  rmSync(extDataDir, { recursive: true, force: true });
 
-  // 4. linkedin-join.mjs resolves tracker via resolveTrackerPath
-  const linkedinCheck = execFileSync(NODE, [
-    '-e',
-    `
-    process.env.CAREER_OPS_TRACKER = ${JSON.stringify(customTracker)};
-    const cp = await import('child_process');
-    try {
-      const out = cp.execFileSync(${JSON.stringify(NODE)}, ['linkedin-join.mjs', '--self-test'], {
-        cwd: ${JSON.stringify(ROOT)},
-        encoding: 'utf-8',
-        env: { ...process.env, CAREER_OPS_TRACKER: ${JSON.stringify(customTracker)} }
-      });
-      console.log('OK');
-    } catch (e) {
-      console.error(e.stderr || e.stdout);
-      process.exit(1);
+  // 7. paste-reply.mjs anchors CANDIDATES_PATH to DATA_ROOT
+  try {
+    const res = evalModule(
+      "import { CANDIDATES_PATH } from './paste-reply.mjs'; console.log(JSON.stringify({ path: CANDIDATES_PATH }));",
+      { CAREER_OPS_REPLY_CANDIDATES: null, CAREER_OPS_DATA_DIR: flatTrackerDir }
+    );
+    const expectedCandidates = join(flatTrackerDir, 'data', 'reply-candidates.json');
+    if (res.path === expectedCandidates) {
+      pass('paste-reply.mjs: CANDIDATES_PATH anchors to CAREER_OPS_DATA_DIR');
+    } else {
+      fail(`paste-reply.mjs: expected ${expectedCandidates}, got ${res.path}`);
     }
-    `,
-  ], { cwd: ROOT, encoding: 'utf-8' });
-
-  if (linkedinCheck.trim() === 'OK') {
-    pass('linkedin-join.mjs: self-test passes with resolveTrackerPath');
-  } else {
-    fail('linkedin-join.mjs: failed with resolveTrackerPath');
+  } catch (err) {
+    fail(`paste-reply.mjs CANDIDATES_PATH test failed: ${err.message}`);
   }
 
+  // 8. paste-reply.mjs appends candidate to DATA_ROOT default path
+  try {
+    const appendTestScript = `
+    import { appendCandidate, CANDIDATES_PATH } from './paste-reply.mjs';
+    appendCandidate({
+      message_id: 'test-cli-msg',
+      subject: 'Interview Confirmation',
+      from: 'talent@acme.com',
+      body_snippet: 'We would love to chat',
+    });
+    console.log(JSON.stringify({ path: CANDIDATES_PATH }));
+    `;
+    evalModule(appendTestScript, {
+      CAREER_OPS_REPLY_CANDIDATES: null,
+      CAREER_OPS_DATA_DIR: flatTrackerDir,
+    });
+    const writtenFile = join(flatTrackerDir, 'data', 'reply-candidates.json');
+    const writtenContent = readFileSync(writtenFile, 'utf-8');
+    if (writtenContent.includes('test-cli-msg') && writtenContent.includes('talent@acme.com')) {
+      pass('paste-reply.mjs: appendCandidate writes to CAREER_OPS_DATA_DIR target');
+    } else {
+      fail(`paste-reply.mjs: candidate not written to ${writtenFile}`);
+    }
+  } catch (err) {
+    fail(`paste-reply.mjs appendCandidate test failed: ${err.message}`);
+  }
+
+  // 9. rejection-latency.mjs DEFAULT_TRACKER_PATH respects CAREER_OPS_TRACKER & flat layout
+  try {
+    const resTracker = evalModule(
+      "import { DEFAULT_TRACKER_PATH } from './rejection-latency.mjs'; console.log(JSON.stringify({ path: DEFAULT_TRACKER_PATH }));",
+      { CAREER_OPS_TRACKER: customTracker }
+    );
+    const resFlat = evalModule(
+      "import { DEFAULT_TRACKER_PATH } from './rejection-latency.mjs'; console.log(JSON.stringify({ path: DEFAULT_TRACKER_PATH }));",
+      { CAREER_OPS_TRACKER: null, CAREER_OPS_DATA_DIR: flatTrackerDir }
+    );
+    if (
+      resTracker.path === canonicalizeTrackerPath(customTracker) &&
+      resFlat.path === canonicalizeTrackerPath(flatTrackerFile)
+    ) {
+      pass('rejection-latency.mjs: DEFAULT_TRACKER_PATH respects CAREER_OPS_TRACKER and flat CAREER_OPS_DATA_DIR');
+    } else {
+      fail(`rejection-latency.mjs: DEFAULT_TRACKER_PATH mismatch (tracker: ${resTracker.path}, flat: ${resFlat.path})`);
+    }
+  } catch (err) {
+    fail(`rejection-latency.mjs DEFAULT_TRACKER_PATH test failed: ${err.message}`);
+  }
+
+  // 10. rejection-latency.mjs CLI loads and evaluates tracker from CAREER_OPS_TRACKER
+  try {
+    const activeInterviews = join(tmp, 'active-interviews.md');
+    writeFileSync(
+      activeInterviews,
+      '# Active Interviews\n\n| # | Company | Role | Round | Date |\n|---|---------|------|-------|------|\n| 1 | Acme Corp | Staff Engineer | Final | 2026-05-01 |\n'
+    );
+
+    const cliOut = execFileSync(NODE, [
+      'rejection-latency.mjs',
+      '--file', activeInterviews,
+      '--today', '2026-07-01',
+    ], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, CAREER_OPS_TRACKER: customTracker },
+    });
+
+    const parsed = JSON.parse(cliOut);
+    if (parsed && Array.isArray(parsed.flags) && parsed.flags.some(f => f.company === 'Acme Corp')) {
+      pass('rejection-latency.mjs: CLI evaluates overdue interview from custom tracker');
+    } else {
+      fail(`rejection-latency.mjs: expected flag for Acme Corp: ${cliOut}`);
+    }
+  } catch (err) {
+    fail(`rejection-latency.mjs CLI execution test failed: ${err.message}`);
+  }
 } finally {
   rmSync(tmp, { recursive: true, force: true });
+  rmSync(flatTrackerDir, { recursive: true, force: true });
 }

--- a/tests/cli-tracker-path-resolution.test.mjs
+++ b/tests/cli-tracker-path-resolution.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * tests/cli-tracker-path-resolution.test.mjs
+ *
+ * Asserts that CLI tools (scan.mjs, reply-watch.mjs, linkedin-join.mjs,
+ * rejection-latency.mjs) resolve their tracker and data paths via
+ * resolveTrackerPath(DATA_ROOT) rather than hardcoding 'data/applications.md'
+ * or anchoring to the code repository (__dirname).
+ */
+
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { canonicalizeTrackerPath } from '../path-resolver.mjs';
+
+console.log('\nCLI tracker path resolution — CAREER_OPS_TRACKER & CAREER_OPS_DATA_DIR support');
+
+const tmp = mkdtempSync(join(tmpdir(), 'co-tracker-res-'));
+
+try {
+  const dataDir = join(tmp, 'data');
+  mkdirSync(dataDir, { recursive: true });
+
+  const customTracker = join(tmp, 'custom-tracker.md');
+  const trackerHeader = '# Applications Tracker\n\n| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n|---|------|---------|------|-------|--------|-----|--------|-------|\n| 1 | 2026-06-01 | Acme | Dev | 4.0/5 | Applied | ❌ | - | |\n';
+  writeFileSync(customTracker, trackerHeader);
+
+  // 1. scan.mjs honors CAREER_OPS_TRACKER for APPLICATIONS_PATH
+  const scanCheck = execFileSync(NODE, [
+    '-e',
+    `
+    process.env.CAREER_OPS_TRACKER = ${JSON.stringify(customTracker)};
+    import('./scan.mjs').then(m => {
+      if (m.APPLICATIONS_PATH === ${JSON.stringify(canonicalizeTrackerPath(customTracker))}) {
+        console.log('OK');
+      } else {
+        console.error('MISMATCH:', m.APPLICATIONS_PATH);
+        process.exit(1);
+      }
+    });
+    `,
+  ], { cwd: ROOT, encoding: 'utf-8' });
+
+  if (scanCheck.trim() === 'OK') {
+    pass('scan.mjs: APPLICATIONS_PATH respects CAREER_OPS_TRACKER');
+  } else {
+    fail('scan.mjs: APPLICATIONS_PATH did not match CAREER_OPS_TRACKER');
+  }
+
+  // 2. scan.mjs honors flat root layout when data/applications.md is absent
+  const flatTrackerDir = mkdtempSync(join(tmpdir(), 'co-flat-'));
+  const flatTrackerFile = join(flatTrackerDir, 'applications.md');
+  writeFileSync(flatTrackerFile, trackerHeader);
+
+  const flatCheck = execFileSync(NODE, [
+    '-e',
+    `
+    delete process.env.CAREER_OPS_TRACKER;
+    process.env.CAREER_OPS_DATA_DIR = ${JSON.stringify(flatTrackerDir)};
+    import('./scan.mjs').then(m => {
+      if (m.APPLICATIONS_PATH === ${JSON.stringify(canonicalizeTrackerPath(flatTrackerFile))}) {
+        console.log('OK');
+      } else {
+        console.error('MISMATCH:', m.APPLICATIONS_PATH);
+        process.exit(1);
+      }
+    });
+    `,
+  ], { cwd: ROOT, encoding: 'utf-8' });
+
+  if (flatCheck.trim() === 'OK') {
+    pass('scan.mjs: APPLICATIONS_PATH resolves flat applications.md layout under CAREER_OPS_DATA_DIR');
+  } else {
+    fail('scan.mjs: APPLICATIONS_PATH did not resolve flat layout');
+  }
+  rmSync(flatTrackerDir, { recursive: true, force: true });
+
+  // 3. reply-watch.mjs resolves tracker against CAREER_OPS_DATA_DIR
+  const extDataDir = mkdtempSync(join(tmpdir(), 'co-ext-data-'));
+  const extDataSubdir = join(extDataDir, 'data');
+  mkdirSync(extDataSubdir, { recursive: true });
+  const extTracker = join(extDataSubdir, 'applications.md');
+  writeFileSync(extTracker, trackerHeader);
+
+  const replyWatchCheck = execFileSync(NODE, [
+    '-e',
+    `
+    delete process.env.CAREER_OPS_TRACKER;
+    process.env.CAREER_OPS_DATA_DIR = ${JSON.stringify(extDataDir)};
+    // Run reply-watch with empty stdin to observe tracker discovery
+    const cp = await import('child_process');
+    try {
+      const out = cp.execFileSync(${JSON.stringify(NODE)}, ['reply-watch.mjs'], {
+        cwd: ${JSON.stringify(ROOT)},
+        input: '',
+        encoding: 'utf-8',
+        env: { ...process.env, CAREER_OPS_DATA_DIR: ${JSON.stringify(extDataDir)} }
+      });
+      console.log('OK');
+    } catch (e) {
+      console.error(e.stderr || e.stdout);
+      process.exit(1);
+    }
+    `,
+  ], { cwd: ROOT, encoding: 'utf-8' });
+
+  if (replyWatchCheck.trim() === 'OK') {
+    pass('reply-watch.mjs: discovers tracker under CAREER_OPS_DATA_DIR without CAREER_OPS_TRACKER');
+  } else {
+    fail('reply-watch.mjs: failed to discover tracker under CAREER_OPS_DATA_DIR');
+  }
+  rmSync(extDataDir, { recursive: true, force: true });
+
+  // 4. linkedin-join.mjs resolves tracker via resolveTrackerPath
+  const linkedinCheck = execFileSync(NODE, [
+    '-e',
+    `
+    process.env.CAREER_OPS_TRACKER = ${JSON.stringify(customTracker)};
+    const cp = await import('child_process');
+    try {
+      const out = cp.execFileSync(${JSON.stringify(NODE)}, ['linkedin-join.mjs', '--self-test'], {
+        cwd: ${JSON.stringify(ROOT)},
+        encoding: 'utf-8',
+        env: { ...process.env, CAREER_OPS_TRACKER: ${JSON.stringify(customTracker)} }
+      });
+      console.log('OK');
+    } catch (e) {
+      console.error(e.stderr || e.stdout);
+      process.exit(1);
+    }
+    `,
+  ], { cwd: ROOT, encoding: 'utf-8' });
+
+  if (linkedinCheck.trim() === 'OK') {
+    pass('linkedin-join.mjs: self-test passes with resolveTrackerPath');
+  } else {
+    fail('linkedin-join.mjs: failed with resolveTrackerPath');
+  }
+
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Problem

Several CLI tools hardcode `path.join(DATA_ROOT, 'data/applications.md')` or pass `__dirname` to `resolveTrackerPath()`, which causes them to ignore `CAREER_OPS_TRACKER` overrides and break under split-checkout (`CAREER_OPS_DATA_DIR` / `CAREER_OPS_ROOT`) or flat root (`applications.md`) layouts (#4087):

- **`scan.mjs`**: `APPLICATIONS_PATH` hardcodes `data/applications.md`. When a user configures `CAREER_OPS_TRACKER` or uses a flat layout, `loadDedupSnapshot()` falls back to an empty tracker string, causing job deduplication against existing applications to fail silently.
- **`reply-watch.mjs`**: passes `__dirname` (code repository) to `resolveTrackerPath()` instead of `DATA_ROOT`, and anchors `data/reply-candidates.json` and `data/follow-ups.md` to `__dirname`. Under `CAREER_OPS_DATA_DIR`, it fails to find the tracker.
- **`paste-reply.mjs`**: anchors `data/reply-candidates.json` to `__dirname` instead of `DATA_ROOT`.
- **`linkedin-join.mjs`**: hardcodes `data/applications.md` rather than using `resolveTrackerPath(DATA_ROOT)`.
- **`rejection-latency.mjs`**: hand-rolls an ad-hoc layout check that misses `CAREER_OPS_TRACKER` and canonicalization.

## Fix

1. In `scan.mjs`, resolve `export const APPLICATIONS_PATH = resolveTrackerPath(DATA_ROOT)`.
2. In `reply-watch.mjs`, resolve `APPS_FILE = resolveTrackerPath(DATA_ROOT)`, and anchor `DEFAULT_CANDIDATES_PATH` and `FOLLOWUPS_FILE` to `DATA_ROOT`.
3. In `paste-reply.mjs`, anchor `CANDIDATES_PATH` to `DATA_ROOT`.
4. In `linkedin-join.mjs`, resolve `TRACKER_PATH = resolveTrackerPath(DATA_ROOT)`.
5. In `rejection-latency.mjs`, resolve `DEFAULT_TRACKER_PATH = resolveTrackerPath(DATA_ROOT)`.
6. Add `tests/cli-tracker-path-resolution.test.mjs` asserting that:
   - `scan.mjs` respects `CAREER_OPS_TRACKER`.
   - `scan.mjs` resolves flat `applications.md` under `CAREER_OPS_DATA_DIR`.
   - `reply-watch.mjs` discovers the tracker under `CAREER_OPS_DATA_DIR` without `CAREER_OPS_TRACKER`.
   - `linkedin-join.mjs` passes self-test with `resolveTrackerPath`.

Closes #4087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can use `CAREER_OPS_TRACKER`, `CAREER_OPS_DATA_DIR`, `CAREER_OPS_ROOT`, split checkouts, and flat `applications.md` layouts without tracker discovery failures.

The CLI tools now resolve trackers with `resolveTrackerPath(DATA_ROOT)` and user-data files with `getCareerOpsRoot()`:

- `scan.mjs:91-110`
- `reply-watch.mjs:21-30`
- `paste-reply.mjs:49-54`
- `linkedin-join.mjs:81-86`
- `rejection-latency.mjs:60-67`

Before this change, these configurations could make tools read the wrong tracker or fail to find user-data files.

Tests in `tests/cli-tracker-path-resolution.test.mjs` cover tracker overrides, flat layouts, split-checkout discovery, and `linkedin-join.mjs --self-test`.

No changes touch `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->