### PR TITLE
test(harness): remove the migration suite's fixture repo on exit

### DIFF
--- a/tests/updater-migration-fixture-cleanup.test.mjs
+++ b/tests/updater-migration-fixture-cleanup.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * updater-migration-fixture-cleanup.test.mjs - the migration suite's git
+ * fixture must not outlive the suite.
+ *
+ * updater-migration-tests.mjs gives a nested .git-less copy a tiny repository
+ * of its own, so update-system's nested-install guard (#3334) lets its apply()
+ * probes through. test-all runs every smoke script from ONE shared copy, and
+ * that repository used to stay behind: `update-system.mjs check`, later in the
+ * same matrix, then passed the guard it should have tripped and fetched
+ * upstream main into the empty fixture repo - a full clone over the network,
+ * killed at the 30s default on a slow connection as
+ * `update-system.mjs check crashed (exit null, signal SIGTERM)`.
+ *
+ * The sections run the real suite from a nested copy inside a throwaway outer
+ * repo (the shape of test-all's shared copy), then `check` from the SAME
+ * directory, which is the order the smoke matrix runs them in. Four files are
+ * enough: update-system.mjs is self-loading (#1706). The suite's manifest
+ * assertions fail against so sparse a copy, which is useful rather than noise:
+ * it sends the suite down its failing-exit path, and the cleanup has to hold
+ * there too.
+ */
+
+import { mkdtempSync, mkdirSync, copyFileSync, existsSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail, NODE, ROOT, rmSync, hermeticGitEnv } from './helpers.mjs';
+import { gitIn } from '../update-system.mjs';
+
+console.log('\n🧪 Testing updater-migration-tests.mjs fixture cleanup...');
+
+const SUITE_FILES = ['update-system.mjs', 'updater-migration-tests.mjs', 'AGENTS.md', 'VERSION'];
+
+// Every proxy variable curl and git read, pointed at a closed local port. With
+// the fixture repository leaked, `check` gets past its guard and reaches for
+// the network; this turns that into an immediate `offline` instead of a
+// download, so the regression fails fast and never depends on connectivity.
+const NO_NETWORK = {
+  ...Object.fromEntries(
+    ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy']
+      .map((name) => [name, 'http://127.0.0.1:9']),
+  ),
+  NO_PROXY: '',
+  no_proxy: '',
+};
+
+function makeCopy(dir) {
+  mkdirSync(dir, { recursive: true });
+  for (const file of SUITE_FILES) copyFileSync(join(ROOT, file), join(dir, file));
+}
+
+function spawnIn(cwd, fixtureDir, args) {
+  return spawnSync(NODE, args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 60000,
+    env: { ...hermeticGitEnv(join(fixtureDir, 'hermetic-gitconfig')), ...NO_NETWORK },
+  });
+}
+
+// ── 1. The suite's fixture repository is gone once the suite exits ──
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-migration-fixture-'));
+  try {
+    gitIn(dir, 'init', '-q', '-b', 'main', '.');
+    const nested = join(dir, 'tools', 'career-ops');
+    makeCopy(nested);
+
+    const suite = spawnIn(nested, dir, ['updater-migration-tests.mjs']);
+    // Proof the fixture existed while the suite ran, so the absence checked
+    // below is not vacuous: without a repository of its own, apply() refuses
+    // the nested copy before its confirmation gate and this line reads FAIL.
+    if (suite.stdout.includes('PASS environment-only confirmation cannot authorize initial apply')) {
+      pass('the suite ran its apply() probes against its own fixture repository');
+    } else {
+      fail(`the suite never reached apply()'s confirmation gate (exit ${suite.status}): ${JSON.stringify((suite.stderr || '').slice(0, 300))}`);
+    }
+    if (!existsSync(join(nested, '.git'))) {
+      pass('the fixture repository is removed when the suite exits');
+    } else {
+      fail('updater-migration-tests.mjs left its fixture .git behind in the copy it ran from');
+    }
+
+    // ── 2. ...so `check`, run next from the same directory, trips the guard ──
+    const check = spawnIn(nested, dir, ['update-system.mjs', 'check']);
+    let status;
+    try { status = JSON.parse(check.stdout).status; } catch { status = undefined; }
+    if (check.status === 0 && status === 'not-a-git-toplevel') {
+      pass('check run after the suite still reports not-a-git-toplevel and never reaches the network');
+    } else {
+      fail(`check run after the suite exited ${check.status} with ${JSON.stringify((check.stdout || '').slice(0, 200))} - a leaked fixture repo makes it fetch upstream`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 3. A repository the suite did not create is never removed ──
+// A copy that is its own checkout, as a clone is when someone runs
+// `node updater-migration-tests.mjs` by hand. The cleanup is keyed on `.git`
+// being absent before the suite ran, so this layout comes out as it went in.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-migration-own-repo-'));
+  try {
+    makeCopy(dir);
+    const g = (...args) => gitIn(dir, ...args);
+    g('init', '-q', '-b', 'main', '.');
+    g('config', 'user.email', 'test@example.com');
+    g('config', 'user.name', 'Test');
+    // Same three lines as the sibling fixtures: a contributor's global gpg
+    // signer or hooksPath would otherwise kill this commit (#2754), and Windows
+    // git would print a CRLF warning per file.
+    g('config', 'commit.gpgsign', 'false');
+    g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
+    g('config', 'core.autocrlf', 'false');
+    g('add', '-A');
+    g('commit', '-qm', 'own checkout');
+    const head = g('rev-parse', 'HEAD');
+
+    spawnIn(dir, dir, ['updater-migration-tests.mjs']);
+    if (existsSync(join(dir, '.git')) && g('rev-parse', 'HEAD') === head) {
+      pass('a checkout that already had its own .git keeps it, and its HEAD, after the suite');
+    } else {
+      fail('updater-migration-tests.mjs removed or rewrote a repository it did not create');
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -9,7 +9,7 @@
 
 import { readFileSync, existsSync, rmSync } from 'fs';
 import { execFileSync, spawnSync } from 'child_process';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { createReexecMarker, consumeReexecMarker } from './update-system.mjs';
 
 let passed = 0;
@@ -43,10 +43,37 @@ try {
 // checkout. Give that copy its own tiny repository so update-system's
 // production guard can distinguish a valid fixture from an install whose git
 // operations would escape into an enclosing repository.
+//
+// That repository is scaffolding for this suite alone, so it is removed again
+// on exit. test-all runs every smoke script from the SAME shared copy, and a
+// `.git` left behind makes that copy a checkout of its own for every script
+// after this one: `update-system.mjs check` then passes its nested-install
+// guard and fetches upstream main into the empty fixture repository - a full
+// clone over the network inside the smoke matrix, killed at the shared 30s
+// budget on any connection slow enough (`exit null, signal SIGTERM`).
+//
+// Removal is keyed on whether `.git` existed BEFORE this script ran, never on
+// the toplevel comparison below. That comparison is unreliable (#3732: on
+// Windows it never matches, so the init branch runs inside the real checkout),
+// and a cleanup keyed on it could delete a real repository. A `.git` this
+// script did not create is never touched, a linked worktree's `.git` file
+// included. The handler is registered before `git init` so a setup that fails
+// halfway still leaves the copy as it found it.
 try {
   const cwd = process.cwd();
   const toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }).trim();
   if (toplevel !== cwd) {
+    const fixtureGitDir = join(cwd, '.git');
+    if (!existsSync(fixtureGitDir)) {
+      process.on('exit', () => {
+        try {
+          rmSync(fixtureGitDir, { recursive: true, force: true });
+        } catch (error) {
+          console.error(`FAIL migration fixture cleanup: ${error.message}`);
+          process.exitCode = 1;
+        }
+      });
+    }
     execFileSync('git', ['init', '-q'], { cwd });
     execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], { cwd });
     execFileSync('git', ['config', 'user.name', 'career-ops tests'], { cwd });


### PR DESCRIPTION
## What does this PR do?

`updater-migration-tests.mjs` gives the smoke matrix's shared throwaway copy a git repository of its own and never removes it. Every smoke script after it then runs inside that repository, including `update-system.mjs check`, which passes its nested-install guard (#3334) and `git fetch`es upstream `main` into the empty fixture repo: a full-history download from GitHub, inside the test suite. On a slow enough connection that crosses the shared 30s budget and the entry is killed as `update-system.mjs check crashed (exit null, signal SIGTERM)`.

This removes the fixture repository when the suite exits.

## Related issue

None - bug fix, sent straight in. Related: #3732 is the same ten-line fixture block (the Windows toplevel comparison). It is not fixed here, but the cleanup is deliberately keyed so it cannot make #3732 worse - details below.

This is also the failure I mentioned in #4036's test-suite note, where I put it down to a cold cache and offered a `timeoutMs` bump. That diagnosis was wrong, and a timeout bump would have been the wrong fix.

## Reproduction

The same sequence the smoke matrix runs, from a copy of the tree nested inside the checkout (`.git`, `node_modules`, `data/`, `reports/` excluded, as `copyDirSync` does):

| step | before | after |
|---|---|---|
| `node updater-migration-tests.mjs` | passes, leaves `.git` in the copy | passes (368/368), leaves nothing |
| `node update-system.mjs check` from the same copy | `rev-parse` finds the fixture repo, then `git fetch --quiet https://github.com/career-ops-hq/career-ops.git main` - 19s on one run here, ~48s on another, and past 30s inside the full suite | `{"status":"not-a-git-toplevel",...}` in 0s, no network |

CI stays green only because GitHub-hosted runners fetch fast, so every CI run of the smoke section currently downloads the repository once more.

## Why not raise the entry's `timeoutMs`

The time is not the script's own work: `check` from a nested copy should return in milliseconds without touching the network, and does once the copy is left alone. A bigger budget would make the matrix wait for a network clone instead of noticing that one is happening, and would still fail offline.

## The fix

- The `exit` handler is registered only when `.git` did **not** exist before the suite ran, and before `git init`, so a setup that throws halfway still cleans up. It runs on normal completion, on the suite's failing exit, and after an uncaught error.
- It is keyed on that pre-existence, never on the `toplevel !== cwd` comparison that guards `git init`. Per #3732 that comparison never matches on Windows, so the init branch runs inside a real checkout there; a cleanup keyed on it could delete the user's `.git`. A `.git` the suite did not create, a linked worktree's `.git` file included, is never touched.
- A failed removal prints `FAIL migration fixture cleanup: ...` and sets a non-zero exit code rather than passing quietly.

**Known limitation:** exit handlers do not run when the process is killed, so a suite that is itself SIGTERM'd for time still leaves the repository behind. That path already reports its own failure.

## Tests

New `tests/updater-migration-fixture-cleanup.test.mjs` (auto-discovered), 4 assertions, hermetic (`hermeticGitEnv`, a throwaway outer repo, and every proxy variable pointed at a closed local port so a regression fails as `offline` in milliseconds instead of downloading):

1. the suite really ran its `apply()` probes against a fixture repository (so the next check is not vacuous), and
2. no `.git` is left in the copy it ran from;
3. `check` run next from the same directory reports `not-a-git-toplevel`;
4. a copy that already was its own checkout keeps its `.git` and its `HEAD`.

Run against `main`'s unfixed `updater-migration-tests.mjs`, exactly 2 of the 4 fail - the leaked `.git`, and `check` returning `{"status":"offline"}` because it got past the guard and reached for the network. The non-vacuity and safety assertions pass either way, which is the point of having them.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt - send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

`node test-all.mjs` here: 8693 passed, 0 failed, 15 warnings - the same 15 as a run without this change (only a random probe filename differs) - and the smoke matrix now reports `update-system.mjs check runs OK`, the entry that was being killed.

https://claude.ai/code/session_01Bzg79mEBiS4AQQeagJ1FUP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The migration test harness now removes the temporary `.git` directory when it created one: `updater-migration-tests.mjs`. Cleanup runs after normal completion, test failure, and uncaught errors. Pre-existing repositories, including linked worktrees, remain unchanged.

A new test verifies fixture cleanup, subsequent `update-system.mjs check` behavior, and preservation of an existing repository: `tests/updater-migration-fixture-cleanup.test.mjs`.

System files touched: `updater-migration-tests.mjs` and `tests/updater-migration-fixture-cleanup.test.mjs`. No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

The full suite passes: 8,693 tests passed with no failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->