### PR TITLE
test(updater): seal git fixture environment

### DIFF
--- a/tests/doctor-tracked-bak-files.test.mjs
+++ b/tests/doctor-tracked-bak-files.test.mjs
@@ -6,7 +6,7 @@
 // untracks a path git already has, so the update looks like it silently did
 // nothing (career-ops#2881) with no signal pointing at .bak. This pins the
 // doctor check that surfaces it instead of letting it stay silent.
-import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { pass, fail, NODE, ROOT, makeHermeticGitRunner } from './helpers.mjs';
 import { execFileSync } from 'child_process';
 import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
@@ -29,24 +29,22 @@ function runDoctor(cwd) {
   }
 }
 
-function git(cwd, ...args) {
-  execFileSync('git', args, { cwd, stdio: 'ignore' });
-}
-
 function initRepo(dir) {
-  git(dir, 'init', '-q');
-  git(dir, 'config', 'user.email', 'test@example.com');
-  git(dir, 'config', 'user.name', 'Test');
+  const git = makeHermeticGitRunner(dir);
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  return git;
 }
 
 // 1. A tracked .bak file is reported as a warning naming the remedy.
 {
   const dir = mkdtempSync(join(tmpdir(), 'co-bak-2-'));
   try {
-    initRepo(dir);
+    const git = initRepo(dir);
     writeFileSync(join(dir, 'notes.md.bak'), 'stale backup\n', 'utf-8');
-    git(dir, 'add', 'notes.md.bak');
-    git(dir, 'commit', '-q', '-m', 'accidentally tracked backup');
+    git('add', 'notes.md.bak');
+    git('commit', '-q', '-m', 'accidentally tracked backup');
 
     const state = runDoctor(dir);
     if (state._error) {
@@ -73,10 +71,10 @@ function initRepo(dir) {
 {
   const dir = mkdtempSync(join(tmpdir(), 'co-bak-3-'));
   try {
-    initRepo(dir);
+    const git = initRepo(dir);
     writeFileSync(join(dir, 'cv.md'), '# CV\n', 'utf-8');
-    git(dir, 'add', 'cv.md');
-    git(dir, 'commit', '-q', '-m', 'add cv');
+    git('add', 'cv.md');
+    git('commit', '-q', '-m', 'add cv');
 
     const state = runDoctor(dir);
     if (state._error) {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -636,11 +636,6 @@ export async function captureConsoleErrors(fn) {
  * pins nothing. They are different fixtures that share a name, not copies of
  * this one.
  *
- * `gitIn` is injected rather than imported so this module keeps depending on
- * nothing but Node builtins — 57 of the 62 suites import it, and none of them
- * should pull in update-system.mjs as a side effect of asking for `pass`/`fail`.
- *
- * @param {(dir: string, ...args: string[]) => any} gitIn - Updater's git runner.
  * @param {object} [options]
  * @param {string} [options.prefix='co-updater-'] - mkdtemp prefix, so a leftover
  *   temp dir names the suite that made it.
@@ -650,9 +645,9 @@ export async function captureConsoleErrors(fn) {
  *   fixture. `isTracked` never reads it.
  * @returns {{dir: string, g: Function, ctx: {git: Function, root?: string}}}
  */
-export function makeUpdaterRepo(gitIn, { prefix = 'co-updater-', includeRoot = false } = {}) {
+export function makeUpdaterRepo({ prefix = 'co-updater-', includeRoot = false } = {}) {
   const dir = mkdtempSync(join(tmpdir(), prefix));
-  const g = (...args) => gitIn(dir, ...args);
+  const g = makeHermeticGitRunner(dir);
   g('init', '-q', '-b', 'main', '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
@@ -709,6 +704,29 @@ export function hermeticGitEnv(gitConfigPath, base = process.env) {
   delete env.GIT_CONFIG_PARAMETERS;
   delete env.GIT_CONFIG;
   return env;
+}
+
+/**
+ * Build a git runner whose every invocation uses hermeticGitEnv().
+ *
+ * The config path lives under .git so fixture `git add -A` calls cannot stage
+ * the pin itself. It may not exist for the initial `git init` or `git clone`;
+ * git treats a missing global/system config as empty, then the repository
+ * creation makes the parent directory available for later commands.
+ *
+ * @param {string} root - Fixture repository root.
+ * @param {object} [base=process.env] - Parent environment to seal.
+ * @returns {(...args: string[]) => string} Trimmed git stdout.
+ */
+export function makeHermeticGitRunner(root, base = process.env) {
+  const env = hermeticGitEnv(join(root, '.git', 'co-hermetic-gitconfig'), base);
+  return (...args) => execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: 30000,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
 }
 
 /**

--- a/tests/hermetic-git-env.test.mjs
+++ b/tests/hermetic-git-env.test.mjs
@@ -24,7 +24,7 @@ import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { pass, fail, hermeticGitEnv } from './helpers.mjs';
+import { pass, fail, hermeticGitEnv, makeUpdaterRepo } from './helpers.mjs';
 
 console.log('\nhermetic git env — ambient GIT_CONFIG* must not reach a fixture');
 
@@ -86,4 +86,49 @@ try {
   }
 } finally {
   rmSync(root, { recursive: true, force: true });
+}
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-updater-fixture-env-'));
+try {
+  const ambient = join(fixtureRoot, 'ambient-config');
+  const excludes = join(fixtureRoot, 'ambient-excludes');
+  writeFileSync(ambient, '[user]\n\tname = config-leak\n');
+  writeFileSync(excludes, '*\n');
+  const poisoned = {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'core.excludesFile',
+    GIT_CONFIG_VALUE_0: excludes,
+    GIT_CONFIG_PARAMETERS: "'user.name=parameters-leak'",
+    GIT_CONFIG: ambient,
+    GIT_CONFIG_GLOBAL: ambient,
+    GIT_CONFIG_SYSTEM: ambient,
+  };
+  const previous = Object.fromEntries(Object.keys(poisoned).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, poisoned);
+  let fixture;
+  try {
+    fixture = makeUpdaterRepo({ prefix: 'co-hermetic-updater-regression-' });
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  try {
+    writeFileSync(join(fixture.dir, 'seed.txt'), 'tracked\n');
+    fixture.g('add', '-A');
+    fixture.g('commit', '-qm', 'base');
+    const seenName = fixture.g('config', 'user.name');
+    const escaped = readFileSync(ambient, 'utf-8');
+    if (seenName === 'Test' && escaped === '[user]\n\tname = config-leak\n') {
+      pass('makeUpdaterRepo keeps every ambient GIT_CONFIG_* channel out of fixture git commands');
+    } else {
+      fail(`makeUpdaterRepo inherited ambient git configuration: user.name=${seenName}`);
+    }
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+} finally {
+  rmSync(fixtureRoot, { recursive: true, force: true });
 }

--- a/tests/updater-add-paths.test.mjs
+++ b/tests/updater-add-paths.test.mjs
@@ -25,14 +25,14 @@
 import { writeFileSync, mkdirSync, rmSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { pass, fail, makeUpdaterRepo } from './helpers.mjs';
-import { gitIn, addPaths, isTracked, expandToShippedFiles, stagingFileList } from '../update-system.mjs';
+import { addPaths, isTracked, expandToShippedFiles, stagingFileList } from '../update-system.mjs';
 
 // Shared with updater-is-tracked.test.mjs so the git-isolation pins live in one
 // body: dropping one has to redden both suites, not leave this one quietly
 // unprotected. `root` is the second half of the seam here — addPaths resolves
 // paths against it to decide what is a directory, and without it the guard
 // would lstat the real repository instead of this fixture.
-const makeRepo = () => makeUpdaterRepo(gitIn, { prefix: 'co-addpaths-', includeRoot: true });
+const makeRepo = () => makeUpdaterRepo({ prefix: 'co-addpaths-', includeRoot: true });
 
 // -z for the same reason the expansion uses it: under core.quotePath (the
 // default) git renders a non-ASCII name as "modes/\346\227\245...", so a

--- a/tests/updater-drift-detection.test.mjs
+++ b/tests/updater-drift-detection.test.mjs
@@ -32,9 +32,8 @@
 import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { execFileSync } from 'child_process';
-import { pass, fail, rmSync } from './helpers.mjs';
-import { gitIn, systemTreeDiffers } from '../update-system.mjs';
+import { pass, fail, rmSync, makeHermeticGitRunner } from './helpers.mjs';
+import { systemTreeDiffers } from '../update-system.mjs';
 
 // System paths the fixtures pretend this install manages. Small and stable:
 // one root-level script, one modes/ file (exercises a directory-style
@@ -45,7 +44,7 @@ const USER_PATH = 'data/applications.md';
 
 function makeOrigin() {
   const dir = mkdtempSync(join(tmpdir(), 'co-drift-origin-'));
-  const g = (...args) => gitIn(dir, ...args);
+  const g = makeHermeticGitRunner(dir);
   g('init', '-q', '-b', 'main', '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
@@ -63,8 +62,8 @@ function makeOrigin() {
 
 function cloneInstall(originDir) {
   const dir = mkdtempSync(join(tmpdir(), 'co-drift-install-'));
-  gitIn(dir, 'clone', '-q', originDir, '.');
-  const g = (...args) => gitIn(dir, ...args);
+  const g = makeHermeticGitRunner(dir);
+  g('clone', '-q', originDir, '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
   g('config', 'core.autocrlf', 'false');
@@ -111,7 +110,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
       fail('fixture: expected post-apply HEAD SHA to differ from upstream');
     }
 
-    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) }) === false) {
+    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: install.g }) === false) {
       pass('post-apply install (equal content, diverged SHA) is NOT drift');
     } else {
       fail('post-apply install (equal content, diverged SHA) reported as drift — the false positive is back');
@@ -131,7 +130,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
     origin.g('commit', '-qm', 'fix scanner');
     install.g('fetch', '-q', origin.dir, 'main');
 
-    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) }) === true) {
+    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: install.g }) === true) {
       pass('genuine upstream system-file change IS drift');
     } else {
       fail('genuine upstream system-file change NOT reported as drift');
@@ -153,7 +152,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
     install.g('commit', '-qm', 'track another application');
     install.g('fetch', '-q', origin.dir, 'main');
 
-    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) }) === false) {
+    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: install.g }) === false) {
       pass('user-layer-only difference is NOT drift');
     } else {
       fail('user-layer-only difference reported as drift');
@@ -173,7 +172,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
     writeFileSync(join(install.dir, 'scan.mjs'), '// local uncommitted tweak\n');
     install.g('fetch', '-q', origin.dir, 'main');
 
-    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) }) === false) {
+    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: install.g }) === false) {
       pass('uncommitted system-file edit is NOT drift (committed-state comparison)');
     } else {
       fail('uncommitted system-file edit reported as drift');
@@ -199,7 +198,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
 
     let crlfDiffIsReal = false;
     try {
-      gitIn(install.dir, 'diff', '--quiet', 'FETCH_HEAD', 'HEAD', '--', 'modes/_shared.md');
+      install.g('diff', '--quiet', 'FETCH_HEAD', 'HEAD', '--', 'modes/_shared.md');
     } catch {
       crlfDiffIsReal = true; // exit 1 = blobs genuinely differ
     }
@@ -207,7 +206,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
       fail('fixture: expected a real CRLF blob difference before the flag-scoped check');
     }
 
-    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: (...a) => gitIn(install.dir, ...a) }) === false) {
+    if (systemTreeDiffers(SYSTEM_PATHS, 'FETCH_HEAD', { git: install.g }) === false) {
       pass('CRLF/LF-only difference is NOT drift (--ignore-cr-at-eol)');
     } else {
       fail('CRLF/LF-only difference reported as drift');
@@ -224,16 +223,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
   const origin = makeOrigin();
   const install = cloneInstall(origin.dir);
   try {
-    // Same seam as production gitIn, but with stderr explicitly piped:
-    // execFileSync's DEFAULT stdio lets git's expected "fatal: bad revision"
-    // leak onto the suite's fd2, and this scenario fails on purpose.
-    const quietGit = (...args) =>
-      execFileSync('git', args, {
-        cwd: install.dir, encoding: 'utf-8', timeout: 30000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-
-    if (systemTreeDiffers(SYSTEM_PATHS, 'refs/heads/does-not-exist', { git: quietGit }) === true) {
+    if (systemTreeDiffers(SYSTEM_PATHS, 'refs/heads/does-not-exist', { git: install.g }) === true) {
       pass('unreadable upstream ref reads as drift (conservative)');
     } else {
       fail('unreadable upstream ref read as no-drift — verification failed open');
@@ -246,7 +236,7 @@ console.log('\n🧪 Testing updater system-tree drift detection...');
 // ── 7. Empty pathspec short-circuits without invoking git ──────────────────
 {
   let calls = 0;
-  const countingGit = (...a) => { calls++; return gitIn(process.cwd(), ...a); };
+  const countingGit = () => { calls++; throw new Error('git must not run'); };
   if (systemTreeDiffers([], 'FETCH_HEAD', { git: countingGit }) === false && calls === 0) {
     pass('empty pathspec returns false without invoking git');
   } else {

--- a/tests/updater-is-tracked.test.mjs
+++ b/tests/updater-is-tracked.test.mjs
@@ -32,12 +32,12 @@
 import { writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { pass, fail, makeUpdaterRepo } from './helpers.mjs';
-import { gitIn, isTracked } from '../update-system.mjs';
+import { isTracked } from '../update-system.mjs';
 
 // Shared with updater-add-paths.test.mjs so the git-isolation pins live in one
 // body: dropping one has to redden both suites, not leave this one quietly
 // unprotected. `root` is omitted because isTracked never reads it.
-const makeRepo = () => makeUpdaterRepo(gitIn, { prefix: 'co-istracked-' });
+const makeRepo = () => makeUpdaterRepo({ prefix: 'co-istracked-' });
 
 console.log('\n🧪 Testing isTracked (ignored-but-tracked vs never-tracked)...');
 

--- a/tests/updater-nested-checkout-guard.test.mjs
+++ b/tests/updater-nested-checkout-guard.test.mjs
@@ -20,8 +20,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, existsSync, realpa
 import { spawnSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { pass, fail, NODE, ROOT, rmSync, hermeticGitEnv } from './helpers.mjs';
-import { gitIn, gitToplevelMismatch } from '../update-system.mjs';
+import { pass, fail, NODE, ROOT, rmSync, hermeticGitEnv, makeHermeticGitRunner } from './helpers.mjs';
+import { gitToplevelMismatch } from '../update-system.mjs';
 
 console.log('\n🧪 Testing updater nested-checkout guard (#3334)...');
 
@@ -31,7 +31,7 @@ const canonicalize = realpathSync.native ?? realpathSync;
 // as vendored content — the layout the ZIP install produces.
 function makeNestedFixture() {
   const dir = mkdtempSync(join(tmpdir(), 'co-nested-'));
-  const g = (...args) => gitIn(dir, ...args);
+  const g = makeHermeticGitRunner(dir);
   g('init', '-q', '-b', 'main', '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');


### PR DESCRIPTION
## What does this PR do?

Seals updater-related Git fixtures so ambient `GIT_CONFIG_*` settings from a contributor's shell cannot change what the fixture stages, commits, or writes. The shared updater fixture now builds its Git runner through `hermeticGitEnv()`, and the affected updater fixture-family suites use that sealed runner consistently.

## Related issue

Fixes #3801

Related: #3732. I did not change `updater-migration-tests.mjs` in this PR because `.github/copilot-instructions.md` lists it as a protected control file for agents.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Validation

- `npm run lint` -- 693 `.mjs` files passed syntax check.
- `node tests/hermetic-git-env.test.mjs && node tests/updater-add-paths.test.mjs && node tests/updater-is-tracked.test.mjs && node tests/updater-drift-detection.test.mjs && node tests/doctor-tracked-bak-files.test.mjs && node tests/updater-nested-checkout-guard.test.mjs` -- affected fixture suites passed.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt -- send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

## AI assistance

CLOUD, using Copilot SDK in VS Code, prepared this patch at the user's request. The user authorized commit, push, and PR submission after repository-guideline review and local validation.

## Human review

- [ ] Diff read
- [ ] Behavior validated
- [ ] Tests reviewed
- [ ] Public-code matches checked