### PR TITLE
fix(templates): honor profile styles in Chinese Minimal CVs

### DIFF
--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -9,13 +9,10 @@ version: 1.0.0
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{NAME}} — CV</title>
 <style>
-  /* Themeable tokens (#1837): only --secondary-color is wired in this template
-     so far (this template does not yet expose --accent-color; that gap is
-     pre-existing and out of scope here). Overridable via config/profile.yml
-     `style:`, which the PDF pipeline injects as a later :root block. */
-  :root {
-    --secondary-color: hsl(270, 70%, 45%);
-  }
+  /* Profile style overrides are injected later by the PDF pipeline (#1837).
+     Keep each surface's existing font and color as its fallback: this template
+     has different defaults from the standard CV, including within its own
+     typography and palette. With no profile override those defaults stay put. */
 
   /* ATS-safe typography (#font-extraction fix):
      The bundled variable woff2 fonts (Space Grotesk / DM Sans) render with
@@ -47,8 +44,8 @@ version: 1.0.0
   }
 
   body {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
-    font-size: 11px;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: var(--font-size, 11px);
     line-height: 1.5;
     color: #1a1a2e;
     background: #ffffff;
@@ -72,7 +69,7 @@ version: 1.0.0
   }
 
   .header h1 {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 28px;
     font-weight: 700;
     color: #1a1a2e;
@@ -83,7 +80,7 @@ version: 1.0.0
 
   .header-gradient {
     height: 2px;
-    background: linear-gradient(to right, hsl(187, 74%, 32%), var(--secondary-color));
+    background: linear-gradient(to right, hsl(187, 74%, 32%), var(--secondary-color, hsl(270, 70%, 45%)));
     border-radius: 1px;
     margin-bottom: 10px;
   }
@@ -92,8 +89,8 @@ version: 1.0.0
     display: flex;
     flex-wrap: wrap;
     gap: 8px 14px;
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
-    font-size: 10.5px;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: var(--font-size, 10.5px);
     line-height: 1.4;
     color: #555;
   }
@@ -129,7 +126,7 @@ version: 1.0.0
   }
 
   .section-title {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 12px;
     font-weight: 700;
     text-transform: uppercase;
@@ -143,7 +140,7 @@ version: 1.0.0
 
   /* === PROFESSIONAL SUMMARY === */
   .summary-text {
-    font-size: 11px;
+    font-size: var(--font-size, 11px);
     line-height: 1.7;
     color: #2f2f2f;
   }
@@ -167,7 +164,7 @@ version: 1.0.0
   }
 
   .competency-tag {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 10px;
     font-weight: 500;
     color: hsl(187, 74%, 28%);
@@ -191,20 +188,20 @@ version: 1.0.0
   }
 
   .job-company {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 12.5px;
     font-weight: 600;
-    color: var(--secondary-color);
+    color: var(--secondary-color, hsl(270, 70%, 45%));
   }
 
   .job-period {
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     color: #777;
     white-space: nowrap;
   }
 
   .job-role {
-    font-size: 11px;
+    font-size: var(--font-size, 11px);
     font-weight: 600;
     color: #333;
     margin-bottom: 6px;
@@ -221,7 +218,7 @@ version: 1.0.0
   }
 
   .job li {
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     line-height: 1.6;
     color: #333;
     margin-bottom: 4px;
@@ -237,10 +234,10 @@ version: 1.0.0
   }
 
   .project-title {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 11.5px;
     font-weight: 600;
-    color: var(--secondary-color);
+    color: var(--secondary-color, hsl(270, 70%, 45%));
   }
 
   .project-badge {
@@ -254,7 +251,7 @@ version: 1.0.0
   }
 
   .project-desc {
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     color: #444;
     margin-top: 3px;
     line-height: 1.55;
@@ -280,12 +277,12 @@ version: 1.0.0
 
   .edu-title {
     font-weight: 600;
-    font-size: 11px;
+    font-size: var(--font-size, 11px);
     color: #333;
   }
 
   .edu-org {
-    color: var(--secondary-color);
+    color: var(--secondary-color, hsl(270, 70%, 45%));
     font-weight: 500;
   }
 
@@ -324,13 +321,13 @@ version: 1.0.0
   }
 
   .cert-title {
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     font-weight: 500;
     color: #333;
   }
 
   .cert-org {
-    color: var(--secondary-color);
+    color: var(--secondary-color, hsl(270, 70%, 45%));
     white-space: nowrap;
   }
 
@@ -359,13 +356,13 @@ version: 1.0.0
   }
 
   .award-title {
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     font-weight: 500;
     color: #333;
   }
 
   .award-org {
-    color: var(--secondary-color);
+    color: var(--secondary-color, hsl(270, 70%, 45%));
     white-space: nowrap;
   }
 
@@ -385,14 +382,14 @@ version: 1.0.0
   }
 
   .skill-item {
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     color: #444;
   }
 
   .skill-category {
     font-weight: 600;
     color: #333;
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
   }
 
   /* === PRINT === */
@@ -453,7 +450,7 @@ version: 1.0.0
   html[lang="ar"] body {
     direction: rtl;
     text-align: right;
-    font-family: 'Segoe UI', Tahoma, Arial, sans-serif;
+    font-family: var(--font-family, 'Segoe UI'), Tahoma, Arial, sans-serif;
   }
 
   html[lang="ar"] .header h1,
@@ -462,11 +459,11 @@ version: 1.0.0
   html[lang="ar"] .project-title,
   html[lang="ar"] .competency-tag,
   html[lang="ar"] .skill-category {
-    font-family: 'Segoe UI', Tahoma, Arial, sans-serif;
+    font-family: var(--font-family, 'Segoe UI'), Tahoma, Arial, sans-serif;
   }
 
   html[lang="ar"] .header-gradient {
-    background: linear-gradient(to left, hsl(187, 74%, 32%), var(--secondary-color));
+    background: linear-gradient(to left, hsl(187, 74%, 32%), var(--secondary-color, hsl(270, 70%, 45%)));
   }
 
   html[lang="ar"] .job ul {
@@ -500,7 +497,7 @@ version: 1.0.0
      browser's per-glyph fallback picks the first installed CJK face for kana
      and kanji. Mirrors the lang="ar" precedent above. */
   html[lang="ja"] body {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
       'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
       Meiryo, 'MS PGothic', sans-serif;
   }
@@ -511,7 +508,7 @@ version: 1.0.0
   html[lang="ja"] .project-title,
   html[lang="ja"] .competency-tag,
   html[lang="ja"] .skill-category {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
       'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
       Meiryo, 'MS PGothic', sans-serif;
   }
@@ -520,17 +517,17 @@ version: 1.0.0
      An opt-in, restrained visual system for Chinese and mixed-language
      technical CVs. The document stays single-column and ATS-readable. */
   :root {
-    --zhm-ink: #172033;
+    --zhm-ink: var(--secondary-color, #172033);
     --zhm-text: #2f3747;
     --zhm-muted: #667085;
     --zhm-rule: #d9dee8;
-    --zhm-accent: #174a7e;
+    --zhm-accent: var(--accent-color, #174a7e);
   }
 
   body,
   html[lang="zh-CN"] body,
   html[lang="zh"] body {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'PingFang SC',
       'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
       'Noto Sans SC', 'Source Han Sans SC', sans-serif;
     color: var(--zhm-text);
@@ -546,7 +543,7 @@ version: 1.0.0
      minimal template, not a general one.) */
   html[lang="zh-TW"] body,
   html[lang="zh-TW"] .contact-row {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang TC',
+    font-family: var(--font-family, 'Liberation Sans'), 'Helvetica Neue', Arial, 'PingFang TC',
       'Microsoft JhengHei', 'Noto Sans CJK TC',
       'Noto Sans TC', 'Source Han Sans TC', sans-serif;
   }
@@ -582,7 +579,7 @@ version: 1.0.0
   .section-title {
     font-family: inherit;
     font-size: 12px;
-    color: var(--zhm-ink);
+    color: var(--accent-color, var(--zhm-ink));
     text-transform: none;
     letter-spacing: 0.08em;
     border-bottom: 1px solid var(--zhm-rule);
@@ -603,7 +600,7 @@ version: 1.0.0
   .competency-tag {
     display: inline;
     font-family: inherit;
-    font-size: 10.5px;
+    font-size: var(--font-size, 10.5px);
     font-weight: 500;
     color: var(--zhm-text);
     background: none;
@@ -678,7 +675,7 @@ version: 1.0.0
 
   .edu-org,
   .cert-org {
-    color: var(--zhm-accent);
+    color: var(--secondary-color, var(--zhm-accent));
   }
 
   .skills-grid {

--- a/tests/theme-style.test.mjs
+++ b/tests/theme-style.test.mjs
@@ -114,7 +114,9 @@ try {
   // color (hsl(270, 70%, 45%), used for company/institution names and the
   // header gradient's second stop) is now themeable via --secondary-color,
   // with no leftover hardcoded occurrences and no circular var() default.
-  for (const tpl of ['templates/cv-template.html', 'templates/cv-template.zh-minimal.html', 'templates/resume-template.html']) {
+  // Chinese Minimal has its own palette and per-surface fallbacks, covered by
+  // zh-minimal-theme.test.mjs instead of this standard-template default guard.
+  for (const tpl of ['templates/cv-template.html', 'templates/resume-template.html']) {
     const src = readFileSync(join(ROOT, tpl), 'utf-8');
     const hasRoot = /:root\s*\{[^}]*--secondary-color:\s*hsl\(270, 70%, 45%\);/s.test(src);
     const usesVar = src.includes('var(--secondary-color)');

--- a/tests/zh-minimal-template.test.mjs
+++ b/tests/zh-minimal-template.test.mjs
@@ -21,7 +21,7 @@ test('Chinese Minimal template is discoverable and valid', () => {
 
 test('Chinese Minimal uses one restrained accent and removes chip styling', () => {
   const html = readFileSync(TEMPLATE, 'utf8');
-  assert.match(html, /--zhm-accent:\s*#174a7e/);
+  assert.match(html, /--zhm-accent:\s*var\(--accent-color,\s*#174a7e\)/);
   assert.match(html, /\.header-gradient\s*\{[^}]*height:\s*1px[^}]*background:\s*var\(--zhm-ink\)/s);
   assert.match(html, /\.competency-tag\s*\{[^}]*background:\s*none[^}]*border:\s*0/s);
   assert.doesNotMatch(html.slice(html.indexOf('CHINESE MINIMAL DESIGN')), /hsl\(270/);

--- a/tests/zh-minimal-theme.test.mjs
+++ b/tests/zh-minimal-theme.test.mjs
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { injectThemeStyle, readStyleTokens } from '../theme-style.mjs';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const TEMPLATE = join(ROOT, 'templates', 'cv-template.zh-minimal.html');
+const FONT_SURFACES = [
+  'body', '.header h1', '.contact-row', '.section-title', '.competency-tag',
+  '.job-company', '.job li', '.project-title', '.edu-org', '.skill-category',
+];
+const BODY_SURFACES = [
+  'body', '.contact-row', '.summary-text', '.competency-tag', '.job-role',
+  '.job li', '.project-desc', '.edu-title', '.cert-title', '.award-title', '.skill-item',
+];
+
+test('Chinese Minimal applies profile typography and colors without changing its defaults', {
+  skip: !existsSync(chromium.executablePath()) && 'Chromium is not installed',
+}, async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'zh-minimal-theme-'));
+  let browser;
+  try {
+    const input = join(dir, 'payload.json');
+    const output = join(dir, 'cv.html');
+    const profile = join(dir, 'profile.yml');
+    writeFileSync(input, JSON.stringify({
+      lang: 'zh-CN', page_format: 'a4',
+      candidate: { name: '测试候选人', email: 'candidate@example.com', location: '中国｜杭州' },
+      summary: 'Engineer building reliable tools.', competencies: ['TypeScript'],
+      experience: [{ company: 'Example Company', role: 'Engineer', dates: '2025 - Present', bullets: ['Shipped reliable tools.'] }],
+      projects: [{ name: 'Example Project', badge: 'Open source', tech: 'Node.js', description: 'A useful tool.' }],
+      education: [{ title: 'Computer Science', org: 'Example University', year: '2024' }],
+      certifications: [{ title: 'Example Certificate', org: 'Example Institute', year: '2024' }],
+      awards: [{ title: 'Example Award', org: 'Example Foundation', year: '2024' }],
+      skills: [{ category: 'Engineering', items: ['TypeScript'] }],
+    }));
+    execFileSync(process.execPath, ['build-cv-html.mjs', input, output, TEMPLATE], { cwd: ROOT });
+    const html = readFileSync(output, 'utf8');
+    writeFileSync(profile, 'style:\n  font_family: "Georgia, serif"\n  font_size: "10pt"\n  accent_color: "#2563eb"\n  secondary_color: "#111827"\n');
+    const tokens = readStyleTokens(profile);
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    await page.emulateMedia({ media: 'print' });
+
+    const readStyles = async () => page.evaluate(({ fontSurfaces, bodySurfaces }) => {
+      const style = (selector) => getComputedStyle(document.querySelector(selector));
+      return {
+        fonts: Object.fromEntries(fontSurfaces.map((selector) => [selector, style(selector).fontFamily])),
+        sizes: Object.fromEntries(bodySurfaces.map((selector) => [selector, style(selector).fontSize])),
+        colors: Object.fromEntries([
+          '.section-title', '.job-company', '.job-role', '.project-title', '.project-badge', '.edu-org', '.cert-org', '.award-org',
+        ].map((selector) => [selector, style(selector).color])),
+        headingSize: style('.header h1').fontSize,
+        chipBackground: style('.competency-tag').backgroundColor,
+      };
+    }, { fontSurfaces: FONT_SURFACES, bodySurfaces: BODY_SURFACES });
+
+    await page.setContent(html);
+    const defaults = await readStyles();
+    assert.equal(defaults.sizes.body, '11px');
+    assert.equal(defaults.sizes['.job li'], '10.5px');
+    assert.equal(defaults.headingSize, '27px');
+    assert.equal(defaults.colors['.section-title'], 'rgb(23, 32, 51)');
+    assert.equal(defaults.colors['.job-company'], 'rgb(23, 32, 51)');
+    assert.equal(defaults.colors['.job-role'], 'rgb(23, 74, 126)');
+    assert.equal(defaults.colors['.edu-org'], 'rgb(23, 74, 126)');
+    assert.equal(defaults.colors['.award-org'], 'rgb(115, 34, 195)');
+    assert.match(defaults.fonts.body, /^"Liberation Sans"/);
+    assert.match(defaults.fonts.body, /"PingFang SC"/);
+
+    for (const [lang, fallback] of [
+      ['en', 'PingFang SC'], ['zh', 'PingFang SC'], ['zh-CN', 'PingFang SC'],
+      ['zh-TW', 'PingFang TC'], ['ja', 'Hiragino Sans'], ['ar', 'Tahoma'],
+    ]) {
+      const localized = html.replace('<html lang="zh-CN">', `<html lang="${lang}">`);
+      await page.setContent(injectThemeStyle(localized, tokens));
+      const custom = await readStyles();
+      for (const [selector, font] of Object.entries(custom.fonts)) {
+        assert.match(font, /^Georgia, serif,/, `${lang}: ${selector} should honor the selected font`);
+      }
+      assert.ok(custom.fonts.body.includes(fallback), `${lang}: keep the locale's fallback faces`);
+      for (const [selector, size] of Object.entries(custom.sizes)) {
+        assert.ok(Math.abs(parseFloat(size) - 40 / 3) < 0.001, `${lang}: ${selector} should use 10pt`);
+      }
+      for (const selector of ['.section-title', '.job-role', '.project-badge']) {
+        assert.equal(custom.colors[selector], 'rgb(37, 99, 235)', `${lang}: ${selector} should use the accent`);
+      }
+      for (const selector of ['.job-company', '.project-title', '.edu-org', '.cert-org', '.award-org']) {
+        assert.equal(custom.colors[selector], 'rgb(17, 24, 39)', `${lang}: ${selector} should use the secondary color`);
+      }
+      assert.equal(custom.headingSize, defaults.headingSize);
+      assert.equal(custom.chipBackground, defaults.chipBackground);
+    }
+
+    // A partial profile must not change unrelated defaults.
+    await page.setContent(injectThemeStyle(html, { '--font-size': '10pt' }));
+    const sizeOnly = await readStyles();
+    assert.deepEqual(sizeOnly.fonts, defaults.fonts);
+    assert.deepEqual(sizeOnly.colors, defaults.colors);
+    await page.setContent(injectThemeStyle(html, {}));
+    assert.deepEqual(await readStyles(), defaults);
+  } finally {
+    if (browser) await browser.close();
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Chinese Minimal silently ignored the existing profile font, size, and color settings because its CSS used fixed values and overrode the shared secondary-color setting later in the template.

Connect its typography and palette to `style.font_family`, `style.font_size`, `style.accent_color`, and `style.secondary_color`. Keep the original values as fallbacks, preserve the locale font stacks, and leave the default appearance unchanged.

## Related issue

Bug fix to existing profile theming. No new settings or template-management UI.

## Validation

`node test-all.mjs`: 8,687 passed, 0 failed, 17 existing warnings. The Chromium regression test ran without a skip. Independent review also passed.

A Chromium regression test renders a synthetic CV and checks default, custom, size-only, and disabled settings across English, Chinese, Traditional Chinese, Japanese, and Arabic locale rules. It fails on upstream when the selected font is ignored.

Separate rendering checks compared all computed styles and element boundaries with upstream across six locales. The default PDF's rendered image was byte-identical, and extracted text matched. A custom font, body size, and palette stayed on one page with English and Chinese text preserved. Both default and custom output were visually inspected for clipping and overlap.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor, no behavior change

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] This is a bug fix, exempt from the issue-first requirement.
- [x] No personal data is included.
- [x] I ran `node test-all.mjs` and all tests pass.
- [x] Changes respect the Data Contract; only system code and synthetic tests change.
- [x] Changes align with the existing PDF workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Chinese Minimal CV templates now honor profile font, font size, accent color, and secondary color settings.

User impact:
: Custom profile styling now changes Chinese Minimal CV output across supported locales.
: Existing locale-specific font fallbacks remain active.
: Default rendering remains unchanged through CSS fallbacks.
: No user-facing behavior breaks are identified.

Files changed:
: `templates/cv-template.zh-minimal.html:47-73, 520-524`: Adds themeable typography and color variables with fallbacks.
: `tests/theme-style.test.mjs:118`: Moves Chinese Minimal coverage to its dedicated test suite.
: `tests/zh-minimal-template.test.mjs:24`: Accepts the accent-color fallback syntax.
: `tests/zh-minimal-theme.test.mjs:23-101`: Adds Chromium regression coverage for locales and custom settings.

System files:
: No changes were made to `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

Validation:
: The supplied results confirm the expected files and implementations.
: Test execution results and review severity counts were not supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->