### PR TITLE
feat(patterns): report predicted skip reasons separately from outcomes

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -1157,6 +1157,59 @@ function extractBlockerType(gap) {
   return 'other';
 }
 
+function recordedDiscardReasons(entry) {
+  if (!REASON_BEARING.has(entry.outcome)) return new Set();
+  const matches = (entry.notes || '').match(/(?:DISCARD|SKIP):\s*([^,;\n]+)/gi) || [];
+  return new Set(matches
+    .map(match => match.replace(/^(?:DISCARD|SKIP):\s*/i, '').trim().toLowerCase())
+    .filter(Boolean));
+}
+
+/**
+ * Forecasts stay separate from recorded outcomes (#2785). The base is tracker
+ * entries whose linked report explicitly supplies prediction data, including
+ * an empty list; a missing or malformed field is unknown, not an empty forecast.
+ * All statuses remain eligible: advancing later does not erase a prediction.
+ * Labels stay open-ended; only case and surrounding whitespace are normalized.
+ */
+export function buildPredictedDiscardReasonSignals(enriched) {
+  const counts = new Map();
+  const coverage = {
+    entriesWithReports: 0,
+    entriesWithPredictionData: 0,
+    entriesWithPredictions: 0,
+    entriesWithRecordedReasons: 0,
+    // Valid prediction data (even []) plus an eligible recorded reason. This
+    // measures comparison coverage, never agreement between the two sources.
+    entriesWithBothSources: 0,
+  };
+  for (const entry of enriched) {
+    const hasRecordedReasons = recordedDiscardReasons(entry).size > 0;
+    if (hasRecordedReasons) coverage.entriesWithRecordedReasons++;
+    if (!entry.report) continue;
+    coverage.entriesWithReports++;
+    const raw = entry.report.machineSummary?.discard_reasons;
+    // normalizeList accepts scalars for older reports, but also stringifies
+    // objects inside lists. Do not publish those coercions as predicted reasons.
+    if (typeof raw !== 'string'
+        && !(Array.isArray(raw) && raw.every(reason => typeof reason === 'string'))) continue;
+    coverage.entriesWithPredictionData++;
+    if (hasRecordedReasons) coverage.entriesWithBothSources++;
+    const reasons = new Set((entry.report.discardReasons || [])
+      .map(reason => reason.trim().toLowerCase()).filter(Boolean));
+    if (reasons.size > 0) coverage.entriesWithPredictions++;
+    for (const reason of reasons) counts.set(reason, (counts.get(reason) || 0) + 1);
+  }
+  const base = coverage.entriesWithPredictionData;
+  return {
+    predictedDiscardReasonStats: [...counts.entries()]
+      .map(([reason, frequency]) => ({ reason, frequency, percentage: Math.round(frequency / base * 100) }))
+      .sort((a, b) => b.frequency - a.frequency || a.reason.localeCompare(b.reason)),
+    predictedDiscardReasonBase: base,
+    discardReasonCoverage: coverage,
+  };
+}
+
 /**
  * Build the blocker, discard-reason, and technology signals used by both the
  * production analysis and regression fixtures.
@@ -1187,15 +1240,7 @@ function buildPatternSignals(enriched) {
 
   const discardReasonCounts = new Map();
   for (const e of enriched) {
-    if (!REASON_BEARING.has(e.outcome)) continue;
-    const notesMatch = (e.notes || '').match(/(?:DISCARD|SKIP):\s*([^,;\n]+)/gi);
-    if (!notesMatch) continue;
-    const entryReasons = new Set();
-    for (const match of notesMatch) {
-      const key = match.replace(/^(?:DISCARD|SKIP):\s*/i, '').trim().toLowerCase();
-      if (key) entryReasons.add(key);
-    }
-    for (const key of entryReasons) {
+    for (const key of recordedDiscardReasons(e)) {
       discardReasonCounts.set(key, (discardReasonCounts.get(key) || 0) + 1);
     }
   }
@@ -1539,6 +1584,7 @@ function analyze() {
     scoreThreshold,
     techStackGaps,
     discardReasonStats,
+    ...buildPredictedDiscardReasonSignals(enriched),
     // Populations the percentages above are shares of. Exported because a
     // consumer cannot sanity-check a rate whose denominator is invisible —
     // that opacity is precisely what let the wrong base survive unnoticed.
@@ -1613,6 +1659,23 @@ function printSummary(result) {
     console.log(`\nTOP DISCARD / SKIP REASONS (of ${result.discardReasonBase} self-filtered / discarded / negative entries)`);
     console.log('-'.repeat(40));
     for (const d of discardReasonStats.slice(0, 10)) {
+      console.log(`  ${d.reason.padEnd(30)} ${String(d.frequency).padStart(2)}x (${d.percentage}%)`);
+    }
+  }
+
+  const coverage = result.discardReasonCoverage;
+  console.log(`\nPREDICTED DISCARD / SKIP REASONS (of ${result.predictedDiscardReasonBase} entries with prediction data)`);
+  console.log('-'.repeat(40));
+  console.log(`  Prediction data: ${coverage.entriesWithPredictionData}/${coverage.entriesWithReports} entries with linked reports; ${coverage.entriesWithPredictions} contain reasons.`);
+  console.log(`  Recorded reasons: ${coverage.entriesWithRecordedReasons}/${result.discardReasonBase} eligible entries; ${coverage.entriesWithBothSources} entries have both sources.`);
+  console.log('  Forecasts cover all statuses; recorded reasons cover skipped, discarded, and rejected entries.');
+  console.log('  Predictions are not outcomes. Missing data is unknown; labels are grouped by spelling, not meaning.');
+  if (result.predictedDiscardReasonBase === 0) {
+    console.log('  No prediction data recorded yet.');
+  } else if (result.predictedDiscardReasonStats.length === 0) {
+    console.log('  No reasons predicted in the recorded data.');
+  } else {
+    for (const d of result.predictedDiscardReasonStats.slice(0, 10)) {
       console.log(`  ${d.reason.padEnd(30)} ${String(d.frequency).padStart(2)}x (${d.percentage}%)`);
     }
   }

--- a/tests/analyze-patterns-predictions.test.mjs
+++ b/tests/analyze-patterns-predictions.test.mjs
@@ -1,0 +1,184 @@
+// Predicted skip reasons and recorded reasons describe different events. Keep
+// their populations separate, and never turn an absent forecast into a verdict.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pass, fail, ROOT, NODE, rmSync } from './helpers.mjs';
+import { buildPredictedDiscardReasonSignals, OUTCOME_BUCKETS } from '../analyze-patterns.mjs';
+
+console.log('\nanalyze-patterns — predicted reasons remain separate from outcomes');
+
+function check(name, fn) {
+  try { fn(); pass(name); }
+  catch (error) { fail(`${name}: ${error.message}`); }
+}
+
+const entry = (raw, outcome = 'pending', notes = '') => ({
+  outcome, notes,
+  report: {
+    machineSummary: { discard_reasons: raw },
+    discardReasons: Array.isArray(raw) ? raw.map(String) : typeof raw === 'string' ? [raw] : [],
+  },
+});
+
+check('an empty population has no predictions and a zero base', () => {
+  const result = buildPredictedDiscardReasonSignals([]);
+  assert.equal(result.predictedDiscardReasonBase, 0);
+  assert.deepEqual(result.predictedDiscardReasonStats, []);
+  assert.ok(Object.values(result.discardReasonCoverage).every(value => value === 0));
+});
+
+check('empty lists are known-none; absent, null and malformed prediction data remain unknown', () => {
+  const input = [entry([]), entry(undefined), entry(null), entry({ reason: 'noise' }), entry(['valid', { reason: 'noise' }]), entry(42), { outcome: 'pending', report: null }];
+  const result = buildPredictedDiscardReasonSignals(input);
+  assert.equal(result.predictedDiscardReasonBase, 1);
+  assert.deepEqual(result.predictedDiscardReasonStats, []);
+  assert.equal(result.discardReasonCoverage.entriesWithReports, 6);
+  assert.equal(result.discardReasonCoverage.entriesWithPredictions, 0);
+});
+
+check('forecasts survive every later outcome, including positive and unanswered applications', () => {
+  const result = buildPredictedDiscardReasonSignals(OUTCOME_BUCKETS.map(outcome => entry(['forecast'], outcome)));
+  assert.equal(result.predictedDiscardReasonBase, OUTCOME_BUCKETS.length);
+  assert.deepEqual(result.predictedDiscardReasonStats, [{ reason: 'forecast', frequency: OUTCOME_BUCKETS.length, percentage: 100 }]);
+});
+
+check('labels deduplicate within each entry without guessing synonyms or dropping unknown labels', () => {
+  const input = [entry([' Visa ', 'VISA', 'visa_unconfirmed', 'Équipe trop petite', '']), entry([]), entry('visa')];
+  const before = JSON.stringify(input);
+  const result = buildPredictedDiscardReasonSignals(input);
+  assert.equal(result.predictedDiscardReasonBase, 3);
+  assert.deepEqual(result.predictedDiscardReasonStats.find(row => row.reason === 'visa'), { reason: 'visa', frequency: 2, percentage: 67 });
+  assert.equal(result.predictedDiscardReasonStats.find(row => row.reason === 'visa_unconfirmed').frequency, 1);
+  assert.equal(result.predictedDiscardReasonStats.find(row => row.reason === 'équipe trop petite').frequency, 1);
+  assert.equal(JSON.stringify(input), before);
+});
+
+check('recorded-reason coverage honors the existing outcome eligibility and counts explicit empty forecasts', () => {
+  const result = buildPredictedDiscardReasonSignals([
+    entry(['forecast'], 'positive', 'SKIP: not an actual skip'),
+    entry([], 'self_filtered', 'SKIP: manual; DISCARD: manual'),
+    entry(undefined, 'negative', 'DISCARD: manual'),
+    { outcome: 'discarded', report: null, notes: 'SKIP: manual' },
+  ]);
+  assert.equal(result.discardReasonCoverage.entriesWithRecordedReasons, 3);
+  assert.equal(result.discardReasonCoverage.entriesWithBothSources, 1);
+  assert.equal(result.discardReasonCoverage.entriesWithPredictions, 1);
+});
+
+// Exercise report parsing, JSON publication and the human summary through the
+// real CLI. Two tracker rows intentionally link the same report: these counts
+// describe tracker entries, not unique report files.
+const work = mkdtempSync(join(tmpdir(), 'cops-pattern-predictions-'));
+mkdirSync(join(work, 'data'));
+mkdirSync(join(work, 'reports'));
+const files = new Map();
+function writeFixture(file, content) {
+  writeFileSync(file, content);
+  files.set(file, content);
+}
+const rows = [
+  [1, 'Rejected', ['salary_too_low', ' SALARY_TOO_LOW ', 'remote_mismatch'], 'DISCARD: salary_too_low; SKIP: SALARY_TOO_LOW'],
+  [2, 'SKIP', [], 'SKIP: manual'],
+  [3, 'Discarded', undefined, 'DISCARD: manual'],
+  [4, 'Interview', 'visa', 'SKIP: ignored_positive'],
+  [5, 'Applied', ['salary_too_low_unconfirmed'], ''],
+  [6, 'Evaluated', ['Équipe trop petite'], 'SKIP: ignored_pending'],
+  [7, 'Offer', [{ reason: 'invalid' }], ''],
+  [8, 'Rejected', undefined, 'DISCARD: manual'], // report is missing
+  [9, 'Hired', undefined, ''],
+  [10, 'Rejected', undefined, ''], // shares report 1
+  [11, 'Applied', undefined, ''], // malformed Machine Summary
+];
+const tracker = [
+  '# Applications Tracker', '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+];
+for (const [num, status, reasons, notes] of rows) {
+  const reportNum = num === 10 ? 1 : num;
+  const filename = `${String(reportNum).padStart(3, '0')}-fixture-2026-01-01.md`;
+  tracker.push(`| ${num} | 2026-01-01 | Fixture ${num} | Engineer | 4.0/5 | ${status} | ❌ | [${reportNum}](../reports/${filename}) | ${notes} |`);
+  if (num === 8 || num === 10) continue;
+  const machine = { company: `Fixture ${num}`, role: 'Engineer', score: 4, discard_reasons: reasons };
+  writeFixture(join(work, 'reports', filename), [
+    `# Evaluation: Fixture ${num}`, '', '## Machine Summary', '', '```yaml',
+    num === 11 ? 'discard_reasons: [unterminated' : JSON.stringify(machine), '```', '',
+  ].join('\n'));
+}
+writeFixture(join(work, 'data', 'applications.md'), tracker.join('\n') + '\n');
+
+try {
+  const run = (...flags) => execFileSync(NODE, [join(ROOT, 'analyze-patterns.mjs'), '--min-threshold', '1', ...flags], {
+    encoding: 'utf8', timeout: 30000,
+    env: { ...process.env, CAREER_OPS_ROOT: work, CAREER_OPS_DATA_DIR: work },
+  });
+  const result = JSON.parse(run());
+  const summary = run('--summary');
+
+  check('CLI JSON publishes prediction shares over explicit data, counting entries that share a report', () => {
+    assert.equal(result.predictedDiscardReasonBase, 6);
+    assert.deepEqual(result.predictedDiscardReasonStats.find(row => row.reason === 'salary_too_low'), { reason: 'salary_too_low', frequency: 2, percentage: 33 });
+    assert.deepEqual(result.predictedDiscardReasonStats.find(row => row.reason === 'remote_mismatch'), { reason: 'remote_mismatch', frequency: 2, percentage: 33 });
+    assert.equal(result.predictedDiscardReasonStats.find(row => row.reason === 'visa').percentage, 17);
+    assert.ok(!result.predictedDiscardReasonStats.some(row => row.reason.includes('object')));
+  });
+  check('CLI coverage exposes missing reports, missing predictions and missing recorded reasons separately', () => {
+    assert.deepEqual(result.discardReasonCoverage, {
+      entriesWithReports: 10, entriesWithPredictionData: 6, entriesWithPredictions: 5,
+      entriesWithRecordedReasons: 4, entriesWithBothSources: 2,
+    });
+  });
+  check('recorded stats keep their own denominator and never include predicted-only labels', () => {
+    assert.equal(result.discardReasonBase, 5);
+    assert.deepEqual(result.discardReasonStats, [
+      { reason: 'manual', frequency: 3, percentage: 60 },
+      { reason: 'salary_too_low', frequency: 1, percentage: 20 },
+    ]);
+  });
+  check('summary distinguishes forecasts, recorded reasons and their populations without a disagreement claim', () => {
+    assert.match(summary, /PREDICTED DISCARD \/ SKIP REASONS \(of 6 entries with prediction data\)/);
+    assert.match(summary, /Prediction data: 6\/10 entries with linked reports; 5 contain reasons/);
+    assert.match(summary, /Recorded reasons: 4\/5 eligible entries; 2 entries have both sources/);
+    assert.match(summary, /Forecasts cover all statuses; recorded reasons cover skipped, discarded, and rejected entries/);
+    assert.match(summary, /Predictions are not outcomes\. Missing data is unknown/);
+    assert.match(summary, /labels are grouped by spelling, not meaning/);
+    assert.doesNotMatch(summary, /disagreement|accuracy|false positive/i);
+  });
+  check('analysis and summary leave every tracker and report byte unchanged', () => {
+    for (const [file, content] of files) assert.equal(readFileSync(file, 'utf8'), content);
+  });
+
+  // Removing only prediction data must not alter the existing output surface,
+  // including filter recommendations. The new series is an observation only.
+  for (const [file, content] of files) {
+    if (dirname(file) !== join(work, 'reports')) continue;
+    writeFileSync(file, content.replace(/"discard_reasons":(?:\[[^\n]*\]|"[^"]*")/, '"unused_predictions":null'));
+  }
+  const withoutPredictions = JSON.parse(run());
+  check('changing predictions cannot change any pre-existing analysis field or recommendation', () => {
+    const { predictedDiscardReasonStats, predictedDiscardReasonBase, discardReasonCoverage, ...before } = result;
+    const { predictedDiscardReasonStats: stats, predictedDiscardReasonBase: base, discardReasonCoverage: coverage, ...after } = withoutPredictions;
+    assert.deepEqual(after, before);
+    assert.equal(base, 0);
+  });
+  check('summary explains the no-prediction-data case instead of reporting zero predicted risk', () => {
+    assert.match(run('--summary'), /No prediction data recorded yet/);
+  });
+  writeFileSync(join(work, 'reports', '001-fixture-2026-01-01.md'), [
+    '# Evaluation: Fixture', '', '## Machine Summary', '', '```json',
+    '{"discard_reasons":[]}', '```', '',
+  ].join('\n'));
+  check('explicit empty forecasts show known-none separately from missing prediction data', () => {
+    const knownNone = JSON.parse(run());
+    assert.equal(knownNone.predictedDiscardReasonBase, 2); // shared report
+    assert.deepEqual(knownNone.predictedDiscardReasonStats, []);
+    assert.match(run('--summary'), /No reasons predicted in the recorded data/);
+  });
+} catch (error) {
+  fail(`prediction fixture CLI run failed: ${String(error.stderr || error.message).slice(0, 400)}`);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What does this PR do?

Evaluations already record predicted skip/discard reasons, but `analyze-patterns.mjs` parsed those values and never used them. Users could see reasons recorded in tracker notes, but could not inspect the evaluator's forecasts alongside them.

Add a separate prediction series to JSON output and `--summary`, with counts and coverage. The existing recorded-reason statistics and recommendations stay unchanged. This is the first reporting step toward comparing forecasts with user decisions, not an accuracy score or automatic learning system.

- `predictedDiscardReasonStats` reports each label's frequency and percentage.
- `predictedDiscardReasonBase` counts tracker entries whose linked report explicitly supplies prediction data. An empty list means no reason was predicted; missing or malformed data remains unknown.
- `discardReasonCoverage` counts linked reports, available forecasts, nonempty forecasts, recorded reasons, and entries carrying both sources.
- Predictions cover all statuses because later progress does not erase an earlier forecast. Recorded reasons keep their existing eligible population. The summary names both populations, so their percentages cannot be mistaken for a matched comparison.
- Labels are grouped by case and surrounding whitespace, without guessing synonyms or closing the vocabulary. Repeated labels count once per tracker entry. Shared reports still count as separate tracker entries, which the summary states explicitly.

## Related issue

Implements the independently mergeable read-side aggregation slice of #2785, following the maintainer's direction in https://github.com/career-ops-hq/career-ops/issues/2785#issuecomment-5297427125. The vocabulary and report-contract discussion remains open.

## Type of change

- [x] New feature, discussed in the issue above

## Validation

- `node test-all.mjs`: 8,700 passed, 0 failed, 17 warnings for missing user data, unavailable Go compiler, stock author references, and opt-in integration checks. The Go dashboard build was skipped.
- Regression fixtures exercise the real CLI's JSON and summary output, all status buckets, duplicate labels, shared reports, explicit-empty versus absent/malformed predictions, non-ASCII labels, coverage, and the existing recorded-reason denominator.
- Changing only predictions leaves every pre-existing JSON field and recommendation identical. Analysis and summary leave tracker/report bytes unchanged.
- No web files changed. The existing minimum of five submitted applications for pattern analysis remains unchanged.

## Checklist

- [x] Read CONTRIBUTING.md and followed the issue's approved scope.
- [x] No personal data or user-layer files are included.
- [x] No report rewrites, Machine Summary contract changes, new files in the user layer, or automatic filter changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Users can now see predicted `DISCARD`/`SKIP` reasons in JSON output and `--summary` reports.

- `analyze-patterns.mjs:~300`: Adds predicted-reason frequencies, percentages, coverage counters, and recorded-reason comparisons.
- `analyze-patterns.mjs:~500`: Includes predictions from all statuses while preserving existing recorded-reason populations and recommendations.
- `tests/analyze-patterns-predictions.test.mjs:1`: Adds regression coverage for CLI output, status handling, duplicate and non-ASCII labels, prediction edge cases, and field preservation.

The change touches `analyze-patterns.mjs` and `tests/analyze-patterns-predictions.test.mjs`. It does not touch `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

Existing JSON fields, recommendations, tracker/report bytes, and the minimum application threshold remain unchanged. No user-facing web or mode files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->