### PR TITLE
fix(web): recover interrupted application fills without losing answers

### DIFF
--- a/web/src/components/apply/apply-provider.tsx
+++ b/web/src/components/apply/apply-provider.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import type { ApplyField } from "@/lib/apply/extract";
 import type { ApplyIssue, DriveStep } from "@/lib/apply/issue";
 import { resolveLateSession } from "@/lib/apply/exit.mjs";
+import { readFillResult } from "@/lib/apply/fill-stream.mjs";
 
 export type FillStep = { fieldId: string; label: string; ok: boolean; thumb?: string };
 type Meta = { needsConfirmation?: boolean };
@@ -357,44 +358,18 @@ export function ApplyProvider({ children }: { children: React.ReactNode }) {
     try {
       const r = await fetch("/api/apply/drive", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ sessionId: sessionId.current, cliId: cliId(), goal: "full", answers: ans }) });
       if (generation.current !== gen) return; // left mid-fill
-      if (!r.body) {
-        setError("The agent couldn't start filling.");
-        setStatus("error");
-        return;
+      const result = await readFillResult(r, (step) => setDriveSteps((p) => [...p, step]), () => generation.current === gen);
+      if (!result || generation.current !== gen) return; // left mid-fill
+      if (result.status === "done") {
+        setIssues((prev) => [...prev, { level: "info", code: "ai-filled", message: result.filled ? "AI filled the form for you — review every answer on the real form, then submit it yourself." : "AI did its best but couldn't finish — check the real form before submitting." }]);
+      } else {
+        setError(result.error);
       }
-      const reader = r.body.getReader();
-      const dec = new TextDecoder();
-      let buf = "";
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        if (generation.current !== gen) return; // left mid-fill
-        buf += dec.decode(value, { stream: true });
-        let nl: number;
-        while ((nl = buf.indexOf("\n")) >= 0) {
-          const line = buf.slice(0, nl).trim();
-          buf = buf.slice(nl + 1);
-          if (!line) continue;
-          let ev: { t?: string; message?: string; filled?: boolean } & DriveStep;
-          try {
-            ev = JSON.parse(line);
-          } catch {
-            continue;
-          }
-          if (ev.t === "step") setDriveSteps((p) => [...p, ev as DriveStep]);
-          else if (ev.t === "done") {
-            setIssues((prev) => [...prev, { level: "info", code: "ai-filled", message: ev.filled ? "AI filled the form for you — review every answer on the real form, then submit it yourself." : "AI did its best but couldn't finish — check the real form before submitting." }]);
-            setStatus("done");
-          } else if (ev.t === "error") {
-            setError(ev.message || "The agent couldn't fill the form.");
-            setStatus("error");
-          }
-        }
-      }
+      setStatus(result.status);
     } catch (e) {
       if (generation.current !== gen) return; // left mid-fill
-      setError(`The agent couldn't fill the form: ${e instanceof Error ? e.message : "stream error"}.`);
-      setStatus("error");
+      setError(`The agent couldn't fill the form: ${e instanceof Error ? e.message : "stream error"}. Check the real form before trying again.`);
+      setStatus("ready");
     }
   }, []);
   const agentFillRef = useRef(agentFill);

--- a/web/src/lib/apply/fill-stream.mjs
+++ b/web/src/lib/apply/fill-stream.mjs
@@ -1,0 +1,69 @@
+/**
+ * Consume full-fill NDJSON. Only a terminal record confirms completion; EOF is
+ * an interruption. Return to the editor on failure so answers remain retryable.
+ *
+ * @param {Response} response
+ * @param {(step: import("./issue").DriveStep) => void} onStep
+ * @param {() => boolean} isCurrent
+ * @returns {Promise<{status: "done", filled: boolean} | {status: "ready", error: string} | null>}
+ */
+export async function readFillResult(response, onStep, isCurrent) {
+  const failed = (error) => ({ status: /** @type {const} */ ("ready"), error });
+  if (!isCurrent()) return null;
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    if (!isCurrent()) return null;
+    return failed(typeof body?.error === "string" && body.error.trim()
+      ? body.error
+      : `The agent couldn't start filling (HTTP ${response.status}).`);
+  }
+  if (!response.body) return failed("The agent couldn't start filling. No response stream was received.");
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const consume = (line) => {
+    if (!line) return null;
+    const unreadable = () => failed("The agent sent an unreadable fill result. Check the real form before trying again.");
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return unreadable();
+    }
+    if (event?.t === "done") {
+      return typeof event.filled === "boolean"
+        ? { status: /** @type {const} */ ("done"), filled: event.filled }
+        : unreadable();
+    }
+    if (event?.t === "error") {
+      return failed(typeof event.message === "string" && event.message.trim()
+        ? event.message
+        : "The agent couldn't fill the form. Check the real form before trying again.");
+    }
+    if (event?.t === "step") onStep(event);
+    return null;
+  };
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (!isCurrent()) return null;
+      buffer += decoder.decode(value, { stream: !done });
+      let newline;
+      while ((newline = buffer.indexOf("\n")) >= 0) {
+        const result = consume(buffer.slice(0, newline).trim());
+        buffer = buffer.slice(newline + 1);
+        if (result) return result;
+      }
+      if (done) {
+        const result = consume(buffer.trim());
+        return result ?? failed("The agent stopped before confirming the fill finished. Check the real form before trying again.");
+      }
+    }
+  } finally {
+    // Stop consuming once a terminal result arrives or the session is replaced.
+    void reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}

--- a/web/tests/lib/apply-fill-stream.test.mjs
+++ b/web/tests/lib/apply-fill-stream.test.mjs
@@ -1,0 +1,161 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFillResult } from "../../src/lib/apply/fill-stream.mjs";
+
+const encoder = new TextEncoder();
+const step = { t: "step", turn: 1, action: "fill", detail: "Filled the name field" };
+const record = (event) => `${JSON.stringify(event)}\n`;
+
+function responseFor(chunks) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(typeof chunk === "string" ? encoder.encode(chunk) : chunk);
+      controller.close();
+    },
+  }));
+}
+
+function read(response, onStep = () => {}, isCurrent = () => true) {
+  return readFillResult(response, onStep, isCurrent);
+}
+
+test("EOF after a progress step releases filling without claiming success", async () => {
+  const steps = [];
+  const response = responseFor([record(step)]);
+  const result = await read(response, (event) => steps.push(event));
+  assert.deepEqual(steps, [step]);
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /stopped before confirming/);
+  assert.match(result.error, /Check the real form before trying again/);
+  assert.equal(response.body.locked, false);
+});
+
+test("an empty response releases filling with an actionable interruption", async () => {
+  const result = await read(responseFor([]));
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /stopped before confirming/);
+});
+
+test("a complete terminal result without a trailing newline finishes the fill", async () => {
+  const result = await read(responseFor([record(step), '{"t":"done","filled":true}']));
+  assert.deepEqual(result, { status: "done", filled: true });
+});
+
+test("an unsuccessful but completed agent attempt preserves its filled=false result", async () => {
+  assert.deepEqual(await read(responseFor([record({ t: "done", filled: false })])), { status: "done", filled: false });
+});
+
+test("split records and split Unicode bytes preserve steps and completion", async () => {
+  const event = { ...step, detail: "Filled José's name" };
+  const bytes = encoder.encode(record(event) + record({ t: "done", filled: true }));
+  const steps = [];
+  const result = await read(responseFor(Array.from(bytes, (byte) => Uint8Array.of(byte))), (value) => steps.push(value));
+  assert.deepEqual(steps, [event]);
+  assert.deepEqual(result, { status: "done", filled: true });
+});
+
+test("a terminal error without a trailing newline restores the editor with its message", async () => {
+  const result = await read(responseFor(['{"t":"error","message":"The page closed."}']));
+  assert.deepEqual(result, { status: "ready", error: "The page closed." });
+});
+
+test("a terminal error with no usable message gives recovery guidance", async () => {
+  const result = await read(responseFor([record({ t: "error", message: {} })]));
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /Check the real form before trying again/);
+});
+
+test("HTTP errors keep the API's explanation instead of waiting for NDJSON", async () => {
+  const result = await read(Response.json({ error: "Apply session expired" }, { status: 404 }));
+  assert.deepEqual(result, { status: "ready", error: "Apply session expired" });
+});
+
+test("non-JSON HTTP errors include their status and never count as done", async () => {
+  const result = await read(new Response("Bad gateway", { status: 502 }));
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /HTTP 502/);
+});
+
+test("a missing response body releases filling", async () => {
+  const result = await read(new Response(null));
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /No response stream/);
+});
+
+test("malformed and unknown records never impersonate successful completion", async () => {
+  for (const text of ['{"t":"done"}', '{"t":"done","filled":"true"}', '{"t":"done",', "null\n", "{}\n", '{"t":"heartbeat"}\n']) {
+    const result = await read(responseFor([text]));
+    assert.equal(result.status, "ready", text);
+    assert.match(result.error, /stopped before confirming|unreadable fill result/, text);
+  }
+});
+
+test("blank and unknown valid progress records do not discard a later valid result", async () => {
+  const result = await read(responseFor(["\r\nnull\n{}\n", record({ t: "done", filled: true })]));
+  assert.deepEqual(result, { status: "done", filled: true });
+});
+
+test("a malformed error record cannot be silently dropped before a later done", async () => {
+  const result = await read(responseFor(['{"t":"error","message":"Page closed"\n', record({ t: "done", filled: true })]));
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /unreadable fill result/);
+});
+
+test("a malformed terminal result cannot be replaced by a later done", async () => {
+  const result = await read(responseFor([record({ t: "done" }), record({ t: "done", filled: true })]));
+  assert.equal(result.status, "ready");
+  assert.match(result.error, /unreadable fill result/);
+});
+
+test("terminal completion does not wait for the transport to close", async () => {
+  let cancelled = false;
+  const response = new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(record({ t: "done", filled: true })));
+    },
+    cancel() { cancelled = true; },
+  }));
+  assert.deepEqual(await read(response), { status: "done", filled: true });
+  assert.equal(cancelled, true);
+  assert.equal(response.body.locked, false);
+});
+
+test("a terminal error cannot be overwritten by a later done record", async () => {
+  const result = await read(responseFor([record({ t: "error", message: "Page closed" }) + record({ t: "done", filled: true })]));
+  assert.deepEqual(result, { status: "ready", error: "Page closed" });
+});
+
+test("a response for an abandoned session produces no updates", async () => {
+  const steps = [];
+  const result = await read(responseFor([record(step), record({ t: "done", filled: true })]), (value) => steps.push(value), () => false);
+  assert.equal(result, null);
+  assert.deepEqual(steps, []);
+});
+
+test("leaving while a read is pending discards its result and releases the reader", async () => {
+  let controller;
+  let current = true;
+  const response = new Response(new ReadableStream({ start(value) { controller = value; } }));
+  const steps = [];
+  const pending = read(response, (value) => steps.push(value), () => current);
+  current = false;
+  controller.enqueue(encoder.encode(record(step) + record({ t: "done", filled: true })));
+  assert.equal(await pending, null);
+  assert.deepEqual(steps, []);
+  assert.equal(response.body.locked, false);
+});
+
+test("transport errors reach the provider's recovery path and release the reader", async () => {
+  const response = new Response(new ReadableStream({
+    start(controller) { controller.error(new Error("Connection dropped")); },
+  }));
+  await assert.rejects(read(response), /Connection dropped/);
+  assert.equal(response.body.locked, false);
+});
+
+test("an explicit retry can complete after an interrupted attempt", async () => {
+  const first = await read(responseFor([record(step)]));
+  const retry = await read(responseFor([record({ t: "done", filled: true })]));
+  assert.equal(first.status, "ready");
+  assert.deepEqual(retry, { status: "done", filled: true });
+});


### PR DESCRIPTION
## What does this PR do?

Full-agent application filling could remain in `filling` forever after `/api/apply/drive` returned HTTP 200 and then closed without a terminal result. The client also dropped final JSON records without a newline and did not handle HTTP errors before reading the stream.

Require a valid terminal fill result, parse the final record, and stop malformed responses from becoming success. On interruption or failure, return to the existing answer editor with a visible error and retain the drafted answers so the user can review the real form and explicitly retry. Responses from a replaced session cannot update the current one, and the reader is released after completion.

This fixes the full-fill client path only. The server route and automatic submission boundary are unchanged; successful fills still instruct the user to review every answer and submit manually.

## Type of change

- [x] Bug fix

## Validation

- `node test-all.mjs`: 8,688 passed, 0 failed, 17 warnings covering missing user data, the unavailable Go compiler, stock author references, and opt-in integration checks. The Go dashboard build was skipped.
- Web: 517 tests passed, type checking passed, production build passed.
- Twenty stream tests cover interrupted and empty responses, terminal records without a newline, malformed JSON, invalid completion payloads, HTTP errors, fragmented data, terminal precedence, reader cleanup, and stale sessions.
- Executed the actual transpiled ApplyProvider with mocked HTTP. Verified interruption returns to the editor with answers retained, explicit retry succeeds, errors remain visible, and resetting the session prevents stale updates. No real AI, employer browser session, or application submission was used.

## Checklist

- [x] Read CONTRIBUTING.md; this bug fix is exempt from the issue-first requirement.
- [x] No personal data or user-layer files are included.
- [x] Keeps the existing apply protocol and human review requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Full-agent form filling now recovers safely from interrupted or malformed `/api/apply/drive` streams.

## User impact

- Interrupted fills return to the answer editor.
- Drafted answers remain available for review and explicit retry.
- Errors explain when the agent did not confirm completion.
- Malformed responses cannot be treated as successful fills.
- Users must still review every answer and submit manually.
- Replaced sessions no longer update the current form.

## Files changed

- `web/src/components/apply/apply-provider.tsx:7`: Uses `readFillResult` and returns failed fills to `"ready"`.
- `web/src/lib/apply/fill-stream.mjs:10-68`: Validates terminal records, handles HTTP errors, parses final records without trailing newlines, supports split UTF-8 data, and releases the stream reader.
- `web/tests/lib/apply-fill-stream.test.mjs:22-161`: Adds stream recovery and retry coverage.

## System files

No changes: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->