### PR TITLE
fix(web): preserve report identity when generating tailored PDFs

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -111,7 +111,7 @@ export async function POST(req: Request) {
     kind === "evaluate"
       ? readInbox().find((j) => j.url === input)?.postedAt ?? readScanDates().get(input)
       : undefined;
-  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang });
+  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt, lang, reportFile: pdfPaths?.reportFile });
 
   const isClaude = cliId === "claude";
   // Which tools each kind gets, and the whole claude argv, live in
@@ -384,7 +384,7 @@ export async function POST(req: Request) {
             root: careerOpsRoot(),
             pdfPaths: paths,
             format,
-            reportNum: input,
+            reportNum: paths.reportNum,
           });
           if (result.kind === "render-failed") {
             send({ type: "error", msg: result.error.slice(0, 200) });

--- a/web/src/lib/pdf-paths.mjs
+++ b/web/src/lib/pdf-paths.mjs
@@ -21,16 +21,18 @@ export function slugify(s) {
 
 /**
  * @typedef {Object} PdfPaths
+ * @property {string} reportNum - Canonical report number, used for filenames and the PDF manifest.
+ * @property {string} reportFile - Resolved report path relative to the data root, used by the tailoring prompt.
  * @property {string} html - Where the backend writes the tailored HTML it parsed out of the agent's envelope (#2185).
- * @property {string} finalPdf - Where the backend renders the final PDF (output/cv-{candidate}-{company}-{date}.pdf).
+ * @property {string} finalPdf - Where the backend renders the final PDF (output/cv-{candidate}-{report}-{company}-{date}.pdf).
  */
 
 /**
  * Precompute the scratch HTML and final PDF paths for a
  * "pdf" run, so the agent never chooses its own filenames — the backend owns
- * naming, writing (#2185) and rendering. Resolves the report (for the company slug)
- * and config/profile.yml (for the candidate slug) — same naming convention
- * modes/pdf.md documents, so web and CLI output stay byte-identical.
+ * naming, writing (#2185) and rendering. Resolves the report for its identity
+ * and company slug, and config/profile.yml for the candidate slug. Including
+ * the report number keeps same-company CVs generated on one day separate.
  *
  * Framework-agnostic: returns a result instead of constructing a Response, so
  * the caller (a Next.js route today) decides how to surface `ok: false`.
@@ -39,7 +41,7 @@ export function slugify(s) {
  * exist yet (the backend writes the parsed envelope there, #2185) — this is
  * NOT a pure path computation, despite the name.
  *
- * @param {string} input - The report number (e.g. "018").
+ * @param {string} input - The application/report selector (e.g. "018").
  * @param {string} today - YYYY-MM-DD.
  * @param {string} root - careerOpsRoot().
  * @param {(input: string) => string | null} findReportFile - career-ops.ts's findReportFile.
@@ -49,8 +51,7 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   // Reject anything but a bare report number before it ever reaches a path.
   // findReportFile()'s parseInt-based matching can still resolve a crafted
   // selector like "123/../../etc/passwd" to a legitimate report file, but the
-  // raw string is also used verbatim below to build cv-web-${input}.html —
-  // path.join would then honor those ".." segments and escape scratchDir.
+  // selector must never become a path segment unless it is purely numeric.
   if (!/^\d+$/.test(input)) {
     return { ok: false, error: `Invalid report selector: "${input}"` };
   }
@@ -58,7 +59,14 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   if (!reportFile) {
     return { ok: false, error: `No report #${input} found — evaluate this posting first.` };
   }
-  const companyMatch = path.basename(reportFile).match(/^\d+-(.+)-\d{4}-\d{2}-\d{2}\.md$/);
+  const reportName = path.basename(reportFile);
+  // A tracker application can point to a differently numbered report. Use
+  // that resolved report's number, not the selector, for the file and manifest.
+  // Normalize padding without converting to Number, which can lose digits.
+  const reportNum = (reportName.match(/^(\d+)-/)?.[1] ?? input)
+    .replace(/^0+(?=\d)/, "")
+    .padStart(3, "0");
+  const companyMatch = reportName.match(/^\d+-(.+)-\d{4}-\d{2}-\d{2}\.md$/);
   const companySlug = companyMatch ? companyMatch[1] : "company";
   let candidateSlug = "candidate";
   try {
@@ -81,8 +89,10 @@ export function resolvePdfPaths(input, today, root, findReportFile) {
   return {
     ok: true,
     paths: {
-      html: path.join(scratchDir, `cv-web-${input}.html`),
-      finalPdf: path.join(root, "output", `cv-${candidateSlug}-${companySlug}-${today}.pdf`),
+      reportNum,
+      reportFile: path.relative(root, reportFile).split(path.sep).join("/"),
+      html: path.join(scratchDir, `cv-web-${reportNum}.html`),
+      finalPdf: path.join(root, "output", `cv-${candidateSlug}-${reportNum}-${companySlug}-${today}.pdf`),
     },
   };
 }

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -51,7 +51,7 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
 /** ISO calendar date, the only form the dashboard's POSTED column parses. */
 const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
 
-export function buildPrompt({ kind, input, memory, today, postedAt, lang }) {
+export function buildPrompt({ kind, input, memory, today, postedAt, lang, reportFile }) {
   // AGENTS.md's "Output Language vs Market Modes" composition rule. The CLI
   // picks this up by reading AGENTS.md interactively; a one-shot headless
   // prompt has no such chance, so the rule has to be stated in the prompt or a
@@ -86,7 +86,7 @@ Target: ${input}`;
     // backend (a plain Node process, no CLI sandbox) writes and renders it, so
     // pdf mode runs with no write tool at all.
     return `You are tailoring the user's ATS-optimized CV for application #${input}, headless, on their machine. Run the REAL career-ops "pdf" mode's CONTENT step: follow modes/pdf.md's TAILORING rules exactly (do not improvise your own scoring or format). Apply its CONTENT rules — keyword injection, ordering, the competency grid, project selection, and its never-invent-a-skill rule. Its steps that shell out (the jd-skill-gap.mjs check, template resolution) and its build/save/render steps are NOT performed on web runs; the platform handles output itself.
-1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at reports/${input}-*.md (for the JD keywords + analysis).
+1. Read modes/pdf.md, cv.md, config/profile.yml, and the evaluation report at ${JSON.stringify(reportFile ?? `reports/${input}-*.md`)} (for the JD keywords + analysis).
 2. Tailor the CV per modes/pdf.md: inject the JD's keywords into the summary + first bullets, reorder experience by relevance, build the competency grid, pick the top 3–4 projects. NEVER invent skills — only reword REAL experience using the JD's vocabulary.
 3. Fill templates/cv-template.html's {{...}} placeholders with the tailored content. Use that template even though modes/pdf.md resolves one via cv-templates.mjs: web runs always use the base template. ${CV_ENVELOPE_INSTRUCTION}
 4. Emit the envelope EXACTLY ONCE. The platform writes the HTML, renders the PDF, and updates the tracker's PDF column itself, only after a confirmed successful render. Do not submit anything anywhere.
@@ -194,4 +194,3 @@ VERDICT: {score}/5 — {reason in 12 words or fewer}
 
 Posting URL: ${input}`;
 }
-

--- a/web/tests/lib/apply-cv-resolver.test.mjs
+++ b/web/tests/lib/apply-cv-resolver.test.mjs
@@ -28,7 +28,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, utimesSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -61,6 +61,8 @@ register('data:text/javascript,' + encodeURIComponent(loaderSrc), pathToFileURL(
 
 const { resolveTailoredCv } = await import('../../src/lib/apply/cv.ts');
 const { sortNewestFirst } = await import('../../src/lib/apply/cv-match.mjs');
+const { findReportFile } = await import('../../src/lib/career-ops.ts');
+const { resolvePdfPaths } = await import('../../src/lib/pdf-paths.mjs');
 
 // Provision a throwaway career-ops root with an output/ dir, redirected via
 // the same CAREER_OPS_ROOT override career-ops.ts's careerOpsRoot() reads
@@ -84,6 +86,7 @@ async function withFixture(files, fn) {
   } finally {
     if (prev === undefined) delete process.env.CAREER_OPS_ROOT;
     else process.env.CAREER_OPS_ROOT = prev;
+    rmSync(root, { recursive: true, force: true });
   }
 }
 
@@ -95,6 +98,35 @@ test('resolveTailoredCv: a multi-word company does NOT match a file whose first 
     // application.
     const result = await resolveTailoredCv('Meta Platforms');
     assert.equal(result, null);
+  });
+});
+
+test('generated CV uses the linked report identity when its application number differs', async () => {
+  await withFixture([], async (outputDir) => {
+    const root = dirname(outputDir);
+    mkdirSync(join(root, 'data'));
+    mkdirSync(join(root, 'reports'));
+    writeFileSync(join(root, 'reports', '018-acme-2026-07-01.md'), '# Acme engineer\n');
+    writeFileSync(join(root, 'reports', '019-acme-2026-07-01.md'), '# Acme manager\n');
+    writeFileSync(join(root, 'data', 'applications.md'), [
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+      '|---|---|---|---|---|---|---|---|---|',
+      '| 309 | 2026-07-01 | Acme | Engineer | 4.5/5 | Evaluated | | [018](../reports/018-acme-2026-07-01.md) | |',
+      '| 310 | 2026-07-01 | Acme | Manager | 4.5/5 | Evaluated | | [019](../reports/019-acme-2026-07-01.md) | |',
+    ].join('\n'));
+
+    const first = resolvePdfPaths('309', '2026-07-26', root, findReportFile);
+    const padded = resolvePdfPaths('0309', '2026-07-26', root, findReportFile);
+    const second = resolvePdfPaths('310', '2026-07-26', root, findReportFile);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(first.paths.reportNum, '018');
+    assert.equal(second.paths.reportNum, '019');
+    assert.deepEqual(first, padded);
+    assert.notEqual(first.paths.finalPdf, second.paths.finalPdf);
+
+    writeFileSync(first.paths.finalPdf, 'stub-pdf-bytes');
+    assert.equal(await resolveTailoredCv('Acme'), first.paths.finalPdf);
   });
 });
 

--- a/web/tests/lib/apply-cv-resolver.test.mjs
+++ b/web/tests/lib/apply-cv-resolver.test.mjs
@@ -127,6 +127,19 @@ test('generated CV uses the linked report identity when its application number d
 
     writeFileSync(first.paths.finalPdf, 'stub-pdf-bytes');
     assert.equal(await resolveTailoredCv('Acme'), first.paths.finalPdf);
+
+    // Use the real core path resolver in this fixture, without a platform-
+    // dependent symlink or a second implementation of its manifest rules.
+    writeFileSync(join(root, 'tracker-utils.mjs'),
+      `export { resolveTrackerPath, resolvePdfIndexPath } from ${JSON.stringify(new URL('../../../tracker-utils.mjs', import.meta.url).href)};\n`);
+    writeFileSync(second.paths.finalPdf, 'second-role-pdf-bytes');
+    writeFileSync(join(root, 'data', 'pdf-index.tsv'), [
+      '# report\tpdf\thtml\tformat\tdate',
+      `018\toutput/${basename(first.paths.finalPdf)}\t\tletter\t2026-07-26`,
+      `019\toutput/${basename(second.paths.finalPdf)}\t\tletter\t2026-07-26`,
+    ].join('\n'));
+    assert.equal(await resolveTailoredCv(undefined, '309'), first.paths.finalPdf);
+    assert.equal(await resolveTailoredCv(undefined, '310'), second.paths.finalPdf);
   });
 });
 

--- a/web/tests/lib/apply-cv-resolver.test.mjs
+++ b/web/tests/lib/apply-cv-resolver.test.mjs
@@ -128,10 +128,13 @@ test('generated CV uses the linked report identity when its application number d
     writeFileSync(first.paths.finalPdf, 'stub-pdf-bytes');
     assert.equal(await resolveTailoredCv('Acme'), first.paths.finalPdf);
 
-    // Use the real core path resolver in this fixture, without a platform-
-    // dependent symlink or a second implementation of its manifest rules.
-    writeFileSync(join(root, 'tracker-utils.mjs'),
-      `export { resolveTrackerPath, resolvePdfIndexPath } from ${JSON.stringify(new URL('../../../tracker-utils.mjs', import.meta.url).href)};\n`);
+    // Supply only this fixture's path endpoints. Web CI installs web dependencies
+    // alone; importing the full core here would require its separate packages.
+    // The application, report and manifest lookups still use the real web code.
+    writeFileSync(join(root, 'tracker-utils.mjs'), [
+      `export const resolveTrackerPath = () => ${JSON.stringify(join(root, 'data', 'applications.md'))};`,
+      `export const resolvePdfIndexPath = () => ${JSON.stringify(join(root, 'data', 'pdf-index.tsv'))};`,
+    ].join('\n'));
     writeFileSync(second.paths.finalPdf, 'second-role-pdf-bytes');
     writeFileSync(join(root, 'data', 'pdf-index.tsv'), [
       '# report\tpdf\thtml\tformat\tdate',

--- a/web/tests/lib/pdf-paths.test.mjs
+++ b/web/tests/lib/pdf-paths.test.mjs
@@ -6,10 +6,12 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { basename, join, relative } from "node:path";
 import { tmpdir } from "node:os";
 import { slugify, resolvePdfPaths } from "../../src/lib/pdf-paths.mjs";
+import { matchesTailoredCv } from "../../src/lib/apply/cv-match.mjs";
+import { pdfPathForReport } from "../../src/lib/apply/cv-selection.mjs";
 
 test("slugify: lowercases and hyphenates", () => {
   assert.equal(slugify("Jane Q. Smith"), "jane-q-smith");
@@ -39,8 +41,66 @@ test("resolvePdfPaths: happy path builds html + finalPdf from report + profile",
 
     // Then it returns deterministic scratch + final paths using the candidate/company slugs
     assert.equal(result.ok, true);
+    assert.equal(result.paths.reportNum, "018");
     assert.equal(result.paths.html, join(root, ".career-ops-web", "pdf-tmp", "cv-web-018.html"));
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-acme-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-018-acme-2026-07-26.pdf"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePdfPaths: two reports at one company on the same day keep separate CVs", () => {
+  const root = makeRoot();
+  const findReportFile = (input) => join(root, "reports", `${input}-acme-2026-07-01.md`);
+  try {
+    const first = resolvePdfPaths("018", "2026-07-26", root, findReportFile);
+    const second = resolvePdfPaths("019", "2026-07-26", root, findReportFile);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.notEqual(first.paths.html, second.paths.html);
+    assert.notEqual(first.paths.finalPdf, second.paths.finalPdf);
+
+    mkdirSync(join(root, "output"));
+    writeFileSync(first.paths.finalPdf, "CV tailored for the first role");
+    writeFileSync(second.paths.finalPdf, "CV tailored for the second role");
+    assert.equal(readFileSync(first.paths.finalPdf, "utf8"), "CV tailored for the first role");
+    assert.equal(readFileSync(second.paths.finalPdf, "utf8"), "CV tailored for the second role");
+
+    const index = [first, second].map(({ paths }) =>
+      `${paths.reportNum}\t${relative(root, paths.finalPdf)}\t${relative(root, paths.html)}\tletter\t2026-07-26`
+    ).join("\n");
+    assert.equal(pdfPathForReport(index, 18), relative(root, first.paths.finalPdf));
+    assert.equal(pdfPathForReport(index, 19), relative(root, second.paths.finalPdf));
+    assert.equal(matchesTailoredCv(basename(first.paths.finalPdf), "acme"), true);
+    assert.equal(matchesTailoredCv(basename(second.paths.finalPdf), "acme"), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePdfPaths: padded and unpadded selectors use the same resolved report identity", () => {
+  const root = makeRoot();
+  const findReportFile = () => join(root, "reports", "018-acme-2026-07-01.md");
+  try {
+    const padded = resolvePdfPaths("018", "2026-07-26", root, findReportFile);
+    const unpadded = resolvePdfPaths("18", "2026-07-26", root, findReportFile);
+    assert.equal(padded.ok, true);
+    assert.equal(unpadded.ok, true);
+    assert.deepEqual(padded.paths, unpadded.paths);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePdfPaths: a tracker selector uses its linked report number for paths and manifest", () => {
+  const root = makeRoot();
+  const findReportFile = () => join(root, "reports", "018-acme-2026-07-01.md");
+  try {
+    const result = resolvePdfPaths("309", "2026-07-26", root, findReportFile);
+    assert.equal(result.ok, true);
+    assert.equal(result.paths.reportNum, "018");
+    assert.equal(result.paths.html, join(root, ".career-ops-web", "pdf-tmp", "cv-web-018.html"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-018-acme-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -92,7 +152,8 @@ test("resolvePdfPaths: missing profile.yml falls back to the default candidate s
 
     // Then it still succeeds, using the "candidate" fallback slug
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-globex-2026-07-26.pdf"));
+    assert.equal(result.paths.reportNum, "005");
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-005-globex-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -108,7 +169,7 @@ test("resolvePdfPaths: malformed profile.yml falls back to the default candidate
 
     // Then it still succeeds, using the "candidate" fallback slug rather than throwing
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-globex-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-005-globex-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -124,7 +185,7 @@ test("resolvePdfPaths: report filename that doesn't match the expected pattern f
 
     // Then it still succeeds, using the "company" fallback slug
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-company-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-jane-smith-007-company-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -140,7 +201,7 @@ test("resolvePdfPaths: profile.yml present but candidate.full_name empty falls b
 
     // Then it still succeeds, using the "candidate" fallback slug
     assert.equal(result.ok, true);
-    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-globex-2026-07-26.pdf"));
+    assert.equal(result.paths.finalPdf, join(root, "output", "cv-candidate-005-globex-2026-07-26.pdf"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -357,3 +357,14 @@ test("buildPrompt: evaluate does not enumerate the report's sections", () => {
   assert.ok(!/blocks?\s+A[–-]F/i.test(prompt), "the prompt must not name a subset of the mode file's sections");
   assert.ok(/EVERY section its report template specifies/i.test(prompt), "it must defer to the mode file for the section set");
 });
+
+test("PDF tailoring reads the resolved report even when the application number differs", () => {
+  const prompt = buildPrompt({
+    kind: "pdf", ...ARGS, input: "309",
+    reportFile: "reports/18-example-2026-09-10.md",
+  });
+  assert.match(prompt, /application #309/);
+  assert.ok(prompt.includes('"reports/18-example-2026-09-10.md"'));
+  assert.ok(!prompt.includes("reports/309-"));
+  assert.ok(!prompt.includes("reports/018-"), "the exact unpadded filename must be retained");
+});


### PR DESCRIPTION
## What does this PR do?

Generating tailored CVs for two roles at the same company on the same day previously reused the same output filename. A tracker application linked to a differently numbered report could also tailor from the wrong report while recording its PDF under the application number.

This change derives the filename, scratch path, manifest key, and tailoring prompt from the resolved report. The prompt receives the exact report path, including unpadded filenames. The company/date suffix stays compatible with existing PDF readers; existing PDFs are not renamed.

Only web-generated filenames change. The CLI mode keeps its existing naming convention, so the terminal examples in the PDF mode documentation remain valid.

## Related issue

Independent PDF fix split from #4103. This PR contains only the six PDF-related files and can merge on its own.

## Type of change

- [x] Bug fix

## Validation

- `node test-all.mjs`: 8,686 passed, 0 failed, 17 warnings. Warnings cover absent user data, the unavailable Go compiler, stock author references, and two opt-in live API checks. The Go dashboard build was skipped.
- Web: 502 tests passed, type checking passed, production build passed.
- Also checked the web-only dependency layout used by CI: 496 passed, with six existing core parity checks skipped because core dependencies are absent.
- Regression tests cover same-company collisions, application/report number mismatches, padding, exact report paths, and compatibility with the existing PDF readers.
- The application lookup regression writes both report entries to the PDF manifest and calls the real resolver for applications 309 and 310, confirming each resolves its own PDF through linked reports 018 and 019.

## Checklist

- [x] Read CONTRIBUTING.md; these bug fixes are exempt from the issue-first requirement.
- [x] No personal data or user-layer files are included.
- [x] Changes preserve the Data Contract and existing local workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Tailored PDFs now preserve the resolved report identity.

Users can generate CVs for multiple roles at the same company on the same day without filename collisions. Tracker applications can use a different application number from the linked report. The backend now uses the resolved report number for filenames, scratch HTML, manifest keys, and PDF paths (`web/src/lib/pdf-paths.mjs:58-95`).

The tailoring prompt receives the exact resolved report path, including unpadded filenames (`web/src/app/api/run/route.ts:92-114`, `web/src/lib/run-prompts.mjs:78-94`). Padded and unpadded selectors resolve to the same report. Existing PDFs are not renamed, and CLI naming remains unchanged.

## Tests

Regression coverage includes same-company collisions, application/report number mismatches, padding, exact report paths, manifest integration, and existing PDF-reader compatibility. The PDF fixture cleanup also isolates web tests from core-only dependencies (`web/tests/lib/apply-cv-resolver.test.mjs`).

Validation passed: 8,686 repository tests, 502 web tests, type checking, and the production build.

## System files

No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->