### PR TITLE
docs(tests): the repo root is where a suite does not run, not where it is registered

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -22,8 +22,9 @@ Node.js (`tests/helpers.mjs`).
   Underscore-prefixed files (e.g. `_html-entities.test.mjs`) test shared
   helper modules.
 - Other `*.test.mjs` files at this level (e.g. `stats.test.mjs`) cover root
-  scripts. Note: standalone `*.test.mjs` files in the repo root are run by
-  `test-all.mjs`'s inline script list, not by this directory's discovery.
+  scripts. Note: a `*.test.mjs` file in the repo root is not discovered and
+  never runs, so no suite may sit there — `no-root-suites.test.mjs` fails the
+  build if one appears (#3303, #3388).
 
 **Web tests do not live here.** `web/` runs its own `npm test` over
 `web/tests/**/*.test.mjs` (see [../web/README.md](../web/README.md)); this


### PR DESCRIPTION
## What does this PR do?

`tests/README.md` told contributors that standalone `*.test.mjs` files in the repo root are run by `test-all.mjs`'s inline script list. That was accurate when it was written in #1714, but #3388 moved all nine root suites into `tests/` and deleted the list, and `tests/no-root-suites.test.mjs` now fails the build if a `*.test.mjs` file shows up at the root at all. A contributor following the README lands a red required check on a file the README told them where to put.

This points the paragraph at the guard instead. `ARCHITECTURE.md:30` already states it correctly, so this brings the third doc into line rather than introducing a new claim.

## Related issue

Closes #4097

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated `tests/README.md:24-26` to match current test discovery behavior.

## User impact

Contributors must place `*.test.mjs` suites in `tests/`. Root-level suites are not discovered or executed. `tests/no-root-suites.test.mjs` rejects root-level suites.

## Files touched

`tests/README.md`: documentation only.

No changes affect `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, or `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->