### PR TITLE
fix(web): preserve existing profiles with invalid YAML structure

### DIFF
--- a/web/src/app/api/followups/cadence/route.ts
+++ b/web/src/app/api/followups/cadence/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import * as yaml from "js-yaml";
 import { careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
+import { isMapping } from "@/lib/portals-config.mjs";
 import { PROFILE_CADENCE_KEYS, type ProfileCadenceKey } from "@/lib/followups";
 
 export const runtime = "nodejs";
@@ -129,7 +130,12 @@ export async function POST(req: Request) {
     } catch {
       return Response.json({ error: "config/profile.yml exists but could not be read as YAML — refusing to overwrite it." }, { status: 409 });
     }
-    base = isObj(parsed) ? parsed : {};
+    // A parseable list/scalar is still an invalid profile. Never replace its
+    // contents with a document containing only the cadence patch.
+    if (!isMapping(parsed)) {
+      return Response.json({ error: "config/profile.yml must contain named settings, not a list or single value. Refusing to overwrite it." }, { status: 409 });
+    }
+    base = parsed as Record<string, unknown>;
   }
 
   const merged = {

--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import * as yaml from "js-yaml";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
+import { isMapping } from "@/lib/portals-config.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -86,7 +87,12 @@ export async function POST(req: Request) {
     } catch {
       return Response.json({ error: "config/profile.yml exists but is not valid YAML — refusing to overwrite it." }, { status: 409 });
     }
-    base = isObj(parsed) ? (parsed as Record<string, unknown>) : {};
+    // Valid YAML can still be a list, scalar, or null. Treating those as an
+    // empty profile would discard the existing document on this partial write.
+    if (!isMapping(parsed)) {
+      return Response.json({ error: "config/profile.yml must contain named settings, not a list or single value. Refusing to overwrite it." }, { status: 409 });
+    }
+    base = parsed as Record<string, unknown>;
   }
 
   const merged = deepMerge(base, proposed);

--- a/web/tests/lib/profile-write-shape.test.mjs
+++ b/web/tests/lib/profile-write-shape.test.mjs
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { register } from "node:module";
+import * as yaml from "js-yaml";
+
+// Same Node alias-loader convention as apply-cv-resolver.test.mjs. Import the
+// real route handlers and safe writer, with only CAREER_OPS_ROOT redirected.
+const webSrc = fileURLToPath(new URL("../../src/", import.meta.url));
+const loader = `
+  import { existsSync } from "node:fs";
+  import path from "node:path";
+  import { pathToFileURL } from "node:url";
+  export async function resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith("@/")) {
+      const base = path.join(${JSON.stringify(webSrc)}, specifier.slice(2));
+      for (const ext of [".ts", ".tsx", ".mjs", ".js", ""]) {
+        if (existsSync(base + ext)) return { url: pathToFileURL(base + ext).href, shortCircuit: true };
+      }
+    }
+    return nextResolve(specifier, context);
+  }
+`;
+register(`data:text/javascript,${encodeURIComponent(loader)}`, pathToFileURL(webSrc));
+
+const { POST: updateProfile } = await import("../../src/app/api/profile/route.ts");
+const { POST: updateCadence } = await import("../../src/app/api/followups/cadence/route.ts");
+
+const routes = [
+  { name: "profile", post: updateProfile, patch: { name: "Updated Fixture Candidate" } },
+  { name: "followups/cadence", post: updateCadence, patch: { applied_first_days: 9 } },
+];
+const template = "candidate:\n  full_name: Template Candidate\n  location: Template City\ncompensation:\n  currency: USD\n";
+
+async function withFixture(source, fn) {
+  const root = mkdtempSync(path.join(tmpdir(), "career-ops-profile-shape-"));
+  const config = path.join(root, "config");
+  const file = path.join(config, "profile.yml");
+  mkdirSync(config);
+  writeFileSync(path.join(config, "profile.example.yml"), template);
+  if (source !== undefined) writeFileSync(file, source);
+  const previous = process.env.CAREER_OPS_ROOT;
+  process.env.CAREER_OPS_ROOT = root;
+  try {
+    await fn({ config, file });
+  } finally {
+    if (previous === undefined) delete process.env.CAREER_OPS_ROOT;
+    else process.env.CAREER_OPS_ROOT = previous;
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function request(route) {
+  return new Request(`http://fixture.invalid/api/${route.name}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(route.patch),
+  });
+}
+
+for (const route of routes) {
+  for (const [shape, source] of [
+    ["list", "- candidate:\n    full_name: Fixture Candidate\n  compensation:\n    target_range: 100-120\n"],
+    ["text scalar", "Fixture candidate notes that must survive\n"],
+    ["number scalar", "42\n"],
+    ["boolean scalar", "true\n"],
+    ["timestamp scalar", "2026-09-12\n"],
+    ["null", "null\n"],
+    ["empty document", "# Existing profile to repair\n"],
+    ["malformed YAML", "candidate: [broken\n"],
+  ]) {
+    test(`${route.name} rejects an existing ${shape} without writing or backing it up`, async () => {
+      await withFixture(source, async ({ config, file }) => {
+        const beforeFiles = readdirSync(config).sort();
+        const response = await route.post(request(route));
+        assert.equal(response.status, 409);
+        assert.match((await response.json()).error, /refusing to overwrite/i);
+        assert.equal(readFileSync(file, "utf8"), source);
+        assert.deepEqual(readdirSync(config).sort(), beforeFiles, "no backup or temp files on rejection");
+      });
+    });
+  }
+
+  test(`${route.name} still merges a valid mapping and backs up the original bytes`, async () => {
+    const source = "# Keep these original bytes in the backup\ncandidate:\n  full_name: Fixture Candidate\n  email: fixture@example.invalid\ncompensation:\n  target_range: 100-120\nfollowup_cadence:\n  applied_first_days: 7\n  applied_max_followups: 3\n";
+    await withFixture(source, async ({ config, file }) => {
+      const response = await route.post(request(route));
+      assert.equal(response.status, 200);
+      assert.equal((await response.json()).ok, true);
+      const expected = yaml.load(source);
+      if (route.name === "profile") expected.candidate.full_name = route.patch.name;
+      else expected.followup_cadence.applied_first_days = route.patch.applied_first_days;
+      assert.deepEqual(yaml.load(readFileSync(file, "utf8")), expected);
+      const backups = readdirSync(config).filter((name) => name.startsWith("profile.yml.bak-"));
+      assert.equal(backups.length, 1);
+      assert.equal(readFileSync(path.join(config, backups[0]), "utf8"), source);
+    });
+  });
+
+  test(`${route.name} still creates a missing profile from the template`, async () => {
+    await withFixture(undefined, async ({ config, file }) => {
+      assert.equal(existsSync(file), false);
+      const response = await route.post(request(route));
+      assert.equal(response.status, 200);
+      assert.equal((await response.json()).ok, true);
+      const expected = yaml.load(template);
+      if (route.name === "profile") expected.candidate.full_name = route.patch.name;
+      else expected.followup_cadence = route.patch;
+      assert.deepEqual(yaml.load(readFileSync(file, "utf8")), expected);
+      assert.deepEqual(readdirSync(config).sort(), ["profile.example.yml", "profile.yml"]);
+    });
+  });
+}


### PR DESCRIPTION
## What does this PR do?

The profile and follow-up cadence writers protected against YAML syntax errors but accepted lists, scalars, and empty documents as an empty profile. Saving one field could then replace the existing document with only the proposed settings.

Both routes now return HTTP 409 when an existing profile is not a mapping, preserving the original file without creating a backup or temporary file. They reuse the existing `isMapping` helper, which also rejects timestamp scalars. Valid profile merges, backups, and first-time creation keep their existing behavior.

## Type of change

- [x] Bug fix

## Validation

- `node test-all.mjs`: 8,687 passed, 0 failed, 17 warnings for missing user data, the unavailable Go compiler, stock author references, and two opt-in live API checks. The Go dashboard build was skipped.
- Web: 517 tests passed, type checking passed, production build passed.
- Twenty tests call the actual route handlers and writer against throwaway fixtures. They check lists, text/numeric/boolean/timestamp scalars, null, empty documents, malformed YAML, valid merges with exact-byte backups, and missing-profile creation.
- Running the new tests against the original route sources reproduces 12 failures. All 20 pass with the guards.

## Checklist

- [x] Read CONTRIBUTING.md; this bug fix is exempt from the issue-first requirement.
- [x] No personal data or user-layer files are included.
- [x] Preserves the Data Contract by refusing destructive partial writes to an invalid existing profile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can safely update profiles and follow-up cadence settings without overwriting invalid YAML.

Existing profiles with a list, scalar, null, empty document, or malformed YAML now return HTTP 409. The routes preserve the original file and create no backup or temporary file: `web/src/app/api/profile/route.ts:84-95`; `web/src/app/api/followups/cadence/route.ts:127-138`.

Valid profile merges, backups, and missing-profile creation remain supported. Tests cover these cases: `web/tests/lib/profile-write-shape.test.mjs:73-103`.

System files touched: none of `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->