### PR TITLE
fix(pdf): use workspace styling for batch and imported renders

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -1445,11 +1445,11 @@ async function runBatchFromManifest(manifestPath, globals) {
   } catch (err) {
     if (err?.code !== 'ENOENT') throw err;
   }
-  // One profile governs the whole batch, so the declared order is read once
-  // rather than per entry. Anchored to workspaceRoot for the same reason the
-  // single render is: it is the anchor readStyleTokens() and the cv.md read
-  // already use, so one profile.yml supplies every setting.
-  const cvSectionOrder = readCvSectionOrder(resolve(workspaceRoot, 'config', 'profile.yml'));
+  // Read one workspace profile for the batch. The working directory must not
+  // choose a different theme from the single-document render.
+  const profilePath = resolve(workspaceRoot, 'config', 'profile.yml');
+  const cvSectionOrder = readCvSectionOrder(profilePath);
+  const styleTokens = readStyleTokens(profilePath);
 
   for (let i = 0; i < manifest.length; i++) {
     const spec = manifest[i];
@@ -1502,6 +1502,7 @@ async function runBatchFromManifest(manifestPath, globals) {
         inputPath: entryInput,
         maxPages: globals.maxPages,
         strictPages: globals.strictPages,
+        styleTokens,
       });
     } catch (err) {
       console.error(`❌ Skipping batch entry ${i} (${spec?.output ?? '?'}): ${err.message}`);
@@ -1703,7 +1704,7 @@ async function renderInPage(browser, html, outputPath, opts = {}) {
   // properties so the templates' var(--x, <default>) reads pick them up (#1837).
   // No `style:` block → no tokens → byte-identical output. Both the CV path and
   // the cover-letter path flow through here, so both are themed from one place.
-  const styleTokens = opts.styleTokens ?? readStyleTokens();
+  const styleTokens = opts.styleTokens ?? readStyleTokens(resolve(outputRoot, 'config', 'profile.yml'));
   html = injectThemeStyle(html, styleTokens);
 
   html = injectPrintPageCss(html, format);

--- a/tests/generate-pdf-batch.test.mjs
+++ b/tests/generate-pdf-batch.test.mjs
@@ -227,6 +227,71 @@ try {
     fail(`single vs batch render diverged: single=${single.status} batch=${singleBatch.status}\n${single.output.trim()}\n${singleBatch.output.trim()}`);
   }
 
+  // A terminal's working directory must not select the candidate's theme.
+  // Capture the HTML passed to Chromium via the stub PDF's Marker field.
+  const workspaceConfig = join(sandbox, 'config');
+  const otherCwd = join(sandbox, 'other-cwd');
+  mkdirSync(workspaceConfig, { recursive: true });
+  mkdirSync(join(otherCwd, 'config'), { recursive: true });
+  writeFileSync(join(workspaceConfig, 'profile.yml'), 'style:\n  accent_color: "#123456"\n  font_family: "Georgia, serif"\n  font_size: "12pt"\n  margin: "0.4in"\n');
+  writeFileSync(join(otherCwd, 'config', 'profile.yml'), 'style:\n  accent_color: "#abcdef"\n  font_family: "Arial, sans-serif"\n  margin: "1in"\n');
+  const themedManifest = join(sandbox, 'themed-batch.json');
+  writeFileSync(themedManifest, JSON.stringify([
+    { input: 'single.html', output: 'out/themed-batch.pdf' },
+    { input: 'single.html', output: 'out/themed-batch-second.pdf' },
+  ]));
+  const themedEnv = { CAREER_OPS_TRACKER: join(sandbox, 'data', 'applications.md') };
+  writeFileSync(themedEnv.CAREER_OPS_TRACKER, '# Applications Tracker\n');
+  const themedSingle = run([join(sandbox, 'single.html'), join(sandbox, 'out', 'themed-single.pdf')], { cwd: otherCwd, env: themedEnv });
+  const themedBatch = run([`--batch=${themedManifest}`], { cwd: otherCwd, env: themedEnv });
+  const renderedHtml = (name) => {
+    const marker = readFileSync(join(sandbox, 'out', name), 'latin1').match(/\/Marker \(([^)]+)\)/)?.[1];
+    return Buffer.from(marker || '', 'base64').toString('utf-8');
+  };
+  const expectedTheme = (html) => html.includes('--accent-color: #123456;')
+    && html.includes('--font-family: Georgia, serif;')
+    && html.includes('--font-size: 12pt;')
+    && html.includes('--page-margin: 0.4in;')
+    && !html.includes('#abcdef');
+  if (themedSingle.status === 0 && themedBatch.status === 0
+      && expectedTheme(renderedHtml('themed-single.pdf'))
+      && renderedHtml('themed-single.pdf') === renderedHtml('themed-batch.pdf')
+      && renderedHtml('themed-batch.pdf') === renderedHtml('themed-batch-second.pdf')) {
+    pass('single and batch renders use the workspace theme from a different working directory');
+  } else {
+    fail(`workspace theme differs between single and batch: single=${themedSingle.status} batch=${themedBatch.status}\n${themedSingle.output}\n${themedBatch.output}`);
+  }
+
+  // Imported callers, including cover-letter generation, share the fallback.
+  // An explicit token map still wins, and {} deliberately disables the theme.
+  const directRunner = join(sandbox, 'render-themed.mjs');
+  writeFileSync(directRunner, `
+import { renderHtmlToPdf } from './generate-pdf.mjs';
+const [outputPath, root, tokens] = process.argv.slice(2);
+await renderHtmlToPdf(${JSON.stringify(htmlDoc('Solo CV'))}, outputPath, {
+  workspaceRoot: root,
+  ...(tokens === undefined ? {} : { styleTokens: JSON.parse(tokens) }),
+});
+`);
+  for (const [label, tokens, accepts] of [
+    ['default', undefined, expectedTheme],
+    ['explicit', { '--accent-color': '#654321' }, (html) => html.includes('--accent-color: #654321;') && !html.includes('#123456')],
+    ['disabled', {}, (html) => !html.includes('career-ops-dynamic-theme')],
+  ]) {
+    const outputName = `themed-direct-${label}.pdf`;
+    const result = spawnSync(NODE, [directRunner, join(sandbox, 'out', outputName), sandbox,
+      ...(tokens === undefined ? [] : [JSON.stringify(tokens)])], {
+      cwd: otherCwd, encoding: 'utf-8', timeout: 30_000,
+      env: { ...process.env, ...themedEnv },
+    });
+    if (result.status === 0 && accepts(renderedHtml(outputName))) {
+      pass(`imported PDF rendering honors ${label} theme selection from a different working directory`);
+    } else {
+      fail(`imported ${label} theme failed: status=${result.status}\n${result.stdout}\n${result.stderr}`);
+    }
+  }
+  rmSync(workspaceConfig, { recursive: true, force: true });
+
   // --- Test 3: an all-success batch exits 0 ---
   const okManifest = join(sandbox, 'ok-batch.json');
   writeFileSync(okManifest, JSON.stringify([


### PR DESCRIPTION
## What does this PR do?

Generating a CV in a batch, or calling the PDF renderer from cover-letter generation, could read `style:` from the terminal's working directory instead of the tracker workspace. A configured font, color, size, or margin could disappear or come from an unrelated profile, even though a single CV generated with the CLI used the correct settings.

Read the batch's style tokens once from its workspace profile and pass them to every render. Imported rendering also resolves its default profile inside its output workspace. Explicit `styleTokens` still win, including an empty map to disable theming.

## Related issue

Bug fix to existing profile theming. No new configuration keys or UI.

## Validation

`node test-all.mjs`: 8,690 passed, 0 failed, 17 existing warnings. Warnings cover absent user fixtures, the unavailable Go compiler, shipped reference strings, and opt-in external checks.

The regression fixture runs the actual CLI from a folder containing conflicting styling settings, then compares the HTML sent to the browser for single and batch renders. It also checks imported rendering with default, explicit, and disabled styling. The new tests reproduced two failures before the fix and pass afterward. Chromium is stubbed in these tests so no personal data or installed browser is needed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor, no behavior change

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] This is a bug fix, exempt from the issue-first requirement.
- [x] No personal data is included.
- [x] I ran `node test-all.mjs` and all tests pass.
- [x] Changes respect the Data Contract; only system code and synthetic tests change.
- [x] Changes align with the existing PDF workflow.
