### PR TITLE
theme: make the competency-tag palette themeable

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -11,6 +11,9 @@
   :root {
     --accent-color: hsl(187 74% 32%);
     --secondary-color: hsl(270, 70%, 45%);
+    --tag-color: hsl(187, 74%, 28%);
+    --tag-bg: hsl(187, 40%, 95%);
+    --tag-border: hsl(187, 40%, 88%);
     --font-family: "Liberation Sans", 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     --font-size: 11px;
     /* Matches generate-pdf.mjs's PDF_PAGE_MARGIN — the actual PDF page margin
@@ -176,11 +179,11 @@
     font-family: var(--font-family);
     font-size: 10px;
     font-weight: 500;
-    color: hsl(187, 74%, 28%);
-    background: hsl(187, 40%, 95%);
+    color: var(--tag-color);
+    background: var(--tag-bg);
     padding: 4px 10px;
     border-radius: 3px;
-    border: 1px solid hsl(187, 40%, 88%);
+    border: 1px solid var(--tag-border);
   }
 
   /* === WORK EXPERIENCE === */
@@ -262,7 +265,7 @@
     font-size: 9px;
     font-weight: 500;
     color: var(--accent-color);
-    background: hsl(187, 40%, 95%);
+    background: var(--tag-bg);
     padding: 1px 6px;
     border-radius: 2px;
     margin-left: 6px;

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -15,6 +15,9 @@ version: 1.0.0
      `style:`, which the PDF pipeline injects as a later :root block. */
   :root {
     --secondary-color: hsl(270, 70%, 45%);
+    --tag-color: hsl(187, 74%, 28%);
+    --tag-bg: hsl(187, 40%, 95%);
+    --tag-border: hsl(187, 40%, 88%);
   }
 
   /* ATS-safe typography (#font-extraction fix):
@@ -170,11 +173,11 @@ version: 1.0.0
     font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 10px;
     font-weight: 500;
-    color: hsl(187, 74%, 28%);
-    background: hsl(187, 40%, 95%);
+    color: var(--tag-color);
+    background: var(--tag-bg);
     padding: 4px 10px;
     border-radius: 3px;
-    border: 1px solid hsl(187, 40%, 88%);
+    border: 1px solid var(--tag-border);
   }
 
   /* === WORK EXPERIENCE === */
@@ -247,7 +250,7 @@ version: 1.0.0
     font-size: 9px;
     font-weight: 500;
     color: hsl(187, 74%, 32%);
-    background: hsl(187, 40%, 95%);
+    background: var(--tag-bg);
     padding: 1px 6px;
     border-radius: 2px;
     margin-left: 6px;

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -61,6 +61,9 @@
      `style:`, which the PDF pipeline injects as a later :root block. */
   :root {
     --secondary-color: hsl(270, 70%, 45%);
+    --tag-color: hsl(187, 74%, 28%);
+    --tag-bg: hsl(187, 40%, 95%);
+    --tag-border: hsl(187, 40%, 88%);
   }
 
   * {
@@ -205,11 +208,11 @@
     font-family: 'DM Sans', sans-serif;
     font-size: 10px;
     font-weight: 500;
-    color: hsl(187, 74%, 28%);
-    background: hsl(187, 40%, 95%);
+    color: var(--tag-color);
+    background: var(--tag-bg);
     padding: 4px 10px;
     border-radius: 3px;
-    border: 1px solid hsl(187, 40%, 88%);
+    border: 1px solid var(--tag-border);
   }
 
   /* === WORK EXPERIENCE === */
@@ -282,7 +285,7 @@
     font-size: 9px;
     font-weight: 500;
     color: hsl(187, 74%, 32%);
-    background: hsl(187, 40%, 95%);
+    background: var(--tag-bg);
     padding: 1px 6px;
     border-radius: 2px;
     margin-left: 6px;

--- a/tests/theme-style.test.mjs
+++ b/tests/theme-style.test.mjs
@@ -15,10 +15,12 @@ try {
   } = await import(pathToFileURL(join(ROOT, 'theme-style.mjs')).href);
 
   // styleTokensFrom: recognized keys → css vars; ignore unknown/non-string/missing
-  const t = styleTokensFrom({ accent_color: '#2563eb', secondary_color: '#111827', font_family: 'Outfit, sans-serif', font_size: '10pt', margin: '0.5in', nope: 'x', font_weight: 700 });
-  if (t['--accent-color'] === '#2563eb' && t['--secondary-color'] === '#111827' && t['--font-family'] === 'Outfit, sans-serif' && t['--font-size'] === '10pt' && t['--page-margin'] === '0.5in'
-      && !('--font-weight' in t) && Object.keys(t).length === 5) {
-    pass('styleTokensFrom maps the 5 recognized keys and ignores unknown/non-string');
+  const t = styleTokensFrom({ accent_color: '#2563eb', secondary_color: '#111827', tag_color: '#0e7490', tag_bg: '#ecfeff', tag_border: '#a5f3fc', font_family: 'Outfit, sans-serif', font_size: '10pt', margin: '0.5in', nope: 'x', font_weight: 700 });
+  if (t['--accent-color'] === '#2563eb' && t['--secondary-color'] === '#111827'
+      && t['--tag-color'] === '#0e7490' && t['--tag-bg'] === '#ecfeff' && t['--tag-border'] === '#a5f3fc'
+      && t['--font-family'] === 'Outfit, sans-serif' && t['--font-size'] === '10pt' && t['--page-margin'] === '0.5in'
+      && !('--font-weight' in t) && Object.keys(t).length === 8) {
+    pass('styleTokensFrom maps the 8 recognized keys and ignores unknown/non-string');
   } else {
     fail(`styleTokensFrom => ${JSON.stringify(t)}`);
   }
@@ -213,6 +215,36 @@ try {
       fail(`page-margin cascade order/value wrong: root=${rootDefaultIdx} override=${overrideIdx} pageSetup=${pageSetupIdx} usesVar=${pageSetupUsesVar}`);
     }
   }
+  // The competency-tag palette was three hardcoded literals, so a profile could
+  // recolor the accents and then had nowhere to go for the tags — and a template
+  // edit is reverted by every `update-system.mjs apply`. Two things must hold: the
+  // template still READS each token (an unreferenced var makes an override inert),
+  // and each :root default is byte-identical to the literal it replaced (or every
+  // existing CV silently changes color).
+  {
+    const DEFAULTS = {
+      '--tag-color':  'hsl(187, 74%, 28%)',
+      '--tag-bg':     'hsl(187, 40%, 95%)',
+      '--tag-border': 'hsl(187, 40%, 88%)',
+    };
+    // every template that carried these literals, not just the default one — a token
+    // the resume/zh templates don't read is a style: key that silently does nothing there
+    const TEMPLATES = ['templates/cv-template.html', 'templates/cv-template.zh-minimal.html', 'templates/resume-template.html'];
+    for (const tpl of TEMPLATES) {
+    const tplSrc = readFileSync(join(ROOT, tpl), 'utf-8');
+    const wrongDefault = Object.entries(DEFAULTS).filter(([v, d]) => !tplSrc.includes(`${v}: ${d};`));
+    const unreferenced = Object.keys(DEFAULTS).filter(v => !tplSrc.includes(`var(${v})`));
+    const selfReferential = Object.keys(DEFAULTS).filter(v => tplSrc.includes(`${v}: var(${v})`));
+    const strays = tplSrc.split('\n')
+      .filter(l => /hsl\(187, 74%, 28%\)|hsl\(187, 40%, (?:95|88)%\)/.test(l) && !/^\s*--tag-/.test(l));
+    if (!wrongDefault.length && !unreferenced.length && !selfReferential.length && !strays.length) {
+      pass(`${tpl}: tag tokens keep the exact colors they replaced, are read, and leave no literal behind`);
+    } else {
+      fail(`${tpl} tag tokens: wrongDefault=${JSON.stringify(wrongDefault)} unreferenced=${unreferenced} selfRef=${selfReferential} strays=${JSON.stringify(strays)}`);
+    }
+    }
+  }
+
 } catch (e) {
   fail(`theme-style tests crashed: ${e.message}`);
 }

--- a/theme-style.mjs
+++ b/theme-style.mjs
@@ -9,6 +9,9 @@
  *   style:
  *     accent_color:    "#2563eb"
  *     secondary_color: "#111827"
+ *     tag_color:       "#0e7490"   # competency-tag text
+ *     tag_bg:          "#ecfeff"   # competency-tag and project-tech fill
+ *     tag_border:      "#a5f3fc"   # competency-tag border
  *     font_family:     "Outfit, Inter, sans-serif"
  *     font_size:       "10pt"
  *     margin:          "0.5in"
@@ -34,6 +37,9 @@ import * as yaml from 'js-yaml';
 export const STYLE_VAR_MAP = {
   accent_color:    '--accent-color',
   secondary_color: '--secondary-color',
+  tag_color:       '--tag-color',
+  tag_bg:          '--tag-bg',
+  tag_border:      '--tag-border',
   font_family:     '--font-family',
   font_size:       '--font-size',
   margin:          '--page-margin',


### PR DESCRIPTION
## Problem

`style:` in `config/profile.yml` can recolor the accents, but the competency-tag palette is three hardcoded literals in every template that draws tags:

- tag text `hsl(187, 74%, 28%)`
- tag and `.project-tech` fill `hsl(187, 40%, 95%)`
- tag border `hsl(187, 40%, 88%)`

So a profile that sets `accent_color` and `secondary_color` to a monochrome palette gets monochrome headings and company lines next to teal-tinted tags, and the only way to finish the job is to edit `templates/`. `theme-style.mjs`'s own header explains why that is the wrong place:

> a setting that lives in config/profile.yml survives `update-system.mjs apply`, while the same customization made in templates/cv-template.html (a SYSTEM_PATHS file) is reverted by every release.

Which is exactly what happens — the edit has to be re-made after every release, or given up.

## Change

Adds `--tag-color`, `--tag-bg` and `--tag-border` with `:root` defaults **byte-identical** to the literals they replace, plus the matching `tag_color` / `tag_bg` / `tag_border` keys in `STYLE_VAR_MAP`. A profile with no `style:` block renders exactly as before.

```yaml
style:
  accent_color:    "#2563eb"
  secondary_color: "#111827"
  tag_color:       "#0e7490"   # competency-tag text
  tag_bg:          "#ecfeff"   # competency-tag and project-tech fill
  tag_border:      "#a5f3fc"   # competency-tag border
```

Applied to all three templates carrying those literals — `cv-template.html`, `cv-template.zh-minimal.html`, `resume-template.html` — because a token only the default template reads is a `style:` key that silently does nothing on the others.

## Tests

`tests/theme-style.test.mjs` gains a per-template guard asserting that each `:root` default equals the exact color it replaced, that the template actually reads every token (an unreferenced `var()` makes an override inert), that no token resolves to itself, and that no palette literal is left behind. The token-count assertion moves 5 → 8.

`node test-all.mjs`: **8690 passed, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can customize competency-tag text, background, and border colors with `tag_color`, `tag_bg`, and `tag_border`.

The change updates all three templates and preserves existing colors by default. Tests verify token mappings, template usage, and removal of hardcoded colors.

Tests: 8690 passed, 0 failed.

System files touched: none. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` were not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->