### PR TITLE
fix(web): make Today actions reliable and preserve PDF report identity

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -111,7 +111,7 @@ export async function POST(req: Request) {
     kind === "evaluate"
       ? readInbox().find((j) => j.url === input)?.postedAt ?? readScanDates().get(input)
       : undefined;
-  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang });
+  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang, reportFile: pdfPaths?.reportFile });
 
   const isClaude = cliId === "claude";
   // Which tools each kind gets, and the whole claude argv, live in
@@ -384,7 +384,7 @@ export async function POST(req: Request) {
             root: careerOpsRoot(),
             pdfPaths: paths,
             format,
-            reportNum: input,
+            reportNum: paths.reportNum,
           });
           if (result.kind === "render-failed") {
             send({ type: "error", msg: result.error.slice(0, 200) });

--- a/web/src/app/api/whats-new/route.ts
+++ b/web/src/app/api/whats-new/route.ts
@@ -30,8 +30,11 @@ export async function GET(req: Request) {
   let rows: string[];
   try {
     rows = fs.readFileSync(path.join(careerOpsRoot(), "data", "scan-history.tsv"), "utf8").split("\n");
-  } catch {
-    return Response.json({ offers: [], count: 0 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return Response.json({ offers: [], count: 0 });
+    }
+    return Response.json({ available: false, offers: [], count: 0, error: "Could not read scan history. Check the file and retry." }, { status: 500 });
   }
 
   // Roles already evaluated → don't resurface as "new". Keyed on company AND

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,6 @@
-import { pipelineSummary, doctorState } from "@/lib/career-ops";
+import { readApplications, readInbox, doctorState } from "@/lib/career-ops";
+import { todaySnapshot } from "@/lib/home/today-snapshot.mjs";
+import { scoreNum } from "@/lib/format";
 import { OnboardingBanner } from "@/components/onboarding-banner";
 import { FirstRunHome } from "@/components/home/first-run-home";
 import { TodayDashboard } from "@/components/home/today-dashboard";
@@ -6,12 +8,13 @@ import { TodayDashboard } from "@/components/home/today-dashboard";
 export const dynamic = "force-dynamic"; // always read fresh local files at request time (never at build — CI has no user data)
 
 export default function Home() {
-  const { phase, onboardingNeeded } = doctorState();
+  const snapshot = { applications: readApplications(), inbox: readInbox() };
+  const { phase, onboardingNeeded } = doctorState(snapshot);
   // First run (truly empty install): the CV-upload takeover IS the home — value
   // before commitment. The full dashboard returns once they have a CV or any data.
   if (phase === "first-run") return <FirstRunHome />;
 
-  const { inbox, applications } = pipelineSummary();
+  const { inbox, applications } = todaySnapshot(snapshot, scoreNum);
   // Established / in-between: the dual-loop retention dashboard. Show the setup
   // banner whenever ANY prereq is missing (mirrors the core doctor.mjs), so a
   // portals-missing user is nudged rather than told "all caught up".

--- a/web/src/components/followups/next-date-dialog.tsx
+++ b/web/src/components/followups/next-date-dialog.tsx
@@ -20,7 +20,8 @@ export function NextDateDialog({
   onClose,
   onChanged,
 }: {
-  entry: CadenceEntry;
+  entry: Pick<CadenceEntry, "num" | "company"> &
+    Partial<Pick<CadenceEntry, "role" | "nextFollowupDate" | "nextOverride">>;
   onClose: () => void;
   onChanged: () => void;
 }) {

--- a/web/src/components/home/decision-card.tsx
+++ b/web/src/components/home/decision-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Check, X, FileText, Loader2 } from "lucide-react";
@@ -8,27 +8,45 @@ import { cn } from "@/lib/cn";
 import { CompanyLogo } from "@/components/company-logo";
 import { scoreNum, scoreTone } from "@/lib/format";
 import { companyPresentation } from "@/lib/company-presentation.mjs";
+import { statusWriteError } from "@/lib/home/status-result.mjs";
 import type { Application } from "@/lib/career-ops";
 
 // Awaiting-decision row: a scored role with no terminal status. Primary action
 // opens the report (PDF + Apply live there). Skip / Applied still write status.
-export function DecisionCard({ app }: { app: Application }) {
+export function DecisionCard({ app, onSaved }: { app: Application; onSaved?: () => void }) {
   const router = useRouter();
   const [busy, setBusy] = useState<"" | "Applied" | "Discarded">("");
   const [done, setDone] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [failedStatus, setFailedStatus] = useState<"Applied" | "Discarded" | null>(null);
+  const submitting = useRef(false);
   const score = scoreNum(app.score);
   const tone = scoreTone(app.score);
   const company = companyPresentation(app);
 
   const setStatus = async (status: "Applied" | "Discarded") => {
+    if (submitting.current) return;
+    submitting.current = true;
     setBusy(status);
+    setError(null);
+    setFailedStatus(null);
     try {
-      await fetch("/api/status", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ n: app.n, status }) });
+      const response = await fetch("/api/status", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ n: app.n, status }) });
+      const result = await response.json().catch(() => null);
+      const failure = statusWriteError(response.ok, result, status);
+      if (failure) {
+        setError(failure);
+        setFailedStatus(status);
+        return;
+      }
       setDone(status);
       router.refresh();
+      onSaved?.();
     } catch {
-      /* ignore */
+      setError("Could not confirm the change. Check your connection and pipeline, then retry.");
+      setFailedStatus(status);
     } finally {
+      submitting.current = false;
       setBusy("");
     }
   };
@@ -82,6 +100,12 @@ export function DecisionCard({ app }: { app: Application }) {
           Applied
         </button>
       </div>
+      {error && (
+        <div role="alert" className="flex items-start gap-2 text-xs text-red-600 dark:text-red-400">
+          <p className="min-w-0 flex-1">{error}</p>
+          {failedStatus && <button type="button" disabled={!!busy} onClick={() => setStatus(failedStatus)} className="shrink-0 underline disabled:opacity-60 max-sm:min-h-[44px]">Retry</button>}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/home/follow-up-card.tsx
+++ b/web/src/components/home/follow-up-card.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Check, Clock, FileText, Loader2 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CompanyLogo } from "@/components/company-logo";
+import { NextDateDialog } from "@/components/followups/next-date-dialog";
 
 export type FollowUp = {
   num?: number;
@@ -16,16 +17,18 @@ export type FollowUp = {
   // are due now, 'waiting'/'cold' are not (#86).
   urgency?: "urgent" | "overdue" | "waiting" | "cold";
   nextFollowupDate?: string | null;
+  nextOverride?: string | null;
   daysUntilNext?: number | null;
 };
 
 // One-tap overdue follow-up row (demand loop). "Mark followed up" appends a
 // table row to data/follow-ups.md (append-only) so the core cadence advances;
-// "Snooze" is a client dismiss. The cadence is the core's — we just surface + record.
+// "Snooze" pins a date through the same persisted schedule as /followups.
 export function FollowUpCard({ followup, onLogged }: { followup: FollowUp; onLogged?: () => void }) {
-  const [state, setState] = useState<"idle" | "logging" | "done" | "snoozed" | "error">("idle");
+  const [state, setState] = useState<"idle" | "logging" | "done" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  if (state === "snoozed" || state === "done") return null;
+  const [showNextDate, setShowNextDate] = useState(false);
+  if (state === "done") return null;
 
   const log = async () => {
     setState("logging");
@@ -93,10 +96,23 @@ export function FollowUpCard({ followup, onLogged }: { followup: FollowUp; onLog
             <FileText className="size-4" />
           </a>
         )}
-        <button type="button" onClick={() => setState("snoozed")} className="inline-flex shrink-0 items-center justify-center text-[11px] text-faint transition hover:text-foreground max-sm:min-h-[44px] max-sm:min-w-[44px]">
+        <button
+          type="button"
+          disabled={state === "logging" || followup.num == null}
+          onClick={() => setShowNextDate(true)}
+          title={followup.num == null ? "An application number is required to snooze this follow-up." : "Choose the next follow-up date"}
+          className="inline-flex shrink-0 items-center justify-center text-[11px] text-faint transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60 max-sm:min-h-[44px] max-sm:min-w-[44px]"
+        >
           Snooze
         </button>
       </div>
+      {showNextDate && followup.num != null && (
+        <NextDateDialog
+          entry={{ ...followup, num: followup.num }}
+          onClose={() => setShowNextDate(false)}
+          onChanged={() => onLogged?.()}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/home/today-dashboard.tsx
+++ b/web/src/components/home/today-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Bell, CircleHelp, Sparkles, ArrowRight } from "lucide-react";
@@ -14,6 +14,9 @@ import { DecisionCard } from "@/components/home/decision-card";
 import { QuickEvaluate } from "@/components/quick-evaluate";
 import { scoreNum } from "@/lib/format";
 import { pickAwaitingDecision } from "@/lib/home/awaiting.mjs";
+import { parseTodayFollowups, parseTodayMatches, pendingInboxCount, summarizeToday } from "@/lib/home/today-state.mjs";
+
+type LoadState = { status: "loading" | "ready" | "error"; error: string | null };
 
 // The retention "Today": a dual-loop action queue (the maintainer's
 // "N new matches this week · M follow-ups due"). SUPPLY loop = fresh free-scan
@@ -26,7 +29,7 @@ export function TodayDashboard({
   inBetween,
 }: {
   applications: Application[];
-  inbox: InboxJob[];
+  inbox: Pick<InboxJob, "url" | "done">[];
   inBetween: boolean;
 }) {
   const [followups, setFollowups] = useState<FollowUp[]>([]);
@@ -34,31 +37,46 @@ export function TodayDashboard({
   const [nextUpcoming, setNextUpcoming] = useState<FollowUp | null>(null);
   const [fresh, setFresh] = useState<DiscoveredOffer[]>([]);
   const [freshCount, setFreshCount] = useState(0);
+  const [followupState, setFollowupState] = useState<LoadState>({ status: "loading", error: null });
+  const [freshState, setFreshState] = useState<LoadState>({ status: "loading", error: null });
+  const activeRequest = useRef<AbortController | null>(null);
   const router = useRouter();
   const dateLabel = useMemo(() => new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" }), []);
 
   const refetch = useCallback(() => {
-    fetch("/api/followups")
-      .then((r) => r.json())
-      .then((d) => {
-        // /api/followups already filters to urgency 'urgent'/'overdue' — due
-        // now, never 'waiting'/'cold' (#86). Both count toward "due"; a
-        // missing metadata.overdue must read as 0 due, never as "every entry
-        // is overdue" (the old `?? d.entries?.length` fallback).
-        setFollowups(Array.isArray(d.entries) ? d.entries : []);
-        setOverdue((d.metadata?.overdue ?? 0) + (d.metadata?.urgent ?? 0));
-        setNextUpcoming(d.nextUpcoming ?? null);
+    // An earlier request can finish after a worker event or a saved follow-up.
+    // Cancel it and check its signal before applying any result or error.
+    activeRequest.current?.abort();
+    const controller = new AbortController();
+    activeRequest.current = controller;
+    const { signal } = controller;
+    setFollowupState({ status: "loading", error: null });
+    setFreshState({ status: "loading", error: null });
+    fetch("/api/followups", { signal, cache: "no-store" })
+      .then(async (r) => parseTodayFollowups(r.ok, await r.json().catch(() => null)))
+      .then((data) => {
+        if (signal.aborted) return;
+        setFollowups(data.entries);
+        setOverdue(data.due);
+        setNextUpcoming(data.nextUpcoming);
+        setFollowupState({ status: "ready", error: null });
       })
-      .catch(() => {});
-    fetch("/api/whats-new")
-      .then((r) => r.json())
-      .then((d) => {
-        const offers = Array.isArray(d.offers) ? d.offers : [];
-        const count = Number(d.count);
-        setFresh(offers);
-        setFreshCount(Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : offers.length);
+      .catch((error) => {
+        if (signal.aborted) return;
+        setFollowupState({ status: "error", error: error instanceof TypeError ? "Could not reach the server. Check your connection and retry." : error instanceof Error ? error.message : "Could not load follow-ups." });
+      });
+    fetch("/api/whats-new", { signal, cache: "no-store" })
+      .then(async (r) => parseTodayMatches(r.ok, await r.json().catch(() => null)))
+      .then((data) => {
+        if (signal.aborted) return;
+        setFresh(data.offers);
+        setFreshCount(data.count);
+        setFreshState({ status: "ready", error: null });
       })
-      .catch(() => {});
+      .catch((error) => {
+        if (signal.aborted) return;
+        setFreshState({ status: "error", error: error instanceof TypeError ? "Could not reach the server. Check your connection and retry." : error instanceof Error ? error.message : "Could not load fresh matches." });
+      });
   }, []);
 
   useEffect(() => {
@@ -71,16 +89,29 @@ export function TodayDashboard({
       refetch();
     };
     window.addEventListener("co-job-done", onDone);
-    return () => window.removeEventListener("co-job-done", onDone);
+    return () => {
+      window.removeEventListener("co-job-done", onDone);
+      activeRequest.current?.abort();
+    };
   }, [refetch, router]);
 
   // Awaiting decision: scored (Evaluated) but no terminal status yet. The
   // ordering lives in lib/home/awaiting.mjs so it can be tested — see the file
   // for why "first six in the array" was a bug waiting for #3529.
-  const awaiting = useMemo(() => pickAwaitingDecision(applications, scoreNum), [applications]);
+  const awaiting = useMemo(() => pickAwaitingDecision(applications, scoreNum, Infinity), [applications]);
 
-  const newThisWeek = freshCount;
-  const allClear = newThisWeek === 0 && overdue === 0 && awaiting.length === 0;
+  const pendingCount = useMemo(() => pendingInboxCount(inbox), [inbox]);
+  const summary = summarizeToday({
+    freshCount,
+    // The route returns only due entries. Metadata can be absent, but a
+    // visible due card still means there is work to do.
+    dueCount: Math.max(overdue, followups.length),
+    decisionCount: awaiting.length,
+    inboxCount: pendingCount,
+    followupState: followupState.status,
+    freshState: freshState.status,
+  });
+  const { allClear } = summary;
   const inboxUrls = useMemo(() => new Set(inbox.map((j) => j.url)), [inbox]);
 
   return (
@@ -94,38 +125,30 @@ export function TodayDashboard({
             <span className="text-faint">//</span> today · <span className="tabular-nums">{dateLabel}</span>
           </p>
           <h1 className={`${instrumentSerif.className} mt-3 text-4xl leading-[1.05] text-landing md:text-5xl`}>
-            {allClear ? (
-              <>You&apos;re all caught up.</>
-            ) : (
-              <>
-                {newThisWeek > 0 && (
-                  <>
-                    <span className="text-brand tabular-nums">{newThisWeek}</span> new match{newThisWeek === 1 ? "" : "es"} this week
-                  </>
-                )}
-                {newThisWeek > 0 && overdue > 0 && <span className="text-faint"> · </span>}
-                {overdue > 0 && (
-                  <>
-                    <span className="text-brand tabular-nums">{overdue}</span> follow-up{overdue === 1 ? "" : "s"} due
-                  </>
-                )}
-              </>
-            )}
+            {summary.items.length ? summary.items.map((item, index) => (
+              <Fragment key={item.label}>
+                {index > 0 && <span className="text-faint"> · </span>}
+                <span className="text-brand tabular-nums">{item.count}</span>{" "}{item.label}
+              </Fragment>
+            )) : summary.emptyHeading}
           </h1>
           <p className="mt-4 max-w-xl text-sm text-muted">
-            {allClear ? "I'll keep scanning the market in the background and surface anything that fits." : "Your action queue for today — discovery and follow-ups, in one place."}
+            {allClear ? "Run a free scan when you want to find more roles." : "Review jobs, make application decisions, and track follow-ups in one place."}
           </p>
           <div className="mt-6 flex flex-wrap gap-2.5">
             <Link href="/explore" className="inline-flex items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground transition hover:bg-brand-200 max-sm:min-h-[44px]">
               Find new roles <ArrowRight className="size-4" />
             </Link>
             <Link href="/pipeline" className="inline-flex items-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-medium text-foreground transition hover:border-brand/40 hover:text-brand max-sm:min-h-[44px]">
-              Open pipeline
+              {pendingCount > 0 ? `Review inbox (${pendingCount})` : "Open pipeline"}
             </Link>
           </div>
           {inBetween && <QuickEvaluate />}
         </div>
       </section>
+
+      <LoadNotice label="Follow-ups" state={followupState} onRetry={refetch} />
+      <LoadNotice label="Fresh matches" state={freshState} onRetry={refetch} />
 
       {/* A. Follow-ups due (demand loop) */}
       {followups.length > 0 ? (
@@ -157,10 +180,11 @@ export function TodayDashboard({
       {awaiting.length > 0 && (
         <Section icon={CircleHelp} title="Awaiting your decision" hint="Scored — apply or skip">
           <div className="grid gap-2.5 sm:grid-cols-2">
-            {awaiting.map((a) => (
-              <DecisionCard key={a.n} app={a} />
+            {awaiting.slice(0, 6).map((a) => (
+              <DecisionCard key={a.n} app={a} onSaved={refetch} />
             ))}
           </div>
+          {awaiting.length > 6 && <Link href="/pipeline?tab=EVALUATED" className="mt-3 inline-flex text-sm text-muted hover:text-brand max-sm:min-h-[44px]">Review all {awaiting.length} decisions →</Link>}
         </Section>
       )}
 
@@ -188,6 +212,20 @@ export function TodayDashboard({
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+function LoadNotice({ label, state, onRetry }: { label: string; state: LoadState; onRetry: () => void }) {
+  if (state.status === "ready") return null;
+  if (state.status === "loading") return <p role="status" className="mt-4 text-sm text-muted">Checking {label.toLowerCase()}…</p>;
+  return (
+    <div role="alert" className="mt-4 flex flex-wrap items-center gap-3 rounded-xl border border-red-500/25 bg-surface/40 px-4 py-3 text-sm">
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-foreground">{label} could not be updated.</p>
+        <p className="mt-1 text-muted">{state.error} Any items shown may be out of date.</p>
+      </div>
+      <button type="button" onClick={onRetry} className="rounded-md border border-border px-3 py-1.5 text-foreground hover:text-brand max-sm:min-h-[44px]">Retry {label.toLowerCase()}</button>
     </div>
   );
 }

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -247,7 +247,7 @@ export type LifecyclePhase = "first-run" | "in-between" | "established";
  *   - established → all 4 prereqs present.
  * onboardingNeeded mirrors doctor.mjs: true if ANY prereq is missing → show banner.
  */
-export function doctorState(): {
+export function doctorState(snapshot?: Pick<PipelineSummary, "applications" | "inbox">): {
   phase: LifecyclePhase;
   onboardingNeeded: boolean;
   missing: string[];
@@ -269,7 +269,10 @@ export function doctorState(): {
   ];
   const missing = prereqs.filter(([rel]) => !has(rel)).map(([, label]) => label);
   const hasCv = has("cv.md");
-  const hasData = readApplications().length > 0 || readInbox().some((j) => !j.done);
+  // Home already reads these files. Reuse that snapshot so its setup check
+  // neither parses the tracker twice nor disagrees with the rendered queue.
+  const hasData = (snapshot?.applications ?? readApplications()).length > 0 ||
+    (snapshot?.inbox ?? readInbox()).some((j) => !j.done);
   const onboardingNeeded = missing.length > 0;
   const phase: LifecyclePhase = !hasCv && !hasData ? "first-run" : onboardingNeeded ? "in-between" : "established";
   return { phase, onboardingNeeded, missing, hasCv, hasData };

--- a/web/src/lib/home/status-result.mjs
+++ b/web/src/lib/home/status-result.mjs
@@ -1,0 +1,6 @@
+/** An HTTP response alone does not confirm that the tracker saved this status. */
+export function statusWriteError(ok, result, requestedStatus) {
+  if (ok && result?.ok === true && result.status === requestedStatus) return null;
+  if (typeof result?.error === "string" && result.error.trim()) return result.error;
+  return "Could not confirm the change. Check the pipeline, then retry.";
+}

--- a/web/src/lib/home/today-snapshot.mjs
+++ b/web/src/lib/home/today-snapshot.mjs
@@ -1,0 +1,17 @@
+import { pickAwaitingDecision } from "./awaiting.mjs";
+
+/**
+ * Send only what Today renders across the server/client boundary. Completed
+ * inbox URLs still identify saved discoveries; their descriptions do not.
+ * Keep every undecided application so the headline can count beyond six cards.
+ *
+ * @template {{date?: string, score?: string, status?: string}} T
+ * @param {{applications: T[], inbox: {url: string, done: boolean}[]}} snapshot
+ * @param {(score: string) => number} scoreOf
+ */
+export function todaySnapshot({ applications, inbox }, scoreOf) {
+  return {
+    applications: pickAwaitingDecision(applications, scoreOf, Infinity),
+    inbox: inbox.map(({ url, done }) => ({ url, done })),
+  };
+}

--- a/web/src/lib/home/today-state.mjs
+++ b/web/src/lib/home/today-state.mjs
@@ -1,0 +1,43 @@
+const countOf = (value) => Number.isFinite(Number(value)) ? Math.max(0, Math.trunc(Number(value))) : 0;
+
+/** An unavailable or malformed response is never an empty queue. */
+export function parseTodayFollowups(ok, data) {
+  if (!ok || data?.available !== true || !Array.isArray(data?.entries)) {
+    throw new Error(typeof data?.error === "string" ? data.error : "Could not load follow-ups. Retry to check what is due.");
+  }
+  return {
+    entries: data.entries,
+    due: countOf(data.metadata?.overdue) + countOf(data.metadata?.urgent),
+    nextUpcoming: data.nextUpcoming ?? null,
+  };
+}
+
+export function parseTodayMatches(ok, data) {
+  if (!ok || data?.available === false || !Array.isArray(data?.offers)) {
+    throw new Error(typeof data?.error === "string" ? data.error : "Could not load fresh matches. Retry to check your scans.");
+  }
+  return {
+    offers: data.offers,
+    count: data.count == null || !Number.isFinite(Number(data.count)) ? data.offers.length : countOf(data.count),
+  };
+}
+
+/** The inbox triages by URL; checked rows and duplicate URLs are not extra work. */
+export function pendingInboxCount(inbox) {
+  return new Set(inbox.filter((job) => !job.done).map((job) => job.url)).size;
+}
+
+/** Only a successfully loaded, empty queue can say the user is caught up. */
+export function summarizeToday({ freshCount, dueCount, decisionCount, inboxCount, followupState, freshState }) {
+  const items = [
+    { count: freshCount, label: `new match${freshCount === 1 ? "" : "es"} this week` },
+    { count: dueCount, label: `follow-up${dueCount === 1 ? "" : "s"} due` },
+    { count: decisionCount, label: `decision${decisionCount === 1 ? "" : "s"} to make` },
+    { count: inboxCount, label: `inbox job${inboxCount === 1 ? "" : "s"} to review` },
+  ].filter((item) => item.count > 0);
+  const loading = followupState === "loading" || freshState === "loading";
+  const failed = followupState === "error" || freshState === "error";
+  const allClear = !items.length && followupState === "ready" && freshState === "ready";
+  const emptyHeading = allClear ? "You're all caught up." : failed ? "Your queue needs another check." : "Checking your queue…";
+  return { items, allClear, loading, failed, emptyHeading };
+}

--- a/web/src/lib/pdf-paths.mjs
+++ b/web/src/lib/pdf-paths.mjs
@@ -21,16 +21,18 @@ export function slugify(s) {
 
 /**
  * @typedef {Object} PdfPaths
+ * @property {string} reportNum - Canonical report number, used for filenames and the PDF manifest.
+ * @property {string} reportFile - Resolved report path relative to the data root, used by the tailoring prompt.
  * @property {string} html - Where the backend writes the tailored HTML it parsed out of the agent's envelope (#2185).
- * @property {string} finalPdf - Where the backend renders the final PDF (output/cv-{candidate}-{company}-{date}.pdf).
+ * @property {string} finalPdf - Where the backend renders the final PDF (output/cv-{candidate}-{report}-{company}-{date}.pdf).
  */
 
 /**
  * Precompute the scratch HTML and final PDF paths for a
  * "pdf" run, so the agent never chooses its own filenames — the backend owns
- * naming, writing (#2185) and rendering. Resolves the report (for the company slug)
- * and config/profile.yml (for the candidate slug) — same naming convention
- * modes/pdf.md documents, so web and CLI output stay byte-identical.
+ * naming, writing (#2185) and rendering. Resolves the report for its identity
+ * and company slug, and config/profile.yml for the candidate slug. Including
+ * the report number keeps same-company CVs generated on one day separate.
  *
  * Framework-agnostic: returns a result instead of constructing a Response, so
  * the caller (a Next.js route today) decides how to surface `ok: false`.
@@ -39,7 +41,7 @@ export function slugify(s) {
  * exist yet (the backend writes the parsed envelope there, #2185) — this is
  * NOT a pure path computation, despite the name.
  *
- * @param {string} input - The report number (e.g. "018").
+ * @param {string} input - The application/report selector (e.g. "018").
  * @param {string} today - YYYY-MM-DD.
  * @param {string} root - careerOpsRoot().
  * @param {(input: string) => string | null} findReportFile - career-ops.ts's findReportFile.
@@ -49,8 +51,7 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   // Reject anything but a bare report number before it ever reaches a path.
   // findReportFile()'s parseInt-based matching can still resolve a crafted
   // selector like "123/../../etc/passwd" to a legitimate report file, but the
-  // raw string is also used verbatim below to build cv-web-${input}.html —
-  // path.join would then honor those ".." segments and escape scratchDir.
+  // selector must never become a path segment unless it is purely numeric.
   if (!/^\d+$/.test(input)) {
     return { ok: false, error: `Invalid report selector: "${input}"` };
   }
@@ -58,7 +59,14 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   if (!reportFile) {
     return { ok: false, error: `No report #${input} found — evaluate this posting first.` };
   }
-  const companyMatch = path.basename(reportFile).match(/^\d+-(.+)-\d{4}-\d{2}-\d{2}\.md$/);
+  const reportName = path.basename(reportFile);
+  // A tracker application can point to a differently numbered report. Use
+  // that resolved report's number, not the selector, for the file and manifest.
+  // Normalize padding without converting to Number, which can lose digits.
+  const reportNum = (reportName.match(/^(\d+)-/)?.[1] ?? input)
+    .replace(/^0+(?=\d)/, "")
+    .padStart(3, "0");
+  const companyMatch = reportName.match(/^\d+-(.+)-\d{4}-\d{2}-\d{2}\.md$/);
   const companySlug = companyMatch ? companyMatch[1] : "company";
   let candidateSlug = "candidate";
   try {
@@ -81,8 +89,10 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   return {
     ok: true,
     paths: {
-      html: path.join(scratchDir, `cv-web-${input}.html`),
-      finalPdf: path.join(root, "output", `cv-${candidateSlug}-${companySlug}-${today}.pdf`),
+      reportNum,
+      reportFile: path.relative(root, reportFile).split(path.sep).join("/"),
+      html: path.join(scratchDir, `cv-web-${reportNum}.html`),
+      finalPdf: path.join(root, "output", `cv-${candidateSlug}-${reportNum}-${companySlug}-${today}.pdf`),
     },
   };
 }

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -51,7 +51,7 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
 /** ISO calendar date, the only form the dashboard's POSTED column parses. */
 const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
 
-export function buildPrompt({ kind, input, memory, today, postedAt, lang }) {
+export function buildPrompt({ kind, input, memory, today, postedAt, lang, reportFile }) {
   // AGENTS.md's "Output Language vs Market Modes" composition rule. The CLI
   // picks this up by reading AGENTS.md interactively; a one-shot headless
   // prompt has no such chance, so the rule has to be stated in the prompt or a
@@ -86,7 +86,7 @@ Target: ${input}`;
     // backend (a plain Node process, no CLI sandbox) writes and renders it, so
     // pdf mode runs with no write tool at all.
     return `You are tailoring the user's ATS-optimized CV for application #${input}, headless, on their machine. Run the REAL career-ops "pdf" mode's CONTENT step: follow modes/pdf.md's TAILORING rules exactly (do not improvise your own scoring or format). Apply its CONTENT rules — keyword injection, ordering, the competency grid, project selection, and its never-invent-a-skill rule. Its steps that shell out (the jd-skill-gap.mjs check, template resolution) and its build/save/render steps are NOT performed on web runs; the platform handles output itself.
-1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md (for the JD keywords + analysis).
+1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at ${JSON.stringify(reportFile ?? `reports/${input}-*.md`)} (for the JD keywords + analysis).
 2. Tailor the CV per modes/pdf.md: inject the JD's keywords into the summary + first bullets, reorder experience by relevance, build the competency grid, pick the top 3–4 projects. NEVER invent skills — only reword REAL experience using the JD's vocabulary.
 3. Fill templates/cv-template.html's {{...}} placeholders with the tailored content. Use that template even though modes/pdf.md resolves one via cv-templates.mjs: web runs always use the base template. ${CV_ENVELOPE_INSTRUCTION}
 4. Emit the envelope EXACTLY ONCE. The platform writes the HTML, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
@@ -194,4 +194,3 @@ VERDICT: {score}/5 — {reason in 12 words or fewer}
 
 Posting URL: ${input}`;
 }
-

--- a/web/tests/lib/apply-cv-resolver.test.mjs
+++ b/web/tests/lib/apply-cv-resolver.test.mjs
@@ -28,7 +28,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, utimesSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -61,6 +61,8 @@ register('data:text/javascript,' + encodeURIComponent(loaderSrc), pathToFileURL(
 
 const { resolveTailoredCv } = await import('../../src/lib/apply/cv.ts');
 const { sortNewestFirst } = await import('../../src/lib/apply/cv-match.mjs');
+const { findReportFile } = await import('../../src/lib/career-ops.ts');
+const { resolvePdfPaths } = await import('../../src/lib/pdf-paths.mjs');
 
 // Provision a throwaway career-ops root with an output/ dir, redirected via
 // the same CAREER_OPS_ROOT override career-ops.ts's careerOpsRoot() reads
@@ -84,6 +86,7 @@ async function withFixture(files, fn) {
   } finally {
     if (prev === undefined) delete process.env.CAREER_OPS_ROOT;
     else process.env.CAREER_OPS_ROOT = prev;
+    rmSync(root, { recursive: true, force: true });
   }
 }
 
@@ -95,6 +98,35 @@ test('resolveTailoredCv: a multi-word company does NOT match a file whose first 
     // application.
     const result = await resolveTailoredCv('Meta Platforms');
     assert.equal(result, null);
+  });
+});
+
+test('generated CV uses the linked report identity when its application number differs', async () => {
+  await withFixture([], async (outputDir) => {
+    const root = dirname(outputDir);
+    mkdirSync(join(root, 'data'));
+    mkdirSync(join(root, 'reports'));
+    writeFileSync(join(root, 'reports', '018-acme-2026-07-01.md'), '# Acme engineer\n');
+    writeFileSync(join(root, 'reports', '019-acme-2026-07-01.md'), '# Acme manager\n');
+    writeFileSync(join(root, 'data', 'applications.md'), [
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+      '|---|---|---|---|---|---|---|---|---|',
+      '| 309 | 2026-07-01 | Acme | Engineer | 4.5/5 | Evaluated | | [018](../reports/018-acme-2026-07-01.md) | |',
+      '| 310 | 2026-07-01 | Acme | Manager | 4.5/5 | Evaluated | | [019](../reports/019-acme-2026-07-01.md) | |',
+    ].join('\n'));
+
+    const first = resolvePdfPaths('309', '2026-07-26', root, findReportFile);
+    const padded = resolvePdfPaths('0309', '2026-07-26', root, findReportFile);
+    const second = resolvePdfPaths('310', '2026-07-26', root, findReportFile);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(first.paths.reportNum, '018');
+    assert.equal(second.paths.reportNum, '019');
+    assert.deepEqual(first, padded);
+    assert.notEqual(first.paths.finalPdf, second.paths.finalPdf);
+
+    writeFileSync(first.paths.finalPdf, 'stub-pdf-bytes');
+    assert.equal(await resolveTailoredCv('Acme'), first.paths.finalPdf);
   });
 });
 

--- a/web/tests/lib/pdf-paths.test.mjs
+++ b/web/tests/lib/pdf-paths.test.mjs
@@ -6,10 +6,12 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { basename, join, relative } from "node:path";
 import { tmpdir } from "node:os";
 import { slugify, resolvePdfPaths } from "../../src/lib/pdf-paths.mjs";
+import { matchesTailoredCv } from "../../src/lib/apply/cv-match.mjs";
+import { pdfPathForReport } from "../../src/lib/apply/cv-selection.mjs";
 
 test("slugify: lowercases and hyphenates", () => {
   assert.equal(slugify("Jane Q. Smith"), "jane-q-smith");
@@ -39,8 +41,66 @@ test("resolvePdfPaths: happy path builds html + finalPdf from report + profile",
 
     // Then it returns deterministic scratch + final paths using the candidate/company slugs
     assert.equal(result.ok, true);
+    assert.equal(result.paths.reportNum, "018");
     assert.equal(result.paths.html, join(root, ".career-ops-web", "pdf-tmp", "cv-web-018.html"));
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-acme-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-018-acme-2026-07-26.pdf"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePdfPaths: two reports at one company on the same day keep separate CVs", () => {
+  const root = makeRoot();
+  const findReportFile = (input) => join(root, "reports", `${input}-acme-2026-07-01.md`);
+  try {
+    const first = resolvePdfPaths("018", "2026-07-26", root, findReportFile);
+    const second = resolvePdfPaths("019", "2026-07-26", root, findReportFile);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.notEqual(first.paths.html, second.paths.html);
+    assert.notEqual(first.paths.finalPdf, second.paths.finalPdf);
+
+    mkdirSync(join(root, "output"));
+    writeFileSync(first.paths.finalPdf, "CV tailored for the first role");
+    writeFileSync(second.paths.finalPdf, "CV tailored for the second role");
+    assert.equal(readFileSync(first.paths.finalPdf, "utf8"), "CV tailored for the first role");
+    assert.equal(readFileSync(second.paths.finalPdf, "utf8"), "CV tailored for the second role");
+
+    const index = [first, second].map(({ paths }) =>
+      `${paths.reportNum}\t${relative(root, paths.finalPdf)}\t${relative(root, paths.html)}\tletter\t2026-07-26`
+    ).join("\n");
+    assert.equal(pdfPathForReport(index, 18), relative(root, first.paths.finalPdf));
+    assert.equal(pdfPathForReport(index, 19), relative(root, second.paths.finalPdf));
+    assert.equal(matchesTailoredCv(basename(first.paths.finalPdf), "acme"), true);
+    assert.equal(matchesTailoredCv(basename(second.paths.finalPdf), "acme"), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePdfPaths: padded and unpadded selectors use the same resolved report identity", () => {
+  const root = makeRoot();
+  const findReportFile = () => join(root, "reports", "018-acme-2026-07-01.md");
+  try {
+    const padded = resolvePdfPaths("018", "2026-07-26", root, findReportFile);
+    const unpadded = resolvePdfPaths("18", "2026-07-26", root, findReportFile);
+    assert.equal(padded.ok, true);
+    assert.equal(unpadded.ok, true);
+    assert.deepEqual(padded.paths, unpadded.paths);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePdfPaths: a tracker selector uses its linked report number for paths and manifest", () => {
+  const root = makeRoot();
+  const findReportFile = () => join(root, "reports", "018-acme-2026-07-01.md");
+  try {
+    const result = resolvePdfPaths("309", "2026-07-26", root, findReportFile);
+    assert.equal(result.ok, true);
+    assert.equal(result.paths.reportNum, "018");
+    assert.equal(result.paths.html, join(root, ".career-ops-web", "pdf-tmp", "cv-web-018.html"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-018-acme-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -92,7 +152,8 @@ test("resolvePdfPaths: missing profile.yml falls back to the default candidate s
 
     // Then it still succeeds, using the "candidate" fallback slug
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-globex-2026-07-26.pdf"));
+    assert.equal(result.paths.reportNum, "005");
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-005-globex-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -108,7 +169,7 @@ test("resolvePdfPaths: malformed profile.yml falls back to the default candidate
 
     // Then it still succeeds, using the "candidate" fallback slug rather than throwing
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-globex-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-005-globex-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -124,7 +185,7 @@ test("resolvePdfPaths: report filename that doesn't match the expected pattern f
 
     // Then it still succeeds, using the "company" fallback slug
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-company-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-007-company-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -140,7 +201,7 @@ test("resolvePdfPaths: profile.yml present but candidate.full_name empty falls b
 
     // Then it still succeeds, using the "candidate" fallback slug
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-globex-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-005-globex-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -357,3 +357,14 @@ test("buildPrompt: evaluate does not enumerate the report's sections", () => {
   assert.ok(!/blocks?\s+A[–-]F/i.test(prompt), "the prompt must not name a subset of the mode file's sections");
   assert.ok(/EVERY section its report template specifies/i.test(prompt), "it must defer to the mode file for the section set");
 });
+
+test("PDF tailoring reads the resolved report even when the application number differs", () => {
+  const prompt = buildPrompt({
+    kind: "pdf", ...ARGS, input: "309",
+    reportFile: "reports/18-example-2026-09-10.md",
+  });
+  assert.match(prompt, /application #309/);
+  assert.ok(prompt.includes('"reports/18-example-2026-09-10.md"'));
+  assert.ok(!prompt.includes("reports/309-"));
+  assert.ok(!prompt.includes("reports/018-"), "the exact unpadded filename must be retained");
+});

--- a/web/tests/lib/status-result.test.mjs
+++ b/web/tests/lib/status-result.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { statusWriteError } from "../../src/lib/home/status-result.mjs";
+
+test("only a confirmed save of the requested status can dismiss a decision", () => {
+  for (const status of ["Applied", "Discarded"]) {
+    assert.equal(statusWriteError(true, { ok: true, status }, status), null);
+    // An idempotent retry still confirms that the desired status is saved.
+    assert.equal(statusWriteError(true, { ok: true, status, changed: false }, status), null);
+    assert.equal(typeof statusWriteError(false, { ok: true, status }, status), "string");
+  }
+});
+
+test("server rejections retain the reason needed to retry or correct a write", () => {
+  for (const error of ["Tracker is busy. Retry shortly.", "Tracker row not found.", "Status update timed out; the change may or may not have been applied."]) {
+    assert.equal(statusWriteError(false, { error }, "Applied"), error);
+  }
+});
+
+test("unconfirmed and mismatched results cannot silently remove a card", () => {
+  for (const result of [null, {}, { ok: false }, { ok: true }, { ok: true, status: "Discarded" }, { error: "" }]) {
+    assert.match(statusWriteError(true, result, "Applied"), /Could not confirm the change/);
+  }
+});

--- a/web/tests/lib/today-snapshot.test.mjs
+++ b/web/tests/lib/today-snapshot.test.mjs
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { todaySnapshot } from "../../src/lib/home/today-snapshot.mjs";
+
+const scoreOf = (score) => Number.parseFloat(score);
+
+test("Today keeps all undecided aliases and saved URLs, without shipping tracker history", () => {
+  const applications = [
+    { n: "1", status: "Applied", notes: "historical notes" },
+    ...Array.from({ length: 8 }, (_, i) => ({
+      n: String(i + 2), status: i % 2 ? "Evaluated 2026-09-10" : "verificar",
+      date: "2026-09-10", score: "4.5/5",
+    })),
+    { n: "10", status: "Discarded" },
+  ];
+  const inbox = [
+    { url: "https://example.com/jobs/1", done: true, role: "Old role", company: "Example" },
+    { url: "https://example.com/jobs/2", done: false, role: "New role", company: "Example" },
+  ];
+  const before = structuredClone({ applications, inbox });
+  const result = todaySnapshot({ applications, inbox }, scoreOf);
+  assert.equal(result.applications.length, 8, "headline must count beyond the six visible cards");
+  assert.deepEqual(result.applications.map((a) => a.n), ["2", "3", "4", "5", "6", "7", "8", "9"]);
+  assert.deepEqual(result.inbox, [
+    { url: "https://example.com/jobs/1", done: true },
+    { url: "https://example.com/jobs/2", done: false },
+  ]);
+  assert.deepEqual({ applications, inbox }, before, "the shared snapshot stays intact for setup detection");
+});
+
+test("a large completed history does not become a large Today payload", () => {
+  const snapshot = {
+    applications: Array.from({ length: 1000 }, (_, i) => ({
+      n: String(i), status: "Discarded", notes: "Archived evaluation detail. ".repeat(40),
+    })),
+    inbox: Array.from({ length: 1000 }, (_, i) => ({
+      url: `https://example.com/jobs/${i}`, done: true, company: "Example", role: "Past role", location: "Remote",
+    })),
+  };
+  const result = todaySnapshot(snapshot, scoreOf);
+  assert.equal(result.applications.length, 0);
+  assert.equal(result.inbox.length, 1000, "saved-offer identity is retained");
+  assert.ok(JSON.stringify(result).length < JSON.stringify(snapshot).length / 10);
+});

--- a/web/tests/lib/today-state.test.mjs
+++ b/web/tests/lib/today-state.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseTodayFollowups, parseTodayMatches, pendingInboxCount, summarizeToday } from "../../src/lib/home/today-state.mjs";
+
+const emptyQueue = {
+  freshCount: 0,
+  dueCount: 0,
+  decisionCount: 0,
+  inboxCount: 0,
+  followupState: "ready",
+  freshState: "ready",
+};
+
+test("caught up requires both requests to finish successfully", () => {
+  assert.equal(summarizeToday(emptyQueue).allClear, true);
+  for (const key of ["followupState", "freshState"]) {
+    for (const state of ["loading", "error"]) {
+      const summary = summarizeToday({ ...emptyQueue, [key]: state });
+      assert.equal(summary.allClear, false);
+      assert.notEqual(summary.emptyHeading, "You're all caught up.");
+      assert.ok(summary.emptyHeading.length);
+    }
+  }
+});
+
+test("a decision-only or inbox-only queue has a useful heading", () => {
+  for (const [key, expectedLabel] of [["decisionCount", "decision to make"], ["inboxCount", "inbox job to review"]]) {
+    const summary = summarizeToday({ ...emptyQueue, [key]: 1 });
+    assert.equal(summary.allClear, false);
+    assert.deepEqual(summary.items, [{ count: 1, label: expectedLabel }]);
+  }
+});
+
+test("known work stays visible while another part of the queue fails", () => {
+  const summary = summarizeToday({ ...emptyQueue, decisionCount: 2, freshState: "error" });
+  assert.equal(summary.failed, true);
+  assert.deepEqual(summary.items, [{ count: 2, label: "decisions to make" }]);
+});
+
+test("each action count prevents an all-clear result", () => {
+  for (const key of ["freshCount", "dueCount", "decisionCount", "inboxCount"]) {
+    const summary = summarizeToday({ ...emptyQueue, [key]: 4 });
+    assert.equal(summary.allClear, false);
+    assert.equal(summary.items[0].count, 4);
+  }
+});
+
+test("pending inbox count agrees with one triage action per unchecked URL", () => {
+  assert.equal(pendingInboxCount([
+    { url: "https://jobs.example/1", done: true },
+    { url: "https://jobs.example/1", done: false },
+    { url: "https://jobs.example/1", done: false },
+    { url: "https://jobs.example/2", done: true },
+    { url: "https://jobs.example/3", done: false },
+  ]), 2);
+});
+
+test("follow-up unavailable, HTTP failure, and malformed JSON cannot clear the queue", () => {
+  for (const [ok, data] of [
+    [true, { available: false, entries: [], metadata: null }],
+    [false, { available: true, entries: [] }],
+    [true, null],
+    [true, { available: true }],
+  ]) assert.throws(() => parseTodayFollowups(ok, data), /Could not load follow-ups/);
+  assert.throws(() => parseTodayFollowups(false, { error: "Follow-up files could not be read." }), /Follow-up files could not be read/);
+});
+
+test("follow-up parser preserves upcoming dates and separately counts due metadata", () => {
+  const upcoming = { company: "Example", nextFollowupDate: "2026-10-14" };
+  assert.deepEqual(parseTodayFollowups(true, { available: true, entries: [], nextUpcoming: upcoming, metadata: { urgent: 2, overdue: 3, waiting: 9 } }), {
+    entries: [], due: 5, nextUpcoming: upcoming,
+  });
+  assert.equal(parseTodayFollowups(true, { available: true, entries: [{ company: "Example" }], metadata: null }).due, 0);
+});
+
+test("fresh matches reject unavailable and broken responses without treating them as empty", () => {
+  for (const [ok, data] of [
+    [false, { offers: [], count: 0 }],
+    [true, { available: false, offers: [] }],
+    [true, null],
+    [true, { offers: "invalid" }],
+  ]) assert.throws(() => parseTodayMatches(ok, data), /Could not load fresh matches/);
+});
+
+test("fresh matches keep the full server count when the offer list is capped", () => {
+  const offers = [{ url: "https://jobs.example/1" }];
+  assert.deepEqual(parseTodayMatches(true, { offers, count: 23 }), { offers, count: 23 });
+  assert.equal(parseTodayMatches(true, { offers }).count, 1);
+  assert.equal(parseTodayMatches(true, { offers, count: "bad" }).count, 1);
+  assert.equal(parseTodayMatches(true, { offers: [], count: -4 }).count, 0);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes existing web flows where Today could hide an unsuccessful status change, lose a snooze on reload, or report an empty queue after a failed read. It also prevents PDFs for different roles at the same company from overwriting one another and reduces the data sent to the home page.

- **PDF identity:** derive filenames, scratch cleanup, and manifest keys from the resolved report. Pass the exact report path to the tailoring prompt, including when a tracker application number differs from its linked report number. Keep the company/date suffix compatible with existing PDF readers.
- **Today actions:** dismiss a decision only after the requested status is confirmed, with a retry on failure. Snooze uses the existing persisted follow-up date dialog and core schedule.
- **Queue accuracy:** distinguish loading and failed reads from an empty queue, preserve existing items during refresh failures, and cancel stale requests. Count pending inbox jobs and all undecided applications while displaying six decision cards. Unreadable scan history returns an error; a missing file remains an empty result.
- **Home performance:** reuse one tracker/inbox snapshot for setup detection and rendering, avoid unused scan-date reads, and send only undecided applications plus inbox URL/completion fields. Completed inbox URLs remain available for discovery deduplication.

## Related issue

Bug fixes to existing functionality; no new mode, data format, or architecture.

## Type of change

- [x] Bug fix

## Validation

- `node test-all.mjs`: 8,692 passed, 0 failed, 17 warnings. Warnings cover the missing Go compiler, absent user data, stock author references, and opt-in live API checks. The Go dashboard build was skipped.
- In `web/`: `npm test` (516 passed), `npm run typecheck`, and `BUILD_DIST=.next-prod npm run build` passed.
- Browser verification with synthetic data on an isolated server: failed status writes remain visible and retry successfully; saved status changes persist; snoozed dates survive reload and move to upcoming follow-ups; unreadable scan history and unavailable follow-up data show recoverable errors. Desktop and 390px mobile checks passed without horizontal overflow or page errors.
- Regression tests cover same-company PDF collisions, application/report number mismatches, exact report paths, existing PDF-reader compatibility, queue errors/counts, and a 1,000-row completed-history fixture with over 90% less serialized queue data.

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] These bug fixes are exempt from the issue-first requirement.
- [x] No personal CV, profile, scan results, or pipeline data is included.
- [x] I ran `node test-all.mjs`; all tests pass with the limitations above.
- [x] Changes respect the Data Contract; no user-layer files are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-visible changes

- Today actions dismiss only after confirmed status changes. Failed changes show an error and support retry: `web/src/components/home/decision-card.tsx`.
- Snooze saves the follow-up date through the standard scheduling flow: `web/src/components/home/follow-up-card.tsx`.
- Today separates loading, failed, and empty states. Refresh failures no longer replace existing items: `web/src/components/home/today-dashboard.tsx`.
- Today counts all pending inbox jobs and undecided applications, while showing up to six decision cards: `web/src/lib/home/today-state.mjs`.
- PDF paths and prompts use the resolved report identity. This fixes cases where application and report numbers differ: `web/src/app/api/run/route.ts:94`, `web/src/app/api/run/route.ts:114`.
- The home page reuses application and inbox data and sends a smaller Today payload: `web/src/app/page.tsx:12-17`, `web/src/lib/home/today-snapshot.mjs`.
- Scan-history read failures now report an error instead of appearing as an empty history: `web/src/app/api/whats-new/route.ts`.

## Validation

- Added tests for PDF identity, status confirmation, Today queue states, and payload reduction.
- Full, web, typecheck, build, browser, and regression validation passed.

## System files

- No changes were found in `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->