### PR TITLE
fix(web): persist snoozes and keep Today failures visible

### DIFF
--- a/web/src/app/api/whats-new/route.ts
+++ b/web/src/app/api/whats-new/route.ts
@@ -30,8 +30,11 @@ export async function GET(req: Request) {
   let rows: string[];
   try {
     rows = fs.readFileSync(path.join(careerOpsRoot(), "data", "scan-history.tsv"), "utf8").split("\n");
-  } catch {
-    return Response.json({ offers: [], count: 0 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return Response.json({ offers: [], count: 0 });
+    }
+    return Response.json({ available: false, offers: [], count: 0, error: "Could not read scan history. Check the file and retry." }, { status: 500 });
   }
 
   // Roles already evaluated → don't resurface as "new". Keyed on company AND

--- a/web/src/components/followups/next-date-dialog.tsx
+++ b/web/src/components/followups/next-date-dialog.tsx
@@ -20,7 +20,8 @@ export function NextDateDialog({
   onClose,
   onChanged,
 }: {
-  entry: CadenceEntry;
+  entry: Pick<CadenceEntry, "num" | "company"> &
+    Partial<Pick<CadenceEntry, "role" | "nextFollowupDate" | "nextOverride">>;
   onClose: () => void;
   onChanged: () => void;
 }) {

--- a/web/src/components/home/decision-card.tsx
+++ b/web/src/components/home/decision-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Check, X, FileText, Loader2 } from "lucide-react";
@@ -8,27 +8,45 @@ import { cn } from "@/lib/cn";
 import { CompanyLogo } from "@/components/company-logo";
 import { scoreNum, scoreTone } from "@/lib/format";
 import { companyPresentation } from "@/lib/company-presentation.mjs";
+import { statusWriteError } from "@/lib/home/status-result.mjs";
 import type { Application } from "@/lib/career-ops";
 
 // Awaiting-decision row: a scored role with no terminal status. Primary action
 // opens the report (PDF + Apply live there). Skip / Applied still write status.
-export function DecisionCard({ app }: { app: Application }) {
+export function DecisionCard({ app, onSaved }: { app: Application; onSaved?: () => void }) {
   const router = useRouter();
   const [busy, setBusy] = useState<"" | "Applied" | "Discarded">("");
   const [done, setDone] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [failedStatus, setFailedStatus] = useState<"Applied" | "Discarded" | null>(null);
+  const submitting = useRef(false);
   const score = scoreNum(app.score);
   const tone = scoreTone(app.score);
   const company = companyPresentation(app);
 
   const setStatus = async (status: "Applied" | "Discarded") => {
+    if (submitting.current) return;
+    submitting.current = true;
     setBusy(status);
+    setError(null);
+    setFailedStatus(null);
     try {
-      await fetch("/api/status", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ n: app.n, status }) });
+      const response = await fetch("/api/status", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ n: app.n, status }) });
+      const result = await response.json().catch(() => null);
+      const failure = statusWriteError(response.ok, result, status);
+      if (failure) {
+        setError(failure);
+        setFailedStatus(status);
+        return;
+      }
       setDone(status);
       router.refresh();
+      onSaved?.();
     } catch {
-      /* ignore */
+      setError("Could not confirm the change. Check your connection and pipeline, then retry.");
+      setFailedStatus(status);
     } finally {
+      submitting.current = false;
       setBusy("");
     }
   };
@@ -82,6 +100,12 @@ export function DecisionCard({ app }: { app: Application }) {
           Applied
         </button>
       </div>
+      {error && (
+        <div role="alert" className="flex items-start gap-2 text-xs text-red-600 dark:text-red-400">
+          <p className="min-w-0 flex-1">{error}</p>
+          {failedStatus && <button type="button" disabled={!!busy} onClick={() => setStatus(failedStatus)} className="shrink-0 underline disabled:opacity-60 max-sm:min-h-[44px]">Retry</button>}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/home/follow-up-card.tsx
+++ b/web/src/components/home/follow-up-card.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Check, Clock, FileText, Loader2 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CompanyLogo } from "@/components/company-logo";
+import { NextDateDialog } from "@/components/followups/next-date-dialog";
 
 export type FollowUp = {
   num?: number;
@@ -16,16 +17,18 @@ export type FollowUp = {
   // are due now, 'waiting'/'cold' are not (#86).
   urgency?: "urgent" | "overdue" | "waiting" | "cold";
   nextFollowupDate?: string | null;
+  nextOverride?: string | null;
   daysUntilNext?: number | null;
 };
 
 // One-tap overdue follow-up row (demand loop). "Mark followed up" appends a
 // table row to data/follow-ups.md (append-only) so the core cadence advances;
-// "Snooze" is a client dismiss. The cadence is the core's — we just surface + record.
+// "Snooze" pins a date through the same persisted schedule as /followups.
 export function FollowUpCard({ followup, onLogged }: { followup: FollowUp; onLogged?: () => void }) {
-  const [state, setState] = useState<"idle" | "logging" | "done" | "snoozed" | "error">("idle");
+  const [state, setState] = useState<"idle" | "logging" | "done" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  if (state === "snoozed" || state === "done") return null;
+  const [showNextDate, setShowNextDate] = useState(false);
+  if (state === "done") return null;
 
   const log = async () => {
     setState("logging");
@@ -93,10 +96,23 @@ export function FollowUpCard({ followup, onLogged }: { followup: FollowUp; onLog
             <FileText className="size-4" />
           </a>
         )}
-        <button type="button" onClick={() => setState("snoozed")} className="inline-flex shrink-0 items-center justify-center text-[11px] text-faint transition hover:text-foreground max-sm:min-h-[44px] max-sm:min-w-[44px]">
+        <button
+          type="button"
+          disabled={state === "logging" || followup.num == null}
+          onClick={() => setShowNextDate(true)}
+          title={followup.num == null ? "An application number is required to snooze this follow-up." : "Choose the next follow-up date"}
+          className="inline-flex shrink-0 items-center justify-center text-[11px] text-faint transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60 max-sm:min-h-[44px] max-sm:min-w-[44px]"
+        >
           Snooze
         </button>
       </div>
+      {showNextDate && followup.num != null && (
+        <NextDateDialog
+          entry={{ ...followup, num: followup.num }}
+          onClose={() => setShowNextDate(false)}
+          onChanged={() => onLogged?.()}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/home/today-dashboard.tsx
+++ b/web/src/components/home/today-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Bell, CircleHelp, Sparkles, ArrowRight } from "lucide-react";
@@ -14,6 +14,9 @@ import { DecisionCard } from "@/components/home/decision-card";
 import { QuickEvaluate } from "@/components/quick-evaluate";
 import { scoreNum } from "@/lib/format";
 import { pickAwaitingDecision } from "@/lib/home/awaiting.mjs";
+import { parseTodayFollowups, parseTodayMatches, pendingInboxCount, summarizeToday } from "@/lib/home/today-state.mjs";
+
+type LoadState = { status: "loading" | "ready" | "error"; error: string | null };
 
 // The retention "Today": a dual-loop action queue (the maintainer's
 // "N new matches this week · M follow-ups due"). SUPPLY loop = fresh free-scan
@@ -26,7 +29,7 @@ export function TodayDashboard({
   inBetween,
 }: {
   applications: Application[];
-  inbox: InboxJob[];
+  inbox: Pick<InboxJob, "url" | "done">[];
   inBetween: boolean;
 }) {
   const [followups, setFollowups] = useState<FollowUp[]>([]);
@@ -34,31 +37,46 @@ export function TodayDashboard({
   const [nextUpcoming, setNextUpcoming] = useState<FollowUp | null>(null);
   const [fresh, setFresh] = useState<DiscoveredOffer[]>([]);
   const [freshCount, setFreshCount] = useState(0);
+  const [followupState, setFollowupState] = useState<LoadState>({ status: "loading", error: null });
+  const [freshState, setFreshState] = useState<LoadState>({ status: "loading", error: null });
+  const activeRequest = useRef<AbortController | null>(null);
   const router = useRouter();
   const dateLabel = useMemo(() => new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" }), []);
 
   const refetch = useCallback(() => {
-    fetch("/api/followups")
-      .then((r) => r.json())
-      .then((d) => {
-        // /api/followups already filters to urgency 'urgent'/'overdue' — due
-        // now, never 'waiting'/'cold' (#86). Both count toward "due"; a
-        // missing metadata.overdue must read as 0 due, never as "every entry
-        // is overdue" (the old `?? d.entries?.length` fallback).
-        setFollowups(Array.isArray(d.entries) ? d.entries : []);
-        setOverdue((d.metadata?.overdue ?? 0) + (d.metadata?.urgent ?? 0));
-        setNextUpcoming(d.nextUpcoming ?? null);
+    // An earlier request can finish after a worker event or a saved follow-up.
+    // Cancel it and check its signal before applying any result or error.
+    activeRequest.current?.abort();
+    const controller = new AbortController();
+    activeRequest.current = controller;
+    const { signal } = controller;
+    setFollowupState({ status: "loading", error: null });
+    setFreshState({ status: "loading", error: null });
+    fetch("/api/followups", { signal, cache: "no-store" })
+      .then(async (r) => parseTodayFollowups(r.ok, await r.json().catch(() => null)))
+      .then((data) => {
+        if (signal.aborted) return;
+        setFollowups(data.entries);
+        setOverdue(data.due);
+        setNextUpcoming(data.nextUpcoming);
+        setFollowupState({ status: "ready", error: null });
       })
-      .catch(() => {});
-    fetch("/api/whats-new")
-      .then((r) => r.json())
-      .then((d) => {
-        const offers = Array.isArray(d.offers) ? d.offers : [];
-        const count = Number(d.count);
-        setFresh(offers);
-        setFreshCount(Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : offers.length);
+      .catch((error) => {
+        if (signal.aborted) return;
+        setFollowupState({ status: "error", error: error instanceof TypeError ? "Could not reach the server. Check your connection and retry." : error instanceof Error ? error.message : "Could not load follow-ups." });
+      });
+    fetch("/api/whats-new", { signal, cache: "no-store" })
+      .then(async (r) => parseTodayMatches(r.ok, await r.json().catch(() => null)))
+      .then((data) => {
+        if (signal.aborted) return;
+        setFresh(data.offers);
+        setFreshCount(data.count);
+        setFreshState({ status: "ready", error: null });
       })
-      .catch(() => {});
+      .catch((error) => {
+        if (signal.aborted) return;
+        setFreshState({ status: "error", error: error instanceof TypeError ? "Could not reach the server. Check your connection and retry." : error instanceof Error ? error.message : "Could not load fresh matches." });
+      });
   }, []);
 
   useEffect(() => {
@@ -71,16 +89,29 @@ export function TodayDashboard({
       refetch();
     };
     window.addEventListener("co-job-done", onDone);
-    return () => window.removeEventListener("co-job-done", onDone);
+    return () => {
+      window.removeEventListener("co-job-done", onDone);
+      activeRequest.current?.abort();
+    };
   }, [refetch, router]);
 
   // Awaiting decision: scored (Evaluated) but no terminal status yet. The
   // ordering lives in lib/home/awaiting.mjs so it can be tested — see the file
   // for why "first six in the array" was a bug waiting for #3529.
-  const awaiting = useMemo(() => pickAwaitingDecision(applications, scoreNum), [applications]);
+  const awaiting = useMemo(() => pickAwaitingDecision(applications, scoreNum, Infinity), [applications]);
 
-  const newThisWeek = freshCount;
-  const allClear = newThisWeek === 0 && overdue === 0 && awaiting.length === 0;
+  const pendingCount = useMemo(() => pendingInboxCount(inbox), [inbox]);
+  const summary = summarizeToday({
+    freshCount,
+    // The route returns only due entries. Metadata can be absent, but a
+    // visible due card still means there is work to do.
+    dueCount: Math.max(overdue, followups.length),
+    decisionCount: awaiting.length,
+    inboxCount: pendingCount,
+    followupState: followupState.status,
+    freshState: freshState.status,
+  });
+  const { allClear } = summary;
   const inboxUrls = useMemo(() => new Set(inbox.map((j) => j.url)), [inbox]);
 
   return (
@@ -94,38 +125,30 @@ export function TodayDashboard({
             <span className="text-faint">//</span> today · <span className="tabular-nums">{dateLabel}</span>
           </p>
           <h1 className={`${instrumentSerif.className} mt-3 text-4xl leading-[1.05] text-landing md:text-5xl`}>
-            {allClear ? (
-              <>You&apos;re all caught up.</>
-            ) : (
-              <>
-                {newThisWeek > 0 && (
-                  <>
-                    <span className="text-brand tabular-nums">{newThisWeek}</span> new match{newThisWeek === 1 ? "" : "es"} this week
-                  </>
-                )}
-                {newThisWeek > 0 && overdue > 0 && <span className="text-faint"> · </span>}
-                {overdue > 0 && (
-                  <>
-                    <span className="text-brand tabular-nums">{overdue}</span> follow-up{overdue === 1 ? "" : "s"} due
-                  </>
-                )}
-              </>
-            )}
+            {summary.items.length ? summary.items.map((item, index) => (
+              <Fragment key={item.label}>
+                {index > 0 && <span className="text-faint"> · </span>}
+                <span className="text-brand tabular-nums">{item.count}</span>{" "}{item.label}
+              </Fragment>
+            )) : summary.emptyHeading}
           </h1>
           <p className="mt-4 max-w-xl text-sm text-muted">
-            {allClear ? "I'll keep scanning the market in the background and surface anything that fits." : "Your action queue for today — discovery and follow-ups, in one place."}
+            {allClear ? "Run a free scan when you want to find more roles." : "Review jobs, make application decisions, and track follow-ups in one place."}
           </p>
           <div className="mt-6 flex flex-wrap gap-2.5">
             <Link href="/explore" className="inline-flex items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground transition hover:bg-brand-200 max-sm:min-h-[44px]">
               Find new roles <ArrowRight className="size-4" />
             </Link>
             <Link href="/pipeline" className="inline-flex items-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-medium text-foreground transition hover:border-brand/40 hover:text-brand max-sm:min-h-[44px]">
-              Open pipeline
+              {pendingCount > 0 ? `Review inbox (${pendingCount})` : "Open pipeline"}
             </Link>
           </div>
           {inBetween && <QuickEvaluate />}
         </div>
       </section>
+
+      <LoadNotice label="Follow-ups" state={followupState} onRetry={refetch} />
+      <LoadNotice label="Fresh matches" state={freshState} onRetry={refetch} />
 
       {/* A. Follow-ups due (demand loop) */}
       {followups.length > 0 ? (
@@ -157,10 +180,11 @@ export function TodayDashboard({
       {awaiting.length > 0 && (
         <Section icon={CircleHelp} title="Awaiting your decision" hint="Scored — apply or skip">
           <div className="grid gap-2.5 sm:grid-cols-2">
-            {awaiting.map((a) => (
-              <DecisionCard key={a.n} app={a} />
+            {awaiting.slice(0, 6).map((a) => (
+              <DecisionCard key={a.n} app={a} onSaved={refetch} />
             ))}
           </div>
+          {awaiting.length > 6 && <Link href="/pipeline?tab=EVALUATED" className="mt-3 inline-flex text-sm text-muted hover:text-brand max-sm:min-h-[44px]">Review all {awaiting.length} decisions →</Link>}
         </Section>
       )}
 
@@ -188,6 +212,20 @@ export function TodayDashboard({
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+function LoadNotice({ label, state, onRetry }: { label: string; state: LoadState; onRetry: () => void }) {
+  if (state.status === "ready") return null;
+  if (state.status === "loading") return <p role="status" className="mt-4 text-sm text-muted">Checking {label.toLowerCase()}…</p>;
+  return (
+    <div role="alert" className="mt-4 flex flex-wrap items-center gap-3 rounded-xl border border-red-500/25 bg-surface/40 px-4 py-3 text-sm">
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-foreground">{label} could not be updated.</p>
+        <p className="mt-1 text-muted">{state.error} Any items shown may be out of date.</p>
+      </div>
+      <button type="button" onClick={onRetry} className="rounded-md border border-border px-3 py-1.5 text-foreground hover:text-brand max-sm:min-h-[44px]">Retry {label.toLowerCase()}</button>
     </div>
   );
 }

--- a/web/src/lib/home/status-result.mjs
+++ b/web/src/lib/home/status-result.mjs
@@ -1,0 +1,6 @@
+/** An HTTP response alone does not confirm that the tracker saved this status. */
+export function statusWriteError(ok, result, requestedStatus) {
+  if (ok && result?.ok === true && result.status === requestedStatus) return null;
+  if (typeof result?.error === "string" && result.error.trim()) return result.error;
+  return "Could not confirm the change. Check the pipeline, then retry.";
+}

--- a/web/src/lib/home/today-state.mjs
+++ b/web/src/lib/home/today-state.mjs
@@ -1,0 +1,43 @@
+const countOf = (value) => Number.isFinite(Number(value)) ? Math.max(0, Math.trunc(Number(value))) : 0;
+
+/** An unavailable or malformed response is never an empty queue. */
+export function parseTodayFollowups(ok, data) {
+  if (!ok || data?.available !== true || !Array.isArray(data?.entries)) {
+    throw new Error(typeof data?.error === "string" ? data.error : "Could not load follow-ups. Retry to check what is due.");
+  }
+  return {
+    entries: data.entries,
+    due: countOf(data.metadata?.overdue) + countOf(data.metadata?.urgent),
+    nextUpcoming: data.nextUpcoming ?? null,
+  };
+}
+
+export function parseTodayMatches(ok, data) {
+  if (!ok || data?.available === false || !Array.isArray(data?.offers)) {
+    throw new Error(typeof data?.error === "string" ? data.error : "Could not load fresh matches. Retry to check your scans.");
+  }
+  return {
+    offers: data.offers,
+    count: data.count == null || !Number.isFinite(Number(data.count)) ? data.offers.length : countOf(data.count),
+  };
+}
+
+/** The inbox triages by URL; checked rows and duplicate URLs are not extra work. */
+export function pendingInboxCount(inbox) {
+  return new Set(inbox.filter((job) => !job.done).map((job) => job.url)).size;
+}
+
+/** Only a successfully loaded, empty queue can say the user is caught up. */
+export function summarizeToday({ freshCount, dueCount, decisionCount, inboxCount, followupState, freshState }) {
+  const items = [
+    { count: freshCount, label: `new match${freshCount === 1 ? "" : "es"} this week` },
+    { count: dueCount, label: `follow-up${dueCount === 1 ? "" : "s"} due` },
+    { count: decisionCount, label: `decision${decisionCount === 1 ? "" : "s"} to make` },
+    { count: inboxCount, label: `inbox job${inboxCount === 1 ? "" : "s"} to review` },
+  ].filter((item) => item.count > 0);
+  const loading = followupState === "loading" || freshState === "loading";
+  const failed = followupState === "error" || freshState === "error";
+  const allClear = !items.length && followupState === "ready" && freshState === "ready";
+  const emptyHeading = allClear ? "You're all caught up." : failed ? "Your queue needs another check." : "Checking your queue…";
+  return { items, allClear, loading, failed, emptyHeading };
+}

--- a/web/tests/lib/status-result.test.mjs
+++ b/web/tests/lib/status-result.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { statusWriteError } from "../../src/lib/home/status-result.mjs";
+
+test("only a confirmed save of the requested status can dismiss a decision", () => {
+  for (const status of ["Applied", "Discarded"]) {
+    assert.equal(statusWriteError(true, { ok: true, status }, status), null);
+    // An idempotent retry still confirms that the desired status is saved.
+    assert.equal(statusWriteError(true, { ok: true, status, changed: false }, status), null);
+    assert.equal(typeof statusWriteError(false, { ok: true, status }, status), "string");
+  }
+});
+
+test("server rejections retain the reason needed to retry or correct a write", () => {
+  for (const error of ["Tracker is busy. Retry shortly.", "Tracker row not found.", "Status update timed out; the change may or may not have been applied."]) {
+    assert.equal(statusWriteError(false, { error }, "Applied"), error);
+  }
+});
+
+test("unconfirmed and mismatched results cannot silently remove a card", () => {
+  for (const result of [null, {}, { ok: false }, { ok: true }, { ok: true, status: "Discarded" }, { error: "" }]) {
+    assert.match(statusWriteError(true, result, "Applied"), /Could not confirm the change/);
+  }
+});

--- a/web/tests/lib/today-state.test.mjs
+++ b/web/tests/lib/today-state.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseTodayFollowups, parseTodayMatches, pendingInboxCount, summarizeToday } from "../../src/lib/home/today-state.mjs";
+
+const emptyQueue = {
+  freshCount: 0,
+  dueCount: 0,
+  decisionCount: 0,
+  inboxCount: 0,
+  followupState: "ready",
+  freshState: "ready",
+};
+
+test("caught up requires both requests to finish successfully", () => {
+  assert.equal(summarizeToday(emptyQueue).allClear, true);
+  for (const key of ["followupState", "freshState"]) {
+    for (const state of ["loading", "error"]) {
+      const summary = summarizeToday({ ...emptyQueue, [key]: state });
+      assert.equal(summary.allClear, false);
+      assert.notEqual(summary.emptyHeading, "You're all caught up.");
+      assert.ok(summary.emptyHeading.length);
+    }
+  }
+});
+
+test("a decision-only or inbox-only queue has a useful heading", () => {
+  for (const [key, expectedLabel] of [["decisionCount", "decision to make"], ["inboxCount", "inbox job to review"]]) {
+    const summary = summarizeToday({ ...emptyQueue, [key]: 1 });
+    assert.equal(summary.allClear, false);
+    assert.deepEqual(summary.items, [{ count: 1, label: expectedLabel }]);
+  }
+});
+
+test("known work stays visible while another part of the queue fails", () => {
+  const summary = summarizeToday({ ...emptyQueue, decisionCount: 2, freshState: "error" });
+  assert.equal(summary.failed, true);
+  assert.deepEqual(summary.items, [{ count: 2, label: "decisions to make" }]);
+});
+
+test("each action count prevents an all-clear result", () => {
+  for (const key of ["freshCount", "dueCount", "decisionCount", "inboxCount"]) {
+    const summary = summarizeToday({ ...emptyQueue, [key]: 4 });
+    assert.equal(summary.allClear, false);
+    assert.equal(summary.items[0].count, 4);
+  }
+});
+
+test("pending inbox count agrees with one triage action per unchecked URL", () => {
+  assert.equal(pendingInboxCount([
+    { url: "https://jobs.example/1", done: true },
+    { url: "https://jobs.example/1", done: false },
+    { url: "https://jobs.example/1", done: false },
+    { url: "https://jobs.example/2", done: true },
+    { url: "https://jobs.example/3", done: false },
+  ]), 2);
+});
+
+test("follow-up unavailable, HTTP failure, and malformed JSON cannot clear the queue", () => {
+  for (const [ok, data] of [
+    [true, { available: false, entries: [], metadata: null }],
+    [false, { available: true, entries: [] }],
+    [true, null],
+    [true, { available: true }],
+  ]) assert.throws(() => parseTodayFollowups(ok, data), /Could not load follow-ups/);
+  assert.throws(() => parseTodayFollowups(false, { error: "Follow-up files could not be read." }), /Follow-up files could not be read/);
+});
+
+test("follow-up parser preserves upcoming dates and separately counts due metadata", () => {
+  const upcoming = { company: "Example", nextFollowupDate: "2026-10-14" };
+  assert.deepEqual(parseTodayFollowups(true, { available: true, entries: [], nextUpcoming: upcoming, metadata: { urgent: 2, overdue: 3, waiting: 9 } }), {
+    entries: [], due: 5, nextUpcoming: upcoming,
+  });
+  assert.equal(parseTodayFollowups(true, { available: true, entries: [{ company: "Example" }], metadata: null }).due, 0);
+});
+
+test("fresh matches reject unavailable and broken responses without treating them as empty", () => {
+  for (const [ok, data] of [
+    [false, { offers: [], count: 0 }],
+    [true, { available: false, offers: [] }],
+    [true, null],
+    [true, { offers: "invalid" }],
+  ]) assert.throws(() => parseTodayMatches(ok, data), /Could not load fresh matches/);
+});
+
+test("fresh matches keep the full server count when the offer list is capped", () => {
+  const offers = [{ url: "https://jobs.example/1" }];
+  assert.deepEqual(parseTodayMatches(true, { offers, count: 23 }), { offers, count: 23 });
+  assert.equal(parseTodayMatches(true, { offers }).count, 1);
+  assert.equal(parseTodayMatches(true, { offers, count: "bad" }).count, 1);
+  assert.equal(parseTodayMatches(true, { offers: [], count: -4 }).count, 0);
+});


### PR DESCRIPTION
## What does this PR do?

Today previously hid a decision after an unsuccessful status write, forgot snoozed follow-ups on reload, and could report an empty queue when its data requests failed. Its heading also omitted pending inbox work and could be blank when only decisions remained.

- Dismiss a decision only after the server confirms the requested status. Keep failures visible with Retry and prevent duplicate submissions.
- Use the existing persisted next-date dialog for Snooze, so the core follow-up schedule remains the source of truth.
- Show loading and retryable errors, keep prior items visible during refresh failures, and cancel stale requests. An unreadable scan history returns an error; a missing file remains an empty result.
- Count pending inbox URLs and every undecided application, while keeping the six-card display limit and linking to the complete decision queue.

## Related issue

Independent Today reliability fix split from #4103. This PR can merge without the PDF or performance changes.

## Type of change

- [x] Bug fix

## Validation

- `node test-all.mjs`: 8,690 passed, 0 failed, 17 warnings. Warnings cover absent user data, the unavailable Go compiler, stock author references, and two opt-in live API checks. The Go dashboard build was skipped.
- Web: 509 tests passed, type checking passed, production build passed.
- Tests cover confirmed status writes, failed/malformed queue responses, loading states, pending URL counts, and decision-only queues.
- Browser checks on synthetic data verified successful status persistence, failed saves retaining the card, snoozed dates surviving reload, retry after unreadable scan history or unavailable follow-up data, and desktop/mobile layout. These checks were run before splitting; the independent branch has also passed its web tests and build.

## Checklist

- [x] Read CONTRIBUTING.md; these bug fixes are exempt from the issue-first requirement.
- [x] No personal data or user-layer files are included.
- [x] Status and follow-up writes use the existing canonical paths and locks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User impact

- Users can snooze follow-ups through the next-date dialog. The date persists in the schedule: `web/src/components/home/follow-up-card.tsx`.
- Decision changes wait for server confirmation. Failed changes show an error and a Retry button: `web/src/components/home/decision-card.tsx`.
- Today shows loading, error, and retry states. Existing items remain visible after refresh errors: `web/src/components/home/today-dashboard.tsx`.
- Today counts pending inbox URLs and all undecided applications. It still displays six cards and links to the full queue: `web/src/lib/home/today-state.mjs`.
- Missing scan history remains an empty result. Other read failures return an unavailable error: `web/src/app/api/whats-new/route.ts`.

## Validation

- Web tests, type checking, and the production build passed.
- The broader suite reported 8,690 passing tests with no failures.

## System files touched

- No changes were found in `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.
- `web/AGENTS.md` exists, but it was not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->