### PR TITLE
fix(verify-cv-facts): strip markdown emphasis so bolded metrics reach the fact gate

### DIFF
--- a/tests/metric-fact-gate-emphasis.test.mjs
+++ b/tests/metric-fact-gate-emphasis.test.mjs
@@ -1,0 +1,57 @@
+import { pass, fail } from './helpers.mjs';
+import { metricClaims, stripMarkup, verifyFacts } from '../verify-cv-facts.mjs';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nMetric fact gate — markdown emphasis');
+
+// cv.md and article-digest.md bold nearly every metric. stripMarkup used to
+// leave `**` in place, and metricClaims only tolerates whitespace between a
+// number and its noun — so a closing `**` severed the pair and the metric was
+// never extracted. A truthful CV quoting the sources verbatim then failed the
+// gate as "invented". Regression for issue #4085.
+
+const bolded = [
+  ['**194** automated tests', '194 tests'],
+  ['Layer A **2,044** tests', '2044 tests'],
+  ['**2,842** commits', '2842 commits'],
+  ['*35* people', '35 people'],
+];
+for (const [input, expected] of bolded) {
+  const claims = [...metricClaims(input)];
+  if (claims.includes(expected)) {
+    pass(`extracts ${JSON.stringify(expected)} from ${JSON.stringify(input)}`);
+  } else {
+    fail(`bolded metric dropped: ${JSON.stringify(input)} -> ${JSON.stringify(claims)}`);
+  }
+}
+
+// The emphasis strip is asterisk-only on purpose. Underscores are load-bearing
+// in these sources (snake_case, env-keys.json, file paths), so they must pass
+// through untouched and the count noun after a bolded number must survive.
+if (stripMarkup('shipped **738** commits to env_keys.json') === 'shipped 738 commits to env_keys.json') {
+  pass('leaves underscores in identifiers alone while stripping asterisks');
+} else {
+  fail(`stripMarkup mangled an identifier: ${JSON.stringify(stripMarkup('shipped **738** commits to env_keys.json'))}`);
+}
+
+// End to end: a CV that quotes a bolded metric from cv.md now clears the gate.
+const tmp = mkdtempSync(join(tmpdir(), 'career-ops-emphasis-facts-'));
+try {
+  const source = join(tmp, 'cv.md');
+  const config = join(tmp, 'cv-facts.json');
+  writeFileSync(source, 'Automated the suite to **2,044** tests across **35** people.');
+  writeFileSync(config, JSON.stringify({ allow_metrics: [], allow_facts: [], forbidden_phrases: [] }));
+
+  const supported = verifyFacts('Automated the suite to 2,044 tests across 35 people.', {
+    sourcePaths: [source], configPath: config,
+  });
+  if (supported.verdict === 'pass' && supported.invented.length === 0) {
+    pass('a CV quoting bolded source metrics clears the gate');
+  } else {
+    fail(`truthful bolded metrics were blocked: ${JSON.stringify(supported)}`);
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -232,6 +232,14 @@ export function stripMarkup(text, { keepLineBreaks = false } = {}) {
     .replace(/<\/?(?:li|p|div|tr|h[1-6]|section|article|ul|ol|table|br)\b[^>\n]*>/gi, '. ')
     .replace(/<\/?[a-zA-Z][^>\n]*>/g, ' ')
     .replace(/\\[a-zA-Z]+\*?(?:\[[^\]]*\])?(?:\{([^}]*)\})?/g, ' $1 ')
+    // Markdown emphasis is markup too, and these sources bold nearly every
+    // metric. Left in, a closing `**` sits between the number and its noun, and
+    // metricClaims only tolerates whitespace there, so `**2,044** tests` never
+    // reads as a claim and a truthful CV quoting cv.md is blocked as invented.
+    // Run this AFTER the LaTeX pass above, which relies on `\cmd*`. Only
+    // asterisks: underscores carry meaning here (snake_case, env-keys.json, file
+    // paths), and the markdown bold in these sources is asterisk-based.
+    .replace(/\*+/g, '')
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&')
     // keepLineBreaks preserves a newline as a CLAUSE boundary for the plan-horizon


### PR DESCRIPTION
Fixes #4085

`stripMarkup()` cleaned out HTML tags and LaTeX commands but never touched markdown emphasis. Since `metricClaims()` only allows whitespace between a number and its noun, a closing `**` sits right in the gap and breaks the pair, so the metric is never extracted. cv.md and article-digest.md bold almost every metric, which means the gate goes blind to the exact numbers it's meant to allow and a truthful CV quoting the sources verbatim gets blocked as "invented".

## The fix

Strip asterisk emphasis in `stripMarkup()`, right after the existing LaTeX pass (that pass depends on `\cmd*`, so order matters):

```js
.replace(/\*+/g, '')
```

Underscores are left alone on purpose. They're load-bearing in these sources (`snake_case`, `env-keys.json`, file paths), and the bold in cv.md / article-digest.md is asterisk-based, so there's no reason to risk mangling an identifier.

## Before / after

Extraction on the reproduction cases from the issue:

```
                            before        after
Layer A **2,044** tests     []            ['2044 tests']
**194** automated tests     []            ['194 tests']
**2,842** commits           []            ['2842 commits']
*35* people                 []            ['35 people']
```

End to end, with a source that bolds its metrics (`Automated the suite to **2,044** tests across **35** people.`) and a CV quoting them:

```
before:  verdict: "block",  invented: ["2044 tests", "35 people"]
after:   verdict: "pass",   invented: []
```

## Tests

Added `tests/metric-fact-gate-emphasis.test.mjs` (pass/fail helpers, same style as the neighboring fact-gate suites): unit extraction of bolded metrics, an underscore-safety check so identifiers survive, and an end-to-end `verifyFacts` pass on source-backed bolded numbers. The new suite fails on `main` and passes with the change.

```
node verify-cv-facts.mjs --self-test   ->  88 passed, 0 failed
node test-all.mjs --only metric-fact-gate-emphasis  ->  6 passed, 0 failed
npm run lint   ->  694 .mjs files passed syntax check
```

Neighboring suites (`nonmetric-fact-gate`, `cover-fact-gate`, `fact-gate-missing-config`, `fact-gate-language-coverage`) stay green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Users can use bold or italic metrics in CV text without false fact-gate failures. `stripMarkup()` removes paired asterisk emphasis at `verify-cv-facts.mjs:216-245`.

Lone asterisks remain unchanged. Underscores remain unchanged, so identifiers and file paths are preserved.

Regression tests cover metric extraction, lone-asterisk handling, underscore safety, and end-to-end verification at `tests/metric-fact-gate-emphasis.test.mjs:20-63`.

Touched files: `verify-cv-facts.mjs`, `tests/metric-fact-gate-emphasis.test.mjs`.

System files not touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->