### PR TITLE
docs(budget): fix OpenCode provider setup — OPENAI_API_BASE is not read

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -104,26 +104,77 @@ Different CLIs offer different levels of flexibility for model routing. The two 
 OpenCode is an open-source coding agent that easily routes to custom API providers (like DeepSeek, OpenRouter, Together AI) or local endpoints (Ollama).
 
 To configure OpenCode with a custom provider:
-1. Initialize/open OpenCode in the project directory:
+
+1. Create `opencode.json` in the project root. OpenCode looks for it in the
+   current directory and then walks up to the nearest git root, so the
+   career-ops checkout is the right place for it. A custom endpoint goes in
+   `provider.<name>.options.baseURL`, and credentials come in through `{env:VAR}`
+   substitution rather than being pasted in:
+
+   ```json
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
+     "provider": {
+       "openrouter": {
+         "options": {
+           "apiKey": "{env:OPENROUTER_API_KEY}"
+         }
+       }
+     }
+   }
+   ```
+
+   `openrouter` is one of OpenCode's built-in providers, so it already knows the
+   base URL — you only supply the key. For a provider OpenCode does not ship,
+   add `"baseURL": "https://your-endpoint/v1"` alongside `apiKey` and set
+   `"npm": "@ai-sdk/openai-compatible"`, as in the verified Kimi recipe below.
+
+2. Export only the key named in the config, then open OpenCode in the project
+   directory:
+
+   ```bash
+   # Git Bash / Linux / macOS:
+   export OPENROUTER_API_KEY="your_openrouter_api_key_here"
+
+   # Windows CMD:
+   set OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+   # Windows PowerShell:
+   $env:OPENROUTER_API_KEY="your_openrouter_api_key_here"
+   ```
+
    ```bash
    opencode
    ```
-2. Open its configuration settings (usually located in `.opencode/config.json` or configured via CLI prompts/settings).
-3. Set the `provider` to your chosen endpoint (e.g., OpenRouter or a custom OpenAI-compatible endpoint).
-4. Configure the environment variables for custom endpoints if needed:
-   ```bash
-   # For Git Bash / Linux / macOS:
-   export OPENAI_API_BASE="https://openrouter.ai/api/v1"
-   export OPENAI_API_KEY="your_openrouter_api_key_here"
 
-   # For Windows CMD:
-   set OPENAI_API_BASE=https://openrouter.ai/api/v1
-   set OPENAI_API_KEY=your_openrouter_api_key_here
+> **`OPENAI_API_BASE` does nothing here.** OpenCode reads neither
+> `OPENAI_API_BASE` nor `OPENAI_BASE_URL`; a base URL is only ever config, as
+> above. Exporting it and nothing else leaves OpenCode with no provider
+> configured — which fails in a confusing way, especially in headless
+> `opencode run` usage where there is no `/models` picker to fall back on.
+> (`OPENAI_BASE_URL` *is* read by career-ops' own direct-API scripts —
+> `openai-eval.mjs`, `openai-tailor.mjs` — see `.env.example`. That is a
+> separate path from running a CLI as your engine.)
 
-   # For Windows PowerShell:
-   $env:OPENAI_API_BASE="https://openrouter.ai/api/v1"
-   $env:OPENAI_API_KEY="your_openrouter_api_key_here"
-   ```
+> **Headless runs need a model in config.** `opencode run` resolves its model
+> from the top-level `model` key (format `provider/model`, so an OpenRouter id
+> that itself contains a slash reads `openrouter/vendor/model:free`). Scripts
+> that shell out to `opencode run` — `rank-pipeline.mjs`, for one — do not pass
+> `--model`, so without that key there is nothing to select one.
+
+Free model ids on OpenRouter rotate, and the one above will eventually stop
+resolving. List what is currently free with:
+
+```bash
+curl -s https://openrouter.ai/api/v1/models \
+  | jq -r '.data[] | select(.id|endswith(":free")) | "\(.context_length)\t\(.id)"' \
+  | sort -rn
+```
+
+Prefer a large context window for career-ops: the batch paths send many rows in
+a single prompt and parse strict JSON back, so a small context or a chatty small
+model both fail the parse.
 ### Kimi K2.5 via OpenCode (Verified)
 
 > **Kimi the model, not Kimi the CLI.** This recipe runs the Kimi K2.5 *model* through the **OpenCode** CLI. That is a different thing from using the standalone **Kimi CLI** as your host (see [Supported CLIs](SUPPORTED_CLIS.md)). The names collide; the setups don't. Follow the steps below inside OpenCode.


### PR DESCRIPTION
## What does this PR do?

Fixes the OpenCode section of `docs/RUNNING_ON_A_BUDGET.md` (published as [Setting Up career-ops Without Paid Plans](https://career-ops.org/docs/free-ai-engine)). It told readers to export `OPENAI_API_BASE` to point OpenCode at a custom provider — OpenCode reads neither `OPENAI_API_BASE` nor `OPENAI_BASE_URL`, so following the instructions leaves it with no provider configured at all. Replaces the three env-var blocks with a working `opencode.json`, and corrects two related details in the same section.

## Related issue

None — docs are exempt from issue-first per the checklist below.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/career-ops-hq/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/career-ops-hq/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/career-ops-hq/career-ops/discussions/156)

---

## Detail

Three corrections, all in `### OpenCode CLI`:

**1. `OPENAI_API_BASE` is read by nothing.** A custom endpoint in OpenCode is only ever provider config — `provider.<name>.options.baseURL` — and credentials arrive through `{env:VAR}` substitution. This is the one that actually breaks setups, and it breaks them quietly: with no provider configured there is no clear error, and under headless `opencode run` there is no `/models` picker to fall back on.

Worth noting `OPENAI_BASE_URL` *is* a real variable in this repo — `openai-eval.mjs:123`, `openai-tailor.mjs:85`, `plugins/_engine.mjs:47`, and `.env.example:33` — but it belongs to the direct-API scripts, not to running a CLI as your engine. The two paths were easy to conflate, so the new text says which is which.

**2. Config path.** The section pointed at `.opencode/config.json`. It's `opencode.json` in the project root (OpenCode walks up to the nearest git root) — which is what `doctor.mjs:251` already checks for, and what the verified Kimi K2.5 recipe further down the same file already uses.

**3. Headless runs need the top-level `model` key.** `opencode run` has no way to resolve a model otherwise, and scripts that shell out to it don't pass `--model` — `rank-pipeline.mjs` explicitly skips the flag when the CLI is `opencode` (the `cli.bin !== 'opencode'` guard in `callCli`). Anyone following the old instructions to set up unattended ranking got a job that couldn't select a model.

The rewritten example uses OpenRouter's built-in provider (so only the key is needed) and notes the `@ai-sdk/openai-compatible` + `baseURL` form for providers OpenCode doesn't ship, consistent with the Kimi recipe below it. Since free OpenRouter model ids rotate, it also adds a one-liner for listing what's currently free — the example id was checked against the live `/api/v1/models` response rather than written from memory.

## How this was found

Following the published guide to set up the free engine for an unattended weekly ranking job. The job exited 0 for weeks without ranking anything: `OPENAI_API_BASE` was set, so it looked configured, and there was no model to resolve. Docs-only change here; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ck1teixbLMSQFRkkp6tmwh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `docs/RUNNING_ON_A_BUDGET.md:103-177` with working OpenCode setup instructions.

- Users can configure OpenRouter or compatible providers in root-level `opencode.json`.
- Headless `opencode run` now works when the top-level `model` key is set.
- `OPENAI_API_BASE` and `OPENAI_BASE_URL` no longer serve as OpenCode configuration.
- `OPENAI_BASE_URL` remains valid for career-ops direct API scripts, such as `openai-eval.mjs` and `openai-tailor.mjs` (`docs/RUNNING_ON_A_BUDGET.md:151-158`).
- Users can list current free OpenRouter models (`docs/RUNNING_ON_A_BUDGET.md:166-177`).
- Small-context or chatty models can break strict JSON parsing in batch paths (`docs/RUNNING_ON_A_BUDGET.md:175-177`).

Only `docs/RUNNING_ON_A_BUDGET.md` is touched. `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/` are not touched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->