### PR TITLE
perf(web): reuse home data reads and reduce queue payload

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,6 @@
-import { pipelineSummary, doctorState } from "@/lib/career-ops";
+import { readApplications, readInbox, doctorState } from "@/lib/career-ops";
+import { todaySnapshot } from "@/lib/home/today-snapshot.mjs";
+import { scoreNum } from "@/lib/format";
 import { OnboardingBanner } from "@/components/onboarding-banner";
 import { FirstRunHome } from "@/components/home/first-run-home";
 import { TodayDashboard } from "@/components/home/today-dashboard";
@@ -6,12 +8,13 @@ import { TodayDashboard } from "@/components/home/today-dashboard";
 export const dynamic = "force-dynamic"; // always read fresh local files at request time (never at build — CI has no user data)
 
 export default function Home() {
-  const { phase, onboardingNeeded } = doctorState();
+  const snapshot = { applications: readApplications(), inbox: readInbox() };
+  const { phase, onboardingNeeded } = doctorState(snapshot);
   // First run (truly empty install): the CV-upload takeover IS the home — value
   // before commitment. The full dashboard returns once they have a CV or any data.
   if (phase === "first-run") return <FirstRunHome />;
 
-  const { inbox, applications } = pipelineSummary();
+  const { inbox, applications } = todaySnapshot(snapshot, scoreNum);
   // Established / in-between: the dual-loop retention dashboard. Show the setup
   // banner whenever ANY prereq is missing (mirrors the core doctor.mjs), so a
   // portals-missing user is nudged rather than told "all caught up".

--- a/web/src/components/home/today-dashboard.tsx
+++ b/web/src/components/home/today-dashboard.tsx
@@ -26,7 +26,7 @@ export function TodayDashboard({
   inBetween,
 }: {
   applications: Application[];
-  inbox: InboxJob[];
+  inbox: Pick<InboxJob, "url" | "done">[];
   inBetween: boolean;
 }) {
   const [followups, setFollowups] = useState<FollowUp[]>([]);

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -247,7 +247,7 @@ export type LifecyclePhase = "first-run" | "in-between" | "established";
  *   - established → all 4 prereqs present.
  * onboardingNeeded mirrors doctor.mjs: true if ANY prereq is missing → show banner.
  */
-export function doctorState(): {
+export function doctorState(snapshot?: Pick<PipelineSummary, "applications" | "inbox">): {
   phase: LifecyclePhase;
   onboardingNeeded: boolean;
   missing: string[];
@@ -269,7 +269,10 @@ export function doctorState(): {
   ];
   const missing = prereqs.filter(([rel]) => !has(rel)).map(([, label]) => label);
   const hasCv = has("cv.md");
-  const hasData = readApplications().length > 0 || readInbox().some((j) => !j.done);
+  // Home already reads these files. Reuse that snapshot so its setup check
+  // neither parses the tracker twice nor disagrees with the rendered queue.
+  const hasData = (snapshot?.applications ?? readApplications()).length > 0 ||
+    (snapshot?.inbox ?? readInbox()).some((j) => !j.done);
   const onboardingNeeded = missing.length > 0;
   const phase: LifecyclePhase = !hasCv && !hasData ? "first-run" : onboardingNeeded ? "in-between" : "established";
   return { phase, onboardingNeeded, missing, hasCv, hasData };

--- a/web/src/lib/home/today-snapshot.mjs
+++ b/web/src/lib/home/today-snapshot.mjs
@@ -1,0 +1,17 @@
+import { pickAwaitingDecision } from "./awaiting.mjs";
+
+/**
+ * Send only what Today renders across the server/client boundary. Completed
+ * inbox URLs still identify saved discoveries; their descriptions do not.
+ * Keep every undecided application so the headline can count beyond six cards.
+ *
+ * @template {{date?: string, score?: string, status?: string}} T
+ * @param {{applications: T[], inbox: {url: string, done: boolean}[]}} snapshot
+ * @param {(score: string) => number} scoreOf
+ */
+export function todaySnapshot({ applications, inbox }, scoreOf) {
+  return {
+    applications: pickAwaitingDecision(applications, scoreOf, Infinity),
+    inbox: inbox.map(({ url, done }) => ({ url, done })),
+  };
+}

--- a/web/tests/lib/today-snapshot.test.mjs
+++ b/web/tests/lib/today-snapshot.test.mjs
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { todaySnapshot } from "../../src/lib/home/today-snapshot.mjs";
+
+const scoreOf = (score) => Number.parseFloat(score);
+
+test("Today keeps all undecided aliases and saved URLs, without shipping tracker history", () => {
+  const applications = [
+    { n: "1", status: "Applied", notes: "historical notes" },
+    ...Array.from({ length: 8 }, (_, i) => ({
+      n: String(i + 2), status: i % 2 ? "Evaluated 2026-09-10" : "verificar",
+      date: "2026-09-10", score: "4.5/5",
+    })),
+    { n: "10", status: "Discarded" },
+  ];
+  const inbox = [
+    { url: "https://example.com/jobs/1", done: true, role: "Old role", company: "Example" },
+    { url: "https://example.com/jobs/2", done: false, role: "New role", company: "Example" },
+  ];
+  const before = structuredClone({ applications, inbox });
+  const result = todaySnapshot({ applications, inbox }, scoreOf);
+  assert.equal(result.applications.length, 8, "headline must count beyond the six visible cards");
+  assert.deepEqual(result.applications.map((a) => a.n), ["2", "3", "4", "5", "6", "7", "8", "9"]);
+  assert.deepEqual(result.inbox, [
+    { url: "https://example.com/jobs/1", done: true },
+    { url: "https://example.com/jobs/2", done: false },
+  ]);
+  assert.deepEqual({ applications, inbox }, before, "the shared snapshot stays intact for setup detection");
+});
+
+test("a large completed history does not become a large Today payload", () => {
+  const snapshot = {
+    applications: Array.from({ length: 1000 }, (_, i) => ({
+      n: String(i), status: "Discarded", notes: "Archived evaluation detail. ".repeat(40),
+    })),
+    inbox: Array.from({ length: 1000 }, (_, i) => ({
+      url: `https://example.com/jobs/${i}`, done: true, company: "Example", role: "Past role", location: "Remote",
+    })),
+  };
+  const result = todaySnapshot(snapshot, scoreOf);
+  assert.equal(result.applications.length, 0);
+  assert.equal(result.inbox.length, 1000, "saved-offer identity is retained");
+  assert.ok(JSON.stringify(result).length < JSON.stringify(snapshot).length / 10);
+});


### PR DESCRIPTION
## What does this PR do?

Home previously parsed the tracker and inbox for setup detection and again for rendering, read scan dates it did not use, and sent completed application history and unused inbox fields to the browser.

Reuse one full snapshot for setup detection, then send only undecided applications and inbox URL/completion fields to Today. Keep all undecided applications and all saved inbox URLs so existing ordering and discovery deduplication remain intact. A synthetic 1,000-row completed-history fixture produces over 90% less serialized queue data.

## Related issue

Independent performance fix split from #4103. The narrowed inbox prop is included here, so this PR can merge without the Today reliability changes.

## Type of change

- [x] Refactor / performance improvement, with existing queue behavior preserved

## Validation

- `node test-all.mjs`: 8,688 passed, 0 failed, 17 warnings. Warnings cover absent user data, the unavailable Go compiler, stock author references, and two opt-in live API checks. The Go dashboard build was skipped.
- Web: 499 tests passed, type checking passed, production build passed.
- Tests cover undecided status aliases, ordering beyond six cards, completed inbox URL retention, input immutability, and the large-history payload reduction.

## Checklist

- [x] Read CONTRIBUTING.md.
- [x] No personal data or user-layer files are included.
- [x] Reuses the existing decision picker and preserves the Data Contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Today now reuses one tracker and inbox snapshot for setup detection and rendering. It sends only undecided applications, inbox URLs, and completion status.

Completed history and unused inbox fields are excluded from the browser payload. Application ordering and inbox URL deduplication remain unchanged.

## User impact

Today uses less browser payload data. Large completed histories can reduce serialized queue data by over 90%. No user-facing workflow changes are expected.

## Files changed

- `web/src/app/page.tsx:11-17`: Builds and reuses the shared snapshot.
- `web/src/lib/career-ops.ts:250,274-275`: Uses the optional snapshot for setup checks.
- `web/src/lib/home/today-snapshot.mjs:12`: Builds the reduced Today payload.
- `web/src/components/home/today-dashboard.tsx:29`: Accepts only inbox `url` and `done`.
- `web/tests/lib/today-snapshot.test.mjs:1`: Tests filtering, ordering, immutability, URL retention, and payload reduction.

The requested system files and directories are present, but this change does not touch `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

## Validation

- 8,688 general tests passed.
- 499 web tests passed.
- Type checking passed.
- Production build passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->