### PR TITLE
fix(web): require confirmed worker completion before showing success

### DIFF
--- a/web/src/components/jobs/job-store.tsx
+++ b/web/src/components/jobs/job-store.tsx
@@ -3,6 +3,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { scoreTone } from "@/lib/format";
 import { readSavedCliId, resolveCliId } from "@/lib/saved-cli";
+import { readJobStream } from "@/lib/job-stream.mjs";
 
 export type JobStep = { kind: "tool" | "status"; label: string; ts: number };
 export type JobResult = { score: number | null; summary: string; tone: "good" | "warn" | "bad" | "muted" };
@@ -161,45 +162,27 @@ export function JobsProvider({ children }: { children: React.ReactNode }) {
             finish("error", e.error || "Failed to start");
             return;
           }
-          const reader = res.body.getReader();
-          const dec = new TextDecoder();
-          let buf = "";
-          for (;;) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            buf += dec.decode(value, { stream: true });
-            let nl: number;
-            while ((nl = buf.indexOf("\n")) !== -1) {
-              const line = buf.slice(0, nl).trim();
-              buf = buf.slice(nl + 1);
-              if (!line) continue;
-              try {
-                const ev = JSON.parse(line);
-                if (ev.type === "tool") {
-                  steps.push({ kind: "tool", label: ev.name, ts: Date.now() });
-                  patch(id, (j) => ({ ...j, steps: [...j.steps, { kind: "tool", label: ev.name, ts: Date.now() }] }));
-                } else if (ev.type === "status") {
-                  steps.push({ kind: "status", label: ev.label, ts: Date.now() });
-                  patch(id, (j) => ({ ...j, steps: [...j.steps, { kind: "status", label: ev.label, ts: Date.now() }] }));
-                } else if (ev.type === "text") {
-                  const full = text + ev.text;
-                  const vm = full.match(/VERDICT:[^\n]*/i);
-                  if (vm) verdictLine = vm[0];
-                  text = full.slice(-8000);
-                  patch(id, (j) => ({ ...j, text }));
-                } else if (ev.type === "done") {
-                  // finish happens on stream-close; capture the per-run cost it carries
-                  if (typeof ev.tokens === "number") doneTokens = ev.tokens;
-                  if (typeof ev.costUsd === "number") doneCostUsd = ev.costUsd;
-                } else if (ev.type === "error") {
-                  finish("error", ev.msg || "Error");
-                  return;
-                }
-              } catch {
-                /* skip */
-              }
+          const completion = await readJobStream(res.body, (ev) => {
+            if (ev.type === "tool") {
+              steps.push({ kind: "tool", label: ev.name, ts: Date.now() });
+              patch(id, (j) => ({ ...j, steps: [...j.steps, { kind: "tool", label: ev.name, ts: Date.now() }] }));
+            } else if (ev.type === "status") {
+              steps.push({ kind: "status", label: ev.label, ts: Date.now() });
+              patch(id, (j) => ({ ...j, steps: [...j.steps, { kind: "status", label: ev.label, ts: Date.now() }] }));
+            } else if (ev.type === "text") {
+              const full = text + ev.text;
+              const vm = full.match(/VERDICT:[^\n]*/i);
+              if (vm) verdictLine = vm[0];
+              text = full.slice(-8000);
+              patch(id, (j) => ({ ...j, text }));
             }
+          });
+          if (completion.status === "error") {
+            finish("error", completion.message);
+            return;
           }
+          doneTokens = completion.tokens ?? 0;
+          doneCostUsd = completion.costUsd ?? null;
           finish("done", "Done");
         } catch {
           finish("error", "Connection error");

--- a/web/src/lib/job-stream.mjs
+++ b/web/src/lib/job-stream.mjs
@@ -1,0 +1,77 @@
+/**
+ * @typedef {{ type: "text", text: string } | { type: "tool", name: string } | { type: "status", label: string }} JobProgress
+ * @typedef {{ status: "done", tokens?: number, costUsd?: number } | { status: "error", message: string }} JobCompletion
+ */
+
+/**
+ * Read the /api/run NDJSON protocol. A closed connection is not proof that the
+ * worker saved its report or rendered its PDF: only the server's `done` event is.
+ *
+ * @param {ReadableStream<Uint8Array>} stream
+ * @param {(event: JobProgress) => void} onProgress
+ * @returns {Promise<JobCompletion>}
+ */
+export async function readJobStream(stream, onProgress) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let ended = false;
+
+  /** @param {string} line @returns {JobCompletion | null} */
+  const consume = (line) => {
+    if (!line.trim()) return null;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return { status: "error", message: "Invalid response from the local server. Check the pipeline before retrying." };
+    }
+    if (event?.type === "error") {
+      return { status: "error", message: typeof event.msg === "string" && event.msg ? event.msg : "Error" };
+    }
+    if (event?.type === "done") {
+      return {
+        status: "done",
+        ...(typeof event.tokens === "number" ? { tokens: event.tokens } : {}),
+        ...(typeof event.costUsd === "number" ? { costUsd: event.costUsd } : {}),
+      };
+    }
+    if (event?.type === "text" && typeof event.text === "string") onProgress(event);
+    else if (event?.type === "tool" && typeof event.name === "string") onProgress(event);
+    else if (event?.type === "status" && typeof event.label === "string") onProgress(event);
+    // Keepalives and future non-terminal events do not confirm completion.
+    return null;
+  };
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      ended = done;
+      buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+      let newline;
+      while ((newline = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        const completion = consume(line);
+        if (completion) return completion;
+      }
+      if (done) {
+        // A final record need not have a trailing newline.
+        return consume(buffer) ?? {
+          status: "error",
+          message: "Connection ended before the server confirmed completion. Check the pipeline before retrying.",
+        };
+      }
+    }
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error && error.name === "AbortError" ? "Interrupted. Check the pipeline before retrying." : "Connection error",
+    };
+  } finally {
+    // A terminal error can arrive while the worker is still streaming. Release
+    // the response instead of leaving an unread body and its reader behind.
+    if (!ended) await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}

--- a/web/tests/lib/job-stream.test.mjs
+++ b/web/tests/lib/job-stream.test.mjs
@@ -1,0 +1,119 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readJobStream } from "../../src/lib/job-stream.mjs";
+
+const encoder = new TextEncoder();
+const record = (event) => `${JSON.stringify(event)}\n`;
+
+function response(chunks, { error, stayOpen = false } = {}) {
+  let cancelled = 0;
+  let index = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      if (index < chunks.length) {
+        const chunk = chunks[index++];
+        controller.enqueue(typeof chunk === "string" ? encoder.encode(chunk) : chunk);
+      } else if (error) controller.error(error);
+      else if (!stayOpen) controller.close();
+    },
+    cancel() { cancelled++; },
+  });
+  return { stream, cancelled: () => cancelled };
+}
+
+async function read(chunks, options) {
+  const fixture = response(chunks, options);
+  const progress = [];
+  const result = await readJobStream(fixture.stream, (event) => progress.push(event));
+  assert.equal(fixture.stream.locked, false, "the reader must always release its lock");
+  return { result, progress, cancelled: fixture.cancelled() };
+}
+
+test("a verdict followed by EOF is an interrupted run, never a confirmed score", async () => {
+  const { result, progress } = await read([record({ type: "text", text: "VERDICT: 4.8/5 — Fixture fit" })]);
+  assert.equal(progress[0].text, "VERDICT: 4.8/5 — Fixture fit");
+  assert.equal(result.status, "error");
+  assert.match(result.message, /before the server confirmed completion/);
+});
+
+test("an empty successful HTTP response does not mean the worker completed", async () => {
+  const { result } = await read([]);
+  assert.equal(result.status, "error");
+});
+
+test("keepalives and future events cannot confirm completion", async () => {
+  const { result, progress } = await read([record({ type: "keepalive" }), record({ type: "future-event" })]);
+  assert.equal(result.status, "error");
+  assert.deepEqual(progress, []);
+});
+
+test("confirmed completion forwards progress and preserves the reported usage", async () => {
+  const events = [
+    { type: "status", label: "Rendering PDF…" },
+    { type: "tool", name: "Read" },
+    { type: "text", text: "CV rendered." },
+  ];
+  const { result, progress } = await read([
+    ...events.map(record),
+    record({ type: "done", tokens: 1234, costUsd: 0.12 }),
+  ]);
+  assert.deepEqual(progress, events);
+  assert.deepEqual(result, { status: "done", tokens: 1234, costUsd: 0.12 });
+});
+
+test("the final done record is accepted without a trailing newline", async () => {
+  const { result } = await read([JSON.stringify({ type: "done", tokens: 0, costUsd: 0 })]);
+  assert.deepEqual(result, { status: "done", tokens: 0, costUsd: 0 });
+});
+
+test("the final error record is preserved without a trailing newline", async () => {
+  const { result } = await read([JSON.stringify({ type: "error", msg: "This evaluation didn't save a report." })]);
+  assert.deepEqual(result, { status: "error", message: "This evaluation didn't save a report." });
+});
+
+test("fragmented UTF-8 and JSON records retain every character", async () => {
+  const event = { type: "text", text: "José — 東京 résumé" };
+  const bytes = encoder.encode(record(event) + JSON.stringify({ type: "done", tokens: 42 }));
+  const chunks = Array.from(bytes, (byte) => new Uint8Array([byte]));
+  const { result, progress } = await read(chunks);
+  assert.deepEqual(progress, [event]);
+  assert.deepEqual(result, { status: "done", tokens: 42 });
+});
+
+test("CRLF records and blank lines are supported", async () => {
+  const { result } = await read(['\r\n  \r\n{"type":"keepalive"}\r\n{"type":"done"}\r\n']);
+  assert.deepEqual(result, { status: "done" });
+});
+
+test("a terminal error cannot be replaced by a later done record", async () => {
+  const { result } = await read([record({ type: "error", msg: "Worker failed" }) + record({ type: "done" })]);
+  assert.deepEqual(result, { status: "error", message: "Worker failed" });
+});
+
+test("malformed JSON cannot be skipped on the way to a successful completion", async () => {
+  const { result } = await read(['{"type":"error",\n' + record({ type: "done" })]);
+  assert.equal(result.status, "error");
+  assert.match(result.message, /Invalid response/);
+});
+
+test("a connection failure before confirmation stays a connection error", async () => {
+  const { result } = await read([record({ type: "text", text: "Almost done" })], { error: new TypeError("network failed") });
+  assert.deepEqual(result, { status: "error", message: "Connection error" });
+});
+
+test("an aborted reader reports interruption rather than completion", async () => {
+  const { result } = await read([], { error: new DOMException("The operation was aborted", "AbortError") });
+  assert.deepEqual(result, { status: "error", message: "Interrupted. Check the pipeline before retrying." });
+});
+
+test("a terminal error releases a response whose producer has not closed", async () => {
+  const { result, cancelled } = await read([record({ type: "error", msg: "Worker failed" })], { stayOpen: true });
+  assert.equal(result.status, "error");
+  assert.equal(cancelled, 1);
+});
+
+test("confirmed success does not wait on or fail with the transport after done", async () => {
+  const { result, cancelled } = await read([record({ type: "done", tokens: 42 })], { stayOpen: true });
+  assert.deepEqual(result, { status: "done", tokens: 42 });
+  assert.equal(cancelled, 1);
+});


### PR DESCRIPTION
## What does this PR do?

The Workers tray treated the end of an HTTP response as successful completion, even when `/api/run` never sent its terminal `done` event. A connection lost after a verdict could therefore display a successful score, save a successful run log, and trigger completion-dependent UI before the server confirmed the report or PDF was saved. A final error record without a newline was also dropped.

Read the existing NDJSON protocol through a small shared helper. Only `done` confirms success; premature EOF, malformed records, aborts, and server errors remain failures. Parse the final unterminated record, preserve successful usage data, and release the reader after completion. Interrupted runs tell the user to check the pipeline before retrying, since the server may have saved work before the connection failed.

## Type of change

- [x] Bug fix

## Validation

- `node test-all.mjs`: 8,688 passed, 0 failed, 17 warnings for missing user data, the unavailable Go compiler, stock author references, and two opt-in live API checks. The Go dashboard build was skipped.
- Web: 511 tests passed, type checking passed, production build passed.
- Fourteen new stream tests cover premature EOF, an empty response, final records without newlines, split UTF-8/JSON chunks, explicit errors, malformed records, cancellation, usage data, and reader cleanup.
- Executed the actual JobsProvider with mocked React/HTTP: premature verdict EOF, empty HTTP 200, and an unterminated server error produce an error with no successful log. A confirmed `done` still produces the score, cost, and one successful log. No AI call or application submission was made.

## Checklist

- [x] Read CONTRIBUTING.md; this bug fix is exempt from the issue-first requirement.
- [x] No personal data or user-layer files are included.
- [x] Uses the existing server completion protocol without changing the core workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Workers now mark runs as successful only after the server sends `done`.

### User impact

- Interrupted runs remain failures.
- The error message tells users to check the pipeline before retrying.
- Final error records remain failures without trailing newlines.
- Completed runs preserve token and cost data.
- Progress events continue to display as before.

### Changes

- `web/src/components/jobs/job-store.tsx:165`: Uses `readJobStream` for job responses.
- `web/src/lib/job-stream.mjs:14`: Adds shared NDJSON stream parsing with completion handling and reader cleanup.
- `web/tests/lib/job-stream.test.mjs:32`: Adds coverage for completion, errors, cancellation, parsing, usage data, and cleanup.

### System files

No changes touched `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->