### PR TITLE
docs(tests): correct stale root-suite sentence in tests/README.md (#4097)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -22,8 +22,9 @@ Node.js (`tests/helpers.mjs`).
   Underscore-prefixed files (e.g. `_html-entities.test.mjs`) test shared
   helper modules.
 - Other `*.test.mjs` files at this level (e.g. `stats.test.mjs`) cover root
-  scripts. Note: standalone `*.test.mjs` files in the repo root are run by
-  `test-all.mjs`'s inline script list, not by this directory's discovery.
+  scripts. Note: standalone `*.test.mjs` files in the repo root are not
+  discovered and will not run — `tests/no-root-suites.test.mjs` fails the
+  build if one shows up (see "Why the flat root" in ARCHITECTURE.md).
 
 **Web tests do not live here.** `web/` runs its own `npm test` over
 `web/tests/**/*.test.mjs` (see [../web/README.md](../web/README.md)); this


### PR DESCRIPTION
Fixes #4097.

## What does this PR do?

`tests/README.md` still tells contributors that standalone `*.test.mjs`
files in the repo root "are run by `test-all.mjs`'s inline script list".
That list was deleted in #3388, zero root suites exist, and
`tests/no-root-suites.test.mjs` fails the build if one shows up — so the
sentence directs contributors to do exactly what CI forbids. This corrects
it to match `ARCHITECTURE.md` ("Why the flat root"), which already states
the true rule.

## Type of change

- [x] Documentation / translation

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] New feature/architecture first: not applicable (docs fix; also fixes #4097)
- [x] No personal data (docs-only, one prose sentence)
- [x] I ran `node test-all.mjs` and all tests pass — 8686 passed, 0 failed
  (17 warnings, byte-identical count on pristine `main`, pre-existing)
- [x] Data Contract: untouched (no user-layer files)
- [x] Roadmap: untouched (docs fix, no behavior change)

## Verification beyond the checklist

- Guard green: `node test-all.mjs --only no-root-suites` — 2 passed.
- Guard proven both directions: with a decoy root `*.test.mjs` present it
  fails (`1 passed, 1 failed`); decoy removed, green again. Decoy deleted,
  tree holds only this edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`tests/README.md:24-26` now states that root-level `*.test.mjs` files are not discovered and will not run. New test suites belong in `tests/`, where discovery finds them automatically. `tests/no-root-suites.test.mjs` fails the build if a root-level suite exists.

Only `tests/README.md` is changed. AGENTS.md, modes/, update-system.mjs, DATA_CONTRACT.md, providers/, and .github/ are not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->