### PR TITLE
chore(web): pin @types/node and typescript to exact versions

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,12 +24,12 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^25.6.0",
+        "@types/node": "25.9.5",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "postcss": "^8.5.18",
         "tailwindcss": "^4.2.2",
-        "typescript": "^7.0.0"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -30,12 +30,12 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^25.6.0",
+    "@types/node": "25.9.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "postcss": "^8.5.18",
     "tailwindcss": "^4.2.2",
-    "typescript": "^7.0.0"
+    "typescript": "7.0.2"
   },
   "overrides": {
     "postcss": "$postcss",


### PR DESCRIPTION
## Summary
- Pins `@types/node` and `typescript` in `web/package.json` (and lockfile) to exact versions instead of caret ranges, avoiding patch/minor drift across installs.

## Test plan
- No behavior change; devDependency-only version pin. `npm install` in `web/` resolves to the same versions already in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcUFuGKD8xcDvmnCkSPpJg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Pins `@types/node` to `25.9.5` and `typescript` to `7.0.2` in `web/package.json:33,38` and `web/package-lock.json:27,32`.

This prevents version drift across installs. The change affects development dependencies only. It does not change application behavior or exported APIs.

No system files were touched: `AGENTS.md`, `modes/`, `update-system.mjs`, `DATA_CONTRACT.md`, `providers/`, and `.github/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->