### PR TITLE
test(cover): render a pack-shaped template through core

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -129,6 +129,36 @@ function buildDateline(letter) {
   return parts.join(" &nbsp;&nbsp; ");
 }
 
+/**
+ * Build the optional recipient address block for a business letter.
+ *
+ * The pack authoring contract places {{RECIPIENT_BLOCK}} bare and expects the
+ * filler to emit its own wrapper, so this returns a complete
+ * `<div class="recipient">` or an empty string, never a bare fragment. Each
+ * line is its own `<div>` rather than a `<br>` join, which is what the packs'
+ * own CSS targets.
+ *
+ * A partial recipient is normal and renders as far as it goes: a company with
+ * no named individual, or a name with no street address, are both ordinary
+ * states for a cover letter. Only a recipient with nothing usable in it, or no
+ * recipient at all, yields the empty string, so a letter without an addressee
+ * still renders instead of failing.
+ *
+ * Accepts `address_lines` (array, the contract's shape) or `address` (string).
+ */
+function buildRecipientBlock(letter) {
+  const r = letter.recipient;
+  if (!r || typeof r !== "object") return "";
+  const addressLines = Array.isArray(r.address_lines)
+    ? r.address_lines
+    : r.address
+      ? [r.address]
+      : [];
+  const lines = [r.name, r.title, r.company, ...addressLines].filter(Boolean).map(escapeHtml);
+  if (!lines.length) return "";
+  return `<div class="recipient">\n${lines.map((l) => `    <div>${l}</div>`).join("\n")}\n  </div>`;
+}
+
 /** Build the optional achievements list for the letter body. */
 function buildAchievementsBlock(achievements) {
   if (!achievements || !achievements.length) return "";
@@ -226,6 +256,7 @@ export function buildHtml(payload, templatePath) {
     "{{CREDENTIALS_BLOCK}}": buildCredentialsBlock(candidate),
     "{{ROLE_TITLE}}": escapeHtml(letter.role_title),
     "{{DATELINE}}": buildDateline(letter),
+    "{{RECIPIENT_BLOCK}}": buildRecipientBlock(letter),
     "{{GREETING_BLOCK}}": greetingBlock,
     "{{OPENING}}": escapeHtml(letter.opening),
     "{{PROFILE_INTRO}}": escapeHtml(letter.profile_intro),

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -140,7 +140,7 @@ function buildDateline(letter) {
  *
  * A partial recipient is normal and renders as far as it goes: a company with
  * no named individual, or a name with no street address, are both ordinary
- * states for a cover letter. Only a recipient with nothing usable in it, or no
+ * states for a cover letter. Only a recipient with nothing usable in it (blank or whitespace-only fields included), or no
  * recipient at all, yields the empty string, so a letter without an addressee
  * still renders instead of failing.
  *
@@ -154,7 +154,12 @@ function buildRecipientBlock(letter) {
     : r.address
       ? [r.address]
       : [];
-  const lines = [r.name, r.title, r.company, ...addressLines].filter(Boolean).map(escapeHtml);
+  // Trim before filtering: `filter(Boolean)` alone keeps "   ", which renders as
+  // a blank line inside the wrapper rather than as the absent field it is.
+  const lines = [r.name, r.title, r.company, ...addressLines]
+    .map((v) => (typeof v === "string" ? v.trim() : v))
+    .filter(Boolean)
+    .map(escapeHtml);
   if (!lines.length) return "";
   return `<div class="recipient">\n${lines.map((l) => `    <div>${l}</div>`).join("\n")}\n  </div>`;
 }

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -124,9 +124,20 @@ function buildCredentialsBlock(candidate) {
 }
 
 /** Build the escaped company, city, and date line for the letter. */
-function buildDateline(letter) {
-  const parts = [letter.company, letter.city, letter.date].filter(Boolean).map(escapeHtml);
-  return parts.join(" &nbsp;&nbsp; ");
+function buildDateline(letter, hasRecipientBlock = false) {
+  // The pack contract gives {{DATELINE}} the date and leaves the company and
+  // city to the address block directly beneath it, so joining all three prints
+  // the company twice, three lines apart.
+  //
+  // Gated on the block actually RENDERING, not on `letter.recipient` merely
+  // being set. An empty or whitespace-only recipient produces no address block,
+  // and dropping company and city for it would lose them with nothing taking
+  // their place. The shipped base template has no address block at all, so it
+  // keeps the full join exactly as before.
+  const parts = hasRecipientBlock
+    ? [letter.date]
+    : [letter.company, letter.city, letter.date];
+  return parts.filter(Boolean).map(escapeHtml).join(" &nbsp;&nbsp; ");
 }
 
 /**
@@ -255,13 +266,14 @@ export function buildHtml(payload, templatePath) {
   // valediction. The <br> is emitted around escaped values, never inside one.
   const signatureBlock = buildSignatureBlock(letter.signature, candidate.name);
 
+  const recipientBlock = buildRecipientBlock(letter);
   const replacements = {
     "{{NAME}}": escapeHtml(candidate.name),
     "{{CONTACT_LINE}}": buildContactLine(candidate),
     "{{CREDENTIALS_BLOCK}}": buildCredentialsBlock(candidate),
     "{{ROLE_TITLE}}": escapeHtml(letter.role_title),
-    "{{DATELINE}}": buildDateline(letter),
-    "{{RECIPIENT_BLOCK}}": buildRecipientBlock(letter),
+    "{{DATELINE}}": buildDateline(letter, Boolean(recipientBlock)),
+    "{{RECIPIENT_BLOCK}}": recipientBlock,
     "{{GREETING_BLOCK}}": greetingBlock,
     "{{OPENING}}": escapeHtml(letter.opening),
     "{{PROFILE_INTRO}}": escapeHtml(letter.profile_intro),

--- a/tests/cover-dateline.test.mjs
+++ b/tests/cover-dateline.test.mjs
@@ -1,0 +1,81 @@
+// tests/cover-dateline.test.mjs — {{DATELINE}} carries the date, not the address.
+//
+// The pack authoring contract fixes both the order and the contents:
+//
+//   {{DATELINE}}                        # the date
+//   {{RECIPIENT_BLOCK}}                 # recipient address block, or empty
+//   Re: Application for {{ROLE_TITLE}}  # reference line
+//   {{GREETING_BLOCK}}                  # salutation
+//
+// buildDateline joined company + city + date, so a letter that renders a
+// recipient printed the company twice, three lines apart. The join is correct
+// for the shipped base template, which has no address block and would otherwise
+// lose that context entirely, so this is a gate rather than a replacement.
+//
+// The absent-recipient case is the one that protects every existing payload:
+// nothing today sets letter.recipient, so nothing today changes.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+function template() {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-dateline-'));
+  const file = join(dir, 'cover-letter-template.html');
+  writeFileSync(file, '{{NAME}}{{ROLE_TITLE}}[D]{{DATELINE}}[/D]{{RECIPIENT_BLOCK}}{{OPENING}}{{PROFILE_INTRO}}');
+  return file;
+}
+
+/** Just the dateline slot's rendered contents. */
+const dateline = (html) => html.slice(html.indexOf('[D]') + 3, html.indexOf('[/D]'));
+
+const payload = (extra) => ({
+  candidate: { name: 'A Candidate' },
+  letter: {
+    role_title: 'Head of Marketing',
+    opening: 'Opening line.',
+    profile_intro: 'Profile intro.',
+    company: 'Example Corp',
+    city: 'Boston, MA',
+    date: 'September 8, 2026',
+    ...extra,
+  },
+});
+
+test('with a recipient, the dateline carries the date alone', () => {
+  // Given the address block below it already names the company and city
+  const html = buildHtml(payload({
+    recipient: { name: 'Jane Reviewer', company: 'Example Corp', address_lines: ['Boston, MA'] },
+  }), template());
+  const d = dateline(html);
+
+  assert.equal(d, 'September 8, 2026');
+  assert.ok(!d.includes('Example Corp'), 'the company belongs to the address block, not the dateline');
+  assert.ok(!d.includes('Boston, MA'), 'the city belongs to the address block, not the dateline');
+  // And it is still present exactly once in the letter as a whole
+  assert.equal((html.match(/Example Corp/g) || []).length, 1, 'the company appears once, not twice');
+});
+
+test('with no recipient, the dateline is unchanged', () => {
+  // This is the compatibility guarantee: no payload today sets a recipient, so
+  // no payload today renders differently.
+  const d = dateline(buildHtml(payload({}), template()));
+
+  assert.equal(d, 'Example Corp &nbsp;&nbsp; Boston, MA &nbsp;&nbsp; September 8, 2026');
+});
+
+test('an empty recipient object does not trigger the gate', () => {
+  // buildRecipientBlock renders nothing for this, so the dateline must keep the
+  // company and city rather than dropping them into a block that never appears.
+  const d = dateline(buildHtml(payload({ recipient: {} }), template()));
+
+  assert.equal(d, 'Example Corp &nbsp;&nbsp; Boston, MA &nbsp;&nbsp; September 8, 2026');
+});
+
+test('a whitespace-only recipient does not trigger the gate either', () => {
+  const d = dateline(buildHtml(payload({ recipient: { name: '   ', company: '\t' } }), template()));
+
+  assert.equal(d, 'Example Corp &nbsp;&nbsp; Boston, MA &nbsp;&nbsp; September 8, 2026');
+});

--- a/tests/cover-pack-contract.test.mjs
+++ b/tests/cover-pack-contract.test.mjs
@@ -1,0 +1,111 @@
+// tests/cover-pack-contract.test.mjs — core must fill every slot the pack
+// cover-letter contract declares.
+//
+// Nothing rendered a pack-shaped template through core before this, which is how
+// the contract and the renderer drifted apart twice without a red test:
+// {{RECIPIENT_BLOCK}} was declared and never filled, so every pack cover template
+// died at substitution; and {{DATELINE}} was declared as the date while the
+// renderer joined company and city into it, so a pack letter printed the company
+// twice.
+//
+// The gap was structural. validateTemplate demands 3 placeholders for kind=cover
+// while the contract declares 14, and tests/template-packs.test.mjs proves a pack
+// RESOLVES without ever rendering one. Every other cover suite builds its own
+// inline fixture carrying just the slots that test needs, so none of them can see
+// a slot core forgot.
+//
+// CONTRACT_SLOTS below is the list from the pack authoring docs, transcribed. It
+// is deliberately a literal rather than something derived from the renderer: a
+// list read out of generate-cover-letter.mjs would agree with itself no matter
+// what the contract says, which is exactly the check that was missing.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+/** The 14 cover-letter slots the pack authoring contract declares. */
+const CONTRACT_SLOTS = [
+  'NAME', 'ROLE_TITLE', 'CONTACT_LINE', 'DATELINE', 'RECIPIENT_BLOCK',
+  'GREETING_BLOCK', 'OPENING', 'PROFILE_INTRO', 'PROBLEMS_BLOCK',
+  'ACHIEVEMENTS_BLOCK', 'CREDENTIALS_BLOCK', 'CLOSING_BLOCK',
+  'LANGUAGE_CLOSING_BLOCK', 'FOOTNOTES_BLOCK',
+];
+
+/** A template carrying every contract slot, each tagged so it can be located. */
+function packTemplate() {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-pack-'));
+  const file = join(dir, 'cover-letter-template.html');
+  writeFileSync(file, CONTRACT_SLOTS.map((s) => `<div data-slot="${s}">{{${s}}}</div>`).join('\n'));
+  return file;
+}
+
+/** A payload that populates every field the contract's slots are fed from. */
+const FULL = {
+  candidate: {
+    name: 'A Candidate',
+    email: 'candidate@example.com',
+    phone: '+1 555 0100',
+    location: 'Boston, MA',
+    linkedin: 'linkedin.com/in/example',
+    website: 'example.com',
+    credentials: ['CRED-ONE', 'CRED-TWO'],
+  },
+  letter: {
+    role_title: 'Head of Marketing',
+    company: 'Example Corp',
+    city: 'Boston, MA',
+    date: 'September 11, 2026',
+    recipient: { name: 'Jane Reviewer', title: 'Director of Talent', company: 'Example Corp', address_lines: ['100 Example Street'] },
+    greeting: 'Dear Jane Reviewer,',
+    opening: 'OPENING-TEXT',
+    profile_intro: 'PROFILE-INTRO-TEXT',
+    achievements: [{ lead: 'ACH-LEAD', impact: 'ACH-IMPACT' }],
+    problems_section: 'PROBLEMS-TEXT',
+    closing: 'CLOSING-TEXT',
+    language_closing: 'LANGUAGE-CLOSING-TEXT',
+    signature: { valediction: 'Sincerely,' },
+    footnotes: ['FOOTNOTE-ONE'],
+  },
+};
+
+test('a template carrying every contract slot renders at all', () => {
+  // The failure this replaces was a hard throw on the first unfilled slot, so
+  // "does not throw" is the first thing worth pinning.
+  assert.doesNotThrow(() => buildHtml(FULL, packTemplate()));
+});
+
+test('core fills every slot the contract declares', () => {
+  const html = buildHtml(FULL, packTemplate());
+
+  // A slot left literal is a slot core does not know about. Report all of them
+  // at once rather than dying on the first, so a contract that grows by three
+  // says so in one run.
+  const unfilled = CONTRACT_SLOTS.filter((s) => html.includes(`{{${s}}}`));
+  assert.deepEqual(unfilled, [], `core left contract slots unsubstituted: ${unfilled.join(', ')}`);
+});
+
+test('every value the payload supplies reaches the letter', () => {
+  // Substitution alone is not enough: {{ACHIEVEMENTS_BLOCK}} was "filled" with
+  // empty <li> elements for the whole life of the achievements-shape bug.
+  const html = buildHtml(FULL, packTemplate());
+
+  for (const v of ['A Candidate', 'Head of Marketing', 'Jane Reviewer', 'Director of Talent',
+                   '100 Example Street', 'OPENING-TEXT', 'PROFILE-INTRO-TEXT', 'ACH-LEAD',
+                   'ACH-IMPACT', 'PROBLEMS-TEXT', 'CLOSING-TEXT', 'LANGUAGE-CLOSING-TEXT',
+                   'CRED-ONE', 'FOOTNOTE-ONE', 'September 11, 2026']) {
+    assert.ok(html.includes(v), `the payload supplied "${v}" and the letter does not carry it`);
+  }
+});
+
+test('the contract list and the renderer have not drifted apart', () => {
+  // The canary. If someone adds a slot to the contract and not to core, the
+  // suite above fails. If core grows a slot the contract does not declare, this
+  // reports it as informational rather than failing, since core is allowed a
+  // superset for its own shipped template.
+  const html = buildHtml(FULL, packTemplate());
+  const literal = [...html.matchAll(/\{\{([A-Z_]+)\}\}/g)].map((m) => m[1]);
+
+  assert.deepEqual(literal, [], `unsubstituted tokens survived into the letter: ${literal.join(', ')}`);
+});

--- a/tests/cover-pack-contract.test.mjs
+++ b/tests/cover-pack-contract.test.mjs
@@ -45,10 +45,10 @@ function packTemplate() {
 const FULL = {
   candidate: {
     name: 'A Candidate',
-    email: 'candidate@example.com',
-    phone: '+1 555 0100',
+    email: 'CANDIDATE-EMAIL-SENTINEL@example.com',
+    phone: '+1 555 0100 PHONE-SENTINEL',
     location: 'Boston, MA',
-    linkedin: 'linkedin.com/in/example',
+    linkedin: 'linkedin.com/in/LINKEDIN-SENTINEL',
     website: 'example.com',
     credentials: ['CRED-ONE', 'CRED-TWO'],
   },
@@ -86,6 +86,12 @@ test('core fills every slot the contract declares', () => {
   assert.deepEqual(unfilled, [], `core left contract slots unsubstituted: ${unfilled.join(', ')}`);
 });
 
+function slotHtml(html, slot) {
+  const match = html.match(new RegExp(`<div data-slot="${slot}">([\\s\\S]*?)</div>`));
+  assert.ok(match, `rendered letter does not contain data-slot="${slot}"`);
+  return match[1];
+}
+
 test('every value the payload supplies reaches the letter', () => {
   // Substitution alone is not enough: {{ACHIEVEMENTS_BLOCK}} was "filled" with
   // empty <li> elements for the whole life of the achievements-shape bug.
@@ -94,8 +100,16 @@ test('every value the payload supplies reaches the letter', () => {
   for (const v of ['A Candidate', 'Head of Marketing', 'Jane Reviewer', 'Director of Talent',
                    '100 Example Street', 'OPENING-TEXT', 'PROFILE-INTRO-TEXT', 'ACH-LEAD',
                    'ACH-IMPACT', 'PROBLEMS-TEXT', 'CLOSING-TEXT', 'LANGUAGE-CLOSING-TEXT',
-                   'CRED-ONE', 'FOOTNOTE-ONE', 'September 11, 2026']) {
+                   'FOOTNOTE-ONE', 'September 11, 2026']) {
     assert.ok(html.includes(v), `the payload supplied "${v}" and the letter does not carry it`);
+  }
+
+  for (const v of ['CANDIDATE-EMAIL-SENTINEL@example.com', '+1 555 0100 PHONE-SENTINEL',
+                   'linkedin.com/in/LINKEDIN-SENTINEL']) {
+    assert.ok(slotHtml(html, 'CONTACT_LINE').includes(v), `CONTACT_LINE does not carry "${v}"`);
+  }
+  for (const v of ['CRED-ONE', 'CRED-TWO']) {
+    assert.ok(slotHtml(html, 'CREDENTIALS_BLOCK').includes(v), `CREDENTIALS_BLOCK does not carry "${v}"`);
   }
 });
 

--- a/tests/cover-recipient-block.test.mjs
+++ b/tests/cover-recipient-block.test.mjs
@@ -1,0 +1,88 @@
+// tests/cover-recipient-block.test.mjs — {{RECIPIENT_BLOCK}} must be fillable.
+//
+// The pack authoring contract lists {{RECIPIENT_BLOCK}} among the required
+// cover-letter slots, but generate-cover-letter.mjs never filled it, so every
+// pack cover template died at substitution with
+// "Unresolved placeholders: {{RECIPIENT_BLOCK}}".
+//
+// The failure is worth a test rather than a one-line map entry because of how it
+// presented: validateTemplate (KINDS.cover) requires only NAME, ROLE_TITLE and
+// OPENING, so a pack template PASSED the validator and then exploded in the
+// substitution pass. A green gate followed by a hard failure is the shape that
+// makes an author distrust the gate, so both halves are pinned here: the slot
+// fills, and an absent recipient is not an error.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+/** A minimal template carrying the pack's recipient slot. */
+function packTemplate() {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-recipient-'));
+  const file = join(dir, 'cover-letter-template.html');
+  writeFileSync(file, '{{NAME}}{{ROLE_TITLE}}{{DATELINE}}{{RECIPIENT_BLOCK}}{{OPENING}}{{PROFILE_INTRO}}');
+  return file;
+}
+
+const base = (recipient) => ({
+  candidate: { name: 'A Candidate' },
+  letter: {
+    role_title: 'Head of Marketing',
+    opening: 'Opening line.',
+    profile_intro: 'Profile intro.',
+    ...(recipient === undefined ? {} : { recipient }),
+  },
+});
+
+test('a template carrying {{RECIPIENT_BLOCK}} renders instead of throwing', () => {
+  // Given the exact shape the pack contract publishes: name, title, company,
+  // then address_lines
+  const html = buildHtml(base({
+    name: 'Jane Reviewer',
+    title: 'Director of Talent',
+    company: 'Example Corp',
+    address_lines: ['100 Example Street', 'Springfield, IL 62704'],
+  }), packTemplate());
+
+  // Then every supplied part reaches the output...
+  for (const part of ['Jane Reviewer', 'Director of Talent', 'Example Corp', '100 Example Street', 'Springfield, IL 62704']) {
+    assert.ok(html.includes(part), `recipient block must carry "${part}"`);
+  }
+  // ...and the token itself is gone
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot must be substituted, not left literal');
+});
+
+test('the recipient block is self-wrapped, one div per line', () => {
+  // The contract is explicit that the filler emits its own wrapper and that the
+  // template places the placeholder bare, so a <br>-joined string would not do.
+  const html = buildHtml(base({ name: 'Jane Reviewer', company: 'Example Corp' }), packTemplate());
+
+  assert.match(html, /<div class="recipient">/, 'the block wraps itself');
+  assert.match(html, /<div>Jane Reviewer<\/div>/);
+  assert.match(html, /<div>Example Corp<\/div>/);
+});
+
+test('an absent recipient renders empty, and is not an error', () => {
+  // Most letters have no addressee. That must stay a rendered letter, not a
+  // failed render, or this fix trades one hard failure for another.
+  const html = buildHtml(base(undefined), packTemplate());
+
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot is still substituted');
+  assert.ok(!html.includes('class="recipient"'), 'no empty wrapper is emitted');
+});
+
+test('a recipient with no usable fields renders empty rather than an empty wrapper', () => {
+  const html = buildHtml(base({ name: '', company: '', address_lines: [] }), packTemplate());
+  assert.ok(!html.includes('class="recipient"'));
+});
+
+test('recipient values are HTML-escaped', () => {
+  // The recipient comes from a payload an agent wrote from a job posting, which
+  // is untrusted content by the project's own rule.
+  const html = buildHtml(base({ name: '<script>alert(1)</script>', company: 'A & B' }), packTemplate());
+
+  assert.ok(!html.includes('<script>'), 'a script tag must not survive into the letter');
+  assert.match(html, /A &amp; B/);
+});

--- a/tests/cover-recipient-block.test.mjs
+++ b/tests/cover-recipient-block.test.mjs
@@ -78,6 +78,28 @@ test('a recipient with no usable fields renders empty rather than an empty wrapp
   assert.ok(!html.includes('class="recipient"'));
 });
 
+test('whitespace-only recipient fields are empty, not content', () => {
+  // filter(Boolean) keeps "   ", so a recipient whose fields are all spaces
+  // produced a wrapper full of blank divs: a visibly indented gap above the Re:
+  // line, on a letter with no addressee. The empty-object case below passes
+  // without this, which is what made it easy to miss.
+  const html = buildHtml(base({ name: '   ', title: '\t', company: '\n', address_lines: ['  ', ''] }), packTemplate());
+
+  assert.ok(!html.includes('class="recipient"'), 'a whitespace-only recipient emits no wrapper');
+  assert.ok(!html.includes('{{RECIPIENT_BLOCK}}'), 'the slot is still substituted');
+});
+
+test('a partially blank recipient keeps only its real lines', () => {
+  // The trim must not become a reason to drop a recipient that has some content.
+  const html = buildHtml(base({ name: '  ', title: 'Director of Talent', company: '   ' }), packTemplate());
+
+  assert.match(html, /<div class="recipient">/);
+  assert.match(html, /<div>Director of Talent<\/div>/);
+  // Bare `<div>` counts content lines only: the wrapper is `<div class="recipient">`
+  // and does not match. Exactly one line survives, so the two blank fields are gone.
+  assert.equal((html.match(/<div>/g) || []).length, 1, 'only the non-blank field renders a line');
+});
+
 test('recipient values are HTML-escaped', () => {
   // The recipient comes from a payload an agent wrote from a job posting, which
   // is untrusted content by the project's own rule.


### PR DESCRIPTION
## What does this PR do?

Adds `tests/cover-pack-contract.test.mjs`, which renders a template carrying every slot the pack cover-letter contract declares and asserts core fills all of them. Nothing did this before, which is how the contract and the renderer drifted apart twice without a red test.

The gap is structural, not an oversight in any one suite. `validateTemplate` demands 3 placeholders for `kind=cover` while the contract declares 14. `tests/template-packs.test.mjs` proves a pack *resolves* but never renders one — its three references to the renderers are all comments. And every other cover suite builds its own inline fixture carrying only the slots that test needs, so none of them can see a slot core forgot.

The slot list in the test is a literal transcribed from the authoring docs rather than something derived from `generate-cover-letter.mjs`. A list read out of the renderer would agree with itself no matter what the contract says — which is exactly the check that was missing.

## Stacking

This branch sits on top of #4043 and #4069, so the diff below carries their commits too. Only the last one is new here:

| Commit | PR | New in this PR |
|---|---|---|
| `8079ed40` fill `{{RECIPIENT_BLOCK}}` | #4043 | no |
| `9fe49937` whitespace-only recipient field | #4043 | no |
| `bccab47c` gate `{{DATELINE}}` | #4069 | no |
| `a7bc35fb` pack-contract test | this PR | **yes** |

Review just `a7bc35fb`, or merge #4043 and #4069 first and this shrinks to the one file. Happy to rebase onto whatever lands.

## Related issue

Closes #4092

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

Test-only — no source file changes in `a7bc35fb`.

## Verification

Run against the unfixed renderer as a positive control: all four tests fail on `main` and pass on this branch. Without that, a test over a contract the renderer already satisfies proves nothing.

```
# with main's generate-cover-letter.mjs
ℹ tests 4 / pass 0 / fail 4

# on this branch
ℹ tests 4 / pass 4 / fail 0
```

`node test-all.mjs`: 8693 passed, 0 failed.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds cover-letter contract tests and fixes recipient and dateline rendering.

### User impact

Users can render pack-shaped cover-letter templates through `buildHtml` with all contract slots populated (`tests/cover-pack-contract.test.mjs:28-34`).

The renderer now:

- Fills `{{RECIPIENT_BLOCK}}` with escaped recipient lines (`generate-cover-letter.mjs:143-176`).
- Renders only the date in `{{DATELINE}}` when the recipient block has content (`generate-cover-letter.mjs:126-140`).
- Preserves the existing company, city, and date format when no recipient block renders (`tests/cover-dateline.test.mjs:61-80`).

The tests verify contract coverage, slot-specific contact and credential values, unresolved tokens, recipient edge cases, and HTML escaping (`tests/cover-pack-contract.test.mjs:79-124`; `tests/cover-recipient-block.test.mjs:39-110`).

### Files changed

- `generate-cover-letter.mjs`: Adds recipient-block rendering and conditional dateline behavior.
- `tests/cover-pack-contract.test.mjs`: Covers every documented cover-letter contract slot.
- `tests/cover-dateline.test.mjs`: Covers dateline behavior.
- `tests/cover-recipient-block.test.mjs`: Covers recipient rendering, escaping, and empty values.

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->