### PR TITLE
fix(web): retain tracker guard until canceled worker closes

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -15,6 +15,7 @@ import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
 import { buildPrompt, isShellSafeCompanyName } from "@/lib/run-prompts.mjs";
 import { claudeCliArgs } from "@/lib/claude-invocation.mjs";
 import { acquireTrackerWrite, releaseTrackerWrite } from "@/lib/core/run-registry";
+import { createRunFinalizer } from "@/lib/run-finalizer.mjs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -179,13 +180,11 @@ export async function POST(req: Request) {
   // until that work actually settles, instead of releasing the tracker-delete
   // guard while mark-pdf-ready.mjs is still actively writing applications.md.
   let pdfRenderPromise: Promise<void> | null = null;
-  let writeTokenReleased = false;
-  const releaseWriteTokenOnce = () => {
-    if (writeToken !== null && !writeTokenReleased) {
-      writeTokenReleased = true;
-      releaseTrackerWrite(writeToken);
-    }
-  };
+  // Cancellation only requests termination. Keep the guard until the child
+  // actually closes and any render/mark work has finished.
+  const finishRun = createRunFinalizer(child, () => {
+    if (writeToken !== null) releaseTrackerWrite(writeToken);
+  });
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       let buf = "";
@@ -267,11 +266,12 @@ export async function POST(req: Request) {
       // Unknown event types are ignored by the client's switch, so old tabs are safe.
       heartbeat = setInterval(() => send({ type: "keepalive" }), 10_000);
       const close = () => {
+        // Resource cleanup is independent of whether the client can still read.
+        finishRun();
         if (!closed) {
           closed = true;
           if (heartbeat) clearInterval(heartbeat);
           if (killer) clearTimeout(killer);
-          releaseWriteTokenOnce();
           try { controller.close(); } catch { /* */ }
         }
       };
@@ -405,12 +405,10 @@ export async function POST(req: Request) {
       child.on("close", (code) => {
         // A trailing line with no newline would otherwise never be tested.
         if (stderrBuf) { flagStderrLine(stderrBuf); stderrBuf = ""; }
-        // A client disconnect can fire cancel() (which kills `child`) before
-        // this event finally arrives — killing a process doesn't make its
-        // 'close' event disappear, just delays it. Without this guard a pdf
-        // run could still start a brand-new render (and re-touch the tracker)
-        // after the stream — and its writeToken guard — is already gone.
-        if (closed) return;
+        // A disconnected client must not start a new PDF render. Still finish
+        // the run here: an enqueue failure closes the transport without calling
+        // cancel(), and must not leave the tracker guard held forever.
+        if (closed) return close();
         // A timeout is the ROOT cause behind every "no report / not clean"
         // symptom the gates below test, so classify it FIRST, for any kind.
         // Otherwise a run we cut off at the time limit reads as "the CLI couldn't
@@ -517,9 +515,9 @@ export async function POST(req: Request) {
         // Render/mark keeps running after this client disconnects — wait for
         // it to settle before releasing the guard, so a concurrent tracker
         // delete can't race mark-pdf-ready.mjs's still-in-flight write.
-        pdfRenderPromise.finally(releaseWriteTokenOnce);
+        pdfRenderPromise.finally(finishRun);
       } else {
-        releaseWriteTokenOnce();
+        finishRun();
       }
     },
   });

--- a/web/src/lib/run-finalizer.mjs
+++ b/web/src/lib/run-finalizer.mjs
@@ -1,0 +1,34 @@
+/**
+ * Release a run's resources after both the worker and its follow-up work finish.
+ *
+ * Sending SIGTERM does not mean the worker has stopped writing. Its `close`
+ * event also waits for stdio to close, so it is the point at which a canceled
+ * run can release the tracker-delete guard. The returned function can be called
+ * earlier on cancellation, or later after PDF rendering and marking complete.
+ *
+ * @param {{ once: (event: string, listener: () => void) => unknown }} child
+ * @param {() => void} release
+ * @returns {() => void}
+ */
+export function createRunFinalizer(child, release) {
+  let workerClosed = false;
+  let runFinished = false;
+  let released = false;
+
+  const releaseIfFinished = () => {
+    if (workerClosed && runFinished && !released) {
+      released = true;
+      release();
+    }
+  };
+
+  child.once("close", () => {
+    workerClosed = true;
+    releaseIfFinished();
+  });
+
+  return () => {
+    runFinished = true;
+    releaseIfFinished();
+  };
+}

--- a/web/tests/lib/run-finalizer.test.mjs
+++ b/web/tests/lib/run-finalizer.test.mjs
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter, once } from "node:events";
+import { spawn } from "node:child_process";
+import { createRunFinalizer } from "../../src/lib/run-finalizer.mjs";
+
+function fixture() {
+  const child = new EventEmitter();
+  let releases = 0;
+  const finish = createRunFinalizer(child, () => { releases++; });
+  return { child, finish, releases: () => releases };
+}
+
+test("canceling keeps the write guard until the worker closes", () => {
+  const run = fixture();
+  run.finish();
+  assert.equal(run.releases(), 0);
+
+  run.child.emit("exit", null, "SIGTERM");
+  assert.equal(run.releases(), 0, "exit may precede the closing of inherited stdio");
+
+  run.child.emit("close", null, "SIGTERM");
+  assert.equal(run.releases(), 1);
+});
+
+test("worker close keeps the guard during PDF rendering and marking", () => {
+  const run = fixture();
+  run.child.emit("close", 0);
+  assert.equal(run.releases(), 0);
+
+  run.finish();
+  assert.equal(run.releases(), 1);
+});
+
+test("error handling cannot release a worker that has not closed", () => {
+  const run = fixture();
+  run.child.on("error", run.finish);
+  run.child.emit("error", new Error("worker failed"));
+  assert.equal(run.releases(), 0);
+
+  run.child.emit("close", -2);
+  assert.equal(run.releases(), 1);
+});
+
+test("late close and repeated completion signals release only once", () => {
+  const run = fixture();
+  run.finish();
+  run.finish();
+  run.child.emit("close", null);
+  run.finish();
+  run.child.emit("close", null);
+  assert.equal(run.releases(), 1);
+  assert.equal(run.child.listenerCount("close"), 0);
+});
+
+test("independent runs keep independent write guards", () => {
+  const first = fixture();
+  const second = fixture();
+  first.finish();
+  second.finish();
+  first.child.emit("close", 0);
+  assert.equal(first.releases(), 1);
+  assert.equal(second.releases(), 0);
+  second.child.emit("close", 0);
+  assert.equal(second.releases(), 1);
+});
+
+test("a real worker remains guarded while it finishes after cancellation", { timeout: 10_000 }, async (t) => {
+  // IPC keeps the child alive without launching an AI CLI or touching user data.
+  // It also lets this exercise the same lifetime on Windows and POSIX.
+  const child = spawn(process.execPath, ["-e", `
+    process.on("message", message => {
+      if (message === "finish") process.exit(0);
+    });
+    process.send("ready");
+  `], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+  t.after(() => { if (child.exitCode === null) child.kill(); });
+  let guarded = true;
+  const finish = createRunFinalizer(child, () => { guarded = false; });
+  await once(child, "message");
+
+  finish();
+  assert.equal(child.exitCode, null);
+  assert.equal(guarded, true);
+
+  const closed = once(child, "close");
+  child.send("finish");
+  await closed;
+  assert.equal(child.exitCode, 0);
+  assert.equal(guarded, false);
+});


### PR DESCRIPTION
## What does this PR do?

Canceling an evaluation or PDF job released the tracker deletion guard as soon as SIGTERM was sent. The worker could still be writing the tracker when a row deletion became available. A failed stream enqueue could also leave the guard stuck after the worker had closed.

Release the guard once both the worker's `close` event and the run's completion have occurred. Cancellation during PDF rendering continues to wait for rendering and tracker marking to finish. Cleanup also runs when the stream has already closed.

## Related issue

Bug fix to the existing tracker deletion guard. Heartbeat cleanup belongs to the separate active work in #2941 and is outside this diff.

## Validation

`node test-all.mjs`: 8,688 passed, 0 failed, 17 existing warnings. Web validation passed with 503 tests, type checking, and a production build. Independent review found no blockers.

Six regression tests cover cancellation, exit before stdio closes, PDF follow-up work, process errors, repeated cleanup, independent runs, and a harmless real Node worker. An additional isolated check executes the actual route with mocked AI workers and PDF rendering to verify cancellation, stream failure, and delayed rendering.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor, no behavior change

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] This is a bug fix, exempt from the issue-first requirement.
- [x] No personal data is included.
- [x] I ran `node test-all.mjs` and all tests pass.
- [x] Changes respect the Data Contract; only system code and synthetic tests change.
- [x] Changes align with the existing evaluation and PDF workflows.
